### PR TITLE
feat: improve multi-workspace chat setup

### DIFF
--- a/scripts/design-system-audit.mjs
+++ b/scripts/design-system-audit.mjs
@@ -122,7 +122,6 @@ const buttonStylingBaseline = new Set([
   "src/features/extensions/ui/ExtensionModal.tsx",
   "src/features/home/widgets/ChecklistWidget.tsx",
   "src/features/home/widgets/StickyNoteWidget.tsx",
-  "src/features/projects/ui/CreateProjectDialog.tsx",
   "src/features/projects/ui/ProjectsView.tsx",
   "src/features/sessions/ui/session-list/SidebarFlatChatsSection.tsx",
   "src/features/sessions/ui/session-list/SidebarProjectList.tsx",

--- a/src-tauri/crates/berdctl/api-surface-feedback.json
+++ b/src-tauri/crates/berdctl/api-surface-feedback.json
@@ -728,7 +728,7 @@
           }
         },
         "set_startup_mode": {
-          "description": "Set the startup behavior for new chats in a project. `worktree` creates an isolated Git worktree per chat, `branch` creates a branch, and `none` uses the configured folders as-is. Existing chats and project folder paths are not changed.",
+          "description": "Set the startup behavior for new chats in a project. `auto-worktree` prompts before creating isolated worktrees, `ask-worktree` leaves worktree creation to the user, and `none` uses configured folders as-is. Legacy `worktree` and `branch` values migrate to those current modes.",
           "fields": [
             {
               "name": "project_id",
@@ -741,7 +741,13 @@
               "required": true,
               "kind": "string",
               "description": "How new chats start from the project's Git workspaces: use them as-is, create a branch, or create an isolated worktree.",
-              "values": ["none", "branch", "worktree"]
+              "values": [
+                "none",
+                "branch",
+                "worktree",
+                "ask-worktree",
+                "auto-worktree"
+              ]
             }
           ],
           "schema": {
@@ -754,7 +760,13 @@
               },
               "mode": {
                 "type": "string",
-                "enum": ["none", "branch", "worktree"],
+                "enum": [
+                  "none",
+                  "branch",
+                  "worktree",
+                  "ask-worktree",
+                  "auto-worktree"
+                ],
                 "description": "How new chats start from the project's Git workspaces: use them as-is, create a branch, or create an isolated worktree."
               }
             },

--- a/src-tauri/crates/berdctl/api-surface.json
+++ b/src-tauri/crates/berdctl/api-surface.json
@@ -728,7 +728,7 @@
           }
         },
         "set_startup_mode": {
-          "description": "Set the startup behavior for new chats in a project. `worktree` creates an isolated Git worktree per chat, `branch` creates a branch, and `none` uses the configured folders as-is. Existing chats and project folder paths are not changed.",
+          "description": "Set the startup behavior for new chats in a project. `auto-worktree` prompts before creating isolated worktrees, `ask-worktree` leaves worktree creation to the user, and `none` uses configured folders as-is. Legacy `worktree` and `branch` values migrate to those current modes.",
           "fields": [
             {
               "name": "project_id",
@@ -741,7 +741,13 @@
               "required": true,
               "kind": "string",
               "description": "How new chats start from the project's Git workspaces: use them as-is, create a branch, or create an isolated worktree.",
-              "values": ["none", "branch", "worktree"]
+              "values": [
+                "none",
+                "branch",
+                "worktree",
+                "ask-worktree",
+                "auto-worktree"
+              ]
             }
           ],
           "schema": {
@@ -754,7 +760,13 @@
               },
               "mode": {
                 "type": "string",
-                "enum": ["none", "branch", "worktree"],
+                "enum": [
+                  "none",
+                  "branch",
+                  "worktree",
+                  "ask-worktree",
+                  "auto-worktree"
+                ],
                 "description": "How new chats start from the project's Git workspaces: use them as-is, create a branch, or create an isolated worktree."
               }
             },

