### PR TITLE
fix(ci): ad-hoc sign unsigned macos app

### DIFF
--- a/.github/workflows/unsigned-desktop-build.yml
+++ b/.github/workflows/unsigned-desktop-build.yml
@@ -75,6 +75,8 @@ jobs:
         run: |
           set -euo pipefail
           scripts/release/build-macos.sh
+          codesign --force --deep --sign - release/macos/Berd.app
+          codesign --verify --deep --strict --verbose=2 release/macos/Berd.app
           scripts/package-macos-dmg.sh release/macos/Berd.app release/macos/Berd-unsigned.dmg
 
       - name: Validate unsigned Windows packaging scripts

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -868,6 +868,12 @@ describe("desktop release workflow platform gate", () => {
     expect(workflow).toMatch(/env:\r?\n\s+JUST_UNSTABLE: ["']1["']/);
     expect(workflow).toContain("node-version: 24.10.0");
     expect(workflow).toContain("corepack prepare pnpm@10.33.0 --activate");
+    expect(workflow).toContain(
+      "codesign --force --deep --sign - release/macos/Berd.app",
+    );
+    expect(workflow).toContain(
+      "codesign --verify --deep --strict --verbose=2 release/macos/Berd.app",
+    );
     expect(workflow).toContain("just bundle-windows nsis");
     expect(workflow).not.toContain("just setup-windows");
     expect(workflow).toContain(


### PR DESCRIPTION
`build-macos.sh` intentionally stages an unsigned app for the release signing action. The unsigned desktop workflow skipped that signing stage and packaged the app with its incomplete linker-generated signature, causing strict code-signature verification to fail.

This change ad-hoc signs `release/macos/Berd.app`, verifies the complete bundle with `codesign --verify --deep --strict`, and only then packages the DMG. The release-script test now pins both commands in the unsigned workflow.

Validation: `just release-scripts-test` (70 tests passed).
