### PR TITLE
feat: improve starter task guidance and restoration

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -48,6 +48,7 @@ import { useProviderModelCacheStore } from "@/features/providers/stores/provider
 import { useProviderCatalogStore } from "@/features/providers/stores/providerCatalogStore";
 import { useRuntimeConfigStore } from "@/shared/runtime-config/runtimeConfigStore";
 import { gooseServeSelectionFromExecutionTarget } from "@/features/chat/lib/gooseServeExecutionTarget";
+import { ASSISTIVE_UX_STORAGE_KEY } from "@/shared/assistive-ux/registry";
 
 import {
   DEFAULT_RUNTIME_CONFIG,
@@ -611,11 +612,38 @@ vi.mock("./ui/AppShellContent", () => ({
         <div data-testid="builderbot-route">
           {JSON.stringify(activeBuilderbotRoute)}
         </div>
+        <div data-testid="starter-tasks-visible">
+          {String(starterTasks?.visible)}
+        </div>
+        <div data-testid="starter-tasks-docked">
+          {String(starterTasks?.docked)}
+        </div>
+        <div data-testid="starter-task-selection">
+          {starterTasks?.selectedTaskId ?? "none"}
+        </div>
+        <button
+          type="button"
+          onClick={() => starterTasks?.onTaskSelect("connect-provider")}
+        >
+          Select provider starter task
+        </button>
         <button
           type="button"
           onClick={() => starterTasks?.onTaskSelect("add-widget")}
         >
           Select add widget starter task
+        </button>
+        <button
+          type="button"
+          onClick={() => starterTasks?.onTaskSelect("create-project")}
+        >
+          Select project starter task
+        </button>
+        <button type="button" onClick={() => starterTasks?.onDismiss()}>
+          Dismiss starter tasks
+        </button>
+        <button type="button" onClick={() => starterTasks?.onRestore()}>
+          Restore starter tasks
         </button>
         <button
           type="button"
@@ -4154,6 +4182,75 @@ describe("AppShell global navigation", () => {
     expect(useChatSessionStore.getState().isRightRailOpen).toBe(false);
   });
 
+  it("navigates a starter task to its relevant settings page", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(
+      screen.getByRole("button", { name: "Select provider starter task" }),
+    );
+
+    expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
+    expect(screen.getByTestId("settings-section")).toHaveTextContent(
+      "providers",
+    );
+  });
+
+  it("keeps background content inert and clears project selection after exit", async () => {
+    const user = userEvent.setup();
+    const appRoot = document.createElement("div");
+    appRoot.id = "root";
+    document.body.append(appRoot);
+    render(appShellWithTheme(), { container: appRoot });
+
+    await user.click(
+      screen.getByRole("button", { name: "Select project starter task" }),
+    );
+    expect(screen.getByTestId("starter-task-selection")).toHaveTextContent(
+      "create-project",
+    );
+    expect(appRoot.inert).toBe(true);
+    await user.click(await screen.findByRole("button", { name: "Close" }));
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("starter-task-selection")).toHaveTextContent(
+          "none",
+        );
+      },
+      { timeout: 1000 },
+    );
+    expect(screen.getByTestId("starter-tasks-docked")).toHaveTextContent(
+      "false",
+    );
+    expect(appRoot.inert).toBeFalsy();
+  });
+
+  it("persists restoring dismissed starter tasks", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(
+      screen.getByRole("button", { name: "Dismiss starter tasks" }),
+    );
+    expect(screen.getByTestId("starter-tasks-visible")).toHaveTextContent(
+      "false",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Restore starter tasks" }),
+    );
+    expect(screen.getByTestId("starter-tasks-visible")).toHaveTextContent(
+      "true",
+    );
+    const persisted = JSON.parse(
+      window.localStorage.getItem(ASSISTIVE_UX_STORAGE_KEY) ?? "{}",
+    );
+    expect(persisted.moments?.["home.starterTasks"]).not.toMatchObject({
+      retiredReason: "dismissed",
+    });
+  });
+
   it("guards the add-widget starter task against unsaved automation changes", async () => {
     const user = userEvent.setup();
     renderAppShell();
@@ -4179,6 +4276,12 @@ describe("AppShell global navigation", () => {
 
     await user.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(screen.getByTestId("active-view")).toHaveTextContent("automations");
+    expect(screen.getByTestId("starter-tasks-docked")).toHaveTextContent(
+      "false",
+    );
+    expect(screen.getByTestId("starter-task-selection")).toHaveTextContent(
+      "none",
+    );
     expect(hasStarterWidgetPickerRequest()).toBe(false);
   });
 

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -637,7 +637,7 @@ vi.mock("./ui/AppShellContent", () => ({
           type="button"
           onClick={() => starterTasks?.onTaskSelect("create-project")}
         >
-          Select project starter task
+          Open project starter task
         </button>
         <button type="button" onClick={() => starterTasks?.onDismiss()}>
           Dismiss starter tasks
@@ -4204,7 +4204,7 @@ describe("AppShell global navigation", () => {
     render(appShellWithTheme(), { container: appRoot });
 
     await user.click(
-      screen.getByRole("button", { name: "Select project starter task" }),
+      screen.getByRole("button", { name: "Open project starter task" }),
     );
     expect(screen.getByTestId("starter-task-selection")).toHaveTextContent(
       "create-project",

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -265,6 +265,7 @@ import {
   recordAssistiveMomentShown,
   shouldShowAssistiveMoment,
 } from "@/shared/assistive-ux/runtime";
+import { resetAssistiveUxMoment } from "@/shared/assistive-ux/state";
 export type { AppView } from "./types/appNavigation";
 
 type AppNavigationHistory = {
@@ -730,8 +731,6 @@ export function AppShell({
   const sessions = useChatSessionStore(selectSessions);
   const activeSessionId = useChatSessionStore(selectActiveSessionId);
   const messagesBySession = useChatStore((state) => state.messagesBySession);
-  const personas = useAgentStore((state) => state.personas);
-  const personasLoading = useAgentStore((state) => state.personasLoading);
   const previousActiveSessionIdRef = useRef(activeSessionId);
   useEffect(() => {
     const previousSessionId = previousActiveSessionIdRef.current;
@@ -786,8 +785,21 @@ export function AppShell({
   const starterTasksVisible =
     starterTasksExperimentEnabled && starterTasksEligible;
   const [starterTasksDocked, setStarterTasksDocked] = useState(false);
+  const [selectedStarterTaskId, setSelectedStarterTaskId] =
+    useState<StarterTaskId | null>(null);
   const [starterProjectId, setStarterProjectId] = useState<string | null>(null);
+  const [starterProjectStickyExiting, setStarterProjectStickyExiting] =
+    useState(false);
+  const starterProjectStickyExitTimerRef = useRef<number | null>(null);
   const starterTasksLeftHomeRef = useRef(false);
+  useEffect(
+    () => () => {
+      if (starterProjectStickyExitTimerRef.current !== null) {
+        window.clearTimeout(starterProjectStickyExitTimerRef.current);
+      }
+    },
+    [],
+  );
   const initialStarterTaskProgressRef = useRef(loadStarterTaskProgress());
   const [starterTaskOverrides, setStarterTaskOverrides] =
     useState<StarterTaskCompletionState>(
@@ -1085,6 +1097,17 @@ export function AppShell({
   } = useProjectDialog({
     onProjectSaved: refreshProjectsAfterDialogSave,
   });
+  useEffect(() => {
+    if (!createProjectOpen || selectedStarterTaskId !== "create-project")
+      return;
+    const appRoot = document.getElementById("root");
+    if (!appRoot) return;
+    const wasInert = appRoot.inert;
+    appRoot.inert = true;
+    return () => {
+      appRoot.inert = wasInert;
+    };
+  }, [createProjectOpen, selectedStarterTaskId]);
   const startup = useAppStartup();
   const [startupLoadingMinElapsed, setStartupLoadingMinElapsed] = useState(
     () => startup.ready,
@@ -4634,8 +4657,6 @@ export function AppShell({
         messagesBySession,
         projectsFetched: hasFetchedProjects,
         projects,
-        personasLoaded: !personasLoading,
-        personas,
       }),
     [
       defaultProviderReadinessStatus,
@@ -4644,8 +4665,6 @@ export function AppShell({
       messagesBySession,
       hasFetchedProjects,
       projects,
-      personasLoading,
-      personas,
     ],
   );
   useEffect(() => {
@@ -4759,18 +4778,29 @@ export function AppShell({
   };
 
   const handleStarterTaskSelect = (taskId: StarterTaskId) => {
-    starterTasksLeftHomeRef.current = renderedLocation.view !== "home";
-    if (derivedStarterTaskCompletion[taskId]) {
-      setStarterTaskOverrides((overrides) => ({
-        ...overrides,
-        [taskId]: true,
-      }));
-    } else {
-      setStarterTasksAwaitingCompletion((awaiting) =>
-        new Set(awaiting).add(taskId),
-      );
+    if (starterProjectStickyExitTimerRef.current !== null) {
+      window.clearTimeout(starterProjectStickyExitTimerRef.current);
+      starterProjectStickyExitTimerRef.current = null;
+      setStarterProjectStickyExiting(false);
     }
-    setStarterTasksDocked(true);
+    const selectTask = () => {
+      setSelectedStarterTaskId(taskId);
+      // The widget task stays on Home. Keep the existing canvas sticky mounted
+      // so its content can crossfade instead of replacing it with an overlay.
+      setStarterTasksDocked(taskId !== "add-widget");
+      starterTasksLeftHomeRef.current = renderedLocation.view !== "home";
+      if (derivedStarterTaskCompletion[taskId]) {
+        setStarterTaskOverrides((overrides) => ({
+          ...overrides,
+          [taskId]: true,
+        }));
+      } else {
+        setStarterTasksAwaitingCompletion((awaiting) =>
+          new Set(awaiting).add(taskId),
+        );
+      }
+    };
+    if (taskId !== "add-widget") selectTask();
     switch (taskId) {
       case "connect-provider":
         openSettings("providers");
@@ -4781,14 +4811,9 @@ export function AppShell({
       case "create-project":
         openCreateProjectDialog({ onCreated: handleStarterProjectCreated });
         break;
-      case "build-agent":
-        agentBuilder.create();
-        break;
       case "add-widget":
         guardAppNavigation(() => {
-          // This task stays on Home, so keep the checklist on the canvas instead
-          // of docking it as an overlay with a redundant back arrow.
-          setStarterTasksDocked(false);
+          selectTask();
           setActiveSession(null);
           clearSettingsSectionUrl();
           setActiveView("home");
@@ -4798,7 +4823,13 @@ export function AppShell({
     }
   };
 
+  const handleCloseStarterTaskSecondary = () => {
+    setSelectedStarterTaskId(null);
+    setStarterTasksDocked(false);
+  };
+
   const handleStarterTasksBackHome = () => {
+    setSelectedStarterTaskId(null);
     setStarterTasksDocked(false);
     handleNavigate("home");
   };
@@ -4806,6 +4837,13 @@ export function AppShell({
   const dismissStarterTasks = () => {
     recordAssistiveMomentRetired("home.starterTasks", "dismissed");
     setStarterTasksEligible(false);
+  };
+
+  const restoreStarterTasks = () => {
+    resetAssistiveUxMoment("home.starterTasks");
+    setStarterTasksDocked(false);
+    setSelectedStarterTaskId(null);
+    setStarterTasksEligible(true);
   };
 
   if (forceStartupLoading || !startup.ready || !startupLoadingMinElapsed) {
@@ -4906,6 +4944,11 @@ export function AppShell({
         createProjectDialog={{
           isOpen: createProjectOpen,
           onClose: () => {
+            const closingStarterProjectTask =
+              selectedStarterTaskId === "create-project" && starterTasksDocked;
+            if (closingStarterProjectTask) {
+              setStarterProjectStickyExiting(true);
+            }
             closeCreateProjectDialog();
             setStarterTasksAwaitingCompletion((awaiting) => {
               if (!awaiting.has("create-project")) return awaiting;
@@ -4914,26 +4957,45 @@ export function AppShell({
               return next;
             });
             if (starterTasksDocked && renderedLocation.view === "home") {
-              setStarterTasksDocked(false);
+              if (closingStarterProjectTask) {
+                starterProjectStickyExitTimerRef.current = window.setTimeout(
+                  () => {
+                    starterProjectStickyExitTimerRef.current = null;
+                    setSelectedStarterTaskId(null);
+                    setStarterTasksDocked(false);
+                    setStarterProjectStickyExiting(false);
+                  },
+                  300,
+                );
+              } else {
+                setStarterTasksDocked(false);
+              }
             }
           },
           onCreated: handleProjectCreated,
           initialWorkingDir: createProjectInitialWorkingDir,
           editingProject: editingProject ?? undefined,
+          // Keep the visual modal backdrop, but let keyboard focus move between
+          // the starter-task sticky and the project panel.
+          modal: selectedStarterTaskId !== "create-project",
         }}
       >
         {children ?? (
           <StarterTasksProvider
             value={{
               completionState: starterTaskCompletion,
+              enabled: starterTasksExperimentEnabled,
               visible: starterTasksVisible,
               docked: starterTasksDocked,
+              selectedTaskId: selectedStarterTaskId,
               starterProjectId,
               omittedTaskIds: omittedStarterTaskIds,
               onTaskSelect: handleStarterTaskSelect,
               onTaskToggle: handleStarterTaskToggle,
               onBackHome: handleStarterTasksBackHome,
+              onCloseSecondary: handleCloseStarterTaskSecondary,
               onDismiss: dismissStarterTasks,
+              onRestore: restoreStarterTasks,
             }}
           >
             <AppShellContent
@@ -5026,10 +5088,16 @@ export function AppShell({
                 completionState={starterTaskCompletion}
                 omittedTaskIds={omittedStarterTaskIds}
                 mode="overlay"
+                selectedTaskId={selectedStarterTaskId}
                 labels={{
                   title: t("home:onboarding.starterTasks.title"),
                   backHome: t("home:onboarding.starterTasks.backHome"),
+                  backToList: t("home:onboarding.starterTasks.backToList"),
+                  markDone: t("home:onboarding.starterTasks.markDone"),
                   dismiss: t("home:onboarding.starterTasks.dismiss"),
+                  closeTaskDetails: t(
+                    "home:onboarding.starterTasks.closeTaskDetails",
+                  ),
                   tasks: {
                     "connect-provider": t(
                       "home:onboarding.starterTasks.connectProvider",
@@ -5038,8 +5106,21 @@ export function AppShell({
                     "create-project": t(
                       "home:onboarding.starterTasks.createProject",
                     ),
-                    "build-agent": t("home:onboarding.starterTasks.buildAgent"),
                     "add-widget": t("home:onboarding.starterTasks.addWidget"),
+                  },
+                  taskDetails: {
+                    "connect-provider": t(
+                      "home:onboarding.starterTasks.taskDetails.connectProvider",
+                    ),
+                    "start-chat": t(
+                      "home:onboarding.starterTasks.taskDetails.startChat",
+                    ),
+                    "create-project": t(
+                      "home:onboarding.starterTasks.taskDetails.createProject",
+                    ),
+                    "add-widget": t(
+                      "home:onboarding.starterTasks.taskDetails.addWidget",
+                    ),
                   },
                   openTask: (label) =>
                     t("home:onboarding.starterTasks.openTask", { label }),
@@ -5051,9 +5132,12 @@ export function AppShell({
                     t("home:onboarding.starterTasks.uncheckTask", { label }),
                 }}
                 onTaskSelect={handleStarterTaskSelect}
+                onTaskDetailsBack={() => setSelectedStarterTaskId(null)}
+                onCloseSecondary={handleCloseStarterTaskSecondary}
                 onTaskToggle={handleStarterTaskToggle}
                 onBackHome={handleStarterTasksBackHome}
                 onDismiss={dismissStarterTasks}
+                exiting={starterProjectStickyExiting}
               />
             ) : null}
             {showGlobalComposerShim ? (

--- a/src/features/home/onboarding/StarterTaskList.test.tsx
+++ b/src/features/home/onboarding/StarterTaskList.test.tsx
@@ -6,13 +6,21 @@ import { StarterTaskList, type StarterTaskListLabels } from "./StarterTaskList";
 const labels: StarterTaskListLabels = {
   title: "Starter task list",
   backHome: "Back to Home",
+  backToList: "Back to starter tasks",
+  markDone: "Mark as done",
   dismiss: "Dismiss starter tasks",
+  closeTaskDetails: "Close task details",
   tasks: {
     "connect-provider": "Connect an AI provider",
     "start-chat": "Start a chat",
     "create-project": "Create a project",
-    "build-agent": "Build an agent",
     "add-widget": "Add a widget to Home",
+  },
+  taskDetails: {
+    "connect-provider": "Connect a provider to choose a model.",
+    "start-chat": "Start a regular chat.",
+    "create-project": "Keep related work together.",
+    "add-widget": "Personalize Home with useful information.",
   },
   openTask: (label) => `Open task: ${label}`,
   completedTask: (label) => `Completed task: ${label}`,
@@ -23,7 +31,6 @@ const incomplete = {
   "connect-provider": false,
   "start-chat": false,
   "create-project": false,
-  "build-agent": false,
   "add-widget": false,
 };
 
@@ -44,20 +51,195 @@ function renderList(
 }
 
 describe("StarterTaskList", () => {
-  it("renders all requested tasks and selects one", () => {
+  it("shows details, navigates, marks the task complete, and returns Home", () => {
     const onTaskSelect = vi.fn();
-    renderList({ onTaskSelect });
-    expect(screen.getAllByRole("listitem")).toHaveLength(5);
+    const onTaskToggle = vi.fn();
+    const onBackHome = vi.fn();
+    renderList({ onTaskSelect, onTaskToggle, onBackHome });
+    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+
     fireEvent.click(
       screen.getByRole("button", { name: "Open task: Start a chat" }),
     );
+
     expect(onTaskSelect).toHaveBeenCalledWith("start-chat");
+    expect(
+      screen.getByRole("heading", { name: "Start a chat" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Start a regular chat.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Mark as done" }));
+    expect(onTaskToggle).toHaveBeenCalledWith("start-chat");
+    expect(onBackHome).toHaveBeenCalledOnce();
+  });
+
+  it("returns Home without unchecking when the task is already done", () => {
+    const onTaskToggle = vi.fn();
+    const onBackHome = vi.fn();
+    renderList({
+      completionState: { ...incomplete, "connect-provider": true },
+      onTaskToggle,
+      onBackHome,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Completed task: Connect an AI provider",
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Mark as done" }));
+
+    expect(onTaskToggle).not.toHaveBeenCalled();
+    expect(onBackHome).toHaveBeenCalledOnce();
+  });
+
+  it("slides the overlay in with eased motion", () => {
+    renderList({ mode: "overlay", selectedTaskId: "create-project" });
+
+    expect(
+      screen.getByRole("region", { name: "Create a project" }),
+    ).toHaveClass(
+      "motion-safe:slide-in-from-right-8",
+      "motion-safe:duration-500",
+      "motion-safe:ease-[cubic-bezier(0.19,1,0.22,1)]",
+      "motion-reduce:animate-none",
+    );
+  });
+
+  it("lets the project task sticky be dragged while the panel is open", () => {
+    renderList({ mode: "overlay", selectedTaskId: "create-project" });
+    const region = screen.getByRole("region", { name: "Create a project" });
+    const header = within(region).getByRole("button", {
+      name: "Back to starter tasks",
+    }).parentElement as HTMLElement;
+    vi.spyOn(region, "getBoundingClientRect").mockReturnValue({
+      left: 100,
+      top: 100,
+      right: 356,
+      bottom: 296,
+      width: 256,
+      height: 196,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    header.setPointerCapture = vi.fn();
+    const downEvent = new Event("pointerdown", { bubbles: true });
+    Object.defineProperties(downEvent, {
+      button: { value: 0 },
+      clientX: { value: 120 },
+      clientY: { value: 120 },
+      pointerId: { value: 1 },
+    });
+    fireEvent(header, downEvent);
+    const moveEvent = new Event("pointermove", { bubbles: true });
+    Object.defineProperties(moveEvent, {
+      clientX: { value: 220 },
+      clientY: { value: 200 },
+    });
+    fireEvent(window, moveEvent);
+    fireEvent.pointerUp(window, { pointerId: 1 });
+
+    expect(region).toHaveStyle({ left: "200px", top: "180px" });
+  });
+
+  it("slides out with the project panel", () => {
+    renderList({
+      mode: "overlay",
+      selectedTaskId: "create-project",
+      exiting: true,
+    });
+
+    expect(
+      screen.getByRole("region", { name: "Create a project" }),
+    ).toHaveClass(
+      "motion-safe:slide-out-to-right",
+      "motion-safe:duration-300",
+      "pointer-events-none",
+    );
+  });
+
+  it("portals project task details above the project modal backdrop", () => {
+    const { container } = renderList({
+      mode: "overlay",
+      selectedTaskId: "create-project",
+    });
+    const region = screen.getByRole("region", { name: "Create a project" });
+
+    expect(region).toHaveClass("bottom-28", "z-[55]");
+    expect(container).not.toContainElement(region);
+    expect(document.body).toContainElement(region);
+  });
+
+  it("keeps the sticky accessible name unambiguous during crossfades", () => {
+    renderList({ selectedTaskId: "start-chat" });
+
+    expect(screen.getByRole("region", { name: "Start a chat" })).toBeVisible();
+    expect(
+      document.querySelectorAll("[id='starter-task-list-title']"),
+    ).toHaveLength(0);
+  });
+
+  it("honors a controlled null selection instead of stale local state", async () => {
+    const { rerender } = renderList();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Start a chat" }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "Start a chat" }),
+    ).toBeVisible();
+
+    rerender(
+      <StarterTaskList
+        completionState={incomplete}
+        mode="canvas"
+        selectedTaskId={null}
+        labels={labels}
+        onTaskSelect={vi.fn()}
+        onTaskToggle={vi.fn()}
+        onBackHome={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Starter task list" }),
+    ).toBeVisible();
+  });
+
+  it("closes only the secondary sticky with an accurate accessible label", () => {
+    const onCloseSecondary = vi.fn();
+    const onDismiss = vi.fn();
+    renderList({
+      mode: "overlay",
+      selectedTaskId: "start-chat",
+      onCloseSecondary,
+      onDismiss,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Close task details" }));
+
+    expect(onCloseSecondary).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("returns Home from task details in overlay mode", () => {
+    const onBackHome = vi.fn();
+    renderList({ mode: "overlay", onBackHome });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open task: Start a chat" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Back to starter tasks" }),
+    );
+
+    expect(onBackHome).toHaveBeenCalledOnce();
   });
 
   it("omits tasks completed in an earlier onboarding flow", () => {
     renderList({ omittedTaskIds: new Set(["connect-provider"]) });
 
-    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
     expect(
       screen.queryByRole("button", {
         name: "Open task: Connect an AI provider",

--- a/src/features/home/onboarding/StarterTaskList.tsx
+++ b/src/features/home/onboarding/StarterTaskList.tsx
@@ -7,6 +7,8 @@ import {
   type CSSProperties,
   type PointerEvent,
 } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import {
@@ -19,8 +21,12 @@ import {
 export interface StarterTaskListLabels {
   title: string;
   backHome: string;
+  backToList: string;
   dismiss: string;
+  closeTaskDetails: string;
+  markDone: string;
   tasks: Record<StarterTaskId, string>;
+  taskDetails: Record<StarterTaskId, string>;
   openTask: (taskLabel: string) => string;
   completedTask: (taskLabel: string) => string;
   checkTask: (taskLabel: string) => string;
@@ -31,10 +37,14 @@ export interface StarterTaskListProps {
   completionState: StarterTaskCompletionState;
   mode: "canvas" | "overlay";
   labels: StarterTaskListLabels;
+  selectedTaskId?: StarterTaskId | null;
   onTaskSelect: (id: StarterTaskId) => void;
+  onTaskDetailsBack?: () => void;
+  onCloseSecondary?: () => void;
   onTaskToggle: (id: StarterTaskId) => void;
   onBackHome: () => void;
   onDismiss: () => void;
+  exiting?: boolean;
   omittedTaskIds?: ReadonlySet<StarterTaskId>;
   className?: string;
 }
@@ -43,14 +53,25 @@ export function StarterTaskList({
   completionState,
   mode,
   labels,
+  selectedTaskId: controlledSelectedTaskId,
   onTaskSelect,
+  onTaskDetailsBack,
+  onCloseSecondary,
   onTaskToggle,
   onBackHome,
   onDismiss,
+  exiting = false,
   omittedTaskIds = new Set(),
   className,
 }: StarterTaskListProps) {
   const noteRef = useRef<HTMLElement | null>(null);
+  const reduceMotion = useReducedMotion();
+  const [localSelectedTaskId, setLocalSelectedTaskId] =
+    useState<StarterTaskId | null>(null);
+  const selectedTaskId =
+    controlledSelectedTaskId !== undefined
+      ? controlledSelectedTaskId
+      : localSelectedTaskId;
   const [overlayPosition, setOverlayPosition] = useState<{
     left: number;
     top: number;
@@ -135,118 +156,208 @@ export function StarterTaskList({
   const visibleTasks = STARTER_TASKS.filter(
     (task) => !omittedTaskIds.has(task.id),
   );
+  const selectedTask = selectedTaskId
+    ? STARTER_TASKS.find((task) => task.id === selectedTaskId)
+    : undefined;
+  const selectedTaskCompleted = selectedTask
+    ? isStarterTaskComplete(completionState, selectedTask.id)
+    : false;
+  const accessibleTitle = selectedTask
+    ? labels.tasks[selectedTask.id]
+    : labels.title;
 
-  return (
+  const taskList = (
     <section
       ref={noteRef}
-      aria-labelledby="starter-task-list-title"
+      aria-label={accessibleTitle}
       data-mode={mode}
+      data-starter-task-list="true"
       style={overlayStyle}
       className={cn(
-        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-blue p-4 text-sm text-sticky-note-foreground shadow-sticky-note",
+        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-blue px-4 pb-4 pt-2 text-sm text-sticky-note-foreground shadow-sticky-note",
         mode === "overlay" &&
-          "fixed right-4 bottom-28 z-40 max-h-[min(24rem,calc(100dvh-8rem))] h-auto w-[min(16rem,calc(100vw-2rem))] overflow-y-auto smooth-shadow-sm",
+          "pointer-events-auto fixed right-4 bottom-28 z-[55] max-h-[min(24rem,calc(100dvh-8rem))] h-auto w-[min(16rem,calc(100vw-2rem))] overflow-y-auto smooth-shadow-sm motion-safe:animate-in motion-safe:slide-in-from-right-8 motion-safe:fade-in-0 motion-safe:duration-500 motion-safe:ease-[cubic-bezier(0.19,1,0.22,1)] motion-safe:will-change-transform motion-reduce:animate-none",
+        mode === "overlay" &&
+          selectedTask?.id === "create-project" &&
+          "right-[min(calc(560px+2.25rem),calc(100vw-17rem))]",
         overlayPosition && "right-auto bottom-auto",
+        exiting &&
+          "pointer-events-none motion-safe:animate-out motion-safe:slide-out-to-right motion-safe:fade-out-0 motion-safe:duration-300 motion-safe:ease-[cubic-bezier(0.215,0.61,0.355,1)] motion-safe:will-change-transform motion-reduce:animate-none",
         className,
       )}
     >
-      <header
-        className={cn(
-          "flex items-center",
-          mode === "overlay" &&
-            "cursor-grab touch-none select-none active:cursor-grabbing",
-        )}
-        onPointerDown={handleOverlayDragStart}
-      >
-        {mode === "overlay" ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={labels.backHome}
-            onPointerDown={(event) => event.stopPropagation()}
-            onClick={onBackHome}
-            className="-ml-1"
+      <div className="grid">
+        <AnimatePresence initial={false}>
+          <motion.div
+            key={selectedTask ? `details-${selectedTask.id}` : "task-list"}
+            initial={reduceMotion ? false : { opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={reduceMotion ? undefined : { opacity: 0 }}
+            transition={{ duration: 0.16, ease: "linear" }}
+            className="col-start-1 row-start-1"
           >
-            <ChevronLeft aria-hidden="true" />
-          </Button>
-        ) : null}
-        <h2
-          id="starter-task-list-title"
-          className="min-w-0 flex-1 text-sm font-semibold"
-        >
-          {labels.title}
-        </h2>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          aria-label={labels.dismiss}
-          onPointerDown={(event) => event.stopPropagation()}
-          onClick={onDismiss}
-          className="-mr-1"
-        >
-          <X aria-hidden="true" />
-        </Button>
-      </header>
-
-      <ul className="mt-2 space-y-0.5">
-        {visibleTasks.map((task) => {
-          const label = labels.tasks[task.id];
-          const completed = isStarterTaskComplete(completionState, task.id);
-
-          return (
-            <li key={task.id}>
-              <div
-                className={cn(
-                  "group/task grid min-h-8 w-full grid-cols-[16px_minmax(0,1fr)_16px] items-center gap-2 px-1 text-left text-sm",
-                  completed && "text-sticky-note-muted",
-                )}
-              >
-                <button
+            <header
+              className={cn(
+                "flex items-center",
+                mode === "overlay" &&
+                  "cursor-grab touch-none select-none active:cursor-grabbing",
+              )}
+              onPointerDown={handleOverlayDragStart}
+            >
+              {mode === "overlay" || selectedTask ? (
+                <Button
                   type="button"
+                  variant="ghost"
+                  size="icon-xxs"
                   aria-label={
-                    completed
-                      ? labels.uncheckTask(label)
-                      : labels.checkTask(label)
+                    selectedTask ? labels.backToList : labels.backHome
                   }
-                  aria-pressed={completed}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onTaskToggle(task.id);
+                  onPointerDown={(event) => event.stopPropagation()}
+                  className="justify-start"
+                  onClick={() => {
+                    if (selectedTask) {
+                      setLocalSelectedTaskId(null);
+                      if (mode === "overlay") {
+                        onBackHome();
+                      } else {
+                        onTaskDetailsBack?.();
+                      }
+                    } else {
+                      onBackHome();
+                    }
                   }}
-                  className="-m-2 flex size-8 items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
-                  <span className="flex size-4 items-center justify-center rounded-[3px] border-[1.5px] border-sticky-note-muted/70">
-                    {completed ? (
-                      <Check className="size-3 stroke-[2.5]" />
-                    ) : null}
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  aria-label={
-                    completed
-                      ? labels.completedTask(label)
-                      : labels.openTask(label)
+                  <ChevronLeft aria-hidden="true" className="size-3" />
+                </Button>
+              ) : null}
+              {!selectedTask ? (
+                <h2 className="min-w-0 flex-1 text-sm font-semibold">
+                  {labels.title}
+                </h2>
+              ) : (
+                <div className="flex-1" />
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label={
+                  selectedTask ? labels.closeTaskDetails : labels.dismiss
+                }
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={() => {
+                  if (selectedTask) {
+                    setLocalSelectedTaskId(null);
+                    onCloseSecondary?.();
+                    return;
                   }
-                  onClick={() => onTaskSelect(task.id)}
-                  className={cn(
-                    "min-w-0 flex-1 whitespace-normal text-left leading-5 group-hover/task:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                    completed && "line-through",
-                  )}
+                  onDismiss();
+                }}
+                className="-mr-1"
+              >
+                <X aria-hidden="true" className="size-3" />
+              </Button>
+            </header>
+
+            {selectedTask ? (
+              <div className="mt-0.5 flex min-h-32 flex-col">
+                <h2 className="text-sm font-semibold">
+                  {labels.tasks[selectedTask.id]}
+                </h2>
+                <p className="mt-1 whitespace-pre-line leading-5">
+                  {labels.taskDetails[selectedTask.id]}
+                </p>
+                <Button
+                  type="button"
+                  onClick={() => {
+                    if (!selectedTaskCompleted) onTaskToggle(selectedTask.id);
+                    setLocalSelectedTaskId(null);
+                    onBackHome();
+                  }}
+                  size="sm"
+                  className="mt-5 self-start px-3"
                 >
-                  {label}
-                </button>
-                <ArrowRight
-                  aria-hidden="true"
-                  className="size-3.5 justify-self-center opacity-0 group-hover/task:opacity-100"
-                />
+                  {labels.markDone}
+                </Button>
               </div>
-            </li>
-          );
-        })}
-      </ul>
+            ) : (
+              <ul className="mt-2 space-y-0.5">
+                {visibleTasks.map((task) => {
+                  const label = labels.tasks[task.id];
+                  const completed = isStarterTaskComplete(
+                    completionState,
+                    task.id,
+                  );
+
+                  return (
+                    <li key={task.id}>
+                      <div
+                        className={cn(
+                          "group/task grid min-h-8 w-full grid-cols-[16px_minmax(0,1fr)_16px] items-center gap-2 px-1 text-left text-sm",
+                          completed && "text-sticky-note-muted",
+                        )}
+                      >
+                        <button
+                          type="button"
+                          aria-label={
+                            completed
+                              ? labels.uncheckTask(label)
+                              : labels.checkTask(label)
+                          }
+                          aria-pressed={completed}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onTaskToggle(task.id);
+                          }}
+                          className="-m-2 flex size-8 items-center justify-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <span className="flex size-4 items-center justify-center rounded-[3px] border-[1.5px] border-sticky-note-muted/70">
+                            {completed ? (
+                              <Check className="size-3 stroke-[2.5]" />
+                            ) : null}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={
+                            completed
+                              ? labels.completedTask(label)
+                              : labels.openTask(label)
+                          }
+                          onClick={() => {
+                            onTaskSelect(task.id);
+                            setLocalSelectedTaskId(task.id);
+                          }}
+                          className={cn(
+                            "min-w-0 flex-1 whitespace-normal text-left leading-5 group-hover/task:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                            completed && "line-through",
+                          )}
+                        >
+                          {label}
+                        </button>
+                        <ArrowRight
+                          aria-hidden="true"
+                          className="size-3.5 justify-self-center opacity-0 group-hover/task:opacity-100"
+                        />
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </motion.div>
+        </AnimatePresence>
+      </div>
     </section>
   );
+
+  if (
+    mode === "overlay" &&
+    selectedTask?.id === "create-project" &&
+    typeof document !== "undefined"
+  ) {
+    return createPortal(taskList, document.body);
+  }
+
+  return taskList;
 }

--- a/src/features/home/onboarding/StarterTasksContext.tsx
+++ b/src/features/home/onboarding/StarterTasksContext.tsx
@@ -3,14 +3,18 @@ import type { StarterTaskCompletionState, StarterTaskId } from "./starterTasks";
 
 export interface StarterTasksContextValue {
   completionState: StarterTaskCompletionState;
+  enabled: boolean;
   visible: boolean;
   docked: boolean;
+  selectedTaskId: StarterTaskId | null;
   starterProjectId: string | null;
   omittedTaskIds: ReadonlySet<StarterTaskId>;
   onTaskSelect: (id: StarterTaskId) => void;
   onTaskToggle: (id: StarterTaskId) => void;
   onBackHome: () => void;
+  onCloseSecondary: () => void;
   onDismiss: () => void;
+  onRestore: () => void;
 }
 
 const StarterTasksContext = createContext<StarterTasksContextValue | null>(

--- a/src/features/home/onboarding/starterTaskCompletion.test.ts
+++ b/src/features/home/onboarding/starterTaskCompletion.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
-import type { Persona } from "@/shared/types/agents";
 import { deriveStarterTaskCompletion } from "./starterTaskCompletion";
 
 const session = (overrides: Partial<ChatSession> = {}): ChatSession => ({
@@ -11,15 +10,6 @@ const session = (overrides: Partial<ChatSession> = {}): ChatSession => ({
   messageCount: 0,
   ...overrides,
 });
-const persona = (overrides: Partial<Persona> = {}): Persona => ({
-  id: "agent-1",
-  displayName: "Agent",
-  systemPrompt: "Help",
-  isBuiltin: false,
-  writable: true,
-  ...overrides,
-});
-
 const base = {
   providerReady: false,
   sessionsHydrated: true,
@@ -27,8 +17,6 @@ const base = {
   messagesBySession: {},
   projectsFetched: true,
   projects: [],
-  personasLoaded: true,
-  personas: [] as Persona[],
 };
 
 describe("deriveStarterTaskCompletion", () => {
@@ -39,27 +27,21 @@ describe("deriveStarterTaskCompletion", () => {
         providerReady: true,
         sessions: [session({ messageCount: 1 })],
         projects: [{ id: "p", archivedAt: null } as never],
-        personas: [persona()],
       }),
     ).toEqual({
       "connect-provider": true,
       "start-chat": true,
       "create-project": true,
-      "build-agent": true,
       "add-widget": false,
     });
   });
 
-  it("does not count agent-builder chats or bundled agents", () => {
+  it("does not count agent-builder chats", () => {
     const result = deriveStarterTaskCompletion({
       ...base,
       sessions: [session({ intent: "build-agent", messageCount: 2 })],
-      personas: [
-        persona({ sourceProperties: { metadata: { berdBundled: true } } }),
-      ],
     });
     expect(result["start-chat"]).toBe(false);
-    expect(result["build-agent"]).toBe(false);
   });
 
   it("waits for canonical stores to hydrate", () => {
@@ -69,11 +51,8 @@ describe("deriveStarterTaskCompletion", () => {
       sessions: [session({ messageCount: 1 })],
       projectsFetched: false,
       projects: [{ id: "p", archivedAt: null } as never],
-      personasLoaded: false,
-      personas: [persona()],
     });
     expect(result["start-chat"]).toBe(false);
     expect(result["create-project"]).toBe(false);
-    expect(result["build-agent"]).toBe(false);
   });
 });

--- a/src/features/home/onboarding/starterTaskCompletion.ts
+++ b/src/features/home/onboarding/starterTaskCompletion.ts
@@ -1,6 +1,5 @@
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
 import type { ProjectInfo } from "@/features/projects/api/projects";
-import type { Persona } from "@/shared/types/agents";
 import type { Message } from "@/shared/types/messages";
 import type { StarterTaskCompletionState } from "./starterTasks";
 
@@ -11,24 +10,6 @@ export interface StarterTaskCompletionInput {
   messagesBySession: Record<string, Message[]>;
   projectsFetched: boolean;
   projects: ProjectInfo[];
-  personasLoaded: boolean;
-  personas: Persona[];
-}
-
-function isUserCreatedPersona(persona: Persona): boolean {
-  const metadata = persona.sourceProperties?.metadata;
-  const metadataRecord =
-    metadata && typeof metadata === "object"
-      ? (metadata as Record<string, unknown>)
-      : undefined;
-
-  return (
-    persona.writable &&
-    persona.sourceProperties?.berdBundled !== true &&
-    persona.sourceProperties?.gooseInternalBundled !== true &&
-    metadataRecord?.berdBundled !== true &&
-    metadataRecord?.gooseInternalBundled !== true
-  );
 }
 
 export function deriveStarterTaskCompletion({
@@ -38,8 +19,6 @@ export function deriveStarterTaskCompletion({
   messagesBySession,
   projectsFetched,
   projects,
-  personasLoaded,
-  personas,
 }: StarterTaskCompletionInput): StarterTaskCompletionState {
   const startedChat =
     sessionsHydrated &&
@@ -61,7 +40,6 @@ export function deriveStarterTaskCompletion({
     "start-chat": startedChat,
     "create-project":
       projectsFetched && projects.some((project) => !project.archivedAt),
-    "build-agent": personasLoaded && personas.some(isUserCreatedPersona),
     "add-widget": false,
   };
 }

--- a/src/features/home/onboarding/starterTaskProgress.test.ts
+++ b/src/features/home/onboarding/starterTaskProgress.test.ts
@@ -41,7 +41,7 @@ describe("starterTaskProgress", () => {
 
   it("clears progress for onboarding reset", () => {
     saveStarterTaskProgress({
-      completion: { ...EMPTY_STARTER_TASK_COMPLETION, "build-agent": true },
+      completion: { ...EMPTY_STARTER_TASK_COMPLETION, "start-chat": true },
       awaiting: new Set(),
     });
     clearStarterTaskProgress();

--- a/src/features/home/onboarding/starterTaskProgress.ts
+++ b/src/features/home/onboarding/starterTaskProgress.ts
@@ -23,7 +23,6 @@ export const EMPTY_STARTER_TASK_COMPLETION: StarterTaskCompletionState = {
   "connect-provider": false,
   "start-chat": false,
   "create-project": false,
-  "build-agent": false,
   "add-widget": false,
 };
 

--- a/src/features/home/onboarding/starterTasks.test.ts
+++ b/src/features/home/onboarding/starterTasks.test.ts
@@ -9,7 +9,6 @@ const incomplete = {
   "connect-provider": false,
   "start-chat": false,
   "create-project": false,
-  "build-agent": false,
   "add-widget": false,
 };
 
@@ -19,17 +18,16 @@ describe("starter task model", () => {
       "connect-provider",
       "start-chat",
       "create-project",
-      "build-agent",
       "add-widget",
     ]);
   });
 
   it("reads completion from the derived state", () => {
-    expect(isStarterTaskComplete(incomplete, "build-agent")).toBe(false);
+    expect(isStarterTaskComplete(incomplete, "start-chat")).toBe(false);
     expect(
       isStarterTaskComplete(
-        { ...incomplete, "build-agent": true },
-        "build-agent",
+        { ...incomplete, "start-chat": true },
+        "start-chat",
       ),
     ).toBe(true);
   });

--- a/src/features/home/onboarding/starterTasks.ts
+++ b/src/features/home/onboarding/starterTasks.ts
@@ -15,10 +15,6 @@ export const STARTER_TASKS = [
     labelKey: "onboarding.starterTasks.createProject",
   },
   {
-    id: "build-agent",
-    labelKey: "onboarding.starterTasks.buildAgent",
-  },
-  {
     id: "add-widget",
     labelKey: "onboarding.starterTasks.addWidget",
   },

--- a/src/features/home/ui/HomeView.test.tsx
+++ b/src/features/home/ui/HomeView.test.tsx
@@ -24,6 +24,8 @@ import { HomeView } from "./HomeView";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import type { Persona } from "@/shared/types/agents";
 import { markStarterAgentPinsEligible } from "@/features/home/onboarding/starterAgents";
+import { StarterTasksProvider } from "@/features/home/onboarding/StarterTasksContext";
+import { EMPTY_STARTER_TASK_COMPLETION } from "@/features/home/onboarding/starterTaskProgress";
 
 const ONBOARDING_STICKIES_SEEDED_STORAGE_KEY =
   "goose:home:onboarding-stickies-seeded";
@@ -141,6 +143,138 @@ beforeEach(() => {
 });
 
 describe("HomeView", () => {
+  it("removes the starter task widget hit area after it is dismissed", async () => {
+    vi.mocked(getLayout).mockResolvedValue(
+      layout({
+        items: [
+          {
+            id: "00000000-0000-0000-0000-000000000098",
+            kind: "stickyNote",
+            targetId: "onboarding:starter-tasks",
+            centerX: 100,
+            centerY: 100,
+            width: 256,
+            height: 196,
+            zIndex: 2,
+            titleOverride: null,
+          },
+        ],
+      }),
+    );
+
+    render(
+      <StarterTasksProvider
+        value={{
+          completionState: EMPTY_STARTER_TASK_COMPLETION,
+          enabled: true,
+          visible: false,
+          docked: false,
+          selectedTaskId: null,
+          starterProjectId: null,
+          omittedTaskIds: new Set(),
+          onTaskSelect: vi.fn(),
+          onTaskToggle: vi.fn(),
+          onBackHome: vi.fn(),
+          onCloseSecondary: vi.fn(),
+          onDismiss: vi.fn(),
+          onRestore: vi.fn(),
+        }}
+      >
+        <HomeView />
+      </StarterTasksProvider>,
+    );
+    await screen.findByText("widget canvas");
+
+    expect(widgetCanvasMock.mock.lastCall?.[0].instances).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          state: expect.objectContaining({
+            noteId: "onboarding:starter-tasks",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("does not offer starter tasks when the experiment is disabled", async () => {
+    vi.mocked(getLayout).mockResolvedValue(layout());
+    render(
+      <StarterTasksProvider
+        value={{
+          completionState: EMPTY_STARTER_TASK_COMPLETION,
+          enabled: false,
+          visible: false,
+          docked: false,
+          selectedTaskId: null,
+          starterProjectId: null,
+          omittedTaskIds: new Set(),
+          onTaskSelect: vi.fn(),
+          onTaskToggle: vi.fn(),
+          onBackHome: vi.fn(),
+          onCloseSecondary: vi.fn(),
+          onDismiss: vi.fn(),
+          onRestore: vi.fn(),
+        }}
+      >
+        <HomeView />
+      </StarterTasksProvider>,
+    );
+    await screen.findByText("widget canvas");
+
+    expect(widgetCanvasMock.mock.lastCall?.[0].starterTasksAvailable).toBe(
+      false,
+    );
+  });
+
+  it("keeps the starter project cube after starter tasks are dismissed", async () => {
+    vi.mocked(getLayout).mockResolvedValue(
+      layout({
+        items: [
+          {
+            id: "00000000-0000-0000-0000-000000000099",
+            kind: "stickyNote",
+            targetId: "onboarding:starter-project",
+            centerX: 500,
+            centerY: 200,
+            width: 400,
+            height: 400,
+            zIndex: 2,
+            titleOverride: null,
+          },
+        ],
+      }),
+    );
+
+    render(
+      <StarterTasksProvider
+        value={{
+          completionState: EMPTY_STARTER_TASK_COMPLETION,
+          enabled: true,
+          visible: false,
+          docked: false,
+          selectedTaskId: null,
+          starterProjectId: null,
+          omittedTaskIds: new Set(),
+          onTaskSelect: vi.fn(),
+          onTaskToggle: vi.fn(),
+          onBackHome: vi.fn(),
+          onCloseSecondary: vi.fn(),
+          onDismiss: vi.fn(),
+          onRestore: vi.fn(),
+        }}
+      >
+        <HomeView />
+      </StarterTasksProvider>,
+    );
+    await screen.findByText("widget canvas");
+
+    expect(widgetCanvasMock.mock.lastCall?.[0].instances).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "onboardingProjectArtifact" }),
+      ]),
+    );
+  });
+
   it("does not add bundled starter agents to an existing customized Home", async () => {
     vi.mocked(getLayout).mockResolvedValue(layout());
     const bundledPersona = (displayName: string): Persona => ({

--- a/src/features/home/ui/HomeView.tsx
+++ b/src/features/home/ui/HomeView.tsx
@@ -406,18 +406,14 @@ export function HomeView({
   const contentInstances = useMemo(
     () =>
       experimentVisibleInstances.filter((instance) => {
-        if (
-          !starterTasks?.visible &&
-          instance.type === "onboardingProjectArtifact" &&
-          instance.state?.projectId === STARTER_PROJECT_ID
-        ) {
-          return false;
-        }
-        return !RETIRED_EDUCATIONAL_STICKY_IDS.has(
+        const noteId =
           typeof instance.state?.noteId === "string"
             ? instance.state.noteId
-            : "",
-        );
+            : "";
+        if (!starterTasks?.visible && noteId === STARTER_TASKS_NOTE_ID) {
+          return false;
+        }
+        return !RETIRED_EDUCATIONAL_STICKY_IDS.has(noteId);
       }),
     [experimentVisibleInstances, starterTasks?.visible],
   );
@@ -695,6 +691,10 @@ export function HomeView({
           onOpenAutomations={onOpenAutomations}
           onStartOnboardingTour={handleStartTour}
           onResolveBerdyAgent={onResolveBerdyAgent}
+          starterTasksAvailable={Boolean(
+            starterTasks?.enabled && !starterTasks.visible,
+          )}
+          onRestoreStarterTasks={starterTasks?.onRestore}
         />
       ) : null}
       <OnboardingTourDialog

--- a/src/features/home/ui/WidgetCanvas.test.tsx
+++ b/src/features/home/ui/WidgetCanvas.test.tsx
@@ -268,6 +268,8 @@ type RenderCanvasOptions = WidgetNavigationHandlers & {
   viewportLeftOcclusionPx?: number;
   onCreatePersona?: () => void;
   onCreateProject?: () => void;
+  starterTasksAvailable?: boolean;
+  onRestoreStarterTasks?: () => void;
 };
 
 function PickerTestProvider({ children }: { children: ReactNode }) {
@@ -1040,6 +1042,57 @@ describe("WidgetCanvas", () => {
     expect(clockNode?.style.zIndex).toBe("1");
   });
 
+  it("keeps the widget picker open while panning the canvas background", async () => {
+    const user = userEvent.setup();
+    const { container } = renderCanvas();
+    const canvas = container.firstElementChild as HTMLElement;
+
+    vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue(canvasRect());
+    fireEvent.contextMenu(canvas, { clientX: 100, clientY: 120 });
+    expect(
+      screen.getByRole("button", { name: PANEL_LABELS.widgets }),
+    ).toBeInTheDocument();
+
+    await user.pointer([
+      {
+        keys: "[MouseLeft>]",
+        target: canvas,
+        coords: { clientX: 200, clientY: 220 },
+      },
+      {
+        target: canvas,
+        coords: { clientX: 224, clientY: 196 },
+      },
+      {
+        keys: "[/MouseLeft]",
+        target: canvas,
+        coords: { clientX: 224, clientY: 196 },
+      },
+    ]);
+
+    expect(
+      screen.getByRole("button", { name: PANEL_LABELS.widgets }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the widget picker when empty canvas is clicked", async () => {
+    const user = userEvent.setup();
+    const { container } = renderCanvas();
+    const canvas = container.firstElementChild as HTMLElement;
+
+    vi.spyOn(canvas, "getBoundingClientRect").mockReturnValue(canvasRect());
+    fireEvent.contextMenu(canvas, { clientX: 100, clientY: 120 });
+    expect(
+      screen.getByRole("button", { name: PANEL_LABELS.widgets }),
+    ).toBeInTheDocument();
+
+    await user.click(canvas);
+
+    expect(
+      screen.queryByRole("button", { name: PANEL_LABELS.widgets }),
+    ).not.toBeInTheDocument();
+  });
+
   it("saves the camera after panning the canvas background", async () => {
     const user = userEvent.setup();
     const { container } = renderCanvas();
@@ -1204,97 +1257,20 @@ describe("WidgetCanvas", () => {
     );
   });
 
-  it("offers Starter stickies and restores only missing onboarding notes", async () => {
+  it("restores the starter task list from the widget picker", async () => {
     const user = userEvent.setup();
-    const addWidget = vi.fn();
-    mocks.homeWidgetState.constraints = CANVAS_CONSTRAINTS;
-
+    const onRestoreStarterTasks = vi.fn();
     const { container } = renderCanvas({
-      instances: [
-        widget({
-          id: "onboarding-tour",
-          type: "onboardingTour",
-          state: { noteId: "onboarding:tour" },
-        }),
-        stickyNoteWidget({
-          id: "build-agent-sticky",
-          state: { noteId: "onboarding:build-agent" },
-        }),
-        stickyNoteWidget({
-          id: "project-sticky",
-          state: { noteId: "onboarding:start-project" },
-        }),
-        stickyNoteWidget({
-          id: "home-sticky",
-          state: { noteId: "onboarding:shape-home" },
-        }),
-        stickyNoteWidget({
-          id: "automation-sticky",
-          state: { noteId: "onboarding:manage-automations" },
-        }),
-      ],
-      mutations: { addWidget },
+      starterTasksAvailable: true,
+      onRestoreStarterTasks,
     });
 
     await openPickerPanel(user, container, "widgets");
     await user.click(
-      screen.getByRole("button", { name: /^starter stickies$/i }),
+      screen.getByRole("button", { name: /^starter task list$/i }),
     );
 
-    expect(addWidget).toHaveBeenCalledTimes(1);
-    expect(addWidget).toHaveBeenCalledWith(
-      "stickyNote",
-      100,
-      120,
-      { noteId: "onboarding:reuse-workflows" },
-      CANVAS_CONSTRAINTS,
-    );
-  });
-
-  it("disables Starter stickies when all onboarding notes are pinned", async () => {
-    const user = userEvent.setup();
-    const addWidget = vi.fn();
-
-    const { container } = renderCanvas({
-      instances: [
-        widget({
-          id: "onboarding-tour",
-          type: "onboardingTour",
-          state: { noteId: "onboarding:tour" },
-        }),
-        stickyNoteWidget({
-          id: "build-agent-sticky",
-          state: { noteId: "onboarding:build-agent" },
-        }),
-        stickyNoteWidget({
-          id: "project-sticky",
-          state: { noteId: "onboarding:start-project" },
-        }),
-        stickyNoteWidget({
-          id: "skills-sticky",
-          state: { noteId: "onboarding:reuse-workflows" },
-        }),
-        stickyNoteWidget({
-          id: "home-sticky",
-          state: { noteId: "onboarding:shape-home" },
-        }),
-        stickyNoteWidget({
-          id: "automation-sticky",
-          state: { noteId: "onboarding:manage-automations" },
-        }),
-      ],
-      mutations: { addWidget },
-    });
-
-    await openPickerPanel(user, container, "widgets");
-
-    const starterStickiesRow = screen.getByRole("button", {
-      name: /^starter stickies$/i,
-    });
-    expect(starterStickiesRow).toBeDisabled();
-    await user.click(starterStickiesRow);
-
-    expect(addWidget).not.toHaveBeenCalled();
+    expect(onRestoreStarterTasks).toHaveBeenCalledOnce();
   });
 
   it("disables the Clock row when a clock is already pinned", async () => {

--- a/src/features/home/ui/WidgetCanvas.tsx
+++ b/src/features/home/ui/WidgetCanvas.tsx
@@ -61,6 +61,8 @@ interface WidgetCanvasProps extends WidgetNavigationHandlers {
   viewportLeftOcclusionPx?: number;
   onCreatePersona?: () => void;
   onCreateProject?: () => void;
+  starterTasksAvailable?: boolean;
+  onRestoreStarterTasks?: () => void;
 }
 
 interface PickerState {
@@ -231,46 +233,6 @@ function renderedWidgetContentStyleForResizePreview({
   };
 }
 
-function starterStickyPlacementsNearAnchor(
-  widgets: WidgetInstance[],
-  anchor: { x: number; y: number },
-) {
-  if (widgets.length === 0) {
-    return [];
-  }
-
-  const bounds = widgets.reduce(
-    (current, widget) => {
-      const size = widgetSizeForInstance(widget);
-      return {
-        minX: Math.min(current.minX, widget.x),
-        minY: Math.min(current.minY, widget.y),
-        maxX: Math.max(current.maxX, widget.x + size.width),
-        maxY: Math.max(current.maxY, widget.y + size.height),
-      };
-    },
-    {
-      minX: Number.POSITIVE_INFINITY,
-      minY: Number.POSITIVE_INFINITY,
-      maxX: Number.NEGATIVE_INFINITY,
-      maxY: Number.NEGATIVE_INFINITY,
-    },
-  );
-  const groupCenter = {
-    x: (bounds.minX + bounds.maxX) / 2,
-    y: (bounds.minY + bounds.maxY) / 2,
-  };
-
-  return widgets.map((widget) => {
-    const size = widgetSizeForInstance(widget);
-    return {
-      widget,
-      centerX: anchor.x + (widget.x + size.width / 2 - groupCenter.x),
-      centerY: anchor.y + (widget.y + size.height / 2 - groupCenter.y),
-    };
-  });
-}
-
 const HOME_MIN_ZOOM_BPS = 5_000;
 const HOME_MAX_ZOOM_BPS = 20_000;
 const WIDGET_TEXT_SCALE_MULTIPLIER = 1.08;
@@ -321,6 +283,8 @@ export function WidgetCanvas({
   onOpenAutomations,
   onStartOnboardingTour,
   onResolveBerdyAgent,
+  starterTasksAvailable = false,
+  onRestoreStarterTasks,
 }: WidgetCanvasProps) {
   const { t } = useTranslation("home");
   const resolvedRecenterLabel =
@@ -390,7 +354,12 @@ export function WidgetCanvas({
     camera,
     constraints: viewportConstraints,
     saveCamera,
-    onViewportGestureStart: closePicker,
+    onViewportGestureStart: (kind) => {
+      if (kind !== "pan") closePicker();
+    },
+    onViewportPanEnd: (moved) => {
+      if (!moved) closePicker();
+    },
     onWidgetDragStart: (instance) => {
       handleVisualLift(instance.id, currentMaxZ + 1);
     },
@@ -599,6 +568,7 @@ export function WidgetCanvas({
     // biome-ignore lint/a11y/noStaticElementInteractions: freeform spatial canvas; child widgets and picker provide semantic controls
     <div
       ref={canvasRef}
+      data-home-widget-canvas="true"
       onContextMenu={handleCanvasContextMenu}
       onPointerDown={handleCanvasPointerDown}
       onPointerMove={handlePointerMove}
@@ -812,6 +782,7 @@ export function WidgetCanvas({
         side={picker.side}
         focusOnOpen={picker.focusOnOpen}
         instances={pickerInstances}
+        starterTasksAvailable={starterTasksAvailable}
         onClose={closePicker}
         onSelect={(type, state) => {
           mutations.addWidget(
@@ -823,20 +794,8 @@ export function WidgetCanvas({
           );
           closePicker();
         }}
-        onSelectStarterStickies={(widgets) => {
-          const placements = starterStickyPlacementsNearAnchor(widgets, {
-            x: picker.worldX,
-            y: picker.worldY,
-          });
-          for (const { widget, centerX, centerY } of placements) {
-            mutations.addWidget(
-              widget.type,
-              centerX,
-              centerY,
-              widget.state,
-              constraints,
-            );
-          }
+        onRestoreStarterTasks={() => {
+          onRestoreStarterTasks?.();
           closePicker();
         }}
       />

--- a/src/features/home/ui/WidgetPicker.tsx
+++ b/src/features/home/ui/WidgetPicker.tsx
@@ -31,11 +31,8 @@ import {
 } from "@/features/skills/lib/resolveSkillPillTone";
 import type { Persona } from "@/shared/types/agents";
 import { cn } from "@/shared/lib/cn";
-import { BERDY_ONBOARDING_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
-import { useExperiment } from "@/features/experiments/experimentPreferences";
 import { Input } from "@/shared/ui/input";
 import { Popover, PopoverAnchor, PopoverContent } from "@/shared/ui/popover";
-import { missingDefaultStickyNoteWidgets } from "../lib/homeLayoutMapper";
 import { HOME_WIDGET_CATEGORIES } from "../widgets/catalog";
 import {
   SKILL_LIST_QUERY_KEY,
@@ -65,9 +62,10 @@ interface WidgetPickerProps {
   /** Moves focus into stage one when opened from a keyboard-driven action. */
   focusOnOpen?: boolean;
   instances: WidgetInstance[];
+  starterTasksAvailable?: boolean;
   onClose: () => void;
   onSelect: (type: string, state?: Record<string, unknown>) => void;
-  onSelectStarterStickies: (widgets: WidgetInstance[]) => void;
+  onRestoreStarterTasks: () => void;
 }
 
 type EntityCategory = "agent" | "chat" | "automation" | "project" | "skill";
@@ -360,13 +358,11 @@ export function WidgetPicker({
   side = "right",
   focusOnOpen = false,
   instances,
+  starterTasksAvailable = false,
   onClose,
   onSelect,
-  onSelectStarterStickies,
+  onRestoreStarterTasks,
 }: WidgetPickerProps) {
-  const berdyOnboardingEnabled = Boolean(
-    useExperiment(BERDY_ONBOARDING_EXPERIMENT_ID)?.enabled,
-  );
   const { t } = useTranslation("home");
   const automationsEnabled = useProfileCapability("automations");
   const visibleWidgetCategories = useMemo(
@@ -424,10 +420,6 @@ export function WidgetPicker({
     skills: skills ?? [],
     automationFallbackTitle: t("widgets.automationOutputPin.fallbackTitle"),
   });
-  const missingStarterStickies = useMemo(
-    () => missingDefaultStickyNoteWidgets(instances, berdyOnboardingEnabled),
-    [berdyOnboardingEnabled, instances],
-  );
 
   const [previousOpen, setPreviousOpen] = useState(open);
   if (previousOpen !== open) {
@@ -537,6 +529,14 @@ export function WidgetPicker({
         align="start"
         side={side}
         sideOffset={WIDGET_PICKER_SIDE_OFFSET}
+        onPointerDownOutside={(event) => {
+          if (
+            event.target instanceof Element &&
+            event.target.closest('[data-home-widget-canvas="true"]')
+          ) {
+            event.preventDefault();
+          }
+        }}
         onPointerDownCapture={(event) => event.stopPropagation()}
         onDoubleClickCapture={(event) => event.stopPropagation()}
         onWheelCapture={(event) => event.stopPropagation()}
@@ -570,9 +570,7 @@ export function WidgetPicker({
             onSelectStickyNote={() => onSelect("stickyNote")}
             onSelectChecklist={() => onSelect("checklist")}
             onSelectPhoto={() => onSelect("photo")}
-            onSelectStarterStickies={() =>
-              onSelectStarterStickies(missingStarterStickies)
-            }
+            onRestoreStarterTasks={onRestoreStarterTasks}
             clockLabel={t("widgets.clock.label")}
             clockPinned={instances.some(
               (instance) => instance.type === "clock",
@@ -580,8 +578,8 @@ export function WidgetPicker({
             stickyNoteLabel={t("widgets.stickyNote.label")}
             checklistLabel={t("widgets.checklist.label")}
             photoLabel={t("widgets.photo.label")}
-            starterStickiesLabel={t("widgets.stickyNote.starterStickies")}
-            starterStickiesPinned={missingStarterStickies.length === 0}
+            starterTasksLabel={t("widgets.stickyNote.starterTasks")}
+            starterTasksAvailable={starterTasksAvailable}
             backLabel={t("widgets.picker.back")}
             title={t(`widgets.picker.selectTitles.${activePanel}`)}
             isLoadingMoreSessions={isLoadingMoreSessions}
@@ -658,14 +656,14 @@ interface PanelStageTwoProps {
   onSelectStickyNote: () => void;
   onSelectChecklist: () => void;
   onSelectPhoto: () => void;
-  onSelectStarterStickies: () => void;
+  onRestoreStarterTasks: () => void;
   clockLabel: string;
   clockPinned: boolean;
   stickyNoteLabel: string;
   checklistLabel: string;
   photoLabel: string;
-  starterStickiesLabel: string;
-  starterStickiesPinned: boolean;
+  starterTasksLabel: string;
+  starterTasksAvailable: boolean;
   backLabel: string;
   title: string;
   isLoadingMoreSessions: boolean;
@@ -687,14 +685,14 @@ function PanelStageTwo({
   onSelectStickyNote,
   onSelectChecklist,
   onSelectPhoto,
-  onSelectStarterStickies,
+  onRestoreStarterTasks,
   clockLabel,
   clockPinned,
   stickyNoteLabel,
   checklistLabel,
   photoLabel,
-  starterStickiesLabel,
-  starterStickiesPinned,
+  starterTasksLabel,
+  starterTasksAvailable,
   backLabel,
   title,
   isLoadingMoreSessions,
@@ -738,9 +736,9 @@ function PanelStageTwo({
               onSelect={onSelectPhoto}
             />
             <WidgetOptionRow
-              label={starterStickiesLabel}
-              pinned={starterStickiesPinned}
-              onSelect={onSelectStarterStickies}
+              label={starterTasksLabel}
+              pinned={!starterTasksAvailable}
+              onSelect={onRestoreStarterTasks}
             />
           </div>
         ) : (

--- a/src/features/home/ui/useHomeCanvasViewport.ts
+++ b/src/features/home/ui/useHomeCanvasViewport.ts
@@ -100,7 +100,8 @@ interface UseHomeCanvasViewportOptions {
   camera: LayoutCamera;
   constraints: LayoutConstraints;
   saveCamera: (camera: LayoutCamera) => void;
-  onViewportGestureStart?: () => void;
+  onViewportGestureStart?: (kind: "pan" | "widget" | "resize" | "zoom") => void;
+  onViewportPanEnd?: (moved: boolean) => void;
   onWidgetDragStart?: (instance: WidgetInstance) => void;
   onWidgetDragEnd?: (drag: WidgetDragEnd) => void;
   onWidgetResizeStart?: (instance: WidgetInstance) => void;
@@ -218,6 +219,7 @@ export function useHomeCanvasViewport({
   constraints,
   saveCamera,
   onViewportGestureStart,
+  onViewportPanEnd,
   onWidgetDragStart,
   onWidgetDragEnd,
   onWidgetResizeStart,
@@ -402,7 +404,7 @@ export function useHomeCanvasViewport({
     (event: React.PointerEvent<HTMLElement>) => {
       lockDocumentSelection();
       event.currentTarget.setPointerCapture(event.pointerId);
-      onViewportGestureStart?.();
+      onViewportGestureStart?.("pan");
       activePointerRef.current = {
         kind: "pan",
         pointerId: event.pointerId,
@@ -420,7 +422,7 @@ export function useHomeCanvasViewport({
         return;
       }
 
-      onViewportGestureStart?.();
+      onViewportGestureStart?.("widget");
       activePointerRef.current = {
         kind: "widget",
         pointerId: event.pointerId,
@@ -445,7 +447,7 @@ export function useHomeCanvasViewport({
 
       lockDocumentSelection();
       event.currentTarget.setPointerCapture?.(event.pointerId);
-      onViewportGestureStart?.();
+      onViewportGestureStart?.("resize");
       onWidgetResizeStart?.(instance);
       activePointerRef.current = {
         kind: "resize",
@@ -552,7 +554,9 @@ export function useHomeCanvasViewport({
       const offset = offsetBetween(eventClient, activePointer.startClient);
 
       if (activePointer.kind === "pan") {
-        if (offset.x === 0 && offset.y === 0) {
+        const moved = offset.x !== 0 || offset.y !== 0;
+        onViewportPanEnd?.(moved);
+        if (!moved) {
           return;
         }
 
@@ -612,6 +616,7 @@ export function useHomeCanvasViewport({
       clearWidgetResizePreview,
       commitCamera,
       constraints,
+      onViewportPanEnd,
       onWidgetDragEnd,
       onWidgetDragStart,
       onWidgetResizeCancel,
@@ -629,7 +634,7 @@ export function useHomeCanvasViewport({
         return;
       }
 
-      onViewportGestureStart?.();
+      onViewportGestureStart?.(event.ctrlKey || event.metaKey ? "zoom" : "pan");
 
       setViewport((currentViewport) => {
         const nextViewport =
@@ -664,7 +669,7 @@ export function useHomeCanvasViewport({
     const handleGestureStart = (event: WebkitGestureEvent) => {
       event.preventDefault();
       gestureScaleRef.current = event.scale ?? 1;
-      onViewportGestureStart?.();
+      onViewportGestureStart?.("zoom");
     };
 
     const handleGestureChange = (event: WebkitGestureEvent) => {

--- a/src/features/home/widgets/StickyNoteWidget.tsx
+++ b/src/features/home/widgets/StickyNoteWidget.tsx
@@ -429,16 +429,29 @@ export function StickyNoteWidget({
         mode="canvas"
         completionState={starterTasks.completionState}
         omittedTaskIds={starterTasks.omittedTaskIds}
+        selectedTaskId={starterTasks.selectedTaskId}
         labels={{
           title: t("onboarding.starterTasks.title"),
           backHome: t("onboarding.starterTasks.backHome"),
+          backToList: t("onboarding.starterTasks.backToList"),
+          markDone: t("onboarding.starterTasks.markDone"),
           dismiss: t("onboarding.starterTasks.dismiss"),
+          closeTaskDetails: t("onboarding.starterTasks.closeTaskDetails"),
           tasks: {
             "connect-provider": t("onboarding.starterTasks.connectProvider"),
             "start-chat": t("onboarding.starterTasks.startChat"),
             "create-project": t("onboarding.starterTasks.createProject"),
-            "build-agent": t("onboarding.starterTasks.buildAgent"),
             "add-widget": t("onboarding.starterTasks.addWidget"),
+          },
+          taskDetails: {
+            "connect-provider": t(
+              "onboarding.starterTasks.taskDetails.connectProvider",
+            ),
+            "start-chat": t("onboarding.starterTasks.taskDetails.startChat"),
+            "create-project": t(
+              "onboarding.starterTasks.taskDetails.createProject",
+            ),
+            "add-widget": t("onboarding.starterTasks.taskDetails.addWidget"),
           },
           openTask: (label) => t("onboarding.starterTasks.openTask", { label }),
           completedTask: (label) =>
@@ -451,6 +464,7 @@ export function StickyNoteWidget({
         onTaskSelect={starterTasks.onTaskSelect}
         onTaskToggle={starterTasks.onTaskToggle}
         onBackHome={starterTasks.onBackHome}
+        onCloseSecondary={starterTasks.onCloseSecondary}
         onDismiss={() => {
           starterTasks.onDismiss();
           onRemoveWidget?.();

--- a/src/features/projects/ui/CreateProjectDialog.tsx
+++ b/src/features/projects/ui/CreateProjectDialog.tsx
@@ -345,6 +345,7 @@ interface CreateProjectDialogProps {
   onCreated: (project: ProjectInfo) => void;
   initialWorkingDir?: string | null;
   editingProject?: ProjectInfo;
+  modal?: boolean;
 }
 
 export function CreateProjectDialog({
@@ -353,6 +354,7 @@ export function CreateProjectDialog({
   onCreated,
   initialWorkingDir,
   editingProject,
+  modal = true,
 }: CreateProjectDialogProps) {
   const { t } = useTranslation(["projects", "common"]);
   const workspaceRepository = useWorkspaceRepository();
@@ -937,9 +939,13 @@ export function CreateProjectDialog({
 
   return (
     <>
-      <Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <Sheet
+        open={isOpen}
+        modal={modal}
+        onOpenChange={(open) => !open && handleClose()}
+      >
         <SheetContent
-          className="top-3 right-3 bottom-3 h-auto w-[calc(100vw-1.5rem)] gap-0 overflow-hidden rounded-[24px] p-0 shadow-[0_22px_72px_rgba(15,23,42,0.18)] backdrop-blur-2xl transition-colors duration-500 ease-out sm:top-5 sm:right-5 sm:bottom-5 sm:w-[560px] sm:max-w-none"
+          className="top-3 right-3 bottom-3 h-auto w-[calc(100vw-1.5rem)] gap-0 overflow-hidden rounded-[24px] p-0 shadow-[0_22px_72px_rgba(15,23,42,0.18)] backdrop-blur-2xl transition-colors duration-500 ease-out data-[state=open]:duration-500 data-[state=open]:ease-[cubic-bezier(0.19,1,0.22,1)] data-[state=closed]:duration-300 data-[state=closed]:ease-[cubic-bezier(0.215,0.61,0.355,1)] sm:top-5 sm:right-5 sm:bottom-5 sm:w-[560px] sm:max-w-none"
           closeButtonClassName="top-5 right-5 rounded-sm bg-transparent opacity-80 hover:bg-card/50"
           overlayClassName="bg-transparent"
           style={{
@@ -952,6 +958,22 @@ export function CreateProjectDialog({
             backgroundColor: `color-mix(in oklab, color-mix(in oklab, ${selectedPanelColor} var(--project-panel-tint), var(--background)) var(--project-panel-alpha), transparent)`,
           }}
           aria-describedby={undefined}
+          onPointerDownOutside={(event) => {
+            if (
+              event.target instanceof Element &&
+              event.target.closest('[data-starter-task-list="true"]')
+            ) {
+              event.preventDefault();
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (
+              event.target instanceof Element &&
+              event.target.closest('[data-starter-task-list="true"]')
+            ) {
+              event.preventDefault();
+            }
+          }}
         >
           <form
             id="project-form"

--- a/src/shared/i18n/locales/en/home.json
+++ b/src/shared/i18n/locales/en/home.json
@@ -11,15 +11,23 @@
       "minimize": "Minimize starter tasks",
       "expand": "Expand starter tasks",
       "connectProvider": "Connect an AI provider",
-      "startChat": "Start a chat",
       "createProject": "Name your first project",
-      "buildAgent": "Build an agent",
-      "addWidget": "Add a widget to Home",
+      "addWidget": "Add a widget",
       "openTask": "Open task: {{label}}",
       "completedTask": "Completed task: {{label}}",
       "checkTask": "Check {{label}}",
       "uncheckTask": "Uncheck {{label}}",
-      "backHome": "Back to Home"
+      "backHome": "Back to Home",
+      "backToList": "Back to starter tasks",
+      "taskDetails": {
+        "connectProvider": "Connect any provider to chat with it in Berd.\n\nYou can switch between models or providers anytime, even mid-chat.",
+        "createProject": "Link projects to a folder or repo, and that context is there in every chat.\n\nChats, files, and history stay together, not scattered across sessions.",
+        "addWidget": "Right-click to add sticky notes, checklists, or photos.\n\nPin them alongside your agents and projects to make Home feel like yours.",
+        "startChat": "Want something more specialized? @mention an agent to call them in.\n\n@Berdy and ask them about your agents."
+      },
+      "markDone": "Mark as done",
+      "startChat": "Start a chat",
+      "closeTaskDetails": "Close task details"
     },
     "callout": {
       "avatarLabel": "Berdy",
@@ -183,7 +191,6 @@
       "placeholder": "Write a note...",
       "preview": "Preview",
       "edit": "Edit",
-      "starterStickies": "Starter stickies",
       "fontSizes": {
         "small": "Small text",
         "medium": "Medium text",
@@ -227,7 +234,8 @@
           "body": "G2 automations live in Berd now. View, create, and manage scheduled work here.",
           "action": "Open automations"
         }
-      }
+      },
+      "starterTasks": "Starter task list"
     },
     "checklist": {
       "label": "Checklist",

--- a/src/shared/i18n/locales/es/home.json
+++ b/src/shared/i18n/locales/es/home.json
@@ -11,15 +11,23 @@
       "minimize": "Minimizar tareas iniciales",
       "expand": "Expandir tareas iniciales",
       "connectProvider": "Conecta un proveedor de IA",
-      "startChat": "Inicia un chat",
       "createProject": "Ponle nombre a tu primer proyecto",
-      "buildAgent": "Crea un agente",
-      "addWidget": "Añade un widget a Inicio",
+      "addWidget": "Añade un widget",
       "openTask": "Abrir tarea: {{label}}",
       "completedTask": "Tarea completada: {{label}}",
       "checkTask": "Marcar {{label}}",
       "uncheckTask": "Desmarcar {{label}}",
-      "backHome": "Volver a Inicio"
+      "backHome": "Volver a Inicio",
+      "backToList": "Volver a las tareas iniciales",
+      "taskDetails": {
+        "connectProvider": "Conecta Berd a un proveedor de IA para elegir un modelo y empezar a chatear.",
+        "createProject": "Crea un proyecto para mantener juntos los chats, archivos y contexto relacionados.",
+        "addWidget": "Personaliza Inicio con un widget que mantenga la información útil a mano.",
+        "startChat": "Hazle una pregunta a Berd o dale una tarea para iniciar tu primera conversación."
+      },
+      "markDone": "Marcar como hecha",
+      "startChat": "Inicia un chat",
+      "closeTaskDetails": "Cerrar detalles de la tarea"
     },
     "callout": {
       "avatarLabel": "Berdy",
@@ -183,7 +191,6 @@
       "placeholder": "Escribe una nota...",
       "preview": "Vista previa",
       "edit": "Editar",
-      "starterStickies": "Notas iniciales",
       "fontSizes": {
         "small": "Texto pequeño",
         "medium": "Texto mediano",
@@ -227,7 +234,8 @@
           "body": "Las automatizaciones de G2 ahora viven en Berd. Puedes ver, crear y gestionar trabajo programado aquí.",
           "action": "Abrir automatizaciones"
         }
-      }
+      },
+      "starterTasks": "Lista de tareas iniciales"
     },
     "checklist": {
       "label": "Lista de tareas",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Starter tasks now open contextual guidance, navigate to the relevant workflow, and can be restored from the Home widget picker.
**Problem:** The starter task list previously acted as a simple checklist, leaving users without task-specific guidance or a reliable way to return to dismissed tasks. **Solution:** This adds contextual task details and completion actions, preserves the sticky across related flows, coordinates project-panel and widget-picker behavior, and hardens persistence, focus, and animation lifecycle states.

<details>
<summary>File changes</summary>

**src/app/AppShell.navigation.test.tsx**
Adds integration coverage for starter-task navigation, guarded widget actions, persistent restoration, project-panel cleanup, and background focus behavior.

**src/app/AppShell.tsx**
Coordinates task selection, navigation, completion, restoration, project-panel animation, and accessibility lifecycle state.

**src/features/home/onboarding/StarterTaskList.test.tsx**
Covers task details, completion, dismissal, animation, dragging, controlled state, and accessible naming.

**src/features/home/onboarding/StarterTaskList.tsx**
Adds task-detail views, completion actions, uniform content fades, overlay dragging, project-panel positioning, and accessible controls.

**src/features/home/onboarding/StarterTasksContext.tsx**
Expands the shared starter-task contract with experiment, selection, close, and restore state.

**src/features/home/onboarding/starterTaskCompletion.test.ts**
Updates completion coverage for the final four-task list.

**src/features/home/onboarding/starterTaskCompletion.ts**
Removes the retired build-agent task derivation.

**src/features/home/onboarding/starterTaskProgress.test.ts**
Updates persisted progress expectations for the final task set.

**src/features/home/onboarding/starterTaskProgress.ts**
Updates the persisted completion shape for the final task set.

**src/features/home/onboarding/starterTasks.test.ts**
Updates task-order and completion tests.

**src/features/home/onboarding/starterTasks.ts**
Defines the final four starter tasks.

**src/features/home/ui/HomeView.test.tsx**
Covers dismissal hit areas, project-cube persistence, and disabled-experiment availability.

**src/features/home/ui/HomeView.tsx**
Keeps the project cube after dismissal and exposes starter-task restoration only when available.

**src/features/home/ui/WidgetCanvas.test.tsx**
Covers picker restoration and click-versus-pan dismissal behavior.

**src/features/home/ui/WidgetCanvas.tsx**
Keeps the picker open while panning and wires starter-task restoration.

**src/features/home/ui/WidgetPicker.tsx**
Adds the Starter task list row and removes the superseded Starter stickies row.

**src/features/home/ui/useHomeCanvasViewport.ts**
Classifies viewport gestures so picker dismissal can distinguish clicks, pans, zooms, and widget manipulation.

**src/features/home/widgets/StickyNoteWidget.tsx**
Renders the canvas starter sticky from shared selected-task state and localized detail labels.

**src/features/projects/ui/CreateProjectDialog.tsx**
Coordinates the project panel with the adjacent starter sticky, including animation and outside-interaction handling.

**src/shared/i18n/locales/en/home.json**
Adds final English task labels, contextual body copy, and accessibility strings.

**src/shared/i18n/locales/es/home.json**
Keeps Spanish localization structurally aligned with the updated starter-task experience.

</details>