--- a/src-tauri/crates/berdctl/cli-surface-feedback.json
+++ b/src-tauri/crates/berdctl/cli-surface-feedback.json
@@ -115,7 +115,7 @@
         "set-startup-mode": {
           "action": "set_startup_mode",
           "about": "Set how a project's new chats start from its Git workspaces",
-          "afterHelp": "The mode applies to every Git workspace configured on the project. Non-Git\nfolders remain in the project but use mode \"none\". Branch and worktree modes\nprompt for a startup name when the next chat is created.\n\nExamples:\n  berdctl project set-startup-mode --project-id <project-id> --mode worktree\n  berdctl project set-startup-mode --project-id <project-id> --mode none\n\nResult:\n  {\"ok\": true, \"mode\": \"worktree\", \"workspaces\": [\n    {\"path\": \"...\", \"startup_mode\": \"worktree\"}\n  ]}"
+          "afterHelp": "The mode applies to every Git workspace configured on the project. Non-Git\nfolders remain in the project but use mode \"none\". Legacy \"worktree\" becomes\n\"auto-worktree\" and legacy \"branch\" becomes \"ask-worktree\".\n\nExamples:\n  berdctl project set-startup-mode --project-id <project-id> --mode auto-worktree\n  berdctl project set-startup-mode --project-id <project-id> --mode none\n\nResult:\n  {\"ok\": true, \"mode\": \"auto-worktree\", \"workspaces\": [\n    {\"path\": \"...\", \"startup_mode\": \"auto-worktree\"}\n  ]}"
         },
         "archive": {
           "action": "archive",

--- a/src-tauri/crates/berdctl/cli-surface.json
+++ b/src-tauri/crates/berdctl/cli-surface.json
@@ -115,7 +115,7 @@
         "set-startup-mode": {
           "action": "set_startup_mode",
           "about": "Set how a project's new chats start from its Git workspaces",
-          "afterHelp": "The mode applies to every Git workspace configured on the project. Non-Git\nfolders remain in the project but use mode \"none\". Branch and worktree modes\nprompt for a startup name when the next chat is created.\n\nExamples:\n  berdctl project set-startup-mode --project-id <project-id> --mode worktree\n  berdctl project set-startup-mode --project-id <project-id> --mode none\n\nResult:\n  {\"ok\": true, \"mode\": \"worktree\", \"workspaces\": [\n    {\"path\": \"...\", \"startup_mode\": \"worktree\"}\n  ]}"
+          "afterHelp": "The mode applies to every Git workspace configured on the project. Non-Git\nfolders remain in the project but use mode \"none\". Legacy \"worktree\" becomes\n\"auto-worktree\" and legacy \"branch\" becomes \"ask-worktree\".\n\nExamples:\n  berdctl project set-startup-mode --project-id <project-id> --mode auto-worktree\n  berdctl project set-startup-mode --project-id <project-id> --mode none\n\nResult:\n  {\"ok\": true, \"mode\": \"auto-worktree\", \"workspaces\": [\n    {\"path\": \"...\", \"startup_mode\": \"auto-worktree\"}\n  ]}"
         },
         "archive": {
           "action": "archive",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -15,8 +15,12 @@ import { eventMatchesShortcutCommand } from "@/features/shortcuts/lib/shortcutRe
 import { useShortcutsDialogStore } from "@/features/shortcuts/stores/shortcutsDialogStore";
 import { prefetchProjectArtifactRenderer } from "@/features/projects/artifact/prefetchProjectArtifactRenderer";
 import { getPlatform, type Platform } from "@/shared/lib/platform";
-import { archiveProject } from "@/features/projects/api/projects";
-import type { ProjectInfo } from "@/features/projects/api/projects";
+import {
+  archiveProject,
+  isWorktreeStartupMode,
+  requiresWorkspaceStartup,
+  type ProjectInfo,
+} from "@/features/projects/api/projects";
 import {
   DEFAULT_SETTINGS_SECTION,
   resolveEnabledSettingsSection,
@@ -1054,6 +1058,9 @@ export function AppShell({
   const retryFailedSessionsForProjectRef = useRef<
     (project: ProjectInfo) => void
   >(() => {});
+  const startChatForCreatedProjectRef = useRef<(project: ProjectInfo) => void>(
+    () => {},
+  );
   const refreshProjectsAfterDialogSave = useCallback(
     (savedProject: ProjectInfo) => {
       useProjectStore
@@ -1084,6 +1091,8 @@ export function AppShell({
     openEditProjectDialog,
   } = useProjectDialog({
     onProjectSaved: refreshProjectsAfterDialogSave,
+    onProjectCreated: (project) =>
+      startChatForCreatedProjectRef.current(project),
   });
   const startup = useAppStartup();
   const [startupLoadingMinElapsed, setStartupLoadingMinElapsed] = useState(
@@ -1941,7 +1950,10 @@ export function AppShell({
             transferSessionTargetOwnership(session.id, sessionId);
             promoteDraftSession(session.id, sessionId, {
               executionTarget: promotedTarget,
-              workingDir,
+              workingDir: latestSessionAfterReady.workingDir ?? workingDir,
+              workspaceAttachments:
+                latestSessionAfterReady.workspaceAttachments,
+              activeWorkspaceId: latestSessionAfterReady.activeWorkspaceId,
               ...latestSessionPatch,
               ...(resolvedConfigOptionsSnapshot?.reasoningEffort
                 ? {
@@ -2344,8 +2356,8 @@ export function AppShell({
       const chatState = useChatStore.getState();
       const needsStartup =
         workspaceRepository.mode === "multi" &&
-        project.projectWorkspaces.some(
-          (workspace) => workspace.startupMode !== "none",
+        project.projectWorkspaces.some((workspace) =>
+          requiresWorkspaceStartup(workspace.startupMode),
         );
       const existingDraft = findExistingDraft({
         sessions: sessionState.sessions,
@@ -2383,7 +2395,9 @@ export function AppShell({
         workspaceAttachments: needsStartup
           ? asIs?.workspaceAttachments.filter(
               (_, index) =>
-                project.projectWorkspaces[index]?.startupMode === "none",
+                !requiresWorkspaceStartup(
+                  project.projectWorkspaces[index]?.startupMode ?? "none",
+                ),
             )
           : asIs?.workspaceAttachments,
       });
@@ -2483,6 +2497,12 @@ export function AppShell({
       startDraftSessionCreation,
     ],
   );
+
+  startChatForCreatedProjectRef.current = (project) => {
+    void createNewProjectDraft(DEFAULT_CHAT_TITLE, project).catch((error) => {
+      logProjectChatStartError("Failed to start chat for new project:", error);
+    });
+  };
 
   const activateDeferredChatSession = useCallback(
     (sessionId: string) => {
@@ -4979,17 +4999,20 @@ export function AppShell({
               onCreatePersona={agentBuilder.create}
               onStartAgentBuilderSession={agentBuilder.start}
               onArchiveChat={handleArchiveChat}
-              onCreateProject={() => {
+              onCreateProject={(options) => {
                 if (starterTasksVisible) {
                   setStarterTasksAwaitingCompletion((awaiting) =>
                     new Set(awaiting).add("create-project"),
                   );
                   openCreateProjectDialog({
-                    onCreated: handleStarterProjectCreated,
+                    onCreated: (projectId) => {
+                      handleStarterProjectCreated(projectId);
+                      options?.onCreated?.(projectId);
+                    },
                   });
                   return;
                 }
-                openCreateProjectDialog();
+                openCreateProjectDialog(options);
               }}
               onOpenProjectSettings={handleEditProject}
               onActivateHomeSession={activateHomeSession}
@@ -5133,8 +5156,8 @@ export function AppShell({
         requestIdentity={pendingWorkspaceName ?? undefined}
         workspaces={pendingWorkspaceName?.workspaces ?? []}
         requiresWorktreeSafeName={Boolean(
-          pendingWorkspaceName?.workspaces.some(
-            (workspace) => workspace.startupMode === "worktree",
+          pendingWorkspaceName?.workspaces.some((workspace) =>
+            isWorktreeStartupMode(workspace.startupMode),
           ),
         )}
         onCancel={closeWorkspaceName}

--- a/src/app/SessionWindowApp.tsx
+++ b/src/app/SessionWindowApp.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { isWorktreeStartupMode } from "@/features/projects/api/projects";
 
 import { runChatRuntimeStartup } from "@/app/lib/chatRuntimeStartup";
 import { SessionWindowTopBar } from "@/app/ui/SessionWindowTopBar";
@@ -447,8 +448,8 @@ export function SessionWindowApp({
         requestIdentity={workspaceName ?? undefined}
         workspaces={workspaceName?.workspaces ?? []}
         requiresWorktreeSafeName={Boolean(
-          workspaceName?.workspaces.some(
-            (workspace) => workspace.startupMode === "worktree",
+          workspaceName?.workspaces.some((workspace) =>
+            isWorktreeStartupMode(workspace.startupMode),
           ),
         )}
         onCancel={cancelWorkspaceNameRequest}

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -3533,7 +3533,7 @@ describe("projects", () => {
             expect.objectContaining({
               id: "ws-main",
               path: "/projects/repo",
-              startupMode: "worktree",
+              startupMode: "auto-worktree",
             }),
             expect.objectContaining({
               id: "ws-docs",
@@ -3545,9 +3545,9 @@ describe("projects", () => {
       );
       expect(result).toEqual({
         ok: true,
-        mode: "worktree",
+        mode: "auto-worktree",
         workspaces: [
-          { path: "/projects/repo", startup_mode: "worktree" },
+          { path: "/projects/repo", startup_mode: "auto-worktree" },
           { path: "/projects/docs", startup_mode: "none" },
         ],
       });
@@ -3582,7 +3582,7 @@ describe("projects", () => {
       );
     });
 
-    it("rejects branch mode across different checkouts of the same repository", async () => {
+    it("migrates legacy branch mode to manual worktree management", async () => {
       const linkedWorkspace = {
         ...mainWorkspace,
         id: "ws-linked",
@@ -3619,15 +3619,14 @@ describe("projects", () => {
         localBranches: ["main", "feature"],
       }));
 
-      await expectCommandError(
-        dispatchCommand(
-          "projects",
-          { action: "set_startup_mode", project_id: "p-1", mode: "branch" },
-          ctx,
-        ),
-        "invalid_args",
+      const result = await dispatchCommand(
+        "projects",
+        { action: "set_startup_mode", project_id: "p-1", mode: "branch" },
+        ctx,
       );
-      expect(mocks.updateProject).not.toHaveBeenCalled();
+
+      expect(result).toMatchObject({ mode: "ask-worktree" });
+      expect(mocks.updateProject).toHaveBeenCalled();
     });
 
     it("rejects branch/worktree mode when the project has no Git workspaces", async () => {

--- a/src/features/berdctl/commands/impl/getProject.ts
+++ b/src/features/berdctl/commands/impl/getProject.ts
@@ -16,7 +16,12 @@ interface GetProjectResult {
   working_dirs: string[];
   workspaces: Array<{
     path: string;
-    startup_mode: "none" | "branch" | "worktree";
+    startup_mode:
+      | "none"
+      | "branch"
+      | "worktree"
+      | "ask-worktree"
+      | "auto-worktree";
   }>;
   archived: boolean;
   session_count: number;

--- a/src/features/berdctl/commands/impl/setProjectStartupMode.ts
+++ b/src/features/berdctl/commands/impl/setProjectStartupMode.ts
@@ -11,7 +11,7 @@ const setProjectStartupModeSchema = z
   .object({
     project_id: z.string().describe("Id of the project to update."),
     mode: z
-      .enum(["none", "branch", "worktree"])
+      .enum(["none", "branch", "worktree", "ask-worktree", "auto-worktree"])
       .describe(
         "How new chats start from the project's Git workspaces: use them as-is, create a branch, or create an isolated worktree.",
       ),
@@ -25,6 +25,14 @@ interface SetProjectStartupModeResult {
     path: string;
     startup_mode: ProjectWorkspaceStartupMode;
   }>;
+}
+
+function normalizeRequestedMode(
+  mode: z.infer<typeof setProjectStartupModeSchema>["mode"],
+): ProjectWorkspaceStartupMode {
+  if (mode === "branch") return "ask-worktree";
+  if (mode === "worktree") return "auto-worktree";
+  return mode;
 }
 
 function workspacePathKey(path: string): string {
@@ -43,24 +51,25 @@ export const setProjectStartupModeCommand = defineCommand({
   destructive: false,
   summary: "Set how a project's new chats start from its Git workspaces",
   description:
-    "Set the startup behavior for new chats in a project. `worktree` creates " +
-    "an isolated Git worktree per chat, `branch` creates a branch, and " +
-    "`none` uses the configured folders as-is. Existing chats and project " +
-    "folder paths are not changed.",
+    "Set the startup behavior for new chats in a project. `auto-worktree` " +
+    "prompts before creating isolated worktrees, `ask-worktree` leaves " +
+    "worktree creation to the user, and `none` uses configured folders as-is. " +
+    "Legacy `worktree` and `branch` values migrate to those current modes.",
   helpFooter: `The mode applies to every Git workspace configured on the project. Non-Git
-folders remain in the project but use mode "none". Branch and worktree modes
-prompt for a startup name when the next chat is created.
+folders remain in the project but use mode "none". Legacy "worktree" becomes
+"auto-worktree" and legacy "branch" becomes "ask-worktree".
 
 Examples:
-  berdctl project set-startup-mode --project-id <project-id> --mode worktree
+  berdctl project set-startup-mode --project-id <project-id> --mode auto-worktree
   berdctl project set-startup-mode --project-id <project-id> --mode none
 
 Result:
-  {"ok": true, "mode": "worktree", "workspaces": [
-    {"path": "...", "startup_mode": "worktree"}
+  {"ok": true, "mode": "auto-worktree", "workspaces": [
+    {"path": "...", "startup_mode": "auto-worktree"}
   ]}`,
   schema: setProjectStartupModeSchema,
   execute: async (args, ctx): Promise<SetProjectStartupModeResult> => {
+    const mode = normalizeRequestedMode(args.mode);
     const [
       { refusePastDeadline },
       { normalizeProjectWorkspaces },
@@ -94,7 +103,7 @@ Result:
       string,
       Awaited<ReturnType<typeof getGitState>>
     >();
-    if (args.mode !== "none") {
+    if (mode !== "none") {
       try {
         await Promise.all(
           initialWorkspaces.map(async (workspace) => {
@@ -141,9 +150,8 @@ Result:
     }
 
     let gitWorkspaceCount = 0;
-    const branchCheckoutByRepository = new Map<string, string>();
     const projectWorkspaces = liveWorkspaces.map((workspace) => {
-      if (args.mode === "none") {
+      if (mode === "none") {
         return { ...workspace, startupMode: "none" as const };
       }
       const gitState = gitStateByPath.get(workspacePathKey(workspace.path));
@@ -155,30 +163,9 @@ Result:
         workspace,
         gitState,
       );
-      if (args.mode === "branch") {
-        // Match the startup planner's invariant: multiple included paths in
-        // one repository can share a branch startup only when they share the
-        // checkout where that branch will be created.
-        const repositoryKey = workspacePathKey(
-          enriched.repositoryPath ??
-            gitState.mainWorktreePath ??
-            workspace.path,
-        );
-        const checkoutKey = workspacePathKey(
-          enriched.worktreePath ?? workspace.path,
-        );
-        const existingCheckout = branchCheckoutByRepository.get(repositoryKey);
-        if (existingCheckout && existingCheckout !== checkoutKey) {
-          throw new CommandError(
-            "invalid_args",
-            `Project "${args.project_id}" includes multiple checkouts from the same repository; branch mode requires those workspaces to share one checkout. Use --mode worktree or edit the project folders.`,
-          );
-        }
-        branchCheckoutByRepository.set(repositoryKey, checkoutKey);
-      }
-      return { ...workspace, ...enriched, startupMode: args.mode };
+      return { ...workspace, ...enriched, startupMode: mode };
     });
-    if (args.mode !== "none" && gitWorkspaceCount === 0) {
+    if (mode !== "none" && gitWorkspaceCount === 0) {
       throw new CommandError(
         "invalid_args",
         `Project "${args.project_id}" has no Git workspaces; mode "${args.mode}" requires at least one Git workspace.`,
@@ -193,13 +180,13 @@ Result:
       project.icon,
       project.color,
       projectWorkspaces.map((workspace) => workspace.path),
-      args.mode === "worktree",
+      mode === "auto-worktree",
       projectWorkspaces,
     );
 
     return {
       ok: true,
-      mode: args.mode,
+      mode,
       workspaces: updated.projectWorkspaces.map((workspace) => ({
         path: workspace.path,
         startup_mode: workspace.startupMode,

--- a/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -577,6 +577,70 @@ describe("useChatSessionController", () => {
     });
   });
 
+  it("offers worktree setup before the first message is sent", () => {
+    useProjectStore.setState({
+      projects: [
+        {
+          id: "project-1",
+          path: "/tmp/project.md",
+          name: "Project",
+          description: "",
+          prompt: "",
+          icon: "",
+          color: "#22c55e",
+          projectWorkspaces: [
+            {
+              id: "workspace-1",
+              path: "/repo/project",
+              kind: "git-main-worktree",
+              source: "selected",
+              branch: "main",
+              usedByAgent: false,
+              repositoryPath: "/repo/project",
+              startupMode: "worktree",
+            },
+          ],
+          workingDirs: ["/repo/project"],
+          useWorktrees: true,
+          order: 0,
+          archivedAt: null,
+          artifact: null,
+        },
+      ],
+      loading: false,
+      activeProjectId: "project-1",
+    });
+    useChatSessionStore.getState().patchSession("session-1", {
+      projectId: "project-1",
+      workingDir: "/repo/project",
+      workspaceAttachments: [],
+    });
+    useChatStore.setState({
+      messagesBySession: {
+        "session-1": [
+          {
+            id: "startup-system-message",
+            role: "system",
+            created: 0,
+            content: [{ type: "text", text: "Session initialized" }],
+          },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: "session-1" }),
+    );
+
+    expect(result.current.defaultWorkspaceSetup).toMatchObject({
+      status: "choice",
+      desired: [{ id: "workspace-1", startupMode: "worktree" }],
+    });
+    expect(
+      useChatStore.getState().queuedMessageBySession["session-1"],
+    ).toBeUndefined();
+  });
+
   it("debounces draft store writes while composer text changes", () => {
     vi.useFakeTimers();
     try {

--- a/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
@@ -902,6 +902,27 @@ describe("useMessageQueue", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not send the next queued message when the head is dismissed", () => {
+    const sendMessage = vi.fn();
+    useChatStore.getState().enqueueTransportReadyMessage("s1", {
+      persona: { kind: "inherit" },
+      text: "first",
+    });
+    useChatStore.getState().enqueueTransportReadyMessage("s1", {
+      persona: { kind: "inherit" },
+      text: "second",
+    });
+
+    const { result } = renderHook(() =>
+      useMessageQueue("s1", "idle", sendMessage, false, true),
+    );
+
+    act(() => result.current.dismiss(result.current.queuedRecord?.recordId));
+
+    expect(result.current.queuedMessage?.text).toBe("second");
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("queued messages are scoped to session", () => {
     const sendMessage = vi.fn();
     useChatStore.getState().enqueueTransportReadyMessage("s2", {

--- a/src/features/chat/hooks/useChatSessionController.ts
+++ b/src/features/chat/hooks/useChatSessionController.ts
@@ -24,6 +24,7 @@ import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { selectPersonas } from "@/features/agents/stores/agentSelectors";
 import { useProviderSelection } from "@/features/agents/hooks/useProviderSelection";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
+import { isAskWorktreeStartupMode } from "@/features/projects/api/projects";
 import { selectProjects } from "@/features/projects/stores/projectSelectors";
 import { resolveAgentProviderCatalogIdStrictFromEntries } from "@/features/providers/providerCatalog";
 import { useProviderCatalogStore } from "@/features/providers/stores/providerCatalogStore";
@@ -64,7 +65,9 @@ import {
   chooseDeferredWorkspaceSetup,
   cancelDeferredWorkspaceNaming,
   createDeferredWorkspaces,
+  provisionPreSendProjectWorkspaces,
   releaseDeferredWorkspaceSend,
+  workspaceAttachmentsEqualConfiguration,
   UNRESOLVED_DEFERRED_SEND_ERROR,
   type DeferredWorkspaceSend,
   type WorkspaceNameRequest,
@@ -361,6 +364,13 @@ export function useChatSessionController({
     useState<SessionExecutionTarget | null>();
   const [pendingModelSelection, setPendingModelSelection] =
     useState<PreferredModelSelection | null>();
+  const preSendWorkspaceOperationRef = useRef(0);
+  const [preSendWorkspaceSetup, setPreSendWorkspaceSetup] = useState<{
+    sessionId: string;
+    status: "choice" | "naming" | "creating" | "selected";
+    startupName?: string | null;
+    error?: string;
+  } | null>(null);
   const pendingDefaultReasoningEffortBySessionRef = useRef<
     Record<string, string>
   >({});
@@ -371,7 +381,11 @@ export function useChatSessionController({
     {},
   );
   const sessionLocalMessageCount = useChatStore((s) =>
-    sessionId ? (s.messagesBySession[sessionId]?.length ?? 0) : 0,
+    sessionId
+      ? (s.messagesBySession[sessionId]?.filter(
+          (message) => message.role !== "system",
+        ).length ?? 0)
+      : 0,
   );
   const sessionHasStarted = session
     ? hasSessionStarted(session, sessionLocalMessageCount)
@@ -1963,6 +1977,9 @@ export function useChatSessionController({
         (s.messagesBySession[sessionId]?.length ?? 0) === 0
       : false,
   );
+  const hasQueuedMessages = useChatStore(
+    (state) => (state.queuedMessageBySession[stateSessionId]?.length ?? 0) > 0,
+  );
   const deferredWorkspaceRecord = useChatStore((state) => {
     const record = state.queuedMessageBySession[stateSessionId]?.[0];
     return record?.kind === "deferred" &&
@@ -1973,6 +1990,39 @@ export function useChatSessionController({
   const unresolvedDeferredSend =
     deferredWorkspaceRecord?.state.error === UNRESOLVED_DEFERRED_SEND_ERROR &&
     !session?.executionTarget;
+  const currentPreSendWorkspaceSetup =
+    preSendWorkspaceSetup?.sessionId === stateSessionId
+      ? preSendWorkspaceSetup
+      : null;
+  const canOfferPreSendWorkspaceSetup = Boolean(
+    !readOnly &&
+      sessionId &&
+      session &&
+      !sessionHasStarted &&
+      !deferredWorkspaceRecord &&
+      !hasQueuedMessages &&
+      workspaceRepository.mode === "multi" &&
+      project?.projectWorkspaces.some((workspace) =>
+        isAskWorktreeStartupMode(workspace.startupMode),
+      ) &&
+      !workspaceAttachmentsEqualConfiguration(
+        project.projectWorkspaces,
+        session.workspaceAttachments,
+      ),
+  );
+  const defaultWorkspaceSetup =
+    (canOfferPreSendWorkspaceSetup || currentPreSendWorkspaceSetup) &&
+    currentPreSendWorkspaceSetup?.status !== "selected"
+      ? {
+          status: currentPreSendWorkspaceSetup?.status ?? ("choice" as const),
+          desired: project?.projectWorkspaces ?? [],
+          error: currentPreSendWorkspaceSetup?.error,
+        }
+      : null;
+  const preselectedWorkspaceStartupName =
+    currentPreSendWorkspaceSetup?.status === "selected"
+      ? currentPreSendWorkspaceSetup.startupName
+      : undefined;
   useEffect(() => {
     if (
       !deferredWorkspaceRecord ||
@@ -2236,6 +2286,9 @@ export function useChatSessionController({
       attachments?: ChatAttachmentDraft[],
       sendOptions?: ChatSendOptions,
     ) => {
+      if (currentPreSendWorkspaceSetup?.status === "creating") {
+        return false;
+      }
       const personaName = personaId
         ? selectedPersona?.id === personaId
           ? selectedPersona.displayName
@@ -2329,6 +2382,7 @@ export function useChatSessionController({
             {
               cancelBuilderDraftPath:
                 builderSession.targetAgentPath ?? undefined,
+              startupName: preselectedWorkspaceStartupName,
               onNeedsName: onBuilderWorkspaceNameRequest,
             },
           );
@@ -2370,7 +2424,10 @@ export function useChatSessionController({
             attachments,
             sendOptions,
           }),
-          { onNeedsName: onWorkspaceNameRequest },
+          {
+            startupName: preselectedWorkspaceStartupName,
+            onNeedsName: onWorkspaceNameRequest,
+          },
         );
         if (firstSend.accepted) {
           recordDraftPreservingSubmission(sessionId, text);
@@ -2402,7 +2459,10 @@ export function useChatSessionController({
           attachments,
           sendOptions: preparedSendOptions,
         }),
-        { onNeedsName: onWorkspaceNameRequest },
+        {
+          startupName: preselectedWorkspaceStartupName,
+          onNeedsName: onWorkspaceNameRequest,
+        },
       );
       if (firstSend.accepted) {
         recordDraftPreservingSubmission(sessionId, text);
@@ -2420,11 +2480,13 @@ export function useChatSessionController({
     },
     [
       captureSessionSelection,
+      currentPreSendWorkspaceSetup?.status,
       enqueueCapturedMessage,
       ensureCurrentSessionIsAgentBuilder,
       handlePersonaChange,
       onMessageAccepted,
       onWorkspaceNameRequest,
+      preselectedWorkspaceStartupName,
       queue,
       readOnly,
       recordDraftPreservingSubmission,
@@ -2908,22 +2970,89 @@ export function useChatSessionController({
       dismiss: dismissQueuedMessage,
     },
     deferredWorkspaceRecord,
+    defaultWorkspaceSetup,
     deferredWorkspaceError: deferredWorkspaceRecord?.state.error,
     unresolvedDeferredSend,
-    cancelDeferredWorkspaceName: () =>
-      readOnly ? false : cancelDeferredWorkspaceNaming(stateSessionId),
-    createDeferredWorkspace: () =>
-      readOnly ? false : chooseDeferredWorkspaceSetup(stateSessionId, true),
-    submitDeferredWorkspaceName: (name: string) =>
-      !readOnly && deferredWorkspaceRecord?.state.status === "naming"
+    cancelDeferredWorkspaceName: () => {
+      if (defaultWorkspaceSetup?.status === "naming") {
+        setPreSendWorkspaceSetup({
+          sessionId: stateSessionId,
+          status: "choice",
+        });
+        return true;
+      }
+      return readOnly ? false : cancelDeferredWorkspaceNaming(stateSessionId);
+    },
+    createDeferredWorkspace: () => {
+      if (defaultWorkspaceSetup?.status === "choice") {
+        setPreSendWorkspaceSetup({
+          sessionId: stateSessionId,
+          status: "naming",
+        });
+        return true;
+      }
+      return readOnly
+        ? false
+        : chooseDeferredWorkspaceSetup(stateSessionId, true);
+    },
+    submitDeferredWorkspaceName: (name: string) => {
+      if (defaultWorkspaceSetup?.status === "naming" && project) {
+        const operationId = preSendWorkspaceOperationRef.current + 1;
+        preSendWorkspaceOperationRef.current = operationId;
+        setPreSendWorkspaceSetup({
+          sessionId: stateSessionId,
+          status: "creating",
+        });
+        void provisionPreSendProjectWorkspaces(
+          stateSessionId,
+          project,
+          name,
+        ).then(
+          () =>
+            setPreSendWorkspaceSetup((current) =>
+              preSendWorkspaceOperationRef.current === operationId &&
+              current?.sessionId === stateSessionId
+                ? null
+                : current,
+            ),
+          (error) => {
+            console.error("Failed to configure project worktree:", error);
+            setPreSendWorkspaceSetup((current) =>
+              preSendWorkspaceOperationRef.current === operationId &&
+              current?.sessionId === stateSessionId
+                ? {
+                    sessionId: stateSessionId,
+                    status: "naming",
+                    error:
+                      error instanceof Error ? error.message : String(error),
+                  }
+                : current,
+            );
+          },
+        );
+        return;
+      }
+      return !readOnly && deferredWorkspaceRecord?.state.status === "naming"
         ? void createDeferredWorkspaces(
             stateSessionId,
             deferredWorkspaceRecord.recordId,
             name,
           )
-        : undefined,
-    skipDeferredWorkspace: () =>
-      readOnly ? false : chooseDeferredWorkspaceSetup(stateSessionId, false),
+        : undefined;
+    },
+    skipDeferredWorkspace: () => {
+      if (defaultWorkspaceSetup) {
+        setPreSendWorkspaceSetup({
+          sessionId: stateSessionId,
+          status: "selected",
+          startupName: null,
+        });
+        return true;
+      }
+      return readOnly
+        ? false
+        : chooseDeferredWorkspaceSetup(stateSessionId, false);
+    },
     sendDeferredAnyway: () =>
       !readOnly &&
       deferredWorkspaceRecord &&
@@ -2935,6 +3064,8 @@ export function useChatSessionController({
           )
         : false,
     handleSend,
+    workspaceSetupInProgress:
+      currentPreSendWorkspaceSetup?.status === "creating",
     steerDraftMessage,
     canSteerMessage: Boolean(
       sessionId &&

--- a/src/features/chat/hooks/useMessageQueue.ts
+++ b/src/features/chat/hooks/useMessageQueue.ts
@@ -106,6 +106,7 @@ export function useMessageQueue(
     QueuedMessageRecord["payload"] | null
   >(null);
   const suppressNextRenderIdleCycleRef = useRef(false);
+  const dismissedRecordIdRef = useRef<string | null>(null);
   const queuedMessageKey = useMemo(
     () => getQueuedMessageKey(queuedRecord),
     [queuedRecord],
@@ -365,6 +366,12 @@ export function useMessageQueue(
       const advancedToNextRecord =
         queuedMessage?.recordId !== previousQueuedMessage?.recordId &&
         previousQueuedMessage !== undefined;
+      const advancedAfterDismiss =
+        advancedToNextRecord &&
+        previousQueuedMessage?.recordId === dismissedRecordIdRef.current;
+      if (advancedAfterDismiss) {
+        dismissedRecordIdRef.current = null;
+      }
 
       if (editedCurrentRecord || advancedToNextRecord) {
         automaticallyRetriedPayloadRef.current = null;
@@ -392,6 +399,10 @@ export function useMessageQueue(
         !editedCurrentRecord &&
         !advancedToNextRecord
       ) {
+        return;
+      }
+
+      if (advancedAfterDismiss) {
         return;
       }
 
@@ -503,6 +514,7 @@ export function useMessageQueue(
     (recordId?: string) => {
       const targetId = recordId ?? queuedRecord?.recordId;
       if (targetId) {
+        dismissedRecordIdRef.current = targetId;
         useChatStore.getState().dismissQueuedMessage(sessionId, targetId);
       }
     },

--- a/src/features/chat/lib/firstWorkspaceSend.test.ts
+++ b/src/features/chat/lib/firstWorkspaceSend.test.ts
@@ -14,6 +14,7 @@ import {
   chooseDeferredWorkspaceSetup,
   createDeferredWorkspaces,
   prepareExistingFirstSend,
+  provisionPreSendProjectWorkspaces,
   releaseDeferredWorkspaceSend,
   releaseWorkspaceSendAfterUserEdit,
   workspaceAttachmentsEqualConfiguration,
@@ -109,6 +110,80 @@ describe("workspace attachment equality", () => {
 });
 
 describe("first workspace send", () => {
+  it("provisions a named worktree before any message is queued", async () => {
+    const created = {
+      ...selected,
+      id: "created",
+      path: "/repo/worktrees/feature/app",
+      source: "created" as const,
+      worktreePath: "/repo/worktrees/feature",
+    };
+    vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce({
+      workingDir: created.path,
+      workspaceAttachments: [created],
+    });
+    vi.mocked(transitionSessionTarget).mockImplementationOnce(async () => {
+      expect(useChatSessionStore.getState().getSession("s1")).toMatchObject({
+        workingDir: "/repo/app",
+        workspaceAttachments: [],
+      });
+      return {
+        status: "committed",
+        applied: true,
+        target: { harnessId: "goose" },
+      };
+    });
+
+    await provisionPreSendProjectWorkspaces("s1", project, "feature");
+
+    expect(planProjectChatWorkspaces).toHaveBeenCalledWith(project, "feature");
+    expect(useChatStore.getState().queuedMessageBySession.s1).toBeUndefined();
+    expect(useChatSessionStore.getState().getSession("s1")).toMatchObject({
+      workingDir: created.path,
+      workspaceAttachments: [created],
+      activeWorkspaceId: created.id,
+    });
+    expect(transitionSessionTarget).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "s1", workingDir: created.path }),
+    );
+  });
+
+  it("restores the backend target before rolling back a stale completed setup", async () => {
+    const created = {
+      ...selected,
+      id: "created",
+      path: "/repo/worktrees/feature/app",
+      source: "created" as const,
+      worktreePath: "/repo/worktrees/feature",
+    };
+    vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce({
+      workingDir: created.path,
+      workspaceAttachments: [created],
+    });
+    let transitionCount = 0;
+    vi.mocked(transitionSessionTarget).mockImplementation(async () => {
+      transitionCount += 1;
+      if (transitionCount === 1) {
+        useProjectStore.setState({ projects: [] });
+      }
+      return {
+        status: "committed",
+        applied: true,
+        target: { harnessId: "goose" },
+      };
+    });
+
+    await expect(
+      provisionPreSendProjectWorkspaces("s1", project, "feature"),
+    ).rejects.toThrow("The project workspace changed during setup. Try again.");
+
+    expect(transitionSessionTarget).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ sessionId: "s1", workingDir: "/repo/app" }),
+    );
+    expect(rollbackProjectChatWorkspacePlan).toHaveBeenCalledOnce();
+  });
+
   it("converts an existing transport-ready first send into the choice flow", () => {
     const onNeedsName = vi.fn();
     const onChoice = vi.fn();
@@ -219,6 +294,65 @@ describe("first workspace send", () => {
         assistantPrompt: "Use the selected skill.",
       },
     });
+  });
+
+  it("shows the piggyback for auto-create worktrees", () => {
+    const onNeedsName = vi.fn();
+    useProjectStore.setState({
+      projects: [
+        {
+          ...project,
+          projectWorkspaces: [{ ...workspace, startupMode: "auto-worktree" }],
+        },
+      ],
+    });
+
+    expect(
+      acceptFirstSend(
+        "s1",
+        { persona: { kind: "inherit" }, text: "hello" },
+        { onNeedsName },
+      ),
+    ).toEqual({
+      accepted: true,
+      deferred: true,
+      needsName: false,
+    });
+    expect(
+      useChatStore.getState().queuedMessageBySession.s1?.[0],
+    ).toMatchObject({
+      kind: "deferred",
+      state: { status: "choice" },
+    });
+    expect(onNeedsName).not.toHaveBeenCalled();
+    expect(planProjectChatWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it("sends normally when worktrees are manually managed", () => {
+    useProjectStore.setState({
+      projects: [
+        {
+          ...project,
+          projectWorkspaces: [{ ...workspace, startupMode: "ask-worktree" }],
+        },
+      ],
+    });
+
+    expect(
+      acceptFirstSend(
+        "s1",
+        { persona: { kind: "inherit" }, text: "hello" },
+        { queueReady: true },
+      ),
+    ).toEqual({
+      accepted: true,
+      deferred: false,
+      needsName: false,
+    });
+    expect(
+      useChatStore.getState().queuedMessageBySession.s1?.[0],
+    ).toMatchObject({ kind: "transport-ready", payload: { text: "hello" } });
+    expect(planProjectChatWorkspaces).not.toHaveBeenCalled();
   });
 
   it("keeps the prior naming flow for non-worktree startup modes", () => {
@@ -380,6 +514,129 @@ describe("first workspace send", () => {
     });
   });
 
+  it("ignores workspace ordering and derived metadata changes during setup", async () => {
+    useProjectStore.setState({
+      projects: [
+        {
+          ...project,
+          projectWorkspaces: [
+            { ...workspace, branch: "enriched", usedByAgent: true },
+          ],
+        },
+      ],
+    });
+    vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce({
+      workingDir: "/repo/app",
+      workspaceAttachments: [selected],
+    });
+    vi.mocked(transitionSessionTarget).mockResolvedValueOnce({
+      status: "committed",
+      applied: true,
+      target: { harnessId: "goose" },
+    });
+    acceptFirstSend(
+      "s1",
+      { persona: { kind: "inherit" }, text: "hello" },
+      { onNeedsName: vi.fn() },
+    );
+    const record = useChatStore.getState().queuedMessageBySession.s1?.[0];
+    if (record?.kind !== "deferred") throw new Error("missing deferred record");
+
+    await createDeferredWorkspaces("s1", record.recordId, "feature");
+
+    expect(
+      useChatStore.getState().queuedMessageBySession.s1?.[0],
+    ).toMatchObject({ kind: "transport-ready", recordId: record.recordId });
+  });
+
+  it("restores ACP and rolls back when project policy changes after prepare", async () => {
+    acceptFirstSend(
+      "s1",
+      { persona: { kind: "inherit" }, text: "hello" },
+      { onNeedsName: vi.fn() },
+    );
+    const record = useChatStore.getState().queuedMessageBySession.s1?.[0];
+    if (record?.kind !== "deferred") throw new Error("missing deferred record");
+    const plan = {
+      workingDir: "/created",
+      workspaceAttachments: [selected],
+    };
+    vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce(plan);
+    vi.mocked(transitionSessionTarget).mockImplementationOnce(async () => {
+      useProjectStore.setState({ projects: [] });
+      return {
+        status: "committed",
+        applied: true,
+        target: { harnessId: "goose" },
+      };
+    });
+    vi.mocked(transitionSessionTarget).mockResolvedValueOnce({
+      status: "committed",
+      applied: true,
+      target: { harnessId: "goose" },
+    });
+
+    await createDeferredWorkspaces("s1", record.recordId, "feature");
+
+    expect(transitionSessionTarget).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ workingDir: "/repo/app" }),
+    );
+    expect(rollbackProjectChatWorkspacePlan).toHaveBeenCalledWith(plan);
+    expect(
+      (
+        useChatStore.getState().queuedMessageBySession.s1?.[0] as {
+          state: { status: string };
+        }
+      ).state.status,
+    ).toBe("held");
+  });
+
+  it("preserves a concurrent workspace edit while rolling back prepared setup", async () => {
+    acceptFirstSend(
+      "s1",
+      { persona: { kind: "inherit" }, text: "hello" },
+      { onNeedsName: vi.fn() },
+    );
+    const record = useChatStore.getState().queuedMessageBySession.s1?.[0];
+    if (record?.kind !== "deferred") throw new Error("missing deferred record");
+    const plan = {
+      workingDir: "/created",
+      workspaceAttachments: [selected],
+    };
+    vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce(plan);
+    vi.mocked(transitionSessionTarget).mockImplementationOnce(async () => {
+      useChatSessionStore.getState().patchSession("s1", {
+        workingDir: "/user-choice",
+        workspaceAttachments: [
+          { ...selected, id: "user-choice", path: "/user-choice" },
+        ],
+      });
+      return {
+        status: "committed",
+        applied: true,
+        target: { harnessId: "goose" },
+      };
+    });
+    vi.mocked(transitionSessionTarget).mockResolvedValueOnce({
+      status: "committed",
+      applied: true,
+      target: { harnessId: "goose" },
+    });
+
+    await createDeferredWorkspaces("s1", record.recordId, "feature");
+
+    expect(transitionSessionTarget).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ workingDir: "/user-choice" }),
+    );
+    expect(useChatSessionStore.getState().getSession("s1")).toMatchObject({
+      workingDir: "/user-choice",
+      workspaceAttachments: [expect.objectContaining({ id: "user-choice" })],
+    });
+    expect(rollbackProjectChatWorkspacePlan).toHaveBeenCalledWith(plan);
+  });
+
   it("stops stale planning before config apply without calling it", async () => {
     acceptFirstSend(
       "s1",
@@ -408,6 +665,41 @@ describe("first workspace send", () => {
         }
       ).state.status,
     ).toBe("held");
+  });
+
+  it("times out stalled draft promotion and rolls back workspace setup", async () => {
+    vi.useFakeTimers();
+    try {
+      const plan = {
+        workingDir: "/repo/worktrees/feature/app",
+        workspaceAttachments: [selected],
+      };
+      vi.mocked(planProjectChatWorkspaces).mockResolvedValueOnce(plan);
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            ...session(),
+            creationState: "pending",
+            clientSessionId: "s1",
+          },
+        ],
+      });
+
+      const provisioning = provisionPreSendProjectWorkspaces(
+        "s1",
+        project,
+        "feature",
+      );
+      const rejection = expect(provisioning).rejects.toThrow(
+        "Chat creation failed during workspace setup.",
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await rejection;
+      expect(rollbackProjectChatWorkspacePlan).toHaveBeenCalledWith(plan);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("waits for draft promotion before applying ACP configuration", async () => {
@@ -445,9 +737,12 @@ describe("first workspace send", () => {
     const creating = createDeferredWorkspaces("s1", record.recordId, "feature");
     await vi.waitFor(() => {
       expect(
-        useChatSessionStore.getState().getSession("s1")?.workspaceAttachments,
-      ).toEqual([selected]);
+        useChatSessionStore.getState().getSession("s1")?.creationState,
+      ).toBe("pending");
     });
+    expect(
+      useChatSessionStore.getState().getSession("s1")?.workspaceAttachments,
+    ).toEqual([expect.objectContaining({ source: "inferred" })]);
     expect(transitionSessionTarget).not.toHaveBeenCalled();
 
     useChatStore.getState().promoteSessionId("s1", "backend-s1");
@@ -492,13 +787,8 @@ describe("first workspace send", () => {
     const creating = createDeferredWorkspaces("s1", record.recordId, "feature");
     await vi.waitFor(() => {
       expect(
-        useChatSessionStore
-          .getState()
-          .getSession("s1")
-          ?.workspaceAttachments?.some(
-            (attachment) => attachment.id === selected.id,
-          ),
-      ).toBe(true);
+        useChatSessionStore.getState().getSession("s1")?.creationState,
+      ).toBe("pending");
     });
     useChatSessionStore.getState().patchSession("s1", {
       creationState: "failed",

--- a/src/features/chat/lib/firstWorkspaceSend.ts
+++ b/src/features/chat/lib/firstWorkspaceSend.ts
@@ -1,6 +1,8 @@
-import type {
-  ProjectInfo,
-  ProjectWorkspace,
+import {
+  isAskWorktreeStartupMode,
+  isWorktreeStartupMode,
+  type ProjectInfo,
+  type ProjectWorkspace,
 } from "@/features/projects/api/projects";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { getWorkspaceRepository } from "@/features/workspaces/workspaceRepository";
@@ -17,6 +19,7 @@ import {
   isSameWorkspacePath,
 } from "./workspaceAttachments";
 import { transitionSessionTarget } from "./sessionTargetCoordinator";
+import type { SessionExecutionTarget } from "./sessionExecutionTarget";
 import { isAdmittedQueuedMessagePayload } from "./admittedSend";
 import {
   useChatStore,
@@ -27,6 +30,30 @@ import { useChatSessionStore } from "../stores/chatSessionStore";
 
 export const UNRESOLVED_DEFERRED_SEND_ERROR =
   "Select a model before sending to this unresolved session.";
+const WORKSPACE_SESSION_PROMOTION_TIMEOUT_MS = 30_000;
+
+function projectWorkspaceConfigurationRevision(
+  workspaces: readonly ProjectWorkspace[],
+): string {
+  return workspaces
+    .map((workspace) => ({
+      path: workspace.path.replace(/\\/g, "/").replace(/\/+$/, ""),
+      startupMode: workspace.startupMode,
+    }))
+    .sort((left, right) => left.path.localeCompare(right.path))
+    .map(({ path, startupMode }) => `${path}\0${startupMode}`)
+    .join("\n");
+}
+
+function projectWorkspaceConfigurationsEqual(
+  left: readonly ProjectWorkspace[],
+  right: readonly ProjectWorkspace[],
+): boolean {
+  return (
+    projectWorkspaceConfigurationRevision(left) ===
+    projectWorkspaceConfigurationRevision(right)
+  );
+}
 
 export interface DeferredWorkspaceSend {
   type: "workspace-first-send";
@@ -34,6 +61,7 @@ export interface DeferredWorkspaceSend {
   projectId: string;
   desired: ProjectWorkspace[];
   cancelBuilderDraftPath?: string;
+  configurationRevision?: string;
   error?: string;
 }
 
@@ -57,12 +85,11 @@ function attachmentMatches(
       isSameWorkspacePath(attachment.path, workspace.path)
     );
   }
-  const requiredCleanup =
-    workspace.startupMode === "worktree"
-      ? "worktree"
-      : workspace.startupMode === "branch"
-        ? "branch"
-        : null;
+  const requiredCleanup = isWorktreeStartupMode(workspace.startupMode)
+    ? "worktree"
+    : workspace.startupMode === "branch"
+      ? "branch"
+      : null;
   if (requiredCleanup && attachment.lifecycle?.cleanup !== requiredCleanup) {
     return false;
   }
@@ -120,6 +147,48 @@ function resolveDeferredSessionId(
     records.some((record) => record.recordId === recordId),
   );
   return queuedEntry?.[0] ?? null;
+}
+
+async function waitForPromotedSessionId(
+  originalSessionId: string,
+): Promise<string | null> {
+  const resolve = (): string | null | undefined => {
+    const session = useChatSessionStore
+      .getState()
+      .sessions.find(
+        (candidate) =>
+          candidate.id === originalSessionId ||
+          candidate.clientSessionId === originalSessionId,
+      );
+    if (!session || session.archivedAt || session.creationState === "failed") {
+      return null;
+    }
+    return session.creationState === "pending" ||
+      session.id === originalSessionId
+      ? undefined
+      : session.id;
+  };
+
+  const initial = resolve();
+  if (initial !== undefined) return initial;
+  return new Promise((finish) => {
+    let settled = false;
+    const complete = (result: string | null) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeoutId);
+      unsubscribe();
+      finish(result);
+    };
+    const unsubscribe = useChatSessionStore.subscribe(() => {
+      const result = resolve();
+      if (result !== undefined) complete(result);
+    });
+    const timeoutId = window.setTimeout(
+      () => complete(null),
+      WORKSPACE_SESSION_PROMOTION_TIMEOUT_MS,
+    );
+  });
 }
 
 async function waitForBackendSessionId(
@@ -226,6 +295,150 @@ export function hasDeferredWorkspaceSend(sessionId: string): boolean {
   return deferredRecord(sessionId) !== null;
 }
 
+export async function provisionPreSendProjectWorkspaces(
+  sessionId: string,
+  project: ProjectInfo,
+  startupName: string,
+): Promise<string> {
+  let resolvedSessionId = resolveDeferredSessionId(sessionId);
+  const session = resolvedSessionId
+    ? useChatSessionStore.getState().getSession(resolvedSessionId)
+    : null;
+  if (!resolvedSessionId || !session || session.archivedAt) {
+    throw new Error("The chat is no longer available for workspace setup.");
+  }
+
+  let originalWorkspaceState = {
+    workingDir: session.workingDir,
+    workspaceAttachments: session.workspaceAttachments,
+    activeWorkspaceId: session.activeWorkspaceId,
+  };
+  let originalWorkspaceSnapshot = sessionSnapshot(sessionId);
+  let switchedTarget: SessionExecutionTarget | undefined;
+  const plan = await planProjectChatWorkspaces(project, startupName);
+  if (!plan) {
+    throw new Error("The project has no folders to configure.");
+  }
+
+  try {
+    const liveProject = useProjectStore
+      .getState()
+      .projects.find((candidate) => candidate.id === project.id);
+    if (
+      !liveProject ||
+      !projectWorkspaceConfigurationsEqual(
+        liveProject.projectWorkspaces,
+        project.projectWorkspaces,
+      )
+    ) {
+      throw new Error("The project folders changed during workspace setup.");
+    }
+
+    if (session.creationState === "pending") {
+      const promotedSessionId = await waitForPromotedSessionId(sessionId);
+      if (!promotedSessionId) {
+        throw new Error("Chat creation failed during workspace setup.");
+      }
+      resolvedSessionId = promotedSessionId;
+      const promotedSession = useChatSessionStore
+        .getState()
+        .getSession(resolvedSessionId);
+      if (!promotedSession) {
+        throw new Error("Chat creation failed during workspace setup.");
+      }
+      originalWorkspaceState = {
+        workingDir: promotedSession.workingDir,
+        workspaceAttachments: promotedSession.workspaceAttachments,
+        activeWorkspaceId: promotedSession.activeWorkspaceId,
+      };
+      originalWorkspaceSnapshot = sessionSnapshot(resolvedSessionId);
+    }
+
+    const currentProject = useProjectStore
+      .getState()
+      .projects.find((candidate) => candidate.id === project.id);
+    const currentSessionSnapshot = sessionSnapshot(resolvedSessionId);
+    if (
+      !currentProject ||
+      !projectWorkspaceConfigurationsEqual(
+        currentProject.projectWorkspaces,
+        project.projectWorkspaces,
+      ) ||
+      currentSessionSnapshot !== originalWorkspaceSnapshot
+    ) {
+      throw new Error("The project workspace changed during setup. Try again.");
+    }
+
+    const preparedSession = useChatSessionStore
+      .getState()
+      .getSession(resolvedSessionId);
+    if (!preparedSession?.executionTarget) {
+      throw new Error("Select a model before configuring this workspace.");
+    }
+    const prepared = await transitionSessionTarget({
+      sessionId: resolvedSessionId,
+      target: preparedSession.executionTarget,
+      workingDir: plan.workingDir,
+    });
+    if (!prepared.applied) {
+      throw new Error("The chat could not switch to the new worktree.");
+    }
+    switchedTarget = preparedSession.executionTarget;
+    const finalProject = useProjectStore
+      .getState()
+      .projects.find((candidate) => candidate.id === project.id);
+    if (
+      !finalProject ||
+      !projectWorkspaceConfigurationsEqual(
+        finalProject.projectWorkspaces,
+        project.projectWorkspaces,
+      ) ||
+      sessionSnapshot(resolvedSessionId) !== originalWorkspaceSnapshot
+    ) {
+      throw new Error("The project workspace changed during setup. Try again.");
+    }
+    useChatSessionStore.getState().patchSession(resolvedSessionId, {
+      workingDir: plan.workingDir,
+      workspaceAttachments: plan.workspaceAttachments,
+      activeWorkspaceId: plan.workspaceAttachments[0]?.id,
+      ...(prepared.configOptionsSnapshot?.reasoningEffort
+        ? { reasoningEffort: prepared.configOptionsSnapshot.reasoningEffort }
+        : {}),
+    });
+    return resolvedSessionId;
+  } catch (error) {
+    let rollbackError: unknown;
+    if (switchedTarget && !originalWorkspaceState.workingDir) {
+      rollbackError = new Error(
+        "Berd couldn’t safely return the chat to its original folder.",
+      );
+    } else if (switchedTarget && originalWorkspaceState.workingDir) {
+      const restored = await transitionSessionTarget({
+        sessionId: resolvedSessionId,
+        target: switchedTarget,
+        workingDir: originalWorkspaceState.workingDir,
+      });
+      if (!restored.applied) {
+        rollbackError = new Error(
+          "Berd couldn’t safely return the chat to its original folder.",
+        );
+      }
+    }
+    if (!rollbackError) {
+      await rollbackProjectChatWorkspacePlan(plan);
+      const rollbackSession = useChatSessionStore
+        .getState()
+        .getSession(resolvedSessionId);
+      if (rollbackSession) {
+        useChatSessionStore
+          .getState()
+          .patchSession(resolvedSessionId, originalWorkspaceState);
+      }
+    }
+    throw rollbackError ?? error;
+  }
+}
+
 /** Call only after an explicit successful user workspace/configuration edit. */
 export function releaseWorkspaceSendAfterUserEdit(sessionId: string): boolean {
   const record = deferredRecord(sessionId);
@@ -277,10 +490,13 @@ export async function createDeferredWorkspaces(
     });
     return;
   }
+  const expectedConfigurationRevision =
+    record.state.configurationRevision ??
+    projectWorkspaceConfigurationRevision(record.state.desired);
   if (
     !project ||
-    JSON.stringify(project.projectWorkspaces) !==
-      JSON.stringify(record.state.desired)
+    projectWorkspaceConfigurationRevision(project.projectWorkspaces) !==
+      expectedConfigurationRevision
   ) {
     useChatStore.getState().updateDeferredMessage(resolvedSessionId, recordId, {
       ...record.state,
@@ -314,8 +530,8 @@ export async function createDeferredWorkspaces(
       .projects.find((candidate) => candidate.id === desiredProjectId);
     if (
       !liveProject ||
-      JSON.stringify(liveProject.projectWorkspaces) !==
-        JSON.stringify(record.state.desired)
+      projectWorkspaceConfigurationRevision(liveProject.projectWorkspaces) !==
+        expectedConfigurationRevision
     ) {
       await rollbackProjectChatWorkspacePlan(plan);
       useChatStore
@@ -352,10 +568,6 @@ export async function createDeferredWorkspaces(
       }
       return;
     }
-    useChatSessionStore.getState().patchSession(resolvedSessionId, {
-      workingDir,
-      workspaceAttachments: plan?.workspaceAttachments,
-    });
     if (current.creationState === "pending") {
       const backendSessionId = await waitForBackendSessionId(
         sessionId,
@@ -392,10 +604,6 @@ export async function createDeferredWorkspaces(
         return;
       }
       resolvedSessionId = backendSessionId;
-      useChatSessionStore.getState().patchSession(resolvedSessionId, {
-        workingDir,
-        workspaceAttachments: plan?.workspaceAttachments,
-      });
     }
     const appliedSnapshot = sessionSnapshot(sessionId, recordId);
     const preparedSession = useChatSessionStore
@@ -426,6 +634,30 @@ export async function createDeferredWorkspaces(
       !prepared.applied ||
       sessionSnapshot(sessionId, recordId) !== appliedSnapshot
     ) {
+      if (prepared.applied) {
+        const concurrentWorkspaceState = useChatSessionStore
+          .getState()
+          .getSession(resolvedSessionId);
+        const restored = concurrentWorkspaceState?.workingDir
+          ? await transitionSessionTarget({
+              sessionId: resolvedSessionId,
+              target: preparedSession.executionTarget,
+              workingDir: concurrentWorkspaceState.workingDir,
+            })
+          : null;
+        if (!restored?.applied) {
+          useChatStore
+            .getState()
+            .updateDeferredMessage(resolvedSessionId, recordId, {
+              ...record.state,
+              status: "failed",
+              error:
+                "Berd couldn’t safely return the chat to its original folder.",
+            });
+          return;
+        }
+      }
+      await rollbackProjectChatWorkspacePlan(plan);
       useChatStore
         .getState()
         .updateDeferredMessage(resolvedSessionId, recordId, {
@@ -440,9 +672,33 @@ export async function createDeferredWorkspaces(
       .projects.find((candidate) => candidate.id === finalProjectId);
     if (
       !finalProject ||
-      JSON.stringify(finalProject.projectWorkspaces) !==
-        JSON.stringify(record.state.desired)
+      projectWorkspaceConfigurationRevision(finalProject.projectWorkspaces) !==
+        expectedConfigurationRevision
     ) {
+      const restored = originalWorkspaceState?.workingDir
+        ? await transitionSessionTarget({
+            sessionId: resolvedSessionId,
+            target: preparedSession.executionTarget,
+            workingDir: originalWorkspaceState.workingDir,
+          })
+        : null;
+      if (!restored?.applied) {
+        useChatStore
+          .getState()
+          .updateDeferredMessage(resolvedSessionId, recordId, {
+            ...record.state,
+            status: "failed",
+            error:
+              "Berd couldn’t safely return the chat to its original folder.",
+          });
+        return;
+      }
+      await rollbackProjectChatWorkspacePlan(plan);
+      if (originalWorkspaceState) {
+        useChatSessionStore
+          .getState()
+          .patchSession(resolvedSessionId, originalWorkspaceState);
+      }
       useChatStore
         .getState()
         .updateDeferredMessage(resolvedSessionId, recordId, {
@@ -464,6 +720,9 @@ export async function createDeferredWorkspaces(
       return;
     }
     useChatSessionStore.getState().patchSession(resolvedSessionId, {
+      workingDir,
+      workspaceAttachments: plan?.workspaceAttachments,
+      activeWorkspaceId: plan?.workspaceAttachments[0]?.id,
       ...(prepared.configOptionsSnapshot?.reasoningEffort
         ? { reasoningEffort: prepared.configOptionsSnapshot.reasoningEffort }
         : {}),
@@ -567,10 +826,16 @@ export function prepareExistingFirstSend(
   }
 
   const needsName = projectRequiresStartupWorkspaceName(project);
-  const usesWorktreeChoice = project.projectWorkspaces.some(
-    (workspace) => workspace.startupMode === "worktree",
+  const usesWorktreeChoice = project.projectWorkspaces.some((workspace) =>
+    isAskWorktreeStartupMode(workspace.startupMode),
   );
-  if (needsName && !options.onNeedsName) return false;
+  const manuallyManaged = project.projectWorkspaces.every(
+    (workspace) =>
+      workspace.startupMode === "none" ||
+      workspace.startupMode === "ask-worktree",
+  );
+  if (manuallyManaged) return true;
+  if (needsName && !usesWorktreeChoice && !options.onNeedsName) return false;
   if (
     !chat.deferTransportReadyMessage(
       sessionId,
@@ -584,6 +849,9 @@ export function prepareExistingFirstSend(
             : "creating",
         projectId: project.id,
         desired: project.projectWorkspaces,
+        configurationRevision: projectWorkspaceConfigurationRevision(
+          project.projectWorkspaces,
+        ),
       },
       payloadForDeferredWorkspaceSetup(record.payload),
     )
@@ -670,10 +938,26 @@ export function acceptFirstSend(
   }
 
   const needsName = projectRequiresStartupWorkspaceName(project);
-  const usesWorktreeChoice = project.projectWorkspaces.some(
-    (workspace) => workspace.startupMode === "worktree",
+  const usesWorktreeChoice = project.projectWorkspaces.some((workspace) =>
+    isAskWorktreeStartupMode(workspace.startupMode),
   );
-  if (needsName && options.startupName === undefined && !options.onNeedsName) {
+  const manuallyManaged = project.projectWorkspaces.every(
+    (workspace) =>
+      workspace.startupMode === "none" ||
+      workspace.startupMode === "ask-worktree",
+  );
+  if (manuallyManaged) {
+    return {
+      accepted:
+        options.queueReady && isAdmittedQueuedMessagePayload(payload)
+          ? chat.enqueueTransportReadyMessage(sessionId, payload)
+          : false,
+      deferred: false,
+      needsName: false,
+    };
+  }
+  const startupName = options.startupName;
+  if (needsName && startupName === undefined && !options.onNeedsName) {
     return {
       accepted: false,
       deferred: false,
@@ -686,13 +970,16 @@ export function acceptFirstSend(
     {
       type: "workspace-first-send",
       status:
-        needsName && options.startupName === undefined
+        needsName && startupName === undefined
           ? usesWorktreeChoice
             ? "choice"
             : "naming"
           : "creating",
       projectId: project.id,
       desired: project.projectWorkspaces,
+      configurationRevision: projectWorkspaceConfigurationRevision(
+        project.projectWorkspaces,
+      ),
       cancelBuilderDraftPath: options.cancelBuilderDraftPath,
     },
   );
@@ -705,7 +992,7 @@ export function acceptFirstSend(
     };
   }
 
-  if (needsName && options.startupName === undefined && !usesWorktreeChoice) {
+  if (needsName && startupName === undefined && !usesWorktreeChoice) {
     options.onNeedsName?.({
       workspaces: project.projectWorkspaces,
       submit: (name) =>
@@ -722,11 +1009,11 @@ export function acceptFirstSend(
         }
       },
     });
-  } else if (!(needsName && options.startupName === undefined)) {
+  } else if (!(needsName && startupName === undefined)) {
     void createDeferredWorkspaces(
       sessionId,
       record.recordId,
-      options.startupName ?? null,
+      startupName ?? null,
     );
   }
   return { accepted: true, deferred: true, needsName: false };

--- a/src/features/chat/lib/sessionTargetCoordinator.test.ts
+++ b/src/features/chat/lib/sessionTargetCoordinator.test.ts
@@ -798,6 +798,73 @@ describe("session target coordinator", () => {
     expect(getSessionTargetSelection("selection")).toBeUndefined();
   });
 
+  it("settles pending draft work when ownership transfers to an existing backend actor", async () => {
+    const { transferSessionTargetOwnership, hydrateSessionTarget } =
+      await import("./sessionTargetCoordinator");
+    const wire = deferred();
+    mockPrepare.mockReturnValueOnce(wire.promise);
+    useChatSessionStore.setState((state) => ({
+      sessions: [
+        ...state.sessions,
+        {
+          ...state.sessions[0],
+          id: "draft",
+          title: "draft",
+        },
+        {
+          ...state.sessions[0],
+          id: "backend",
+          title: "backend",
+        },
+      ],
+    }));
+    const pending = transitionSessionTarget({
+      sessionId: "draft",
+      target: target("b"),
+      workingDir: "/w",
+    });
+    await vi.waitFor(() => expect(mockPrepare).toHaveBeenCalledOnce());
+    hydrateSessionTarget("backend", target("a"));
+
+    transferSessionTargetOwnership("draft", "backend");
+
+    await expect(pending).resolves.toMatchObject({
+      status: "superseded",
+      applied: false,
+    });
+    expect(getSessionTargetState("backend")).toMatchObject({
+      status: "settled",
+      committed: target("a"),
+    });
+    wire.resolve();
+  });
+
+  it("preserves an existing backend actor while transferring draft selection", async () => {
+    const {
+      recordSessionTargetSelection,
+      getSessionTargetSelection,
+      transferSessionTargetOwnership,
+    } = await import("./sessionTargetCoordinator");
+    recordSessionTargetSelection({
+      sessionId: "backend",
+      operationId: "op-backend",
+      target: target("a"),
+    });
+    recordSessionTargetSelection({
+      sessionId: "draft",
+      operationId: "op-draft",
+      target: target("b"),
+    });
+
+    transferSessionTargetOwnership("draft", "backend");
+
+    expect(getSessionTargetSelection("draft")).toBeUndefined();
+    expect(getSessionTargetSelection("backend")).toMatchObject({
+      operationId: "op-backend",
+      target: target("a"),
+    });
+  });
+
   it("transfers pending selection ownership from a draft id", async () => {
     const {
       recordSessionTargetSelection,

--- a/src/features/chat/lib/sessionTargetCoordinator.ts
+++ b/src/features/chat/lib/sessionTargetCoordinator.ts
@@ -1207,6 +1207,25 @@ export function transferSessionTargetOwnership(
   const source = actors.get(fromSessionId);
   if (!source) return;
   actors.delete(fromSessionId);
+  const destination = actors.get(toSessionId);
+  if (destination) {
+    destination.selection ??= source.selection;
+    destination.deferredSelection ??= source.deferredSelection;
+    destination.deferredTargetMutation ??= source.deferredTargetMutation;
+    source.cancelled = true;
+    const pending = new Set(
+      [source.current, source.latest].filter(
+        (operation): operation is PendingOperation => operation !== undefined,
+      ),
+    );
+    for (const operation of pending) {
+      settleOperation(operation, { status: "superseded", applied: false });
+    }
+    source.current = undefined;
+    source.latest = undefined;
+    source.dispatch?.release();
+    return;
+  }
   source.tracksLiveSession = true;
   actors.set(toSessionId, source);
 }

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -1231,10 +1231,6 @@ export function ChatInput({
           void handleSteerCurrentMessage();
           return;
         }
-        if (canSteerQueuedMessageWithShortcut) {
-          handleSteerQueuedMessage();
-          return;
-        }
       }
 
       void handleSend();

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -11,6 +11,7 @@ import {
 import { Pencil, X } from "lucide-react";
 import { IconCheck, IconCornerDownLeft } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import {
   attachmentSnapshotsMatch,
   skillDraftSnapshotsMatch,
@@ -478,16 +479,35 @@ export function ChatInput({
     };
   }, [scheduleResizeTextarea, surface]);
 
-  const visibleQueuedMessages = (
+  const shouldReduceMotion = useReducedMotion();
+  const queuedMessageContentRef = useRef<HTMLDivElement>(null);
+  const [queuedMessageContentHeight, setQueuedMessageContentHeight] =
+    useState<number>();
+  const allQueuedMessages =
     queuedMessages ??
-    (queuedMessage ? [{ recordId: "legacy", payload: queuedMessage }] : [])
-  ).filter(({ payload }) => payload.showInComposer !== false);
+    (queuedMessage ? [{ recordId: "legacy", payload: queuedMessage }] : []);
+  const visibleQueuedMessages = allQueuedMessages.filter(
+    ({ payload }) => payload.showInComposer !== false,
+  );
   // A record being edited lives in the composer, so its pill is hidden to
   // avoid showing the same message both queued and in the composer. Queue
   // positions (head-only actions) still come from the unfiltered list.
   const queuedMessagePills = visibleQueuedMessages
     .map((entry, index) => ({ ...entry, index }))
     .filter(({ recordId }) => recordId !== editingQueuedRecordId);
+  useLayoutEffect(() => {
+    const content = queuedMessageContentRef.current;
+    if (!content) {
+      setQueuedMessageContentHeight(undefined);
+      return;
+    }
+    const updateHeight = () =>
+      setQueuedMessageContentHeight(content.scrollHeight);
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(content);
+    return () => observer.disconnect();
+  });
   const hasDraftContext =
     (scopedControls.attachments && attachments.length > 0) ||
     visibleSelectedSkills.length > 0;
@@ -504,6 +524,30 @@ export function ChatInput({
     canSteerMessage &&
     visibleQueuedMessages.length === 0 &&
     Boolean(onSteerMessage);
+  // Steering acts on the true queue head, so it is only offered when that
+  // head is also the message the user can see. In practice hidden records
+  // (reliable startup handoffs) cannot coexist with an active run today;
+  // this is a tripwire so a future longer-lived hidden record makes
+  // steering go inert instead of steering something off-screen.
+  const queuedHeadIsVisible =
+    allQueuedMessages.length > 0 &&
+    allQueuedMessages[0].payload.showInComposer !== false;
+  // With an empty composer, the send shortcut steers the first queued
+  // message instead of no-oping — the double-enter flow (enter queues,
+  // enter again steers). Draft content keeps the shortcut on the draft so
+  // it can never discard or bypass what the user is composing, and an
+  // in-progress queue edit keeps the shortcut inert because the edited
+  // message lives in the composer, not the queue.
+  const canSteerQueuedMessageWithShortcut =
+    !hasDraftContent &&
+    !attachmentWorkPending &&
+    !disabled &&
+    !sendDisabled &&
+    isStreaming &&
+    canSteerQueuedMessage &&
+    editingQueuedRecordId === null &&
+    queuedHeadIsVisible &&
+    Boolean(onSteerQueuedMessage);
 
   const effectivePersonaId = editingQueuedPersona
     ? editingQueuedPersona.kind === "persona"
@@ -1148,6 +1192,10 @@ export function ChatInput({
           void handleSteerCurrentMessage();
           return;
         }
+        if (canSteerQueuedMessageWithShortcut) {
+          handleSteerQueuedMessage();
+          return;
+        }
       }
       void handleSend();
       return;
@@ -1181,6 +1229,10 @@ export function ChatInput({
         );
         if (action === "steer" && canSteerCurrentMessage) {
           void handleSteerCurrentMessage();
+          return;
+        }
+        if (canSteerQueuedMessageWithShortcut) {
+          handleSteerQueuedMessage();
           return;
         }
       }
@@ -1553,11 +1605,20 @@ export function ChatInput({
           )}
         >
           <Popover open={mentionOpen}>
+            {queuedMessageAccessory ? (
+              <div
+                data-slot="queued-message-accessory"
+                className="relative z-0 -mb-2 overflow-hidden rounded-t-sm bg-surface-composer-action pb-2"
+              >
+                {queuedMessageAccessory}
+              </div>
+            ) : null}
+
             {/* biome-ignore lint/a11y/noStaticElementInteractions: drop zone for file attachments */}
             <div
               ref={containerRef}
               className={cn(
-                "relative transition-colors",
+                "relative z-10 transition-colors",
                 "chat-composer-shell",
                 surface === "bare"
                   ? cn(
@@ -1626,92 +1687,138 @@ export function ChatInput({
               />
 
               {queuedMessagePills.length > 0 && (
-                <div className="mb-2 flex max-h-36 flex-col gap-1 overflow-y-auto">
-                  {queuedMessagePills.map(({ recordId, payload, index }) => (
-                    <div
-                      key={recordId}
-                      data-slot="queued-message"
-                      className="flex items-center gap-2 rounded-full bg-surface-chat-responding-pill-bg px-3 py-1.5 text-surface-chat-responding-pill-fg shadow-[var(--shadow-chat)]"
-                    >
-                      <span className="flex-1 truncate text-xs opacity-75">
-                        {payload.text}
-                      </span>
-                      {index === 0 && isStreaming && canSteerQueuedMessage ? (
-                        <button
-                          type="button"
-                          onClick={handleSteerQueuedMessage}
-                          className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-current opacity-75 hover:bg-surface-chat-responding-pill-fg/15 hover:opacity-100"
-                          aria-label={t("toolbar.steer")}
-                          title={t("toolbar.steerQueued")}
-                        >
-                          <IconCornerDownLeft
-                            className="size-3"
-                            aria-hidden="true"
-                          />
-                          {t("toolbar.steer")}
-                        </button>
-                      ) : null}
-                      {index === 0 && onSendQueue ? (
-                        <button
-                          type="button"
-                          onClick={() => void onSendQueue()}
-                          className="shrink-0 rounded-full px-2 text-xs"
-                        >
-                          {t("toolbar.send")}
-                        </button>
-                      ) : null}
-                      {(
-                        recordId === "legacy"
-                          ? Boolean(onDismissQueue)
-                          : Boolean(onUpdateQueue)
-                      ) ? (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            handleEditQueuedMessage(recordId, payload)
+                <div className="-mx-1 mb-2 max-h-36 overflow-y-auto">
+                  <motion.div
+                    initial={false}
+                    animate={
+                      queuedMessageContentHeight == null
+                        ? undefined
+                        : { height: queuedMessageContentHeight }
+                    }
+                    data-slot="queued-message-group"
+                    transition={
+                      shouldReduceMotion
+                        ? { duration: 0 }
+                        : {
+                            height: {
+                              duration: 0.18,
+                              ease: [0.215, 0.61, 0.355, 1],
+                            },
                           }
-                          className="shrink-0 rounded-full p-0.5 text-current opacity-75 hover:opacity-100"
-                          aria-label={t("queue.edit")}
-                          title={t("queue.edit")}
-                        >
-                          <Pencil className="size-3.5" aria-hidden="true" />
-                        </button>
-                      ) : null}
-                      {onDismissQueue ? (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (editingQueuedRecordIdRef.current === recordId) {
-                              setEditingQueuedRecord(null);
-                              setEditingQueuedPersona(null);
-                            }
-                            onDismissQueue?.(
-                              recordId === "legacy" ? undefined : recordId,
-                            );
-                          }}
-                          className="shrink-0 rounded-full p-0.5 text-current opacity-75 hover:opacity-100"
-                          aria-label={t("queue.dismiss")}
-                        >
-                          <X className="size-3.5" />
-                        </button>
-                      ) : null}
+                    }
+                    className={cn(
+                      "overflow-hidden bg-surface-chat-responding-pill-bg text-surface-chat-responding-pill-fg shadow-[var(--shadow-chat)]",
+                      queuedMessagePills.length > 1
+                        ? "rounded-xs"
+                        : "rounded-full",
+                    )}
+                  >
+                    <div
+                      ref={queuedMessageContentRef}
+                      className="flex flex-col gap-1.5 p-1.5"
+                    >
+                      <AnimatePresence initial={false} mode="popLayout">
+                        {queuedMessagePills.map(
+                          ({ recordId, payload, index }) => (
+                            <motion.div
+                              key={recordId}
+                              data-slot="queued-message"
+                              initial={
+                                shouldReduceMotion ? false : { opacity: 0 }
+                              }
+                              animate={{ opacity: 1 }}
+                              exit={{
+                                opacity: 0,
+                                transition: {
+                                  duration: shouldReduceMotion ? 0 : 0.08,
+                                },
+                              }}
+                              transition={{
+                                duration: shouldReduceMotion ? 0 : 0.14,
+                                ease: [0.165, 0.84, 0.44, 1],
+                              }}
+                              className="flex items-center gap-2"
+                            >
+                              <span className="flex-1 truncate pl-1.5 text-sm opacity-75">
+                                {payload.text}
+                              </span>
+                              {index === 0 &&
+                              isStreaming &&
+                              canSteerQueuedMessage &&
+                              queuedHeadIsVisible ? (
+                                <button
+                                  type="button"
+                                  onClick={handleSteerQueuedMessage}
+                                  className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium text-current opacity-75 hover:bg-surface-chat-responding-pill-fg/15 hover:opacity-100"
+                                  aria-label={t("toolbar.steer")}
+                                  title={t("toolbar.steerQueued")}
+                                >
+                                  <IconCornerDownLeft
+                                    className="size-3"
+                                    aria-hidden="true"
+                                  />
+                                  {t("toolbar.steer")}
+                                </button>
+                              ) : null}
+                              {index === 0 && onSendQueue ? (
+                                <button
+                                  type="button"
+                                  onClick={() => void onSendQueue()}
+                                  className="shrink-0 rounded-full px-2 text-xs"
+                                >
+                                  {t("common:actions.send")}
+                                </button>
+                              ) : null}
+                              {(
+                                recordId === "legacy"
+                                  ? Boolean(onDismissQueue)
+                                  : Boolean(onUpdateQueue)
+                              ) ? (
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleEditQueuedMessage(recordId, payload)
+                                  }
+                                  className="shrink-0 rounded-full p-0.5 text-current opacity-75 hover:opacity-100"
+                                  aria-label={t("queue.edit")}
+                                  title={t("queue.edit")}
+                                >
+                                  <Pencil
+                                    className="size-3.5"
+                                    aria-hidden="true"
+                                  />
+                                </button>
+                              ) : null}
+                              {onDismissQueue ? (
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    if (
+                                      editingQueuedRecordIdRef.current ===
+                                      recordId
+                                    ) {
+                                      setEditingQueuedRecord(null);
+                                      setEditingQueuedPersona(null);
+                                    }
+                                    onDismissQueue?.(
+                                      recordId === "legacy"
+                                        ? undefined
+                                        : recordId,
+                                    );
+                                  }}
+                                  className="shrink-0 rounded-full p-0.5 text-current opacity-75 hover:opacity-100"
+                                  aria-label={t("queue.dismiss")}
+                                >
+                                  <X className="size-3.5" />
+                                </button>
+                              ) : null}
+                            </motion.div>
+                          ),
+                        )}
+                      </AnimatePresence>
                     </div>
-                  ))}
+                  </motion.div>
                 </div>
-              )}
-
-              {visibleQueuedMessages.length > 0 && queuedMessageAccessory ? (
-                <div
-                  data-slot="queued-message-accessory"
-                  className={cn(
-                    "mb-3 overflow-hidden rounded-t-sm bg-surface-composer-action",
-                    surface === "bare" ? "-mx-4" : "-mx-5",
-                  )}
-                >
-                  {queuedMessageAccessory}
-                </div>
-              ) : (
-                queuedMessageAccessory
               )}
 
               <div

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -726,8 +726,11 @@ export function ChatView({
     return null;
   }, [controller.messages]);
 
+  const workspaceSetup = controller.defaultWorkspaceSetup
+    ? controller.defaultWorkspaceSetup
+    : controller.deferredWorkspaceRecord?.state;
   const deferredWorkspaceStartup = summarizeProjectWorkspaceStartup(
-    controller.deferredWorkspaceRecord?.state.desired ?? [],
+    workspaceSetup?.desired ?? [],
   );
 
   const composerFooter = (
@@ -751,16 +754,15 @@ export function ChatView({
               </p>
             ) : !isReadOnly &&
               deferredWorkspaceStartup.worktreeCount > 0 &&
-              (controller.deferredWorkspaceRecord?.state.status === "choice" ||
-                controller.deferredWorkspaceRecord?.state.status === "naming" ||
-                controller.deferredWorkspaceRecord?.state.status ===
-                  "creating") ? (
+              (workspaceSetup?.status === "choice" ||
+                workspaceSetup?.status === "naming" ||
+                workspaceSetup?.status === "creating") ? (
               <WorkspaceSetupChoice
-                state={controller.deferredWorkspaceRecord.state.status}
+                state={workspaceSetup.status}
                 worktreeCount={deferredWorkspaceStartup.worktreeCount}
                 branchCount={deferredWorkspaceStartup.branchCount}
                 exactCounts={deferredWorkspaceStartup.exact}
-                workspaces={controller.deferredWorkspaceRecord.state.desired}
+                error={workspaceSetup.error}
                 onCancelName={controller.cancelDeferredWorkspaceName}
                 onCreate={controller.createDeferredWorkspace}
                 onSubmitName={controller.submitDeferredWorkspaceName}
@@ -791,7 +793,8 @@ export function ChatView({
             sendDisabled:
               isReadOnly ||
               effectiveSession?.creationState != null ||
-              isAgentBuilderTargetPending,
+              isAgentBuilderTargetPending ||
+              controller.workspaceSetupInProgress,
             sendDisabledReason,
             queuedMessage: composerHandoffInProgress
               ? null

--- a/src/features/chat/ui/WorkspaceSetupChoice.test.tsx
+++ b/src/features/chat/ui/WorkspaceSetupChoice.test.tsx
@@ -3,6 +3,13 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { WorkspaceSetupChoice } from "./WorkspaceSetupChoice";
 
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false;
+}
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 describe("WorkspaceSetupChoice", () => {
   it("matches Cynthia's collapsed prompt interaction", async () => {
     const user = userEvent.setup();
@@ -77,17 +84,6 @@ describe("WorkspaceSetupChoice", () => {
     render(
       <WorkspaceSetupChoice
         state="naming"
-        workspaces={[
-          {
-            id: "workspace-1",
-            path: "/Berd-internal",
-            kind: "repository",
-            source: "selected",
-            usedByAgent: true,
-            repositoryPath: "/Berd-internal",
-            startupMode: "worktree",
-          },
-        ]}
         onCancelName={onCancelName}
         onCreate={vi.fn()}
         onSubmitName={onSubmitName}
@@ -96,17 +92,17 @@ describe("WorkspaceSetupChoice", () => {
     );
 
     const input = screen.getByRole("textbox", { name: "Worktree name" });
-    expect(
-      screen.getByRole("combobox", { name: "Project folder" }),
-    ).toHaveValue("/Berd-internal");
-    expect(
-      screen.getByRole("option", { name: "Berd-internal" }),
-    ).toBeInTheDocument();
-    expect(input.parentElement?.parentElement).toHaveClass(
-      "grid-cols-1",
-      "sm:grid-cols-[minmax(8rem,0.34fr)_minmax(0,1fr)]",
-    );
     expect(input).toHaveAttribute("placeholder", "Enter worktree name");
+    expect(input).toHaveClass(
+      "text-base",
+      "md:text-sm",
+      "border-transparent",
+      "shadow-none",
+      "placeholder:text-muted-foreground/60",
+      "dark:bg-muted/55",
+      "dark:placeholder:text-muted-foreground/50",
+      "dark:focus-visible:border-ring/50",
+    );
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onCancelName).toHaveBeenCalledOnce();
     await user.type(input, "feature/name");
@@ -115,6 +111,28 @@ describe("WorkspaceSetupChoice", () => {
     await user.type(input, "feature-name");
     await user.click(screen.getByRole("button", { name: "Save" }));
     expect(onSubmitName).toHaveBeenCalledWith("feature-name");
+  });
+
+  it("aligns an error to the left of the naming actions", () => {
+    render(
+      <WorkspaceSetupChoice
+        state="naming"
+        error="Choose a Git repository."
+        onCancelName={vi.fn()}
+        onCreate={vi.fn()}
+        onSubmitName={vi.fn()}
+        onSkip={vi.fn()}
+      />,
+    );
+
+    const error = screen.getByRole("alert");
+    expect(error).toHaveClass("flex-1", "truncate");
+    expect(error).toHaveAttribute("title", "Choose a Git repository.");
+    const actionRow = error.parentElement;
+    expect(actionRow).toHaveClass("items-center", "justify-between");
+    expect(actionRow?.lastElementChild).toContainElement(
+      screen.getByRole("button", { name: "Save" }),
+    );
   });
 
   it("reuses the piggyback surface while preparing", () => {

--- a/src/features/chat/ui/WorkspaceSetupChoice.tsx
+++ b/src/features/chat/ui/WorkspaceSetupChoice.tsx
@@ -1,9 +1,7 @@
-import { useMemo, useState } from "react";
-import { ArrowRight, ChevronDown } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
-import type { ProjectWorkspace } from "@/features/projects/api/projects";
-import { getWorkspaceTitle } from "@/features/chat/lib/workspaceAttachments";
 import { Button } from "@/shared/ui/button";
 import { ComposerActionButton } from "@/shared/ui/composer-action-button";
 import { Input } from "@/shared/ui/input";
@@ -14,7 +12,7 @@ interface WorkspaceSetupChoiceProps {
   worktreeCount?: number;
   branchCount?: number;
   exactCounts?: boolean;
-  workspaces?: ProjectWorkspace[];
+  error?: string;
   onCancelName: () => void;
   onCreate: () => void;
   onSubmitName: (name: string) => void;
@@ -26,35 +24,29 @@ export function WorkspaceSetupChoice({
   worktreeCount = 1,
   branchCount = 0,
   exactCounts = true,
-  workspaces = [],
+  error,
   onCancelName,
   onCreate,
   onSubmitName,
   onSkip,
 }: WorkspaceSetupChoiceProps) {
   const { t } = useTranslation("chat");
+  const shouldReduceMotion = useReducedMotion();
   const [name, setName] = useState("");
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState<number>();
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+    const updateHeight = () => setContentHeight(content.scrollHeight);
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, []);
   const trimmedName = name.trim();
   const invalidName =
     trimmedName === "." || trimmedName === ".." || /[/\\]/.test(trimmedName);
-  const projectFolders = useMemo(
-    () =>
-      Array.from(
-        new Map(
-          workspaces
-            .filter((workspace) => workspace.startupMode === "worktree")
-            .map((workspace) => [
-              workspace.repositoryPath ??
-                workspace.worktreePath ??
-                workspace.path,
-              getWorkspaceTitle(workspace),
-            ]),
-        ).entries(),
-      ),
-    [workspaces],
-  );
-  const selectedProjectFolder = projectFolders[0]?.[0] || "";
-
   const choiceLabel = !exactCounts
     ? t("queue.configureWorkspaces")
     : worktreeCount === 1 && branchCount === 0
@@ -71,142 +63,150 @@ export function WorkspaceSetupChoice({
 
   return (
     <motion.div
-      layout="size"
+      initial={false}
+      animate={contentHeight == null ? undefined : { height: contentHeight }}
       className="overflow-hidden"
-      transition={{ layout: { duration: 0.18, ease: "easeOut" } }}
+      transition={
+        shouldReduceMotion
+          ? { duration: 0 }
+          : { height: { duration: 0.42, ease: [0.4, 0, 0.2, 1] } }
+      }
     >
-      <AnimatePresence initial={false} mode="popLayout">
-        {state === "choice" ? (
-          <motion.div
-            key="choice"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.14, ease: "easeOut" }}
-            className="overflow-hidden"
-          >
-            <div className="flex min-h-10 items-center justify-between gap-3 px-3 py-1.5">
-              <span className="text-sm font-semibold text-foreground">
-                {choiceLabel}
-              </span>
-              <div className="flex shrink-0 items-center gap-3">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={onSkip}
-                  flush
-                >
-                  {t("queue.configureWorktreeSkip")}
-                </Button>
-                <ComposerActionButton
-                  type="button"
-                  size="icon-sm"
-                  onClick={onCreate}
-                  aria-label={t("queue.configureWorktreeYes")}
-                >
-                  <ArrowRight className="size-4" aria-hidden="true" />
-                </ComposerActionButton>
-              </div>
-            </div>
-          </motion.div>
-        ) : state === "naming" ? (
-          <motion.form
-            key="naming"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.14, ease: "easeOut" }}
-            className="overflow-hidden px-3 pb-3 pt-2"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (trimmedName && !invalidName) onSubmitName(trimmedName);
-            }}
-          >
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(8rem,0.34fr)_minmax(0,1fr)]">
-              <label className="grid gap-1 text-xs font-medium text-foreground">
-                {t("queue.projectFolder")}
-                <span className="relative">
-                  <select
-                    aria-label={t("queue.projectFolder")}
-                    value={selectedProjectFolder}
-                    disabled
-                    className="h-9 w-full appearance-none rounded-sm border-0 bg-background px-3 pr-8 text-sm text-foreground outline-none disabled:cursor-default disabled:opacity-100 focus-visible:ring-1 focus-visible:ring-ring"
-                  >
-                    {projectFolders.length ? (
-                      projectFolders.map(([value, label]) => (
-                        <option key={value} value={value}>
-                          {label}
-                        </option>
-                      ))
-                    ) : (
-                      <option value="">
-                        {t("queue.projectFolderCurrent")}
-                      </option>
-                    )}
-                  </select>
-                  <ChevronDown className="pointer-events-none absolute right-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+      <div ref={contentRef} className="grid">
+        <AnimatePresence initial={false} mode="sync">
+          {state === "choice" ? (
+            <motion.div
+              key="choice"
+              initial={false}
+              animate={{ opacity: 1 }}
+              exit={{
+                opacity: 0,
+                transition: { duration: shouldReduceMotion ? 0 : 0.08 },
+              }}
+              transition={{
+                duration: shouldReduceMotion ? 0 : 0.18,
+                ease: [0.165, 0.84, 0.44, 1],
+              }}
+              className="col-start-1 row-start-1 overflow-hidden"
+            >
+              <div className="flex min-h-10 items-center justify-between gap-3 px-5 py-1">
+                <span className="text-sm font-normal text-foreground">
+                  {choiceLabel}
                 </span>
-              </label>
-              <label
-                htmlFor="deferred-worktree-name"
-                className="grid gap-1 text-xs font-medium text-foreground"
-              >
-                {t("queue.worktreeName")}
-                <Input
-                  id="deferred-worktree-name"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  aria-label={t("queue.worktreeName")}
-                  placeholder={t("queue.worktreeNamePlaceholder")}
-                  autoComplete="off"
-                  autoCorrect="off"
-                  autoCapitalize="none"
-                  spellCheck={false}
-                  autoFocus
-                  className="h-9 border-0 bg-background shadow-none"
-                />
-              </label>
-            </div>
-            <div className="mt-3 flex justify-end gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                onClick={onCancelName}
-              >
-                {t("queue.cancelWorktree")}
-              </Button>
-              <Button
-                type="submit"
-                size="sm"
-                className="min-w-16 rounded-full"
-                disabled={!trimmedName || invalidName}
-              >
-                {t("queue.createWorktree")}
-              </Button>
-            </div>
-          </motion.form>
-        ) : (
-          <motion.div
-            key="creating"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.14, ease: "easeOut" }}
-            className="overflow-hidden"
-          >
-            <div className="px-3 py-2.5 text-sm text-foreground">
-              <span className="font-semibold">
-                {t("queue.preparingWorkspaceTitle")}
-              </span>{" "}
-              <Shimmer as="span" tone="current">
-                {t("queue.preparingWorkspaceBody")}
-              </Shimmer>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+                <div className="flex shrink-0 items-center gap-3">
+                  <Button
+                    type="button"
+                    size="compact"
+                    variant="ghost"
+                    onClick={onSkip}
+                    flush
+                  >
+                    {t("queue.configureWorktreeSkip")}
+                  </Button>
+                  <ComposerActionButton
+                    type="button"
+                    size="icon-pill-sm"
+                    onClick={onCreate}
+                    aria-label={t("queue.configureWorktreeYes")}
+                  >
+                    <ArrowRight className="size-4" aria-hidden="true" />
+                  </ComposerActionButton>
+                </div>
+              </div>
+            </motion.div>
+          ) : state === "naming" ? (
+            <motion.form
+              key="naming"
+              initial={shouldReduceMotion ? false : { opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{
+                opacity: 0,
+                transition: { duration: shouldReduceMotion ? 0 : 0.08 },
+              }}
+              transition={{
+                duration: shouldReduceMotion ? 0 : 0.18,
+                ease: [0.165, 0.84, 0.44, 1],
+              }}
+              className="col-start-1 row-start-1 overflow-hidden px-5 pb-3.5 pt-4.5"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (trimmedName && !invalidName) onSubmitName(trimmedName);
+              }}
+            >
+              <div>
+                <label
+                  htmlFor="deferred-worktree-name"
+                  className="grid gap-1.5 text-sm font-normal text-foreground"
+                >
+                  {t("queue.worktreeName")}
+                  <Input
+                    id="deferred-worktree-name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    aria-label={t("queue.worktreeName")}
+                    placeholder={t("queue.worktreeNamePlaceholder")}
+                    autoComplete="off"
+                    autoCorrect="off"
+                    autoCapitalize="none"
+                    spellCheck={false}
+                    autoFocus
+                    className="border-transparent bg-background shadow-none placeholder:text-muted-foreground/60 hover:border-transparent focus-visible:border-ring/50 dark:bg-muted/55 dark:placeholder:text-muted-foreground/50 dark:hover:border-transparent dark:focus-visible:border-ring/50"
+                  />
+                </label>
+              </div>
+              <div className="mt-4 flex items-center justify-between gap-4">
+                {error ? (
+                  <p
+                    className="min-w-0 flex-1 truncate text-sm text-destructive"
+                    role="alert"
+                    title={error}
+                  >
+                    {error}
+                  </p>
+                ) : (
+                  <span aria-hidden="true" />
+                )}
+                <div className="flex shrink-0 gap-2">
+                  <Button
+                    type="button"
+                    size="compact"
+                    variant="ghost"
+                    onClick={onCancelName}
+                  >
+                    {t("queue.cancelWorktree")}
+                  </Button>
+                  <Button
+                    type="submit"
+                    size="compact"
+                    className="min-w-16"
+                    disabled={!trimmedName || invalidName}
+                  >
+                    {t("queue.createWorktree")}
+                  </Button>
+                </div>
+              </div>
+            </motion.form>
+          ) : (
+            <motion.div
+              key="creating"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.14, ease: [0.165, 0.84, 0.44, 1] }}
+              className="col-start-1 row-start-1 overflow-hidden"
+            >
+              <div className="px-3 py-2.5 text-sm text-foreground">
+                <span className="font-semibold">
+                  {t("queue.preparingWorkspaceTitle")}
+                </span>{" "}
+                <Shimmer as="span" tone="current">
+                  {t("queue.preparingWorkspaceBody")}
+                </Shimmer>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
     </motion.div>
   );
 }

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -318,7 +318,7 @@ describe("ChatInput", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the queue pill outside and above the composer piggyback", () => {
+  it("keeps the composer piggyback at the top with queued messages below it", () => {
     render(
       <ChatInput
         surface="bare"
@@ -332,21 +332,30 @@ describe("ChatInput", () => {
 
     const queue = screen.getByText("queued follow up");
     const accessory = screen.getByText("Configure a new worktree?");
-    expect(queue.parentElement).toHaveClass(
+    expect(
+      queue.parentElement?.parentElement?.parentElement?.parentElement,
+    ).toHaveClass("-mx-1");
+    expect(queue.parentElement).toHaveClass("flex", "items-center", "gap-2");
+    expect(queue.parentElement?.parentElement).toHaveClass(
       "flex",
-      "items-center",
-      "gap-2",
+      "flex-col",
+      "gap-1.5",
+      "p-1.5",
+    );
+    expect(queue.parentElement?.parentElement?.parentElement).toHaveClass(
       "rounded-full",
       "bg-surface-chat-responding-pill-bg",
-      "px-3",
-      "py-1.5",
       "text-surface-chat-responding-pill-fg",
       "shadow-[var(--shadow-chat)]",
     );
+    expect(queue).toHaveClass("pl-1.5", "text-sm");
     expect(accessory.parentElement).toHaveClass(
+      "relative",
+      "z-0",
+      "-mb-2",
       "rounded-t-sm",
       "bg-surface-composer-action",
-      "-mx-4",
+      "pb-2",
     );
     expect(accessory.parentElement).toHaveAttribute(
       "data-slot",
@@ -356,17 +365,18 @@ describe("ChatInput", () => {
       .getByTestId("chat-composer")
       .closest(".chat-composer-shell");
     expect(composerShell).toHaveClass(
+      "z-10",
+      "rounded-sm",
       "bg-surface-chat-composer",
       "[backdrop-filter:var(--backdrop-composer-glass)]",
     );
     expect(composerShell?.parentElement).not.toHaveClass(
       "bg-surface-chat-composer",
     );
-    expect(queue.parentElement?.parentElement).not.toBe(
-      accessory.parentElement?.parentElement,
-    );
+    expect(accessory.parentElement?.nextElementSibling).toBe(composerShell);
+    expect(composerShell?.contains(queue.parentElement)).toBe(true);
     expect(
-      queue.compareDocumentPosition(accessory) &
+      accessory.compareDocumentPosition(queue) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
@@ -2494,12 +2504,14 @@ describe("ChatInput", () => {
 
     // Editing the head hides its pill; the tail pill must not inherit
     // head-only actions like steering.
-    const pillTexts = Array.from(
-      document.querySelectorAll('[data-slot="queued-message"]'),
-    ).map((pill) => pill.textContent);
-    expect(pillTexts).toHaveLength(1);
-    expect(pillTexts[0]).toContain("second");
-    expect(pillTexts[0]).not.toContain("first");
+    await waitFor(() => {
+      const pillTexts = Array.from(
+        document.querySelectorAll('[data-slot="queued-message"]'),
+      ).map((pill) => pill.textContent);
+      expect(pillTexts).toHaveLength(1);
+      expect(pillTexts[0]).toContain("second");
+      expect(pillTexts[0]).not.toContain("first");
+    });
     expect(screen.queryByTitle("Steer queued message")).not.toBeInTheDocument();
   });
 
@@ -2528,8 +2540,21 @@ describe("ChatInput", () => {
       />,
     );
 
-    expect(screen.getByText("first")).toBeInTheDocument();
-    expect(screen.getByText("second")).toBeInTheDocument();
+    const firstQueuedMessage = screen.getByText("first");
+    const secondQueuedMessage = screen.getByText("second");
+    expect(firstQueuedMessage).toBeInTheDocument();
+    expect(secondQueuedMessage).toBeInTheDocument();
+    const queuedMessageGroup =
+      firstQueuedMessage.parentElement?.parentElement?.parentElement;
+    expect(queuedMessageGroup).toBe(
+      secondQueuedMessage.parentElement?.parentElement?.parentElement,
+    );
+    expect(queuedMessageGroup).toHaveAttribute(
+      "data-slot",
+      "queued-message-group",
+    );
+    expect(queuedMessageGroup).toHaveClass("rounded-xs");
+    expect(queuedMessageGroup).not.toHaveClass("rounded-full");
     expect(screen.queryByText("1. first")).not.toBeInTheDocument();
     expect(screen.queryByText("2. second")).not.toBeInTheDocument();
 

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -431,6 +431,7 @@ describe("ChatView MCP app messaging", () => {
       stopStreaming: vi.fn(),
       projectMetadataPending: false,
       isCompactingContext: false,
+      workspaceSetupInProgress: false,
       queue: { queuedMessage: null, dismiss: vi.fn() },
       draftValue: "",
       handleDraftChange: mocks.handleDraftChange,

--- a/src/features/chat/ui/widgets/WorkspaceIdentity.tsx
+++ b/src/features/chat/ui/widgets/WorkspaceIdentity.tsx
@@ -9,6 +9,7 @@ import {
 import type { WorkspaceAttachment } from "@/shared/types/chat";
 import type { GitState } from "@/shared/types/git";
 import { cn } from "@/shared/lib/cn";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import {
   isPathWithin,
   isSamePath,
@@ -228,11 +229,13 @@ interface WorkspaceIdentityProps {
   gitState: GitState | undefined;
   gitContext?: WorkspaceGitContext;
   showMetadata?: boolean;
+  iconKind?: WorkspaceIdentityIconKind;
   className?: string;
   iconClassName?: string;
   titleClassName?: string;
   metadataClassName?: string;
   showHoverChevron?: boolean;
+  iconTooltip?: string;
 }
 
 export function WorkspaceIdentity({
@@ -240,15 +243,17 @@ export function WorkspaceIdentity({
   gitState,
   gitContext,
   showMetadata = true,
+  iconKind: iconKindOverride,
   className,
   iconClassName,
   titleClassName,
   metadataClassName,
   showHoverChevron = true,
+  iconTooltip,
 }: WorkspaceIdentityProps) {
   const { t } = useTranslation("chat");
   const context = gitContext ?? getWorkspaceGitContext(workspace, gitState);
-  const iconKind = getWorkspaceIdentityIconKind(context);
+  const iconKind = iconKindOverride ?? getWorkspaceIdentityIconKind(context);
   const metadataItems = getWorkspaceIdentityMetadataItems(context, {
     mainCheckout: t("contextPanel.includedWorkspaces.mainCheckout"),
     worktree: t("contextPanel.includedWorkspaces.worktree"),
@@ -256,25 +261,30 @@ export function WorkspaceIdentity({
 
   return (
     <div className={cn("flex min-w-0 items-start gap-2", className)}>
-      <span className="relative mt-px size-3.5 shrink-0 text-muted-foreground">
-        <WorkspaceKindIcon
-          kind={iconKind}
-          className={cn(
-            "absolute inset-0 size-3.5 transition-opacity duration-100",
-            showHoverChevron && "group-hover/workspace-row:opacity-0",
-            iconClassName,
-          )}
-        />
-        {showHoverChevron ? (
-          <ChevronDown
-            className={cn(
-              "absolute inset-0 size-3.5 opacity-0 transition-opacity duration-100 group-hover/workspace-row:opacity-100",
-              iconClassName,
-            )}
-            aria-hidden="true"
-          />
-        ) : null}
-      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="relative mt-px size-3.5 shrink-0 text-muted-foreground">
+            <WorkspaceKindIcon
+              kind={iconKind}
+              className={cn(
+                "absolute inset-0 size-3.5 transition-opacity duration-100",
+                showHoverChevron && "group-hover/workspace-row:opacity-0",
+                iconClassName,
+              )}
+            />
+            {showHoverChevron ? (
+              <ChevronDown
+                className={cn(
+                  "absolute inset-0 size-3.5 opacity-0 transition-opacity duration-100 group-hover/workspace-row:opacity-100",
+                  iconClassName,
+                )}
+                aria-hidden="true"
+              />
+            ) : null}
+          </span>
+        </TooltipTrigger>
+        {iconTooltip ? <TooltipContent>{iconTooltip}</TooltipContent> : null}
+      </Tooltip>
       <div className="min-w-0 flex-1">
         <span
           className={cn(

--- a/src/features/design-system/generated/componentManifest.ts
+++ b/src/features/design-system/generated/componentManifest.ts
@@ -571,6 +571,7 @@ export const designSystemComponentManifest = [
             "xs",
             "default",
             "sm",
+            "compact",
             "lg",
             "icon",
             "icon-xxs",

--- a/src/features/design-system/ui/DesignSystemView.tsx
+++ b/src/features/design-system/ui/DesignSystemView.tsx
@@ -768,6 +768,7 @@ const buttonTextSizeBySize = {
   xxs: "text-[11px]",
   xs: "text-xs",
   sm: "text-xs",
+  compact: "text-sm",
   default: "text-sm",
   lg: "text-sm",
   icon: "text-sm",

--- a/src/features/projects/api/projects.test.ts
+++ b/src/features/projects/api/projects.test.ts
@@ -166,15 +166,63 @@ describe("projects API artifact metadata", () => {
     expect(createRequest.properties.projectWorkspaces).toEqual([
       expect.objectContaining({
         path: "/tmp/launch/packages/app",
-        startupMode: "worktree",
+        startupMode: "auto-worktree",
       }),
     ]);
     expect(project.workingDirs).toEqual(["/tmp/launch/packages/app"]);
     expect(project.projectWorkspaces).toEqual([
       expect.objectContaining({
         path: "/tmp/launch/packages/app",
-        startupMode: "worktree",
+        startupMode: "auto-worktree",
       }),
+    ]);
+  });
+
+  it("migrates legacy branch startup to manually managed worktrees", async () => {
+    const { normalizeProjectWorkspaces } = await import("./projects");
+
+    expect(
+      normalizeProjectWorkspaces([
+        {
+          id: "legacy-branch",
+          path: "/tmp/legacy",
+          kind: "repository",
+          source: "selected",
+          branch: "main",
+          usedByAgent: false,
+          startupMode: "branch",
+        },
+      ]),
+    ).toEqual([expect.objectContaining({ startupMode: "ask-worktree" })]);
+  });
+
+  it("round-trips the new worktree startup policies", async () => {
+    const { normalizeProjectWorkspaces } = await import("./projects");
+
+    expect(
+      normalizeProjectWorkspaces([
+        {
+          id: "auto",
+          path: "/tmp/auto",
+          kind: "repository",
+          source: "selected",
+          branch: "main",
+          usedByAgent: false,
+          startupMode: "auto-worktree",
+        },
+        {
+          id: "ask",
+          path: "/tmp/ask",
+          kind: "repository",
+          source: "selected",
+          branch: "main",
+          usedByAgent: false,
+          startupMode: "ask-worktree",
+        },
+      ]),
+    ).toEqual([
+      expect.objectContaining({ startupMode: "auto-worktree" }),
+      expect.objectContaining({ startupMode: "ask-worktree" }),
     ]);
   });
 

--- a/src/features/projects/api/projects.ts
+++ b/src/features/projects/api/projects.ts
@@ -16,7 +16,30 @@ import {
 import { toIdentityKey } from "@/shared/lib/pathIdentity";
 import type { ProjectArtifactMetadata } from "../artifact/types";
 
-export type ProjectWorkspaceStartupMode = "none" | "branch" | "worktree";
+export type ProjectWorkspaceStartupMode =
+  | "none"
+  | "branch"
+  | "worktree"
+  | "ask-worktree"
+  | "auto-worktree";
+
+export function isWorktreeStartupMode(
+  mode: ProjectWorkspaceStartupMode,
+): boolean {
+  return mode === "worktree" || mode === "auto-worktree";
+}
+
+export function isAskWorktreeStartupMode(
+  mode: ProjectWorkspaceStartupMode,
+): boolean {
+  return mode === "worktree" || mode === "auto-worktree";
+}
+
+export function requiresWorkspaceStartup(
+  mode: ProjectWorkspaceStartupMode,
+): boolean {
+  return mode === "branch" || isWorktreeStartupMode(mode);
+}
 
 export interface ProjectWorkspace extends WorkspaceAttachment {
   startupMode: ProjectWorkspaceStartupMode;
@@ -64,7 +87,10 @@ function createArtifactMetadata(
 }
 
 function validStartupMode(value: unknown): ProjectWorkspaceStartupMode {
-  return value === "branch" || value === "worktree" ? value : "none";
+  if (value === "worktree") return "auto-worktree";
+  if (value === "branch") return "ask-worktree";
+  if (value === "ask-worktree" || value === "auto-worktree") return value;
+  return "none";
 }
 
 function validWorkspaceKind(value: unknown): WorkspaceAttachmentKind {

--- a/src/features/projects/lib/projectChatWorkspaces.test.ts
+++ b/src/features/projects/lib/projectChatWorkspaces.test.ts
@@ -635,6 +635,26 @@ describe("project chat workspaces", () => {
     expect(gitMocks.createBranch).not.toHaveBeenCalled();
   });
 
+  it("turns raw git worktree failures into plain English", async () => {
+    gitMocks.createWorktree.mockRejectedValueOnce(
+      new Error(
+        "git worktree add -b test test /Users/test/repo-worktrees/test failed: fatal: not a valid branch name",
+      ),
+    );
+
+    await expect(
+      planProjectChatWorkspaces(
+        project({
+          projectWorkspaces: [workspace("/repo/builderbot", "worktree")],
+          workingDirs: ["/repo/builderbot"],
+        }),
+        "test test",
+      ),
+    ).rejects.toThrow(
+      "That name can’t be used for a worktree. Use letters, numbers, hyphens, or underscores.",
+    );
+  });
+
   it("rejects configured startup for non-git workspaces before mutating git", async () => {
     gitMocks.getGitState.mockResolvedValue({
       isGitRepo: false,
@@ -780,7 +800,9 @@ describe("project chat workspaces", () => {
         }),
         "chat-123",
       ),
-    ).rejects.toThrow("git lock");
+    ).rejects.toThrow(
+      "Berd couldn’t prepare the project workspace. Try again.",
+    );
 
     expect(gitMocks.deleteBranch).toHaveBeenCalledWith(
       "/repo",
@@ -831,7 +853,9 @@ describe("project chat workspaces", () => {
         }),
         "chat-123",
       ),
-    ).rejects.toThrow("worktree locked");
+    ).rejects.toThrow(
+      "Berd couldn’t prepare the project workspace. Try again.",
+    );
 
     expect(gitMocks.removeWorktree).toHaveBeenCalledWith(
       "/repo",

--- a/src/features/projects/lib/projectChatWorkspaces.ts
+++ b/src/features/projects/lib/projectChatWorkspaces.ts
@@ -16,10 +16,12 @@ import {
   normalizeComparableWorkspacePath,
   workspaceAttachmentIdForPath,
 } from "@/features/chat/lib/workspaceAttachments";
-import type {
-  ProjectInfo,
-  ProjectWorkspace,
-  ProjectWorkspaceStartupMode,
+import {
+  isWorktreeStartupMode,
+  requiresWorkspaceStartup,
+  type ProjectInfo,
+  type ProjectWorkspace,
+  type ProjectWorkspaceStartupMode,
 } from "@/features/projects/api/projects";
 
 export interface ProjectWorkspaceStartupSummary {
@@ -37,15 +39,14 @@ export function summarizeProjectWorkspaceStartup(
   let exact = true;
 
   for (const workspace of workspaces) {
-    if (workspace.startupMode === "none") continue;
+    if (!requiresWorkspaceStartup(workspace.startupMode)) continue;
     exact &&= Boolean(workspace.repositoryPath || workspace.worktreePath);
     const repositoryKey = normalizedKey(
       workspace.repositoryPath ?? workspace.worktreePath ?? workspace.path,
     );
-    const repositories =
-      workspace.startupMode === "worktree"
-        ? worktreeRepositories
-        : branchRepositories;
+    const repositories = isWorktreeStartupMode(workspace.startupMode)
+      ? worktreeRepositories
+      : branchRepositories;
     repositories.add(repositoryKey);
   }
 
@@ -113,6 +114,47 @@ function defaultBaseBranch(gitState: GitState): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function friendlyWorkspaceSetupError(error: unknown): Error {
+  const message = errorMessage(error);
+  if (
+    /choose a different name/i.test(message) ||
+    /requires a Git repository/i.test(message) ||
+    /name is required/i.test(message)
+  ) {
+    return new Error(message);
+  }
+  if (/already exists/i.test(message) && /branch/i.test(message)) {
+    return new Error(
+      "That worktree name is already in use. Choose another name.",
+    );
+  }
+  if (
+    /not a valid branch name|invalid branch name|cannot lock ref/i.test(message)
+  ) {
+    return new Error(
+      "That name can’t be used for a worktree. Use letters, numbers, hyphens, or underscores.",
+    );
+  }
+  if (/not inside one|not a git repository/i.test(message)) {
+    return new Error("Choose a project folder that contains a Git repository.");
+  }
+  if (/timed out/i.test(message)) {
+    return new Error("Creating the worktree took too long. Try again.");
+  }
+  if (/permission denied|operation not permitted/i.test(message)) {
+    return new Error(
+      "Berd doesn’t have permission to create a worktree there.",
+    );
+  }
+  if (
+    /git\s+worktree\s+add/i.test(message) ||
+    /failed to create worktree/i.test(message)
+  ) {
+    return new Error("Berd couldn’t create that worktree. Try another name.");
+  }
+  return new Error("Berd couldn’t prepare the project workspace. Try again.");
 }
 
 async function rollbackStartupMutations(
@@ -242,7 +284,8 @@ function gitOperationPathCandidates(
   ];
   const worktreeCandidates = [classifiedWorktreePath, workspace.worktreePath];
   const candidates =
-    workspace.startupMode === "branch" || workspace.startupMode === "worktree"
+    workspace.startupMode === "branch" ||
+    isWorktreeStartupMode(workspace.startupMode)
       ? [...worktreeCandidates, workspace.path, ...repositoryCandidates]
       : [...repositoryCandidates, ...worktreeCandidates, workspace.path];
   return candidates.filter((path): path is string => Boolean(path));
@@ -384,8 +427,8 @@ function attachmentForCreatedBranch(
 export function projectRequiresStartupWorkspaceName(
   project: Pick<ProjectInfo, "projectWorkspaces">,
 ): boolean {
-  return (project.projectWorkspaces ?? []).some(
-    (workspace) => workspace.startupMode !== "none",
+  return (project.projectWorkspaces ?? []).some((workspace) =>
+    requiresWorkspaceStartup(workspace.startupMode),
   );
 }
 
@@ -417,7 +460,9 @@ function validateStartupName(
     throw new Error("A branch or worktree name is required.");
   }
 
-  if (workspaces.some((workspace) => workspace.startupMode === "worktree")) {
+  if (
+    workspaces.some((workspace) => isWorktreeStartupMode(workspace.startupMode))
+  ) {
     if (startupName === "." || startupName === "..") {
       throw new Error(
         "Worktree startup names must be real folder names. Choose a different name.",
@@ -513,8 +558,8 @@ export async function planProjectChatWorkspaces(
   const rollbackActions: StartupRollbackAction[] = [];
   const attachments: WorkspaceAttachment[] = [];
   const trimmedStartupName = startupName?.trim() ?? "";
-  const startupWorkspaces = workspaces.filter(
-    (workspace) => workspace.startupMode !== "none",
+  const startupWorkspaces = workspaces.filter((workspace) =>
+    requiresWorkspaceStartup(workspace.startupMode),
   );
   const gitStateForPath = async (path: string): Promise<GitState> => {
     const pathKey = normalizedKey(path);
@@ -582,7 +627,7 @@ export async function planProjectChatWorkspaces(
     }
     startupModeByRepo.set(repoKey, workspace.startupMode);
 
-    if (workspace.startupMode === "worktree") {
+    if (isWorktreeStartupMode(workspace.startupMode)) {
       const targetWorktreePath = deriveStartupWorktreePath(
         gitContext,
         trimmedStartupName,
@@ -612,7 +657,7 @@ export async function planProjectChatWorkspaces(
 
   try {
     for (const workspace of workspaces) {
-      if (workspace.startupMode === "none") {
+      if (!requiresWorkspaceStartup(workspace.startupMode)) {
         attachments.push(projectWorkspaceToAttachment(workspace));
         continue;
       }
@@ -629,7 +674,7 @@ export async function planProjectChatWorkspaces(
       const repoKey = repositoryKeyForGitContext(gitContext);
       const repositoryPath = repositoryPathForGitContext(gitContext);
       const baseBranch = defaultBaseBranch(gitState);
-      if (workspace.startupMode === "worktree") {
+      if (isWorktreeStartupMode(workspace.startupMode)) {
         let createdWorktree = createdWorktreeByRepo.get(repoKey);
         if (!createdWorktree) {
           const newWorktree = await createWorktree(
@@ -701,7 +746,7 @@ export async function planProjectChatWorkspaces(
         `${errorMessage(error)} Rollback also failed: ${rollbackErrors.join("; ")}`,
       );
     }
-    throw error;
+    throw friendlyWorkspaceSetupError(error);
   }
 
   return {

--- a/src/features/projects/ui/CreateProjectDialog.tsx
+++ b/src/features/projects/ui/CreateProjectDialog.tsx
@@ -38,6 +38,7 @@ import {
   type ProjectInfo,
   type ProjectWorkspace,
   type ProjectWorkspaceStartupMode,
+  isWorktreeStartupMode,
 } from "../api/projects";
 import {
   classifyWorkspaceAttachment,
@@ -80,46 +81,36 @@ function getDefaultProjectName(path: string | null | undefined): string {
   return parts[parts.length - 1] ?? "";
 }
 
+function configuredWorktreeStartupMode(
+  mode: ProjectWorkspaceStartupMode,
+): "ask-worktree" | "auto-worktree" | null {
+  if (mode === "worktree" || mode === "auto-worktree") {
+    return "auto-worktree";
+  }
+  return mode === "ask-worktree" ? mode : null;
+}
+
 function projectWorkspaceStartupModeLabel(
   mode: ProjectWorkspaceStartupMode,
   t: ReturnType<typeof useTranslation<"projects">>["t"],
 ) {
   switch (mode) {
     case "worktree":
-      return t("dialog.workspacePolicy.createWorktree");
+    case "ask-worktree":
+      return t("dialog.workspacePolicy.askWorktree");
+    case "auto-worktree":
+      return t("dialog.workspacePolicy.autoWorktree");
     case "branch":
       return t("dialog.workspacePolicy.createBranch");
     case "none":
-      return t("dialog.workspacePolicy.neither");
+      return t("dialog.workspacePolicy.noWorktree");
   }
 }
 
 function defaultStartupModeForCandidate(
-  candidate: WorkspaceAddCandidate,
-  projectWorkspaces: ProjectWorkspace[] = [],
+  _candidate: WorkspaceAddCandidate,
+  _projectWorkspaces: ProjectWorkspace[] = [],
 ): ProjectWorkspaceStartupMode {
-  const matchingProjectMode = startupModeFromProjectWorkspaceContext(
-    candidate,
-    projectWorkspaces,
-  );
-  if (matchingProjectMode) {
-    return matchingProjectMode;
-  }
-
-  const { kind, repositoryPath, worktreePath } = candidate.classification;
-  if (
-    !repositoryPath ||
-    (worktreePath && !isSameWorkspacePath(repositoryPath, worktreePath))
-  ) {
-    return "none";
-  }
-  if (
-    kind === "repository" ||
-    kind === "git-main-worktree" ||
-    kind === "subdirectory"
-  ) {
-    return "worktree";
-  }
   return "none";
 }
 
@@ -225,19 +216,6 @@ function workspaceStartupModeAppliesToCandidate(
   );
 }
 
-function startupModeFromProjectWorkspaceContext(
-  candidate: WorkspaceAddCandidate,
-  projectWorkspaces: ProjectWorkspace[],
-): ProjectWorkspaceStartupMode | null {
-  for (const workspace of projectWorkspaces) {
-    if (workspaceStartupModeAppliesToCandidate(candidate, workspace)) {
-      return workspace.startupMode;
-    }
-  }
-
-  return null;
-}
-
 function nonNoneStartupModeFromProjectWorkspaceContext(
   candidate: WorkspaceAddCandidate,
   projectWorkspaces: ProjectWorkspace[],
@@ -292,14 +270,6 @@ function hasGitWorkspaceKind(workspace: Pick<ProjectWorkspace, "kind">) {
   );
 }
 
-function canConfigureGitStartup(workspace: ProjectWorkspace): boolean {
-  return Boolean(
-    workspace.repositoryPath ||
-      workspace.worktreePath ||
-      hasGitWorkspaceKind(workspace),
-  );
-}
-
 function workspaceUsesLinkedWorktree(workspace: ProjectWorkspace): boolean {
   if (
     workspace.kind === "git-linked-worktree" ||
@@ -315,28 +285,19 @@ function workspaceUsesLinkedWorktree(workspace: ProjectWorkspace): boolean {
   );
 }
 
-function startupModeOptionsForWorkspace(
-  workspace: ProjectWorkspace,
-): ProjectWorkspaceStartupMode[] {
-  if (!canConfigureGitStartup(workspace)) {
-    return ["none"];
-  }
-
-  return ["none", "worktree", "branch"];
+function startupModeOptionsForWorkspace(): ProjectWorkspaceStartupMode[] {
+  return ["ask-worktree", "auto-worktree"];
 }
 
 function startupModeAllowedForWorkspace(
   workspace: ProjectWorkspace,
   startupMode: ProjectWorkspaceStartupMode,
 ): boolean {
-  return startupModeOptionsForWorkspace(workspace).includes(startupMode);
-}
-
-function sanitizeStartupMode(workspace: ProjectWorkspace): ProjectWorkspace {
-  if (startupModeAllowedForWorkspace(workspace, workspace.startupMode)) {
-    return workspace;
-  }
-  return { ...workspace, startupMode: "none" };
+  return (
+    startupMode === "none" ||
+    hasGitWorkspaceKind(workspace) ||
+    Boolean(workspace.repositoryPath)
+  );
 }
 
 interface CreateProjectDialogProps {
@@ -378,6 +339,8 @@ export function CreateProjectDialog({
   const [projectWorkspaceGitStates, setProjectWorkspaceGitStates] = useState<
     Record<string, GitState>
   >({});
+  const [confirmedNonGitWorkspaceIds, setConfirmedNonGitWorkspaceIds] =
+    useState<Set<string>>(() => new Set());
   const {
     icon,
     iconCandidates,
@@ -446,9 +409,16 @@ export function CreateProjectDialog({
     const results = await Promise.all(
       missingWorkspaces.map(async (workspace) => {
         try {
+          const resolved = await resolvePath({ parts: [workspace.path] });
+          const gitState = await getGitState(resolved.path);
           return {
             key: normalizeComparableWorkspacePath(workspace.path),
-            gitState: await getGitState(workspace.path),
+            workspaceId: workspace.id,
+            classification: classifyWorkspaceAttachment(
+              resolved.path,
+              gitState,
+            ),
+            gitState,
           };
         } catch {
           return null;
@@ -457,9 +427,13 @@ export function CreateProjectDialog({
     );
 
     const nextGitStates: Record<string, GitState> = {};
+    const nextConfirmedNonGitIds = new Set<string>();
     for (const result of results) {
       if (result) {
         nextGitStates[result.key] = result.gitState;
+        if (!result.gitState.isGitRepo) {
+          nextConfirmedNonGitIds.add(result.workspaceId);
+        }
       }
     }
     if (Object.keys(nextGitStates).length === 0) {
@@ -470,6 +444,25 @@ export function CreateProjectDialog({
       ...current,
       ...nextGitStates,
     }));
+    setConfirmedNonGitWorkspaceIds((current) => {
+      const next = new Set(current);
+      for (const workspaceId of nextConfirmedNonGitIds) next.add(workspaceId);
+      return next;
+    });
+    setProjectWorkspaces((current) =>
+      current.map((workspace) => {
+        const result = results.find(
+          (candidate) => candidate?.workspaceId === workspace.id,
+        );
+        if (!result) return workspace;
+        return {
+          ...workspace,
+          ...result.classification,
+          path: workspace.path,
+          startupMode: workspace.startupMode,
+        };
+      }),
+    );
   }, [projectWorkspaceGitStates, projectWorkspaces]);
 
   useEffect(() => {
@@ -564,6 +557,7 @@ export function CreateProjectDialog({
     setProjectWorkspaces([]);
     setWorkingDir("");
     setProjectWorkspaceGitStates({});
+    setConfirmedNonGitWorkspaceIds(new Set());
     setPendingWorktreePolicyWorkspaceId(null);
     resetIcon(DEFAULT_PROJECT_ICON);
     setColor(DEFAULT_PROJECT_COLOR);
@@ -614,8 +608,12 @@ export function CreateProjectDialog({
         }
       }
     }
-    const sanitizedProjectWorkspaces =
-      savedProjectWorkspaces.map(sanitizeStartupMode);
+    const sanitizedProjectWorkspaces = savedProjectWorkspaces.map(
+      (workspace) =>
+        confirmedNonGitWorkspaceIds.has(workspace.id)
+          ? { ...workspace, startupMode: "none" as const }
+          : workspace,
+    );
     const savedWorkingDirs = sanitizedProjectWorkspaces.map(
       (workspace) => workspace.path,
     );
@@ -724,11 +722,7 @@ export function CreateProjectDialog({
           return { ...workspace, startupMode };
         }
 
-        if (
-          !targetSyncKey ||
-          startupMode === "none" ||
-          workspace.startupMode === "none"
-        ) {
+        if (!targetSyncKey || startupMode === "none") {
           return workspace;
         }
 
@@ -844,8 +838,8 @@ export function CreateProjectDialog({
     }
 
     if (
-      startupMode === "worktree" &&
-      workspace.startupMode !== "worktree" &&
+      isWorktreeStartupMode(startupMode) &&
+      !isWorktreeStartupMode(workspace.startupMode) &&
       workspaceUsesLinkedWorktree(workspace)
     ) {
       setPendingWorktreePolicyWorkspaceId(workspace.id);
@@ -1116,14 +1110,17 @@ export function CreateProjectDialog({
                     {enrichedProjectWorkspaces.length > 0 ? (
                       <div className="overflow-hidden rounded-sm bg-card text-card-foreground">
                         {enrichedProjectWorkspaces.map((workspace, index) => {
-                          const gitConfigurable =
-                            canConfigureGitStartup(workspace);
                           const startupModeOptions =
-                            startupModeOptionsForWorkspace(workspace);
+                            startupModeOptionsForWorkspace();
                           const workspaceGitState =
                             projectWorkspaceGitStates[
                               normalizeComparableWorkspacePath(workspace.path)
                             ];
+                          const canConfigureWorktrees =
+                            hasGitWorkspaceKind(workspace) ||
+                            Boolean(workspace.repositoryPath) ||
+                            (!confirmedNonGitWorkspaceIds.has(workspace.id) &&
+                              workspace.startupMode !== "none");
                           return (
                             <div
                               key={workspace.id}
@@ -1133,7 +1130,12 @@ export function CreateProjectDialog({
                                   "border-t border-card-foreground/10",
                               )}
                             >
-                              <div className="min-w-0 flex-1 space-y-2">
+                              <div
+                                className={cn(
+                                  "min-w-0 flex-1 space-y-2",
+                                  !canConfigureWorktrees && "self-center",
+                                )}
+                              >
                                 <button
                                   type="button"
                                   onClick={() =>
@@ -1144,24 +1146,36 @@ export function CreateProjectDialog({
                                       workspace.path,
                                     ),
                                   })}
-                                  className="block w-full rounded-sm text-left outline-none transition-colors hover:bg-card-foreground/[0.03] focus-visible:ring-1 focus-visible:ring-card-foreground/30"
+                                  className="block w-full rounded-sm text-left outline-none focus-visible:ring-1 focus-visible:ring-card-foreground/30"
                                 >
                                   <WorkspaceIdentity
                                     workspace={workspace}
                                     gitState={workspaceGitState}
                                     className="min-w-0"
+                                    iconKind={
+                                      canConfigureWorktrees
+                                        ? "repository"
+                                        : "folder"
+                                    }
+                                    showMetadata={false}
+                                    showHoverChevron={false}
+                                    iconTooltip={t(
+                                      canConfigureWorktrees
+                                        ? "dialog.workspacePolicy.gitFolderTooltip"
+                                        : "dialog.workspacePolicy.regularFolderTooltip",
+                                    )}
                                     iconClassName="text-card-foreground"
                                     titleClassName="text-card-foreground"
-                                    metadataClassName="text-card-foreground/55"
                                   />
                                 </button>
-                                {gitConfigurable ? (
-                                  <div className="max-w-[220px] space-y-1 pl-[22px]">
-                                    <span className="block text-xs leading-none text-card-foreground/55">
-                                      {t("dialog.workspacePolicy.sectionLabel")}
-                                    </span>
+                                {canConfigureWorktrees ? (
+                                  <div className="mt-1 max-w-[260px] pl-[22px]">
                                     <Select
-                                      value={workspace.startupMode}
+                                      value={
+                                        configuredWorktreeStartupMode(
+                                          workspace.startupMode,
+                                        ) ?? "none"
+                                      }
                                       onValueChange={(value) =>
                                         handleWorkspaceStartupModeChange(
                                           workspace.id,
@@ -1178,11 +1192,29 @@ export function CreateProjectDialog({
                                             ),
                                           },
                                         )}
-                                        className="h-8 w-full rounded-[12px] border-0 bg-muted px-2.5 text-xs shadow-none hover:bg-accent-hover"
+                                        className={cn(
+                                          "relative h-8 w-full rounded-sm border border-card-foreground/10 bg-muted px-3 text-sm shadow-none hover:bg-accent-hover focus-visible:ring-0",
+                                          configuredWorktreeStartupMode(
+                                            workspace.startupMode,
+                                          ) === null &&
+                                            "text-card-foreground/40",
+                                        )}
                                       >
-                                        <SelectValue />
+                                        <SelectValue
+                                          placeholder={t(
+                                            "dialog.workspacePolicy.placeholder",
+                                          )}
+                                        />
                                       </SelectTrigger>
                                       <SelectContent>
+                                        <SelectItem
+                                          value="none"
+                                          className="hidden"
+                                        >
+                                          {t(
+                                            "dialog.workspacePolicy.placeholder",
+                                          )}
+                                        </SelectItem>
                                         {startupModeOptions.map((mode) => (
                                           <SelectItem key={mode} value={mode}>
                                             {projectWorkspaceStartupModeLabel(
@@ -1199,6 +1231,7 @@ export function CreateProjectDialog({
                               <Button
                                 type="button"
                                 variant="ghost"
+                                destructive
                                 size="icon-xs"
                                 onClick={() =>
                                   handleRemoveWorkspace(workspace.id)
@@ -1206,7 +1239,12 @@ export function CreateProjectDialog({
                                 aria-label={t("dialog.removeWorkspace", {
                                   name: getWorkspaceDisplayName(workspace.path),
                                 })}
-                                className="mt-0.5 shrink-0 text-muted-foreground hover:text-destructive"
+                                className={cn(
+                                  "shrink-0",
+                                  canConfigureWorktrees
+                                    ? "mt-0.5"
+                                    : "self-center",
+                                )}
                               >
                                 <IconTrash className="size-4" />
                               </Button>

--- a/src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx
+++ b/src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx
@@ -81,7 +81,11 @@ vi.mock("../../api/projects", () => ({
   projectWorkspaceFromDirectory: vi.fn(
     (
       directory: string,
-      startupMode: "none" | "branch" | "worktree" = "none",
+      startupMode:
+        | "none"
+        | "auto-worktree"
+        | "ask-worktree"
+        | "worktree" = "none",
     ) =>
       directory
         ? {
@@ -95,12 +99,22 @@ vi.mock("../../api/projects", () => ({
           }
         : null,
   ),
+  isWorktreeStartupMode: vi.fn(
+    (mode: string) =>
+      mode === "worktree" ||
+      mode === "auto-worktree" ||
+      mode === "ask-worktree",
+  ),
   normalizeProjectWorkspaces: vi.fn(
     (
       workspaces:
         | Array<{
             path: string;
-            startupMode?: "none" | "branch" | "worktree";
+            startupMode?:
+              | "none"
+              | "auto-worktree"
+              | "ask-worktree"
+              | "worktree";
           }>
         | undefined,
       workingDirs: string[] = [],
@@ -116,7 +130,7 @@ vi.mock("../../api/projects", () => ({
         source: "inferred",
         branch: null,
         usedByAgent: false,
-        startupMode: useWorktrees ? "worktree" : "none",
+        startupMode: useWorktrees ? "auto-worktree" : "none",
       }));
     },
   ),
@@ -381,6 +395,30 @@ describe("CreateProjectDialog", () => {
       await waitFor(() => expect(gitMocks.getGitState).toHaveBeenCalled());
     });
 
+    it("shows workspace policy for a resolved Git initial folder", async () => {
+      vi.mocked(resolvePath).mockImplementation(async ({ parts }) => ({
+        path: parts[0].replace("~", "/home/user"),
+      }));
+      gitMocks.getGitState.mockResolvedValue(
+        gitStateForPath("/home/user/code"),
+      );
+
+      render(
+        <CreateProjectDialog
+          {...defaultProps}
+          isOpen={true}
+          initialWorkingDir="~/code"
+        />,
+      );
+
+      expect(
+        await screen.findByRole("combobox", {
+          name: /new chat behavior for code/i,
+        }),
+      ).toHaveTextContent("Configure new chats");
+      expect(gitMocks.getGitState).toHaveBeenCalledWith("/home/user/code");
+    });
+
     it("labels the submit button as create project", () => {
       render(<CreateProjectDialog {...defaultProps} isOpen={true} />);
 
@@ -535,7 +573,7 @@ describe("CreateProjectDialog", () => {
         expect.arrayContaining([
           expect.objectContaining({
             path: "/home/user/newcode",
-            startupMode: "worktree",
+            startupMode: "none",
           }),
         ]),
       );
@@ -633,7 +671,7 @@ describe("CreateProjectDialog", () => {
       ).toEqual([
         expect.objectContaining({
           path: "/home/user/other",
-          startupMode: "worktree",
+          startupMode: "none",
         }),
         expect.objectContaining({
           path: "/home/user/docs",
@@ -642,365 +680,215 @@ describe("CreateProjectDialog", () => {
       ]);
     });
 
-    it("uses the destination repo policy when replacing a project folder", async () => {
+    it("shows the new worktree policies with no branch option", async () => {
       const user = userEvent.setup();
-      vi.mocked(openDialog).mockResolvedValue("/home/user/code/web");
-      gitMocks.getGitState.mockImplementation(async (path: string) => {
-        const repositoryPath = path.startsWith("/home/user/code")
-          ? "/home/user/code"
-          : path;
-        return {
-          isGitRepo: true,
-          currentBranch: "main",
-          dirtyFileCount: 0,
-          incomingCommitCount: 0,
-          worktrees: [{ path: repositoryPath, branch: "main", isMain: true }],
-          isWorktree: false,
-          mainWorktreePath: repositoryPath,
-          localBranches: ["main"],
-        };
-      });
-      const existingRepoWorkspace = {
-        id: "path:/home/user/code/api",
-        path: "/home/user/code/api",
-        kind: "subdirectory" as const,
+      const workspace = {
+        id: "path:/home/user/code",
+        path: "/home/user/code",
+        kind: "git-main-worktree" as const,
         source: "selected" as const,
         branch: "main",
         repositoryPath: "/home/user/code",
         worktreePath: "/home/user/code",
         usedByAgent: false,
-        startupMode: "branch" as const,
-      };
-      const editedWorkspace = {
-        id: "path:/home/user/old",
-        path: "/home/user/old",
-        kind: "git-main-worktree" as const,
-        source: "selected" as const,
-        branch: "main",
-        repositoryPath: "/home/user/old",
-        worktreePath: "/home/user/old",
-        usedByAgent: false,
-        startupMode: "worktree" as const,
-      };
-      const editingProject = makeEditingProject({
-        workingDirs: [existingRepoWorkspace.path, editedWorkspace.path],
-        projectWorkspaces: [existingRepoWorkspace, editedWorkspace],
-      });
-
-      render(
-        <CreateProjectDialog
-          {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
-        />,
-      );
-
-      await user.click(screen.getByRole("button", { name: "Edit old" }));
-      expect(
-        await screen.findByRole("button", { name: "Edit web" }),
-      ).toBeInTheDocument();
-      await user.click(screen.getByRole("button", { name: "Save changes" }));
-
-      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
-      expect(
-        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
-      ).toEqual([
-        expect.objectContaining({
-          path: "/home/user/code/api",
-          startupMode: "branch",
-        }),
-        expect.objectContaining({
-          path: "/home/user/code/web",
-          startupMode: "branch",
-        }),
-      ]);
-    });
-
-    it("confirms before using a linked worktree folder to create new worktrees", async () => {
-      const user = userEvent.setup();
-      const linkedWorktreeWorkspace = {
-        id: "path:/home/user/code-feature/service",
-        path: "/home/user/code-feature/service",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "feature",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-feature",
-        usedByAgent: false,
         startupMode: "none" as const,
       };
-      const editingProject = makeEditingProject({
-        workingDirs: [linkedWorktreeWorkspace.path],
-        projectWorkspaces: [linkedWorktreeWorkspace],
-      });
 
       render(
         <CreateProjectDialog
           {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
+          editingProject={makeEditingProject({
+            workingDirs: [workspace.path],
+            projectWorkspaces: [workspace],
+          })}
         />,
       );
 
       const policySelect = screen.getByRole("combobox", {
-        name: /new chat behavior for service/i,
+        name: /new chat behavior for code/i,
       });
+      expect(policySelect).toHaveTextContent("Configure new chats");
+
       await user.click(policySelect);
-      await user.click(
-        await screen.findByRole("option", { name: "Create worktree" }),
-      );
-
       expect(
-        await screen.findByRole("dialog", {
-          name: "Create a different worktree?",
+        await screen.findByRole("option", {
+          name: "Manually create worktrees",
         }),
       ).toBeInTheDocument();
-      await user.click(screen.getByRole("button", { name: "Create worktree" }));
       expect(
-        screen.getByRole("combobox", {
-          name: /new chat behavior for service/i,
+        screen.getByRole("option", {
+          name: "Auto-create worktrees",
         }),
-      ).toHaveTextContent("Create worktree");
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("option", { name: "Don’t create worktrees" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("option", { name: /branch/i }),
+      ).not.toBeInTheDocument();
     });
 
-    it("defaults a new workspace to the existing policy for the same repo", async () => {
+    it("keeps worktree policy when Git inspection temporarily fails", async () => {
       const user = userEvent.setup();
-      vi.mocked(openDialog).mockResolvedValue("/home/user/newcode");
-      gitMocks.getGitState.mockResolvedValue(
-        gitStateForPath("/home/user/newcode"),
-      );
-      const existingWorkspace = {
-        id: "path:/home/user/newcode/api",
-        path: "/home/user/newcode/api",
-        kind: "subdirectory" as const,
+      gitMocks.getGitState.mockRejectedValueOnce(new Error("Git unavailable"));
+      const workspace = {
+        id: "path:/home/user/code",
+        path: "/home/user/code",
+        kind: "git-main-worktree" as const,
         source: "selected" as const,
         branch: "main",
-        repositoryPath: "/home/user/newcode",
-        worktreePath: "/home/user/newcode",
+        repositoryPath: "/home/user/code",
+        worktreePath: "/home/user/code",
         usedByAgent: false,
-        startupMode: "branch" as const,
+        startupMode: "auto-worktree" as const,
       };
-      const editingProject = makeEditingProject({
-        workingDirs: [existingWorkspace.path],
-        projectWorkspaces: [existingWorkspace],
-      });
 
       render(
         <CreateProjectDialog
           {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
+          editingProject={makeEditingProject({
+            workingDirs: [workspace.path],
+            projectWorkspaces: [workspace],
+          })}
         />,
       );
 
-      await user.click(
-        screen.getByRole("button", {
-          name: "Add another folder",
-        }),
-      );
-      expect(
-        await screen.findByRole("button", { name: "Edit newcode" }),
-      ).toBeInTheDocument();
+      await waitFor(() => expect(gitMocks.getGitState).toHaveBeenCalled());
       await user.click(screen.getByRole("button", { name: "Save changes" }));
 
       await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
       expect(
         vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
-      ).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            path: "/home/user/newcode",
-            startupMode: "branch",
-          }),
-        ]),
-      );
+      ).toEqual([expect.objectContaining({ startupMode: "auto-worktree" })]);
     });
 
-    it("does not inherit branch policy from a different worktree of the same repo", async () => {
+    it("syncs auto-worktree policy across folders in the same repository", async () => {
       const user = userEvent.setup();
-      vi.mocked(openDialog).mockResolvedValue("/home/user/code-other/web");
-      gitMocks.getGitState.mockResolvedValue({
-        isGitRepo: true,
-        currentBranch: "other",
-        dirtyFileCount: 0,
-        incomingCommitCount: 0,
-        worktrees: [
-          { path: "/home/user/code", branch: "main", isMain: true },
-          { path: "/home/user/code-feature", branch: "feature", isMain: false },
-          { path: "/home/user/code-other", branch: "other", isMain: false },
-        ],
-        isWorktree: true,
-        mainWorktreePath: "/home/user/code",
-        localBranches: ["main", "feature", "other"],
-      });
-      const existingWorkspace = {
-        id: "path:/home/user/code-feature/api",
-        path: "/home/user/code-feature/api",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "feature",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-feature",
-        usedByAgent: false,
-        startupMode: "branch" as const,
-      };
-      const editingProject = makeEditingProject({
-        workingDirs: [existingWorkspace.path],
-        projectWorkspaces: [existingWorkspace],
-      });
-
-      render(
-        <CreateProjectDialog
-          {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
-        />,
-      );
-
-      await user.click(
-        screen.getByRole("button", {
-          name: "Add another folder",
-        }),
-      );
-      expect(
-        await screen.findByRole("button", { name: "Edit web" }),
-      ).toBeInTheDocument();
-      await user.click(screen.getByRole("button", { name: "Save changes" }));
-
-      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
-      expect(
-        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
-      ).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            path: "/home/user/code-feature/api",
-            startupMode: "branch",
-          }),
-          expect.objectContaining({
-            path: "/home/user/code-other/web",
-            startupMode: "none",
-          }),
-        ]),
-      );
-    });
-
-    it("does not preserve branch policy when replacing a folder with a different worktree", async () => {
-      const user = userEvent.setup();
-      vi.mocked(openDialog).mockResolvedValue("/home/user/code-other/web");
-      gitMocks.getGitState.mockResolvedValue({
-        isGitRepo: true,
-        currentBranch: "other",
-        dirtyFileCount: 0,
-        incomingCommitCount: 0,
-        worktrees: [
-          { path: "/home/user/code", branch: "main", isMain: true },
-          { path: "/home/user/code-feature", branch: "feature", isMain: false },
-          { path: "/home/user/code-other", branch: "other", isMain: false },
-        ],
-        isWorktree: true,
-        mainWorktreePath: "/home/user/code",
-        localBranches: ["main", "feature", "other"],
-      });
-      const existingWorkspace = {
-        id: "path:/home/user/code-feature/api",
-        path: "/home/user/code-feature/api",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "feature",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-feature",
-        usedByAgent: false,
-        startupMode: "branch" as const,
-      };
-      const editedWorkspace = {
-        id: "path:/home/user/code-feature/tools",
-        path: "/home/user/code-feature/tools",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "feature",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-feature",
-        usedByAgent: false,
-        startupMode: "branch" as const,
-      };
-      const editingProject = makeEditingProject({
-        workingDirs: [existingWorkspace.path, editedWorkspace.path],
-        projectWorkspaces: [existingWorkspace, editedWorkspace],
-      });
-
-      render(
-        <CreateProjectDialog
-          {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
-        />,
-      );
-
-      await user.click(screen.getByRole("button", { name: "Edit tools" }));
-      expect(
-        await screen.findByRole("button", { name: "Edit web" }),
-      ).toBeInTheDocument();
-      await user.click(screen.getByRole("button", { name: "Save changes" }));
-
-      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
-      expect(
-        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
-      ).toEqual([
-        expect.objectContaining({
-          path: "/home/user/code-feature/api",
-          startupMode: "branch",
-        }),
-        expect.objectContaining({
-          path: "/home/user/code-other/web",
-          startupMode: "none",
-        }),
-      ]);
-    });
-
-    it("keeps non-none startup policies in sync for folders in the same repo", async () => {
-      const user = userEvent.setup();
-      const apiWorkspace = {
-        id: "path:/home/user/code/api",
-        path: "/home/user/code/api",
+      const workspaces = ["api", "web"].map((name) => ({
+        id: `path:/home/user/code/${name}`,
+        path: `/home/user/code/${name}`,
         kind: "subdirectory" as const,
         source: "selected" as const,
         branch: "main",
         repositoryPath: "/home/user/code",
         worktreePath: "/home/user/code",
         usedByAgent: false,
-        startupMode: "worktree" as const,
-      };
-      const webWorkspace = {
-        id: "path:/home/user/code/web",
-        path: "/home/user/code/web",
-        kind: "subdirectory" as const,
+        startupMode: "ask-worktree" as const,
+      }));
+
+      render(
+        <CreateProjectDialog
+          {...defaultProps}
+          editingProject={makeEditingProject({
+            workingDirs: workspaces.map(({ path }) => path),
+            projectWorkspaces: workspaces,
+          })}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("combobox", { name: /new chat behavior for api/i }),
+      );
+      await user.click(
+        await screen.findByRole("option", { name: "Auto-create worktrees" }),
+      );
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
+      expect(
+        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
+      ).toEqual([
+        expect.objectContaining({
+          path: workspaces[0].path,
+          startupMode: "auto-worktree",
+        }),
+        expect.objectContaining({
+          path: workspaces[1].path,
+          startupMode: "auto-worktree",
+        }),
+      ]);
+    });
+
+    it("does not sync policy across different repositories", async () => {
+      const user = userEvent.setup();
+      const workspaces = ["api", "web"].map((name) => ({
+        id: `path:/home/user/${name}`,
+        path: `/home/user/${name}`,
+        kind: "git-main-worktree" as const,
+        source: "selected" as const,
+        branch: "main",
+        repositoryPath: `/home/user/${name}`,
+        worktreePath: `/home/user/${name}`,
+        usedByAgent: false,
+        startupMode: "ask-worktree" as const,
+      }));
+
+      render(
+        <CreateProjectDialog
+          {...defaultProps}
+          editingProject={makeEditingProject({
+            workingDirs: workspaces.map(({ path }) => path),
+            projectWorkspaces: workspaces,
+          })}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("combobox", { name: /new chat behavior for api/i }),
+      );
+      await user.click(
+        await screen.findByRole("option", { name: "Auto-create worktrees" }),
+      );
+      await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
+      expect(
+        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
+      ).toEqual([
+        expect.objectContaining({
+          path: workspaces[0].path,
+          startupMode: "auto-worktree",
+        }),
+        expect.objectContaining({
+          path: workspaces[1].path,
+          startupMode: "ask-worktree",
+        }),
+      ]);
+    });
+
+    it("saves the selected auto-worktree policy", async () => {
+      const user = userEvent.setup();
+      const workspace = {
+        id: "path:/home/user/code",
+        path: "/home/user/code",
+        kind: "git-main-worktree" as const,
         source: "selected" as const,
         branch: "main",
         repositoryPath: "/home/user/code",
         worktreePath: "/home/user/code",
         usedByAgent: false,
-        startupMode: "worktree" as const,
+        startupMode: "none" as const,
       };
-      const editingProject = makeEditingProject({
-        workingDirs: [apiWorkspace.path, webWorkspace.path],
-        projectWorkspaces: [apiWorkspace, webWorkspace],
-      });
 
       render(
         <CreateProjectDialog
           {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
+          editingProject={makeEditingProject({
+            workingDirs: [workspace.path],
+            projectWorkspaces: [workspace],
+          })}
         />,
       );
 
       await user.click(
         screen.getByRole("combobox", {
-          name: /new chat behavior for api/i,
+          name: /new chat behavior for code/i,
         }),
       );
       await user.click(
-        await screen.findByRole("option", { name: "Create branch" }),
+        await screen.findByRole("option", {
+          name: "Auto-create worktrees",
+        }),
       );
       await user.click(screen.getByRole("button", { name: "Save changes" }));
 
@@ -1009,79 +897,13 @@ describe("CreateProjectDialog", () => {
         vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
       ).toEqual([
         expect.objectContaining({
-          path: "/home/user/code/api",
-          startupMode: "branch",
-        }),
-        expect.objectContaining({
-          path: "/home/user/code/web",
-          startupMode: "branch",
+          path: "/home/user/code",
+          startupMode: "auto-worktree",
         }),
       ]);
     });
 
-    it("does not sync branch startup policies across different worktrees of the same repo", async () => {
-      const user = userEvent.setup();
-      const apiWorkspace = {
-        id: "path:/home/user/code-feature/api",
-        path: "/home/user/code-feature/api",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "feature",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-feature",
-        usedByAgent: false,
-        startupMode: "worktree" as const,
-      };
-      const webWorkspace = {
-        id: "path:/home/user/code-other/web",
-        path: "/home/user/code-other/web",
-        kind: "subdirectory" as const,
-        source: "selected" as const,
-        branch: "other",
-        repositoryPath: "/home/user/code",
-        worktreePath: "/home/user/code-other",
-        usedByAgent: false,
-        startupMode: "worktree" as const,
-      };
-      const editingProject = makeEditingProject({
-        workingDirs: [apiWorkspace.path, webWorkspace.path],
-        projectWorkspaces: [apiWorkspace, webWorkspace],
-      });
-
-      render(
-        <CreateProjectDialog
-          {...defaultProps}
-          isOpen={true}
-          editingProject={editingProject}
-        />,
-      );
-
-      await user.click(
-        screen.getByRole("combobox", {
-          name: /new chat behavior for api/i,
-        }),
-      );
-      await user.click(
-        await screen.findByRole("option", { name: "Create branch" }),
-      );
-      await user.click(screen.getByRole("button", { name: "Save changes" }));
-
-      await waitFor(() => expect(updateProject).toHaveBeenCalledOnce());
-      expect(
-        vi.mocked(updateProject).mock.calls[0][1].projectWorkspaces,
-      ).toEqual([
-        expect.objectContaining({
-          path: "/home/user/code-feature/api",
-          startupMode: "branch",
-        }),
-        expect.objectContaining({
-          path: "/home/user/code-other/web",
-          startupMode: "worktree",
-        }),
-      ]);
-    });
-
-    it("does not preserve branch or worktree policy for non-git directories", async () => {
+    it("hides and clears workspace policy for non-Git directories", async () => {
       const user = userEvent.setup();
       gitMocks.getGitState.mockResolvedValue({
         isGitRepo: false,
@@ -1134,7 +956,10 @@ describe("CreateProjectDialog", () => {
       ]);
     });
 
-    it("renders workspace titles and git root context like chat workspace rows", async () => {
+    it("renders a simple folder row without git metadata", async () => {
+      gitMocks.getGitState.mockResolvedValue(
+        gitStateForPath("/home/user/Development/cash-server"),
+      );
       const workspace = {
         id: "path:/home/user/wt/cash-server-feature/packages/builderbot",
         path: "/home/user/wt/cash-server-feature/packages/builderbot",
@@ -1162,9 +987,14 @@ describe("CreateProjectDialog", () => {
       expect(
         await screen.findByText("cash-server/.../builderbot"),
       ).toBeInTheDocument();
-      expect(screen.getByText("cash-server-feature")).toBeInTheDocument();
+      expect(screen.queryByText("cash-server-feature")).not.toBeInTheDocument();
+      expect(screen.queryByText("feature/builderbot")).not.toBeInTheDocument();
+      expect(document.querySelector(".lucide-folder-git")).toBeInTheDocument();
+      expect(document.querySelector(".lucide-folder")).not.toBeInTheDocument();
+      expect(
+        document.querySelector(".lucide-folder-git")?.closest("button"),
+      ).toHaveAttribute("aria-label");
       expect(screen.getByText("Project folders")).toBeInTheDocument();
-      expect(screen.getByText("When starting a new chat")).toBeInTheDocument();
     });
 
     it("preserves description metadata while saving prompt changes", async () => {

--- a/src/shared/i18n/locales/en/projects.json
+++ b/src/shared/i18n/locales/en/projects.json
@@ -24,6 +24,12 @@
     "workspacePolicy": {
       "label": "New chat behavior for {{name}}",
       "sectionLabel": "When starting a new chat",
+      "placeholder": "Configure new chats",
+      "gitFolderTooltip": "Git-connected folder",
+      "regularFolderTooltip": "No Git repository — worktrees unavailable",
+      "autoWorktree": "Auto-create worktrees",
+      "askWorktree": "Manually create worktrees",
+      "noWorktree": "Don’t create worktrees",
       "createWorktree": "Create worktree",
       "createBranch": "Create branch",
       "neither": "Use as-is",

--- a/src/shared/i18n/locales/es/projects.json
+++ b/src/shared/i18n/locales/es/projects.json
@@ -24,6 +24,12 @@
     "workspacePolicy": {
       "label": "Comportamiento de chats nuevos para {{name}}",
       "sectionLabel": "Al iniciar un chat nuevo",
+      "placeholder": "Configurar chats nuevos",
+      "gitFolderTooltip": "Carpeta conectada a Git",
+      "regularFolderTooltip": "Sin repositorio Git — worktrees no disponibles",
+      "autoWorktree": "Crear worktrees automáticamente",
+      "askWorktree": "Crear worktrees manualmente",
+      "noWorktree": "No crear worktrees",
       "createWorktree": "Crear worktree",
       "createBranch": "Crear rama",
       "neither": "Usar tal cual",

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -29,6 +29,8 @@ const buttonVariants = cva(
         default:
           "h-9 px-4 py-2 [&_svg:not([class*='size-']):not([class*='h-']):not([class*='w-'])]:size-3.5",
         sm: "h-8 px-3 text-xs [&_svg:not([class*='size-']):not([class*='h-']):not([class*='w-'])]:size-3",
+        compact:
+          "h-8 px-3 text-sm [&_svg:not([class*='size-']):not([class*='h-']):not([class*='w-'])]:size-3",
         lg: "h-10 px-8 [&_svg:not([class*='size-']):not([class*='h-']):not([class*='w-'])]:size-4",
         icon: "h-9 w-9 [&_svg:not([class*='size-']):not([class*='h-']):not([class*='w-'])]:size-4",
         "icon-xxs":
@@ -133,6 +135,7 @@ const buttonIconSizeClasses = {
   xs: "size-3",
   default: "size-3.5",
   sm: "size-3",
+  compact: "size-3",
   lg: "size-4",
   icon: "size-4",
   "icon-xxs": "size-3.5",
@@ -166,6 +169,7 @@ function getButtonSpinnerClass(
   switch (size) {
     case "xs":
     case "sm":
+    case "compact":
     case "icon-xxs":
     case "icon-xs":
       return "size-3";


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Multi-folder project chats can now configure worktree behavior up front, create and attach worktrees safely, and manage queued messages more clearly from the composer.
**Problem:** Multi-workspace chats did not explain or reliably coordinate worktree setup, project folder policies, session promotion, and queued-message behavior. This led to hidden worktree actions, stale workspace state, and confusing composer feedback.
**Solution:** Add explicit per-folder new-chat policies, an immediate composer piggyback for prompted worktree setup, and coordinated workspace/session transitions with rollback, timeout, migration, and queue-order safeguards. The UI now distinguishes Git-connected folders, preserves policy through transient Git failures, and groups queued messages consistently.

<details>
<summary>File changes</summary>

**scripts/design-system-audit.mjs**
Removes a stale baseline exception after Project dialog buttons moved back onto supported design-system treatments.

**src-tauri/crates/berdctl/api-surface.json**
**src-tauri/crates/berdctl/api-surface-feedback.json**
**src-tauri/crates/berdctl/cli-surface.json**
**src-tauri/crates/berdctl/cli-surface-feedback.json**
Regenerates berdctl project startup-mode contracts for manual and prompted worktree policies and legacy-mode migration.

**src/app/AppShell.tsx**
Starts a fresh chat after project creation, preserves full workspace state during draft promotion, and initializes project chats according to the selected workspace policy.

**src/app/SessionWindowApp.tsx**
Uses the shared worktree-mode interpretation when restoring session-window project context.

**src/features/berdctl/commands/impl/getProject.ts**
Returns the expanded project workspace startup-mode contract.

**src/features/berdctl/commands/impl/setProjectStartupMode.ts**
Normalizes legacy modes, applies policy only to Git workspaces, and returns the actual persisted mode.

**src/features/berdctl/__tests__/commands/commands.test.ts**
Covers current and migrated startup-mode command behavior.

**src/features/chat/hooks/useChatSessionController.ts**
Offers pre-send workspace setup immediately, provisions named worktrees safely, and protects async UI state from stale completions.

**src/features/chat/hooks/__tests__/useChatSessionController.test.ts**
Covers initial piggyback visibility and startup system-message behavior.

**src/features/chat/hooks/useMessageQueue.ts**
Prevents dismissing one queued message from sending the next message as a side effect.

**src/features/chat/hooks/__tests__/useMessageQueue.test.ts**
Protects explicit queue removal and remaining-message order.

**src/features/chat/lib/firstWorkspaceSend.ts**
Coordinates workspace planning, session promotion, target switching, timeout, validation, rollback, migration, and deferred-message release.

**src/features/chat/lib/firstWorkspaceSend.test.ts**
Adds adversarial coverage for promotion waits, rollback, stale state, interrupted setup, and policy behavior.

**src/features/chat/lib/sessionTargetCoordinator.ts**
Makes draft-to-backend coordinator transfer collision-safe and settles superseded operations.

**src/features/chat/lib/sessionTargetCoordinator.test.ts**
Covers existing backend actors and in-flight draft operation cleanup.

**src/features/chat/ui/ChatInput.tsx**
Places the workspace piggyback behind the composer and groups/animates queued messages in one responsive container.

**src/features/chat/ui/__tests__/ChatInput.test.tsx**
Covers piggyback ordering, grouped queue geometry, editing, and action ownership.

**src/features/chat/ui/ChatView.tsx**
Connects immediate and deferred workspace setup states to the composer accessory.

**src/features/chat/ui/WorkspaceSetupChoice.tsx**
Implements the animated worktree choice, naming, progress, and inline error states with dark-mode and reduced-motion support.

**src/features/chat/ui/WorkspaceSetupChoice.test.tsx**
Covers setup copy, naming validation, error layout, progress, and visual contracts.

**src/features/chat/ui/widgets/WorkspaceIdentity.tsx**
Supports explicit Git-folder identity icons and icon-scoped explanatory tooltips.

**src/features/design-system/generated/componentManifest.ts**
**src/features/design-system/ui/DesignSystemView.tsx**
Documents the compact 32px text-button size used by composer actions.

**src/features/projects/api/projects.ts**
Adds current workspace policy modes and migrates legacy branch/worktree settings.

**src/features/projects/api/projects.test.ts**
Covers policy normalization, migration, and persistence.

**src/features/projects/lib/projectChatWorkspaces.ts**
Plans project-wide worktrees, formats friendly errors, and provides rollback-safe cleanup.

**src/features/projects/lib/projectChatWorkspaces.test.ts**
Covers multi-folder planning, validation, rollback, and plain-English failures.

**src/features/projects/ui/CreateProjectDialog.tsx**
Redesigns Project folders with Git-aware icons, per-folder new-chat policy controls, policy synchronization, and non-Git handling.

**src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx**
Covers Git detection, policy synchronization, transient probe failures, migration, and folder management.

**src/shared/i18n/locales/en/projects.json**
**src/shared/i18n/locales/es/projects.json**
Adds localized policy labels and concise Git-folder tooltip copy.

**src/shared/ui/button.tsx**
Adds a shared compact 32px text-button size for composer action groups.

</details>
