### PR TITLE
fix: patch mermaid dependency vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,13 @@ settings:
 
 overrides:
   '@babel/core': 7.29.6
-  dompurify: 3.4.12
+  dompurify: 3.4.13
   uuid: '>=11.1.1 <12.0.0'
   hono: 4.12.34
   '@hono/node-server': 2.0.12
   js-yaml: 4.3.0
   path-to-regexp: '>=8.4.0'
-  mermaid: 11.15.0
+  mermaid: 11.16.1
   fast-uri: 3.1.5
   body-parser: 2.3.0
   brace-expansion: 5.0.9
@@ -3423,8 +3423,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@10.2.0:
     resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
@@ -4356,8 +4356,8 @@ packages:
     resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
     engines: {node: '>=18.0.0'}
 
-  mermaid@11.15.0:
-    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
+  mermaid@11.16.1:
+    resolution: {integrity: sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==}
 
   meshline@3.3.1:
     resolution: {integrity: sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==}
@@ -7410,7 +7410,7 @@ snapshots:
 
   '@streamdown/mermaid@1.0.2(react@19.2.8)':
     dependencies:
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.8
 
   '@tabler/icons-react@3.46.0(react@19.2.8)':
@@ -8499,7 +8499,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9574,7 +9574,7 @@ snapshots:
 
   meriyah@6.1.4: {}
 
-  mermaid@11.15.0:
+  mermaid@11.16.1:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
       '@iconify/utils': 3.1.4
@@ -9588,7 +9588,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       es-toolkit: 1.50.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -10607,7 +10607,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.6
-      mermaid: 11.15.0
+      mermaid: 11.16.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       rehype-harden: 1.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,13 +4,13 @@ packages:
 
 overrides:
   "@babel/core": "7.29.6"
-  dompurify: "3.4.12"
+  dompurify: "3.4.13"
   uuid: ">=11.1.1 <12.0.0"
   hono: "4.12.34"
   "@hono/node-server": "2.0.12"
   js-yaml: "4.3.0"
   path-to-regexp: ">=8.4.0"
-  mermaid: "11.15.0"
+  mermaid: "11.16.1"
   fast-uri: "3.1.5"
   body-parser: "2.3.0"
   brace-expansion: "5.0.9"


### PR DESCRIPTION
## changes

- update the pnpm `mermaid` override from 11.15.0 to 11.16.1
- update the pnpm `dompurify` override from 3.4.12 to 3.4.13
- refresh the lockfile so `streamdown` and `@streamdown/mermaid` resolve the patched transitive versions

## validation

- `pnpm install --frozen-lockfile`
- `pnpm vitest run src/shared/ui/ai-elements/message.test.tsx`
- `just check`
