### PR TITLE
feat: add guarded release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -18,4 +18,4 @@ Anything else that helps — links, screenshots, prior art.
 
 ---
 
-Before opening: please [search open issues and PRs](https://github.com/squareup/berd/issues?q=is%3Aopen) for duplicates — link the closest one, or say "none found".
+Before opening: please [search open issues and PRs](https://github.com/block/berd/issues?q=is%3Aopen) for duplicates — link the closest one, or say "none found".

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Run frontend checks
         run: just check
 
-      - name: Verify lockstep release versions
-        run: just release-version-check
-
       - name: Run unit tests
         run: just test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run frontend checks
         run: just check
 
+      - name: Verify lockstep release versions
+        run: just release-version-check
+
       - name: Run unit tests
         run: just test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           set -euo pipefail
           scripts/release/github/verify-release-ref.sh "$TAG"
+          git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
           echo "source_sha=$(git rev-parse 'HEAD^{commit}')" >> "$GITHUB_OUTPUT"
 
       - name: Load release channel boundary
@@ -113,6 +114,19 @@ jobs:
 
       - name: Activate Hermit
         uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1
+
+      - name: Verify release source and committed version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ steps.channel.outputs.repository }}
+          SOURCE_SHA: ${{ steps.source.outputs.source_sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          just release-version-check "$VERSION"
+          scripts/release/github/verify-release-source.sh \
+            "$REPOSITORY" "$TAG" "$VERSION" "$SOURCE_SHA"
 
       - name: Ensure immutable versioned release
         env:
@@ -150,7 +164,7 @@ jobs:
       PLATFORM: ${{ needs.setup.outputs.macos_platform }}
       BERD_RELEASE_CHANNEL: public
       BERD_UPDATER_ENDPOINT: https://github.com/${{ needs.setup.outputs.repository }}/releases/download/${{ needs.setup.outputs.rolling_tag }}/latest.json
-      BERD_UPDATER_PUBLIC_KEY: ${{ vars.BERD_UPDATER_PUBLIC_KEY }}
+      BERD_UPDATER_PUBLIC_KEY: ${{ secrets.BERD_UPDATER_PUBLIC_KEY }}
     steps:
       - name: Check out verified source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -167,7 +181,7 @@ jobs:
 
       - name: Require updater public key
         run: |
-          : "${BERD_UPDATER_PUBLIC_KEY:?BERD_UPDATER_PUBLIC_KEY repository variable is required}"
+          : "${BERD_UPDATER_PUBLIC_KEY:?BERD_UPDATER_PUBLIC_KEY repository secret is required}"
 
       - name: Install locked signer tooling
         run: pnpm install --frozen-lockfile
@@ -266,7 +280,7 @@ jobs:
       PLATFORM: ${{ needs.setup.outputs.windows_platform }}
       BERD_RELEASE_CHANNEL: public
       BERD_UPDATER_ENDPOINT: https://github.com/${{ needs.setup.outputs.repository }}/releases/download/${{ needs.setup.outputs.rolling_tag }}/latest.json
-      BERD_UPDATER_PUBLIC_KEY: ${{ vars.BERD_UPDATER_PUBLIC_KEY }}
+      BERD_UPDATER_PUBLIC_KEY: ${{ secrets.BERD_UPDATER_PUBLIC_KEY }}
       # Windows selects generated [script] recipes that Just 1.40 still gates as unstable.
       JUST_UNSTABLE: "1"
     steps:
@@ -289,7 +303,7 @@ jobs:
       - name: Require updater public key
         shell: pwsh
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:BERD_UPDATER_PUBLIC_KEY)) { throw 'BERD_UPDATER_PUBLIC_KEY repository variable is required' }
+          if ([string]::IsNullOrWhiteSpace($env:BERD_UPDATER_PUBLIC_KEY)) { throw 'BERD_UPDATER_PUBLIC_KEY repository secret is required' }
 
       - name: Set up Windows build dependencies
         shell: pwsh
@@ -376,7 +390,7 @@ jobs:
       PLATFORM: ${{ needs.setup.outputs.linux_platform }}
       BERD_RELEASE_CHANNEL: public
       BERD_UPDATER_ENDPOINT: https://github.com/${{ needs.setup.outputs.repository }}/releases/download/${{ needs.setup.outputs.rolling_tag }}/latest.json
-      BERD_UPDATER_PUBLIC_KEY: ${{ vars.BERD_UPDATER_PUBLIC_KEY }}
+      BERD_UPDATER_PUBLIC_KEY: ${{ secrets.BERD_UPDATER_PUBLIC_KEY }}
       BERD_TAURI_CARGO_TARGET_DIR: ${{ github.workspace }}/src-tauri/target
     steps:
       - name: Check out verified source
@@ -405,7 +419,7 @@ jobs:
 
       - name: Require updater public key
         run: |
-          : "${BERD_UPDATER_PUBLIC_KEY:?BERD_UPDATER_PUBLIC_KEY repository variable is required}"
+          : "${BERD_UPDATER_PUBLIC_KEY:?BERD_UPDATER_PUBLIC_KEY repository secret is required}"
 
       - name: Set up Linux release dependencies and locked signer tooling
         run: |
@@ -503,7 +517,7 @@ jobs:
       BERD_WRITES_DATA_EPOCH: "1"
       BERD_MIN_READABLE_DATA_EPOCH: "1"
       BERD_MAX_READABLE_DATA_EPOCH: "1"
-      BERD_UPDATER_PUBLIC_KEY: ${{ vars.BERD_UPDATER_PUBLIC_KEY }}
+      BERD_UPDATER_PUBLIC_KEY: ${{ secrets.BERD_UPDATER_PUBLIC_KEY }}
     steps:
       - name: Check out verified source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,8 +414,7 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev \
-            rpm
+            librsvg2-dev
 
       - name: Require updater public key
         run: |
@@ -442,7 +441,7 @@ jobs:
           VITE_APP_VERSION="$VERSION" \
           VITE_ENVIRONMENT=production \
           VITE_UPDATER_ENABLED=true \
-          pnpm tauri build --bundles appimage,deb,rpm --features berdctl \
+          pnpm tauri build --bundles appimage,deb --features berdctl \
             --config src-tauri/tauri.release.conf.json
 
       - name: Package and sign Linux updater archive
@@ -454,24 +453,20 @@ jobs:
           bundle_dir="$BERD_TAURI_CARGO_TARGET_DIR/release/bundle"
           built_appimage=$(find "$bundle_dir/appimage" -maxdepth 1 -type f -name '*.AppImage' -print -quit)
           built_deb=$(find "$bundle_dir/deb" -maxdepth 1 -type f -name '*.deb' -print -quit)
-          built_rpm=$(find "$bundle_dir/rpm" -maxdepth 1 -type f -name '*.rpm' -print -quit)
           : "${built_appimage:?Linux build produced no AppImage}"
           : "${built_deb:?Linux build produced no deb}"
-          : "${built_rpm:?Linux build produced no rpm}"
           asset_dir="$RUNNER_TEMP/release-assets"
           mkdir -p "$asset_dir"
           appimage_name="Berd_${VERSION}_${PLATFORM}.AppImage"
           deb_name="Berd_${VERSION}_${PLATFORM}.deb"
-          rpm_name="Berd_${VERSION}_${PLATFORM}.rpm"
           cp "$built_deb" "$asset_dir/$deb_name"
-          cp "$built_rpm" "$asset_dir/$rpm_name"
           scripts/release/package-signed-updater-linux.sh \
             --appimage "$built_appimage" \
             --version "$VERSION" \
             --output-dir "$asset_dir"
           archive_name="$(source scripts/release/lib.sh; release_archive_name "$VERSION" "$PLATFORM")"
           just release-write-provenance "$SOURCE_SHA" "$VERSION" "$PLATFORM" "$asset_dir" \
-            "$appimage_name" "$deb_name" "$rpm_name" \
+            "$appimage_name" "$deb_name" \
             "$archive_name" "$archive_name.sig" "$archive_name.sha256"
           echo "asset_dir=$asset_dir" >> "$GITHUB_ENV"
 
@@ -490,7 +485,6 @@ jobs:
           scripts/release/github/upload-immutable-assets.sh "$REPOSITORY" "$TAG" \
             "$asset_dir/Berd_${VERSION}_${PLATFORM}.AppImage" \
             "$asset_dir/Berd_${VERSION}_${PLATFORM}.deb" \
-            "$asset_dir/Berd_${VERSION}_${PLATFORM}.rpm" \
             "$asset_dir/$archive_name" "$asset_dir/$archive_name.sig" \
             "$asset_dir/$archive_name.sha256" "$asset_dir/$provenance_name"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/bb-cli/docs/RELEASING-sq.md
+++ b/bb-cli/docs/RELEASING-sq.md
@@ -101,7 +101,7 @@ The current shape in `../homebrew-formulas/sq-kgoose.rb` is:
 class SqKgoose < Formula
   version "0.1.0"
   stable do
-    url "https://github.com/squareup/berd.git", tag: version.to_s
+    url "https://github.com/block/berd.git", tag: version.to_s
   end
 
   @sq_pack = {

--- a/docker/linux/Dockerfile
+++ b/docker/linux/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     patchelf \
     protobuf-compiler \
-    rpm \
     xz-utils \
     zstd \
   && if apt-cache show libwebkit2gtk-4.1-dev >/dev/null 2>&1; then \

--- a/docs/release-and-updates.md
+++ b/docs/release-and-updates.md
@@ -6,11 +6,13 @@ The endpoint and verification key form one trust contract. `scripts/release/buil
 
 ## Feed and assets
 
-The release boundary is centralized in `scripts/release/release-channel.json`. While the repository remains at `squareup/berd`, its rolling release endpoint is:
+The release boundary is centralized in `scripts/release/release-channel.json`. The rolling release endpoint is:
 
-`https://github.com/squareup/berd/releases/download/berd-desktop-latest/latest.json`
+`https://github.com/block/berd/releases/download/berd-desktop-latest/latest.json`
 
-The repository is expected to move to `block/berd`. Update the repository value and derived URLs only as part of that transfer so documentation and shipped clients continue to match the active release location.
+Public releases must be at least `0.6.0-rc.1`. The app, bundled `berdctl`,
+internal `tauri-plugin-berdctl`, their Cargo lock entries, and the changelog are
+validated at the immutable tag before GitHub creates a release.
 
 A version `X.Y.Z` publishes architecture-qualified assets for macOS, Windows, and Linux:
 
@@ -36,14 +38,17 @@ The updater manifest contains `darwin-aarch64`, `windows-x86_64`, and `linux-x86
 
 Release tags use canonical SemVer without build metadata, such as `v1.2.3` or `v1.2.3-rc.1`.
 
-1. An authorized maintainer creates and pushes a protected `v<semver>` tag.
-2. The workflow verifies that the checkout, local tag, and canonical remote tag resolve to the same commit.
-3. It creates or safely resumes an immutable versioned GitHub release.
-4. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb/rpm packages.
-5. The macOS signing action signs, notarizes, and staples its artifacts. The Windows NSIS installer and Linux packages are published without platform-native code signatures.
-6. Each platform produces a minisign-signed updater archive, SHA-256 digest, and attested source-bound provenance receipt. Minisign authenticates the Windows and Linux updater archives even though their enclosed payloads lack platform-native code signatures.
-7. Promotion waits for all three platform jobs and approval in the GitHub `release` environment, then re-downloads and verifies every immutable staged artifact. It rejects version downgrades, rejects changed same-version manifests, and rechecks the rolling manifest immediately before publication.
-8. The promotion script uploads all three platform payloads and uploads a three-platform `latest.json` last.
+1. Draft notes with `just release-notes ... output=/tmp/vX.Y.Z.md`, then review the Markdown.
+2. Run `just release-prepare X.Y.Z /tmp/vX.Y.Z.md`. It creates `release/vX.Y.Z`, synchronizes every release version and Cargo lock entry, updates `CHANGELOG.md`, validates, commits, pushes, and opens a PR.
+3. Review and squash-merge the release PR after CI passes.
+4. Run `just release-publish X.Y.Z`. It resolves the PR's squash-merge commit, verifies the committed release state, creates an annotated tag on that exact commit, and pushes only `refs/tags/vX.Y.Z`.
+5. The workflow verifies that the checkout and canonical remote tag resolve to the same main-reachable commit and that the tag is annotated.
+6. It creates or safely resumes an immutable versioned GitHub release using the matching `CHANGELOG.md` section.
+7. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb/rpm packages.
+8. The macOS signing action signs, notarizes, and staples its artifacts. The Windows NSIS installer and Linux packages are published without platform-native code signatures.
+9. Each platform produces a minisign-signed updater archive, SHA-256 digest, and attested source-bound provenance receipt. Minisign authenticates the Windows and Linux updater archives even though their enclosed payloads lack platform-native code signatures.
+10. Promotion waits for all three platform jobs and approval in the GitHub `release` environment, then re-downloads and verifies every immutable staged artifact. It rejects version downgrades, rejects changed same-version manifests, and rechecks the rolling manifest immediately before publication.
+11. The promotion script uploads all three platform payloads and uploads a three-platform `latest.json` last.
 
 Uploading the manifest last keeps installed clients on the previous release if staging or verification fails. Rollback is a new, higher patch release containing reverted code rather than a lower manifest version.
 
@@ -55,12 +60,12 @@ Recovery is limited to the same immutable tag and source:
 
 ```bash
 gh workflow run release.yml \
-  --repo squareup/berd \
+  --repo block/berd \
   --ref v1.2.3 \
   -f tag=v1.2.3
 ```
 
-Change `--repo` to `block/berd` after the repository transfer. Recovery verifies the selected tag. A complete platform payload is reused only after its attested receipt is checked during promotion; an incomplete platform payload is deleted as a unit and rebuilt before promotion.
+Recovery verifies the selected tag and is source-bound to that immutable tag and commit. A complete platform payload is reused only after its attested receipt is checked during promotion; an incomplete platform payload is deleted as a unit and rebuilt before promotion.
 
 ## Downstream distributions
 
@@ -74,14 +79,17 @@ configuration, stamps the suffixed version, stages resources, and builds the
 unsigned app; distribution-specific orchestration and artifact destinations do
 not live in this repository.
 
-## Repository transfer
+## GitHub repository setup
 
-When the repository moves from `squareup/berd` to `block/berd`:
+`block/berd` must have a `release` environment that requires maintainer review,
+prevents self-approval, and allows deployments only from `v*` tags. Configure
+the `BERD_UPDATER_PUBLIC_KEY`, `TAURI_SIGNING_PRIVATE_KEY`,
+`TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, `OSX_CODESIGN_ROLE`, and
+`CODESIGN_S3_BUCKET` secrets used by the workflow.
 
-1. Update `repository` in `scripts/release/release-channel.json`.
-2. Recreate the release environment, updater and macOS signing configuration, and protected tag rules at the destination.
-3. Preserve updater feed and signing-key continuity for already-installed builds. If release-asset URLs do not redirect after transfer, publish a bridge release or retain the old rolling feed.
-4. Run a non-promoting tagged rehearsal, approve promotion, and verify anonymous archive and manifest access before announcing the new feed.
+Protect `v*` with paired repository rulesets: one restricts tag creation to
+release maintainers, while the other has no bypass and blocks tag updates,
+deletion, and force changes.
 
 ## Verification before promotion
 
@@ -99,6 +107,8 @@ When the repository moves from `squareup/berd` to `block/berd`:
 |---|---|
 | `scripts/release/release-channel.json` | Repository, rolling tag, and platform boundary |
 | `scripts/release/lib.sh` | Release validation, naming, paths, and explicit inputs |
+| `scripts/release/version.mjs` | Shared canonical SemVer parsing and comparison |
+| `scripts/release/release.mjs` | Lockstep version checks and prepare/publish maintainer commands |
 | `scripts/release/build-macos.sh` | Version, resources, sidecar, and macOS build |
 | `scripts/release/build-tauri-release-config.mjs` | Fail-closed updater profile overlay |
 | `scripts/release/package-signed-updater.sh` | macOS signed-app verification, archive, signature, and digest |

--- a/docs/release-and-updates.md
+++ b/docs/release-and-updates.md
@@ -38,17 +38,16 @@ The updater manifest contains `darwin-aarch64`, `windows-x86_64`, and `linux-x86
 
 Release tags use canonical SemVer without build metadata, such as `v1.2.3` or `v1.2.3-rc.1`.
 
-1. Draft notes with `just release-notes ... output=/tmp/vX.Y.Z.md`, then review the Markdown.
-2. Run `just release-prepare X.Y.Z /tmp/vX.Y.Z.md`. It creates `release/vX.Y.Z`, synchronizes every release version and Cargo lock entry, updates `CHANGELOG.md`, validates, commits, pushes, and opens a PR.
-3. Review and squash-merge the release PR after CI passes.
-4. Run `just release-publish X.Y.Z`. It resolves the PR's squash-merge commit, verifies the committed release state, creates an annotated tag on that exact commit, and pushes only `refs/tags/vX.Y.Z`.
-5. The workflow verifies that the checkout and canonical remote tag resolve to the same main-reachable commit and that the tag is annotated.
-6. It creates or safely resumes an immutable versioned GitHub release using the matching `CHANGELOG.md` section.
-7. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb/rpm packages.
-8. The macOS signing action signs, notarizes, and staples its artifacts. The Windows NSIS installer and Linux packages are published without platform-native code signatures.
-9. Each platform produces a minisign-signed updater archive, SHA-256 digest, and attested source-bound provenance receipt. Minisign authenticates the Windows and Linux updater archives even though their enclosed payloads lack platform-native code signatures.
-10. Promotion waits for all three platform jobs and approval in the GitHub `release` environment, then re-downloads and verifies every immutable staged artifact. It rejects version downgrades, rejects changed same-version manifests, and rechecks the rolling manifest immediately before publication.
-11. The promotion script uploads all three platform payloads and uploads a three-platform `latest.json` last.
+1. Run `just release-prepare X.Y.Z`. It generates and prints release notes, requires explicit approval, then creates `release/vX.Y.Z`, synchronizes every release version and Cargo lock entry, updates `CHANGELOG.md`, validates, commits, pushes, and opens a PR.
+2. Review and squash-merge the release PR after CI passes.
+3. Run `just release-publish X.Y.Z`. It resolves the PR's squash-merge commit, verifies the committed release state, creates an annotated tag on that exact commit, and pushes only `refs/tags/vX.Y.Z`.
+4. The workflow verifies that the checkout and canonical remote tag resolve to the same main-reachable commit and that the tag is annotated.
+5. It creates or safely resumes an immutable versioned GitHub release using the matching `CHANGELOG.md` section.
+6. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb/rpm packages.
+7. The macOS signing action signs, notarizes, and staples its artifacts. The Windows NSIS installer and Linux packages are published without platform-native code signatures.
+8. Each platform produces a minisign-signed updater archive, SHA-256 digest, and attested source-bound provenance receipt. Minisign authenticates the Windows and Linux updater archives even though their enclosed payloads lack platform-native code signatures.
+9. Promotion waits for all three platform jobs and approval in the GitHub `release` environment, then re-downloads and verifies every immutable staged artifact. It rejects version downgrades, rejects changed same-version manifests, and rechecks the rolling manifest immediately before publication.
+10. The promotion script uploads all three platform payloads and uploads a three-platform `latest.json` last.
 
 Uploading the manifest last keeps installed clients on the previous release if staging or verification fails. Rollback is a new, higher patch release containing reverted code rather than a lower manifest version.
 

--- a/docs/release-and-updates.md
+++ b/docs/release-and-updates.md
@@ -27,7 +27,6 @@ A version `X.Y.Z` publishes architecture-qualified assets for macOS, Windows, an
 - `Berd_X.Y.Z_windows-x86_64-setup.nsis.zip.sha256`
 - `Berd_X.Y.Z_linux-x86_64.AppImage`
 - `Berd_X.Y.Z_linux-x86_64.deb`
-- `Berd_X.Y.Z_linux-x86_64.rpm`
 - `Berd_X.Y.Z_linux-x86_64.AppImage.tar.gz`
 - `Berd_X.Y.Z_linux-x86_64.AppImage.tar.gz.sig`
 - `Berd_X.Y.Z_linux-x86_64.AppImage.tar.gz.sha256`
@@ -43,7 +42,7 @@ Release tags use canonical SemVer without build metadata, such as `v1.2.3` or `v
 3. Run `just release-publish X.Y.Z`. It resolves the PR's squash-merge commit, verifies the committed release state, creates an annotated tag on that exact commit, and pushes only `refs/tags/vX.Y.Z`.
 4. The workflow verifies that the checkout and canonical remote tag resolve to the same main-reachable commit and that the tag is annotated.
 5. It creates or safely resumes an immutable versioned GitHub release using the matching `CHANGELOG.md` section.
-6. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb/rpm packages.
+6. The platform jobs produce the macOS app/DMG, Windows NSIS installer, and Linux AppImage/deb packages.
 7. The macOS signing action signs, notarizes, and staples its artifacts. The Windows NSIS installer and Linux packages are published without platform-native code signatures.
 8. Each platform produces a minisign-signed updater archive, SHA-256 digest, and attested source-bound provenance receipt. Minisign authenticates the Windows and Linux updater archives even though their enclosed payloads lack platform-native code signatures.
 9. Promotion waits for all three platform jobs and approval in the GitHub `release` environment, then re-downloads and verifies every immutable staged artifact. It rejects version downgrades, rejects changed same-version manifests, and rechecks the rolling manifest immediately before publication.

--- a/docs/windows-onboarding.md
+++ b/docs/windows-onboarding.md
@@ -72,7 +72,7 @@ Bootstrap installs or validates:
 
 Bootstrap does not create or mutate npm registry or TLS configuration. If your environment uses a registry mirror, proxy, or custom certificate authority, configure those through your normal Node/npm tooling before running `just setup-windows`. Never bypass TLS verification with `strict-ssl=false`.
 
-> **Current limitation:** the checked-in Windows scripts still validate a legacy organization-specific npm mirror. External contributors cannot complete `doctor-windows` or `setup-windows` on a fresh machine until those checks are made distribution-neutral. This guide intentionally does not publish the private environment configuration; contributors working on Windows should follow [the tracking issue](https://github.com/squareup/berd/issues) or use the supported macOS setup in the meantime.
+> **Current limitation:** the checked-in Windows scripts still validate a legacy organization-specific npm mirror. External contributors cannot complete `doctor-windows` or `setup-windows` on a fresh machine until those checks are made distribution-neutral. This guide intentionally does not publish the private environment configuration; contributors working on Windows should follow [the tracking issue](https://github.com/block/berd/issues) or use the supported macOS setup in the meantime.
 
 Open a fresh PowerShell after install mode if PATH changes are not visible.
 

--- a/justfile
+++ b/justfile
@@ -228,7 +228,7 @@ _tauri-test-windows:
     just _tauri-cargo-windows test -p berdctl
 
 # Run the local CI gate.
-ci: check tauri-fmt-check tauri-check tauri-test clippy test release-scripts-test build
+ci: release-version-check check tauri-fmt-check tauri-check tauri-test clippy test release-scripts-test build
 
 # Native x64 MSVC CI gate for the managed Node runtime + ACP bridge.
 # Runs the managed_node / managed_acp_tools module tests (including the
@@ -240,6 +240,27 @@ ci-windows:
 # Run release/updater script tests.
 release-scripts-test:
     pnpm test:release-scripts
+
+# Verify lockstep app, CLI, plugin, and Cargo.lock versions. An expected version
+# also requires the matching linked CHANGELOG.md entry.
+release-version-check expected="":
+    node scripts/release/release.mjs version-check {{ quote(expected) }}
+
+# Focused validation used by release preparation and release PRs.
+release-validate expected="":
+    node scripts/release/release.mjs version-check {{ quote(expected) }}
+    cargo metadata --locked --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml >/dev/null
+    pnpm test:release-scripts
+
+# Prepare, push, and open a reviewed release PR. This never merges or tags.
+[unix]
+release-prepare version notes_file:
+    node scripts/release/release.mjs prepare {{ quote(version) }} {{ quote(notes_file) }}
+
+# Sign and publish the immutable tag for an already squash-merged release PR.
+[unix]
+release-publish version:
+    node scripts/release/release.mjs publish {{ quote(version) }}
 
 # Create or verify the immutable GitHub release for a tag.
 [unix]
@@ -576,10 +597,11 @@ bump-goose ref="main":
 bump-node-runtime *ARGS:
     node scripts/update-node-runtime-lock.mjs {{ ARGS }}
 
-# Generate release notes from commits since the previous release tag (formatting guidelines: scripts/release-notes-prompt.md).
+# Draft release notes from commits without mutating GitHub. Pass output=<path>
+# to create the file consumed by release-prepare.
 [unix]
-release-notes from="" to="HEAD":
-    FROM_REF="{{ from }}" TO_REF="{{ to }}" ./scripts/generate-release-notes.sh
+release-notes from="" to="HEAD" output="":
+    FROM_REF="{{ from }}" TO_REF="{{ to }}" NOTES_FILE="{{ output }}" ./scripts/generate-release-notes.sh
 
 # ── Utilities ────────────────────────────────────────────────
 

--- a/justfile
+++ b/justfile
@@ -392,12 +392,12 @@ _bundle-unix:
 bundle-macos:
     ./scripts/build_darwin.sh
 
-# Build Linux deb, rpm, and AppImage bundles. Must run on Linux.
+# Build Linux deb and AppImage bundles. Must run on Linux.
 [linux]
 bundle-linux:
     ./scripts/build_linux.sh
 
-# Build Linux deb, rpm, and AppImage bundles inside Docker.
+# Build Linux deb and AppImage bundles inside Docker.
 [linux]
 bundle-linux-docker:
     ./scripts/build_linux_docker.sh

--- a/justfile
+++ b/justfile
@@ -252,10 +252,11 @@ release-validate expected="":
     cargo metadata --locked --no-deps --format-version 1 --manifest-path src-tauri/Cargo.toml >/dev/null
     pnpm test:release-scripts
 
-# Prepare, push, and open a reviewed release PR. This never merges or tags.
+# Generate and approve notes, then prepare, push, and open a release PR.
+# This never merges or tags.
 [unix]
-release-prepare version notes_file:
-    node scripts/release/release.mjs prepare {{ quote(version) }} {{ quote(notes_file) }}
+release-prepare version:
+    node scripts/release/release.mjs prepare {{ quote(version) }}
 
 # Sign and publish the immutable tag for an already squash-merged release PR.
 [unix]
@@ -597,11 +598,10 @@ bump-goose ref="main":
 bump-node-runtime *ARGS:
     node scripts/update-node-runtime-lock.mjs {{ ARGS }}
 
-# Draft release notes from commits without mutating GitHub. Pass output=<path>
-# to create the file consumed by release-prepare.
+# Draft release notes from commits without mutating GitHub.
 [unix]
-release-notes from="" to="HEAD" output="":
-    FROM_REF="{{ from }}" TO_REF="{{ to }}" NOTES_FILE="{{ output }}" ./scripts/generate-release-notes.sh
+release-notes from="" to="HEAD":
+    FROM_REF="{{ from }}" TO_REF="{{ to }}" ./scripts/generate-release-notes.sh
 
 # ── Utilities ────────────────────────────────────────────────
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -23,6 +23,6 @@ require rustc
 require jq
 
 # Tauri reads src-tauri/tauri.conf.json and emits the configured Linux bundles:
-# deb, rpm, and AppImage. System packages such as webkitgtk, librsvg, rpm, and
-# appimage tooling still need to be provided by the Linux builder image.
+# deb and AppImage. System packages such as webkitgtk, librsvg, and appimage
+# tooling still need to be provided by the Linux builder image.
 exec just bundle

--- a/scripts/build_linux_docker.sh
+++ b/scripts/build_linux_docker.sh
@@ -110,7 +110,7 @@ fi
 
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
-find "$bundle_dir" -type f \( -name '*.deb' -o -name '*.rpm' -o -name '*.AppImage' \) \
+find "$bundle_dir" -type f \( -name '*.deb' -o -name '*.AppImage' \) \
   -exec cp '{}' "$OUTPUT_DIR/" \;
 
 echo "Linux Docker bundle artifacts:"

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Generate release notes from commits since the previous release tag.
+# Draft release notes from commits since the previous release tag.
 #
 # Usage:
 #   ./scripts/generate-release-notes.sh [from-ref] [to-ref]
@@ -19,7 +19,7 @@ if [[ -z "$RELEASE_REPOSITORY" && -f "$REPO_ROOT/scripts/release/release-channel
   RELEASE_REPOSITORY="$(jq -er .repository "$REPO_ROOT/scripts/release/release-channel.json")"
 fi
 if [[ -z "$RELEASE_REPOSITORY" ]]; then
-  echo "BERD_REPO must be configured for release-note publishing." >&2
+  echo "BERD_REPO must be configured for release-note generation." >&2
   exit 1
 fi
 
@@ -84,56 +84,10 @@ NOTES="${NOTES}
 
 **Full Changelog**: https://github.com/${RELEASE_REPOSITORY}/compare/${FROM_REF}...${COMPARE_TO}"
 
-echo
-echo "$NOTES"
-echo >&2
-
-# Publishing requires a real tag to target; a symbolic ref like HEAD has no
-# corresponding GitHub release.
-if [[ "$TO_REF" == "HEAD" ]]; then
-  echo "to-ref is HEAD, not a release tag; skipping publish." >&2
-  exit 0
+if [[ -n "${NOTES_FILE:-}" ]]; then
+  printf '%s\n' "$NOTES" > "$NOTES_FILE"
+  echo "Drafted release notes at $NOTES_FILE; review them before release preparation." >&2
+else
+  printf '\n%s\n' "$NOTES"
+  echo "Draft only; review these notes before release preparation." >&2
 fi
-
-# Review gate: require explicit acceptance before publishing.
-read -r -p "Accept these release notes and publish to the GitHub release ${TO_REF}? [y/N] " REPLY
-if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
-  echo "Rejected; not publishing." >&2
-  exit 1
-fi
-
-echo "Publishing release notes for ${TO_REF}..." >&2
-
-# The release body may carry provenance from release automation. Editing the
-# release replaces the whole body, so preserve the existing body by appending it
-# after the new notes.
-EXISTING_BODY="$(gh release view "$TO_REF" --repo "$RELEASE_REPOSITORY" --json body -q .body 2>/dev/null || true)"
-if [[ -n "$EXISTING_BODY" ]]; then
-  NOTES="${NOTES}
-
----
-
-${EXISTING_BODY}"
-fi
-
-# Second goose run with the developer extension enabled so the agent can use
-# the gh CLI to update the release.
-goose run --quiet --no-session --no-profile --with-builtin developer --instructions - <<EOF
-You are publishing release notes for the configured public repository (${RELEASE_REPOSITORY}).
-
-Use the \`gh\` CLI to set the notes on the GitHub release for tag \`${TO_REF}\`:
-
-1. Verify the release exists: \`gh release view ${TO_REF} --repo ${RELEASE_REPOSITORY}\`.
-   If it does not exist, stop and report that — do not create a release.
-2. Update only the release notes body, leaving title, tag, target, and assets
-   unchanged. Write the notes below to a temp file and run:
-   \`gh release edit ${TO_REF} --repo ${RELEASE_REPOSITORY} --notes-file <tempfile>\`.
-3. Confirm the update succeeded and print the release URL.
-
-Use the release notes below verbatim — do not edit, reformat, or summarize
-them. They already include any existing release provenance at the end; keep it.
-
----BEGIN RELEASE NOTES---
-${NOTES}
----END RELEASE NOTES---
-EOF

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -84,10 +84,5 @@ NOTES="${NOTES}
 
 **Full Changelog**: https://github.com/${RELEASE_REPOSITORY}/compare/${FROM_REF}...${COMPARE_TO}"
 
-if [[ -n "${NOTES_FILE:-}" ]]; then
-  printf '%s\n' "$NOTES" > "$NOTES_FILE"
-  echo "Drafted release notes at $NOTES_FILE; review them before release preparation." >&2
-else
-  printf '\n%s\n' "$NOTES"
-  echo "Draft only; review these notes before release preparation." >&2
-fi
+printf '\n%s\n' "$NOTES"
+echo "Draft only; review these notes before release preparation." >&2

--- a/scripts/release/github/ensure-versioned-release.sh
+++ b/scripts/release/github/ensure-versioned-release.sh
@@ -26,10 +26,19 @@ validate_source_sha "$SOURCE_SHA" || exit 1
   exit 1
 }
 
+changelog_path="${BERD_CHANGELOG_PATH:-$REPO_ROOT/CHANGELOG.md}"
+changelog_notes="$(
+  node "$REPO_ROOT/scripts/release/release.mjs" \
+    changelog-notes "$VERSION" "$changelog_path"
+)"
+notes="$(printf '%s\n\n---\n\nSource commit: `%s`\n\nThe Windows NSIS installer and Linux packages lack platform-native code signatures; their updater archives remain minisign-authenticated.\n' "$changelog_notes" "$SOURCE_SHA")"
+
 if gh release view "$TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
-  existing_release="$(gh release view "$TAG" --repo "$REPOSITORY" --json tagName,isDraft)"
+  existing_release="$(gh release view "$TAG" --repo "$REPOSITORY" --json tagName,isDraft,name,body)"
   existing_tag="$(jq -r .tagName <<< "$existing_release")"
   is_draft="$(jq -r .isDraft <<< "$existing_release")"
+  existing_name="$(jq -r .name <<< "$existing_release")"
+  existing_body="$(jq -r .body <<< "$existing_release")"
   [[ "$existing_tag" == "$TAG" ]] || {
     release_error "existing release tag mismatch: $existing_tag"
     exit 1
@@ -38,13 +47,20 @@ if gh release view "$TAG" --repo "$REPOSITORY" >/dev/null 2>&1; then
     release_error "existing versioned release must not be a draft: $TAG"
     exit 1
   }
+  [[ "$existing_name" == "Berd v$VERSION" ]] || {
+    release_error "existing release title mismatch: $existing_name"
+    exit 1
+  }
+  [[ "$existing_body" == "$notes" ]] || {
+    release_error "existing release notes do not match CHANGELOG.md: $TAG"
+    exit 1
+  }
   echo "Using existing versioned release $TAG"
 else
   prerelease=()
   if [[ "$VERSION" == *-* ]]; then
     prerelease=(--prerelease --latest=false)
   fi
-  notes="$(printf 'Berd v%s\n\nSource commit: `%s`\n\nThe Windows NSIS installer and Linux packages lack platform-native code signatures; their updater archives remain minisign-authenticated.\n' "$VERSION" "$SOURCE_SHA")"
   gh release create "$TAG" \
     --repo "$REPOSITORY" \
     --verify-tag \

--- a/scripts/release/github/reconcile-staged-assets.sh
+++ b/scripts/release/github/reconcile-staged-assets.sh
@@ -49,8 +49,7 @@ platform_assets() {
     linux-*)
       printf '%s\n' \
         "Berd_${VERSION}_${platform}.AppImage" \
-        "Berd_${VERSION}_${platform}.deb" \
-        "Berd_${VERSION}_${platform}.rpm"
+        "Berd_${VERSION}_${platform}.deb"
       ;;
   esac
   printf '%s\n' "$archive" "$archive.sig" "$archive.sha256" "$provenance"

--- a/scripts/release/github/verify-release-ref.sh
+++ b/scripts/release/github/verify-release-ref.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Verify a release checkout is bound to an existing immutable v<semver> tag on
-# the canonical remote. Handles lightweight and annotated tags.
+# Verify a release checkout is bound to an existing immutable annotated
+# v<semver> tag on the canonical remote.
 set -euo pipefail
 [[ $# -eq 1 ]] || { echo "Usage: $0 <v-prefixed-tag>" >&2; exit 2; }
 
@@ -9,6 +9,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib.sh"
 TAG="$1"
 validate_release_tag "$TAG" || exit 1
+
+[[ "$(git cat-file -t "refs/tags/$TAG" 2>/dev/null)" == "tag" ]] || {
+  echo "release tag must be annotated: $TAG" >&2
+  exit 1
+}
 
 HEAD_SHA="$(git rev-parse 'HEAD^{commit}')"
 TAG_SHA="$(git rev-parse "refs/tags/${TAG}^{commit}" 2>/dev/null)" || {

--- a/scripts/release/github/verify-release-source.sh
+++ b/scripts/release/github/verify-release-source.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Verify the immutable, annotated, main-reachable source before creating a release.
+set -euo pipefail
+
+[[ $# -eq 4 ]] || {
+  echo "Usage: $0 <repository> <v-prefixed-tag> <version> <source-sha>" >&2
+  exit 2
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+REPOSITORY="$1"
+TAG="$2"
+VERSION="$3"
+SOURCE_SHA="$4"
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+validate_repository "$REPOSITORY"
+validate_release_tag "$TAG"
+validate_release_version "$VERSION"
+validate_source_sha "$SOURCE_SHA"
+[[ "$TAG" == "v$VERSION" ]] || release_error "tag/version mismatch: $TAG vs $VERSION"
+validate_minimum_public_version "$VERSION" "${BERD_RELEASE_CHANNEL_CONFIG:-}"
+[[ "$REPOSITORY" == "$RELEASE_REPOSITORY" ]] ||
+  release_error "release repository mismatch: $REPOSITORY vs $RELEASE_REPOSITORY"
+
+[[ "$(git rev-parse 'HEAD^{commit}')" == "$SOURCE_SHA" ]] ||
+  release_error "HEAD does not match release source $SOURCE_SHA"
+[[ "$(git cat-file -t "refs/tags/$TAG")" == "tag" ]] ||
+  release_error "release tag must be annotated: $TAG"
+LOCAL_TAG_OBJECT="$(git rev-parse "refs/tags/$TAG")"
+[[ "$(git rev-parse "refs/tags/$TAG^{commit}")" == "$SOURCE_SHA" ]] ||
+  release_error "release tag does not target $SOURCE_SHA"
+git merge-base --is-ancestor "$SOURCE_SHA" refs/remotes/origin/main ||
+  release_error "release source is not reachable from origin/main"
+
+REMOTE_REF="$(gh api "repos/$REPOSITORY/git/ref/tags/$TAG")"
+REMOTE_TYPE="$(jq -r '.object.type' <<< "$REMOTE_REF")"
+REMOTE_TAG_OBJECT="$(jq -r '.object.sha' <<< "$REMOTE_REF")"
+[[ "$REMOTE_TYPE" == "tag" ]] ||
+  release_error "GitHub release tag must be annotated: $TAG"
+[[ "$REMOTE_TAG_OBJECT" == "$LOCAL_TAG_OBJECT" ]] ||
+  release_error "local and GitHub tag objects disagree for $TAG"
+
+TAG_OBJECT="$(gh api "repos/$REPOSITORY/git/tags/$REMOTE_TAG_OBJECT")"
+[[ "$(jq -r '.object.type' <<< "$TAG_OBJECT")" == "commit" ]] ||
+  release_error "release tag must target a commit"
+[[ "$(jq -r '.object.sha' <<< "$TAG_OBJECT")" == "$SOURCE_SHA" ]] ||
+  release_error "GitHub release tag does not target $SOURCE_SHA"
+echo "verified annotated $TAG at $SOURCE_SHA on origin/main"

--- a/scripts/release/github/verify-versioned-release.sh
+++ b/scripts/release/github/verify-versioned-release.sh
@@ -67,7 +67,6 @@ case "$PLATFORM" in
     EXPECTED_ASSETS=(
       "Berd_${VERSION}_${PLATFORM}.AppImage"
       "Berd_${VERSION}_${PLATFORM}.deb"
-      "Berd_${VERSION}_${PLATFORM}.rpm"
     )
     ;;
   *)

--- a/scripts/release/lib.sh
+++ b/scripts/release/lib.sh
@@ -44,7 +44,6 @@ activate_hermit() {
   . "$REPO_ROOT/bin/activate-hermit"
 }
 
-SEMVER_PATTERN='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
 RELEASE_PLATFORM_PATTERN='^(darwin-(aarch64|x86_64)|windows-x86_64|linux-x86_64)$'
 REPOSITORY_PATTERN='^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'
 ROLLING_TAG_PATTERN='^[A-Za-z0-9_.-]+$'
@@ -64,7 +63,7 @@ trim_whitespace() {
 
 validate_release_version() {
   local version="$1"
-  [[ "$version" =~ $SEMVER_PATTERN ]] ||
+  node "$REPO_ROOT/scripts/release/version.mjs" validate "$version" >/dev/null ||
     release_error "refusing to use non-canonical semver without build metadata: $version"
 }
 
@@ -166,6 +165,7 @@ load_release_channel() {
   fi
   RELEASE_REPOSITORY="$(jq -er '.repository' "$config")"
   RELEASE_ROLLING_TAG="$(jq -er '.rollingTag' "$config")"
+  RELEASE_MINIMUM_PUBLIC_VERSION="$(jq -er '.minimumPublicVersion' "$config")"
   RELEASE_PLATFORMS=()
   while IFS= read -r platform; do
     [[ -n "$platform" ]] && RELEASE_PLATFORMS+=("$platform")
@@ -183,6 +183,7 @@ load_release_channel() {
   )
   validate_repository "$RELEASE_REPOSITORY"
   validate_rolling_tag "$RELEASE_ROLLING_TAG"
+  validate_release_version "$RELEASE_MINIMUM_PUBLIC_VERSION"
   local platform seen_platforms='|'
   for platform in "${RELEASE_PLATFORMS[@]}"; do
     validate_release_platform "$platform" || return 1
@@ -192,6 +193,14 @@ load_release_channel() {
     }
     seen_platforms="${seen_platforms}${platform}|"
   done
+}
+
+validate_minimum_public_version() {
+  local version="$1"
+  local config="${2:-}"
+  load_release_channel "$config"
+  node "$REPO_ROOT/scripts/release/version.mjs" at-least \
+    "$version" "$RELEASE_MINIMUM_PUBLIC_VERSION"
 }
 
 release_input_version() {

--- a/scripts/release/release-channel.json
+++ b/scripts/release/release-channel.json
@@ -1,5 +1,6 @@
 {
-  "repository": "squareup/berd",
+  "repository": "block/berd",
   "rollingTag": "berd-desktop-latest",
+  "minimumPublicVersion": "0.6.0-rc.1",
   "platforms": ["darwin-aarch64", "windows-x86_64", "linux-x86_64"]
 }

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -216,8 +216,8 @@ export function updateChangelog(content, version, notes, date, repository) {
   return `${prefix}${newEntry}${existingEntries ? `\n\n${existingEntries}` : ""}\n`;
 }
 
-async function fileReader(root) {
-  return async (path) => readFile(join(root, path), "utf8");
+function fileReader(root) {
+  return (path) => readFile(join(root, path), "utf8");
 }
 
 function gitReader(root, ref) {
@@ -282,9 +282,7 @@ async function releaseConfig(read) {
 export async function checkVersions({ root, expected, ref } = {}) {
   const resolvedRoot = root || repoRoot();
   if (expected) parseSemver(expected, "expected version");
-  const read = ref
-    ? gitReader(resolvedRoot, ref)
-    : await fileReader(resolvedRoot);
+  const read = ref ? gitReader(resolvedRoot, ref) : fileReader(resolvedRoot);
   const versions = await versionState(read);
   const unique = new Set(versions.values());
   if (unique.size !== 1) {
@@ -370,8 +368,18 @@ async function restoreReleaseFiles(root, originals) {
     cwd: root,
   });
   for (const [path, content] of Object.entries(originals)) {
-    if (content === null) await unlink(join(root, path)).catch(() => {});
-    else await writeFile(join(root, path), content);
+    await writeFile(join(root, path), content);
+  }
+}
+
+function assertReleaseFileSet(output, failureMessage) {
+  const paths = output.split("\n").filter(Boolean).sort();
+  const expected = [...RELEASE_FILES].sort();
+  if (
+    paths.length !== expected.length ||
+    paths.some((path, index) => path !== expected[index])
+  ) {
+    fail(`${failureMessage}:\n${paths.join("\n")}`);
   }
 }
 
@@ -390,6 +398,19 @@ function refExists(root, ref) {
   return succeeds("git", ["show-ref", "--verify", "--quiet", ref], {
     cwd: root,
   });
+}
+
+function fetchOriginMain(root) {
+  run(
+    "git",
+    [
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/heads/main:refs/remotes/origin/main",
+    ],
+    { cwd: root },
+  );
 }
 
 function releasePrs(root, repository, branch) {
@@ -428,14 +449,8 @@ function validatePreparedCommit(root, version) {
     "git",
     ["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
     { cwd: root },
-  )
-    .split("\n")
-    .filter(Boolean)
-    .sort();
-  const expected = [...RELEASE_FILES].sort();
-  if (JSON.stringify(changed) !== JSON.stringify(expected)) {
-    fail(`release commit changed unexpected files:\n${changed.join("\n")}`);
-  }
+  );
+  assertReleaseFileSet(changed, "release commit changed unexpected files");
 }
 
 async function validatePreparedFiles(root, version) {
@@ -459,7 +474,7 @@ async function validatePreparedFiles(root, version) {
 async function prepare(version, notesPath) {
   parseSemver(version, "release version");
   const root = repoRoot();
-  const read = await fileReader(root);
+  const read = fileReader(root);
   const config = await releaseConfig(read);
   const branch = `release/v${version}`;
   const subject = `chore: release v${version}`;
@@ -468,16 +483,7 @@ async function prepare(version, notesPath) {
   if (notes.includes("\0")) fail("release notes file contains a NUL byte");
   assertClean(root);
   run("gh", ["auth", "status", "--hostname", "github.com"], { cwd: root });
-  run(
-    "git",
-    [
-      "fetch",
-      "--no-tags",
-      "origin",
-      "refs/heads/main:refs/remotes/origin/main",
-    ],
-    { cwd: root },
-  );
+  fetchOriginMain(root);
 
   const remoteBranchOutput = commandResult(
     "git",
@@ -560,17 +566,11 @@ async function prepare(version, notesPath) {
         "git",
         ["diff", "--cached", "--name-only", "--diff-filter=ACMRT"],
         { cwd: root },
-      )
-        .split("\n")
-        .filter(Boolean)
-        .sort();
-      if (
-        JSON.stringify(staged) !== JSON.stringify([...RELEASE_FILES].sort())
-      ) {
-        fail(
-          `release preparation staged unexpected files:\n${staged.join("\n")}`,
-        );
-      }
+      );
+      assertReleaseFileSet(
+        staged,
+        "release preparation staged unexpected files",
+      );
       run("git", ["commit", "-m", subject, "-m", RELEASE_COMMIT_BODY], {
         cwd: root,
         visible: true,
@@ -664,7 +664,7 @@ async function prepare(version, notesPath) {
 async function publish(version) {
   parseSemver(version, "release version");
   const root = repoRoot();
-  const read = await fileReader(root);
+  const read = fileReader(root);
   const config = await releaseConfig(read);
   const branch = `release/v${version}`;
   const tag = `v${version}`;
@@ -686,16 +686,7 @@ async function publish(version) {
   );
   if (remoteTag.status !== 0) fail("failed to inspect remote tags");
   if (remoteTag.stdout.trim()) fail(`remote tag already exists: ${tag}`);
-  run(
-    "git",
-    [
-      "fetch",
-      "--no-tags",
-      "origin",
-      "refs/heads/main:refs/remotes/origin/main",
-    ],
-    { cwd: root },
-  );
+  fetchOriginMain(root);
   run("git", ["fetch", "--tags", "origin"], { cwd: root });
 
   const prs = releasePrs(root, config.repository, branch);
@@ -757,7 +748,7 @@ async function publish(version) {
 async function notes(version, changelogPath) {
   parseSemver(version, "release version");
   const root = repoRoot();
-  const read = await fileReader(root);
+  const read = fileReader(root);
   const config = await releaseConfig(read);
   const content = await readFile(
     changelogPath || join(root, "CHANGELOG.md"),

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { compareSemver, parseSemver, sameNumericVersion } from "./version.mjs";
 
@@ -135,7 +136,7 @@ function releaseHeadingPattern() {
   return /^## \[v([^\]]+)\]\(([^)]+)\) - (\d{4}-\d{2}-\d{2})\s*$/gm;
 }
 
-export function changelogEntries(content) {
+function changelogEntries(content) {
   if (!content.startsWith("# Changelog\n")) {
     fail("CHANGELOG.md must start with '# Changelog'");
   }
@@ -279,7 +280,15 @@ async function releaseConfig(read) {
   return config;
 }
 
-export async function checkVersions({ root, expected, ref } = {}) {
+function validateMinimumPublicVersion(version, config) {
+  if (compareSemver(version, config.minimumPublicVersion) < 0) {
+    fail(
+      `release version ${version} is below minimum public version ${config.minimumPublicVersion}`,
+    );
+  }
+}
+
+async function checkVersions({ root, expected, ref } = {}) {
   const resolvedRoot = root || repoRoot();
   if (expected) parseSemver(expected, "expected version");
   const read = ref ? gitReader(resolvedRoot, ref) : fileReader(resolvedRoot);
@@ -413,6 +422,66 @@ function fetchOriginMain(root) {
   );
 }
 
+function remoteTagTarget(root, tag) {
+  const result = commandResult(
+    "git",
+    [
+      "ls-remote",
+      "--tags",
+      "origin",
+      `refs/tags/${tag}`,
+      `refs/tags/${tag}^{}`,
+    ],
+    { cwd: root },
+  );
+  if (result.status !== 0) fail("failed to inspect remote tags");
+  const lines = result.stdout.trim().split("\n").filter(Boolean);
+  if (lines.length === 0) return null;
+  const tagRef = `refs/tags/${tag}`;
+  const tagObject = lines.find((line) => line.endsWith(`\t${tagRef}`));
+  const peeledTag = lines.find((line) => line.endsWith(`\t${tagRef}^{}`));
+  if (!tagObject || !peeledTag) fail(`remote tag must be annotated: ${tag}`);
+  const [target] = peeledTag.split(/\s+/, 1);
+  if (!/^[0-9a-f]{40}$/.test(target)) {
+    fail(`remote tag has invalid target: ${tag}`);
+  }
+  return target;
+}
+
+function validateLocalTag(root, tag, expectedTarget) {
+  if (
+    run("git", ["cat-file", "-t", `refs/tags/${tag}`], { cwd: root }) !== "tag"
+  ) {
+    fail(`local tag must be annotated: ${tag}`);
+  }
+  const target = run("git", ["rev-parse", `refs/tags/${tag}^{commit}`], {
+    cwd: root,
+  });
+  if (target !== expectedTarget) {
+    fail(`local tag ${tag} targets ${target}, expected ${expectedTarget}`);
+  }
+}
+
+async function generateReviewedNotes(root) {
+  process.stderr.write("generating release notes...\n");
+  const notes = run("just", ["release-notes"], { cwd: root });
+  if (!notes) fail("generated release notes are empty");
+  process.stdout.write(`\n${notes}\n\n`);
+  const prompt = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const answer = await prompt.question("use these release notes? [y/N] ");
+    if (!/^y(?:es)?$/i.test(answer.trim())) {
+      fail("release preparation cancelled");
+    }
+  } finally {
+    prompt.close();
+  }
+  return notes;
+}
+
 function releasePrs(root, repository, branch) {
   const json = run(
     "gh",
@@ -476,12 +545,15 @@ async function prepare(version, notesPath) {
   const root = repoRoot();
   const read = fileReader(root);
   const config = await releaseConfig(read);
+  validateMinimumPublicVersion(version, config);
   const branch = `release/v${version}`;
   const subject = `chore: release v${version}`;
-  const notes = (await readFile(resolve(notesPath), "utf8")).trim();
+  assertClean(root);
+  const notes = notesPath
+    ? (await readFile(resolve(notesPath), "utf8")).trim()
+    : await generateReviewedNotes(root);
   if (!notes) fail("release notes file must contain reviewed Markdown");
   if (notes.includes("\0")) fail("release notes file contains a NUL byte");
-  assertClean(root);
   run("gh", ["auth", "status", "--hostname", "github.com"], { cwd: root });
   fetchOriginMain(root);
 
@@ -666,28 +738,13 @@ async function publish(version) {
   const root = repoRoot();
   const read = fileReader(root);
   const config = await releaseConfig(read);
+  validateMinimumPublicVersion(version, config);
   const branch = `release/v${version}`;
   const tag = `v${version}`;
   const subject = `chore: release v${version}`;
   assertClean(root);
   run("gh", ["auth", "status", "--hostname", "github.com"], { cwd: root });
-  if (refExists(root, `refs/tags/${tag}`))
-    fail(`local tag already exists: ${tag}`);
-  const remoteTag = commandResult(
-    "git",
-    [
-      "ls-remote",
-      "--tags",
-      "origin",
-      `refs/tags/${tag}`,
-      `refs/tags/${tag}^{}`,
-    ],
-    { cwd: root },
-  );
-  if (remoteTag.status !== 0) fail("failed to inspect remote tags");
-  if (remoteTag.stdout.trim()) fail(`remote tag already exists: ${tag}`);
   fetchOriginMain(root);
-  run("git", ["fetch", "--tags", "origin"], { cwd: root });
 
   const prs = releasePrs(root, config.repository, branch);
   if (prs.length !== 1) fail(`expected exactly one PR for ${branch}`);
@@ -719,27 +776,33 @@ async function publish(version) {
   });
   if (mergeTitle !== subject) fail(`merge commit title is not '${subject}'`);
   await checkVersions({ root, expected: version, ref: mergeSha });
+  const sourceConfig = await releaseConfig(gitReader(root, mergeSha));
+  validateMinimumPublicVersion(version, sourceConfig);
 
-  run(
-    "git",
-    ["tag", "--annotate", "--no-sign", tag, mergeSha, "--message", subject],
-    { cwd: root },
-  );
-  if (
-    run("git", ["cat-file", "-t", `refs/tags/${tag}`], { cwd: root }) !== "tag"
-  ) {
-    fail(`created tag is not annotated: ${tag}`);
+  const remoteTarget = remoteTagTarget(root, tag);
+  if (remoteTarget) {
+    if (remoteTarget !== mergeSha) {
+      fail(`remote tag ${tag} targets ${remoteTarget}, expected ${mergeSha}`);
+    }
+    if (refExists(root, `refs/tags/${tag}`)) {
+      validateLocalTag(root, tag, mergeSha);
+    }
+  } else {
+    if (refExists(root, `refs/tags/${tag}`)) {
+      validateLocalTag(root, tag, mergeSha);
+    } else {
+      run(
+        "git",
+        ["tag", "--annotate", "--no-sign", tag, mergeSha, "--message", subject],
+        { cwd: root },
+      );
+      validateLocalTag(root, tag, mergeSha);
+    }
+    run("git", ["push", "origin", `refs/tags/${tag}`], {
+      cwd: root,
+      visible: true,
+    });
   }
-  if (
-    run("git", ["rev-parse", `refs/tags/${tag}^{commit}`], { cwd: root }) !==
-    mergeSha
-  ) {
-    fail(`created tag does not target ${mergeSha}`);
-  }
-  run("git", ["push", "origin", `refs/tags/${tag}`], {
-    cwd: root,
-    visible: true,
-  });
   console.log(
     `https://github.com/${config.repository}/actions/workflows/release.yml\nwait for all platform assets, then approve the release environment promotion`,
   );
@@ -763,7 +826,7 @@ function usage() {
   console.error(`Usage:
   release.mjs version-check [expected-version] [--ref <commit>]
   release.mjs changelog-notes <version> [changelog-path]
-  release.mjs prepare <version> <notes-file>
+  release.mjs prepare <version> [notes-file]
   release.mjs publish <version>`);
   process.exit(2);
 }
@@ -788,7 +851,7 @@ async function main() {
     await notes(args[0], args[1]);
     return;
   }
-  if (command === "prepare" && args.length === 2) {
+  if (command === "prepare" && args.length >= 1 && args.length <= 2) {
     await prepare(args[0], args[1]);
     return;
   }

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -1,0 +1,819 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { compareSemver, parseSemver, sameNumericVersion } from "./version.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = resolve(scriptDir, "../..");
+const RELEASE_FILES = [
+  "package.json",
+  "src-tauri/tauri.conf.json",
+  "src-tauri/Cargo.toml",
+  "src-tauri/crates/berdctl/Cargo.toml",
+  "src-tauri/plugins/berdctl/Cargo.toml",
+  "src-tauri/Cargo.lock",
+  "CHANGELOG.md",
+];
+const RELEASE_COMMIT_BODY =
+  "synchronize app, cli, plugin, lockfile, and changelog versions.";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function commandResult(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...options.env },
+    input: options.input,
+    stdio: options.visible ? "inherit" : "pipe",
+  });
+}
+
+function run(command, args, options = {}) {
+  const result = commandResult(command, args, options);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr]
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    fail(`${command} ${args.join(" ")} failed${detail ? `:\n${detail}` : ""}`);
+  }
+  return (result.stdout ?? "").trim();
+}
+
+function succeeds(command, args, options = {}) {
+  return commandResult(command, args, options).status === 0;
+}
+
+function repoRoot() {
+  return resolve(process.env.BERD_RELEASE_REPO_ROOT || defaultRepoRoot);
+}
+
+function cargoPackage(content, path) {
+  const start = content.indexOf("[package]");
+  if (start < 0) fail(`${path} has no [package] section`);
+  const nextSection = content.indexOf("\n[", start + "[package]".length);
+  const end = nextSection < 0 ? content.length : nextSection;
+  const section = content.slice(start, end);
+  const name = /^name\s*=\s*"([^"]+)"\s*$/m.exec(section)?.[1];
+  const version = /^version\s*=\s*"([^"]+)"\s*$/m.exec(section)?.[1];
+  if (!name || !version) fail(`${path} has an incomplete [package] section`);
+  parseSemver(version, `${path} package version`);
+  return { name, version, start, end, section };
+}
+
+function updateCargoPackage(content, path, expectedName, version) {
+  const pkg = cargoPackage(content, path);
+  if (pkg.name !== expectedName) {
+    fail(`${path} package is ${pkg.name}, expected ${expectedName}`);
+  }
+  const updatedSection = pkg.section.replace(
+    /^(version\s*=\s*")[^"]+("\s*)$/m,
+    `$1${version}$2`,
+  );
+  return `${content.slice(0, pkg.start)}${updatedSection}${content.slice(pkg.end)}`;
+}
+
+function cargoLockPackages(content) {
+  const starts = [...content.matchAll(/^\[\[package\]\]\s*$/gm)].map(
+    (match) => match.index,
+  );
+  return starts.map((start, index) => {
+    const end = starts[index + 1] ?? content.length;
+    const block = content.slice(start, end);
+    return {
+      start,
+      end,
+      block,
+      name: /^name\s*=\s*"([^"]+)"\s*$/m.exec(block)?.[1],
+      version: /^version\s*=\s*"([^"]+)"\s*$/m.exec(block)?.[1],
+    };
+  });
+}
+
+function lockVersion(content, packageName) {
+  const matches = cargoLockPackages(content).filter(
+    (pkg) => pkg.name === packageName,
+  );
+  if (matches.length !== 1 || !matches[0].version) {
+    fail(
+      `src-tauri/Cargo.lock must contain exactly one ${packageName} package entry`,
+    );
+  }
+  parseSemver(matches[0].version, `${packageName} Cargo.lock version`);
+  return matches[0].version;
+}
+
+function updateLockVersions(content, version) {
+  let updated = content;
+  for (const packageName of ["Berd", "berdctl", "tauri-plugin-berdctl"]) {
+    const matches = cargoLockPackages(updated).filter(
+      (pkg) => pkg.name === packageName,
+    );
+    if (matches.length !== 1) {
+      fail(
+        `src-tauri/Cargo.lock must contain exactly one ${packageName} package entry`,
+      );
+    }
+    const pkg = matches[0];
+    const block = pkg.block.replace(
+      /^(version\s*=\s*")[^"]+("\s*)$/m,
+      `$1${version}$2`,
+    );
+    updated = `${updated.slice(0, pkg.start)}${block}${updated.slice(pkg.end)}`;
+  }
+  return updated;
+}
+
+function releaseHeadingPattern() {
+  return /^## \[v([^\]]+)\]\(([^)]+)\) - (\d{4}-\d{2}-\d{2})\s*$/gm;
+}
+
+export function changelogEntries(content) {
+  if (!content.startsWith("# Changelog\n")) {
+    fail("CHANGELOG.md must start with '# Changelog'");
+  }
+  const matches = [...content.matchAll(releaseHeadingPattern())];
+  const releaseShapedHeadings = [...content.matchAll(/^## \[v[^\]]+\].*$/gm)];
+  if (releaseShapedHeadings.length !== matches.length) {
+    fail("CHANGELOG.md contains a malformed release heading");
+  }
+  return matches.map((match, index) => {
+    const version = match[1];
+    parseSemver(version, "changelog version");
+    const bodyStart = match.index + match[0].length;
+    const end = matches[index + 1]?.index ?? content.length;
+    const body = content.slice(bodyStart, end).trim();
+    if (!body) fail(`CHANGELOG.md entry v${version} is empty`);
+    return {
+      version,
+      url: match[2],
+      date: match[3],
+      start: match.index,
+      end,
+      body,
+    };
+  });
+}
+
+function changelogEntry(content, version, repository) {
+  const entries = changelogEntries(content).filter(
+    (entry) => entry.version === version,
+  );
+  if (entries.length !== 1) {
+    fail(`CHANGELOG.md must contain exactly one v${version} entry`);
+  }
+  const entry = entries[0];
+  const expectedUrl = `https://github.com/${repository}/releases/tag/v${version}`;
+  if (entry.url !== expectedUrl) {
+    fail(`CHANGELOG.md v${version} must link to ${expectedUrl}`);
+  }
+  return entry;
+}
+
+export function updateChangelog(content, version, notes, date, repository) {
+  const prefix = "# Changelog\n\n";
+  if (content !== "# Changelog\n" && !content.startsWith(prefix)) {
+    fail("CHANGELOG.md must contain only release entries after its title");
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    fail(`invalid release date: ${date}`);
+  }
+  const parsedDate = new Date(`${date}T00:00:00Z`);
+  if (
+    Number.isNaN(parsedDate.valueOf()) ||
+    parsedDate.toISOString().slice(0, 10) !== date
+  ) {
+    fail(`invalid release date: ${date}`);
+  }
+  const entries = changelogEntries(content);
+  if (entries[0] && entries[0].start !== prefix.length) {
+    fail("CHANGELOG.md must contain only release entries after its title");
+  }
+  if (entries.some((entry) => entry.version === version)) {
+    fail(`CHANGELOG.md already contains v${version}`);
+  }
+  const parsed = parseSemver(version);
+  const link = `https://github.com/${repository}/releases/tag/v${version}`;
+  const newEntry = `## [v${version}](${link}) - ${date}\n\n${notes.trim()}`;
+  let existingEntries = content.slice(content.indexOf("\n") + 1).trim();
+
+  if (
+    parsed.prerelease.length === 0 &&
+    entries[0]?.version &&
+    sameNumericVersion(entries[0].version, version) &&
+    parseSemver(entries[0].version).prerelease[0] === "rc"
+  ) {
+    existingEntries = content.slice(entries[0].end).trim();
+  }
+
+  return `${prefix}${newEntry}${existingEntries ? `\n\n${existingEntries}` : ""}\n`;
+}
+
+async function fileReader(root) {
+  return async (path) => readFile(join(root, path), "utf8");
+}
+
+function gitReader(root, ref) {
+  if (!/^[0-9a-f]{40}$/.test(ref)) fail(`invalid git commit: ${ref}`);
+  return async (path) => run("git", ["show", `${ref}:${path}`], { cwd: root });
+}
+
+async function versionState(read) {
+  const [packageJson, tauriJson, appCargo, cliCargo, pluginCargo, lock] =
+    await Promise.all([
+      read("package.json"),
+      read("src-tauri/tauri.conf.json"),
+      read("src-tauri/Cargo.toml"),
+      read("src-tauri/crates/berdctl/Cargo.toml"),
+      read("src-tauri/plugins/berdctl/Cargo.toml"),
+      read("src-tauri/Cargo.lock"),
+    ]);
+  const packageVersion = JSON.parse(packageJson).version;
+  const tauriVersion = JSON.parse(tauriJson).version;
+  const app = cargoPackage(appCargo, "src-tauri/Cargo.toml");
+  const cli = cargoPackage(cliCargo, "src-tauri/crates/berdctl/Cargo.toml");
+  const plugin = cargoPackage(
+    pluginCargo,
+    "src-tauri/plugins/berdctl/Cargo.toml",
+  );
+  if (
+    app.name !== "Berd" ||
+    cli.name !== "berdctl" ||
+    plugin.name !== "tauri-plugin-berdctl"
+  ) {
+    fail("release Cargo package names do not match the lockstep package set");
+  }
+  const versions = new Map([
+    ["package.json", packageVersion],
+    ["src-tauri/tauri.conf.json", tauriVersion],
+    ["Berd Cargo.toml", app.version],
+    ["berdctl Cargo.toml", cli.version],
+    ["tauri-plugin-berdctl Cargo.toml", plugin.version],
+    ["Berd Cargo.lock", lockVersion(lock, "Berd")],
+    ["berdctl Cargo.lock", lockVersion(lock, "berdctl")],
+    [
+      "tauri-plugin-berdctl Cargo.lock",
+      lockVersion(lock, "tauri-plugin-berdctl"),
+    ],
+  ]);
+  for (const [label, version] of versions) parseSemver(version, label);
+  return versions;
+}
+
+async function releaseConfig(read) {
+  const config = JSON.parse(await read("scripts/release/release-channel.json"));
+  if (
+    typeof config.repository !== "string" ||
+    !config.repository.includes("/")
+  ) {
+    fail("release-channel.json has an invalid repository");
+  }
+  parseSemver(config.minimumPublicVersion, "minimum public version");
+  return config;
+}
+
+export async function checkVersions({ root, expected, ref } = {}) {
+  const resolvedRoot = root || repoRoot();
+  if (expected) parseSemver(expected, "expected version");
+  const read = ref
+    ? gitReader(resolvedRoot, ref)
+    : await fileReader(resolvedRoot);
+  const versions = await versionState(read);
+  const unique = new Set(versions.values());
+  if (unique.size !== 1) {
+    fail(
+      `release versions are not in lockstep:\n${[...versions]
+        .map(([label, version]) => `- ${label}: ${version}`)
+        .join("\n")}`,
+    );
+  }
+  const actual = [...unique][0];
+  if (expected && actual !== expected) {
+    fail(`release version is ${actual}, expected ${expected}`);
+  }
+  if (expected) {
+    const config = await releaseConfig(read);
+    const changelog = await read("CHANGELOG.md");
+    changelogEntry(changelog, expected, config.repository);
+  }
+  return actual;
+}
+
+async function writeReleaseFiles(root, version, notes, date, repository) {
+  const paths = Object.fromEntries(
+    await Promise.all(
+      RELEASE_FILES.map(async (path) => [
+        path,
+        await readFile(join(root, path)),
+      ]),
+    ),
+  );
+  const text = (path) => paths[path].toString("utf8");
+  const packageJson = JSON.parse(text("package.json"));
+  const tauriJson = JSON.parse(text("src-tauri/tauri.conf.json"));
+  packageJson.version = version;
+  tauriJson.version = version;
+  const updates = new Map([
+    ["package.json", `${JSON.stringify(packageJson, null, 2)}\n`],
+    ["src-tauri/tauri.conf.json", `${JSON.stringify(tauriJson, null, 2)}\n`],
+    [
+      "src-tauri/Cargo.toml",
+      updateCargoPackage(
+        text("src-tauri/Cargo.toml"),
+        "src-tauri/Cargo.toml",
+        "Berd",
+        version,
+      ),
+    ],
+    [
+      "src-tauri/crates/berdctl/Cargo.toml",
+      updateCargoPackage(
+        text("src-tauri/crates/berdctl/Cargo.toml"),
+        "src-tauri/crates/berdctl/Cargo.toml",
+        "berdctl",
+        version,
+      ),
+    ],
+    [
+      "src-tauri/plugins/berdctl/Cargo.toml",
+      updateCargoPackage(
+        text("src-tauri/plugins/berdctl/Cargo.toml"),
+        "src-tauri/plugins/berdctl/Cargo.toml",
+        "tauri-plugin-berdctl",
+        version,
+      ),
+    ],
+    [
+      "src-tauri/Cargo.lock",
+      updateLockVersions(text("src-tauri/Cargo.lock"), version),
+    ],
+    [
+      "CHANGELOG.md",
+      updateChangelog(text("CHANGELOG.md"), version, notes, date, repository),
+    ],
+  ]);
+  for (const [path, content] of updates) {
+    await writeFile(join(root, path), content);
+  }
+  return paths;
+}
+
+async function restoreReleaseFiles(root, originals) {
+  run("git", ["restore", "--staged", "--", ...RELEASE_FILES], {
+    cwd: root,
+  });
+  for (const [path, content] of Object.entries(originals)) {
+    if (content === null) await unlink(join(root, path)).catch(() => {});
+    else await writeFile(join(root, path), content);
+  }
+}
+
+function assertClean(root) {
+  const status = run(
+    "git",
+    ["status", "--porcelain=v1", "--untracked-files=all"],
+    {
+      cwd: root,
+    },
+  );
+  if (status) fail(`working tree must be clean:\n${status}`);
+}
+
+function refExists(root, ref) {
+  return succeeds("git", ["show-ref", "--verify", "--quiet", ref], {
+    cwd: root,
+  });
+}
+
+function releasePrs(root, repository, branch) {
+  const json = run(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      repository,
+      "--head",
+      branch,
+      "--state",
+      "all",
+      "--limit",
+      "100",
+      "--json",
+      "number,url,state,isDraft,mergedAt,headRefName,baseRefName,headRefOid,title,mergeCommit",
+    ],
+    { cwd: root },
+  );
+  const prs = JSON.parse(json);
+  if (!Array.isArray(prs)) fail("GitHub returned an invalid PR list");
+  return prs;
+}
+
+function validatePreparedCommit(root, version) {
+  const subject = `chore: release v${version}`;
+  const body = run("git", ["log", "-1", "--format=%B", "HEAD"], {
+    cwd: root,
+  });
+  if (body !== `${subject}\n\n${RELEASE_COMMIT_BODY}`) {
+    fail("existing release commit has unexpected subject or body");
+  }
+  const changed = run(
+    "git",
+    ["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"],
+    { cwd: root },
+  )
+    .split("\n")
+    .filter(Boolean)
+    .sort();
+  const expected = [...RELEASE_FILES].sort();
+  if (JSON.stringify(changed) !== JSON.stringify(expected)) {
+    fail(`release commit changed unexpected files:\n${changed.join("\n")}`);
+  }
+}
+
+async function validatePreparedFiles(root, version) {
+  await checkVersions({ root, expected: version });
+  run(
+    "cargo",
+    [
+      "metadata",
+      "--locked",
+      "--no-deps",
+      "--format-version",
+      "1",
+      "--manifest-path",
+      "src-tauri/Cargo.toml",
+    ],
+    { cwd: root },
+  );
+  run("pnpm", ["test:release-scripts"], { cwd: root });
+}
+
+async function prepare(version, notesPath) {
+  parseSemver(version, "release version");
+  const root = repoRoot();
+  const read = await fileReader(root);
+  const config = await releaseConfig(read);
+  const branch = `release/v${version}`;
+  const subject = `chore: release v${version}`;
+  const notes = (await readFile(resolve(notesPath), "utf8")).trim();
+  if (!notes) fail("release notes file must contain reviewed Markdown");
+  if (notes.includes("\0")) fail("release notes file contains a NUL byte");
+  assertClean(root);
+  run("gh", ["auth", "status", "--hostname", "github.com"], { cwd: root });
+  run(
+    "git",
+    [
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/heads/main:refs/remotes/origin/main",
+    ],
+    { cwd: root },
+  );
+
+  const remoteBranchOutput = commandResult(
+    "git",
+    ["ls-remote", "--heads", "origin", `refs/heads/${branch}`],
+    { cwd: root },
+  );
+  if (remoteBranchOutput.status !== 0) {
+    fail("failed to inspect the remote release branch");
+  }
+  const remoteBranchExists = Boolean(remoteBranchOutput.stdout.trim());
+  const localBranchExists = refExists(root, `refs/heads/${branch}`);
+  if (remoteBranchExists) {
+    run(
+      "git",
+      [
+        "fetch",
+        "--no-tags",
+        "origin",
+        `refs/heads/${branch}:refs/remotes/origin/${branch}`,
+      ],
+      { cwd: root },
+    );
+  }
+
+  const currentBranch = run("git", ["branch", "--show-current"], { cwd: root });
+  if (currentBranch !== branch) {
+    if (localBranchExists) {
+      if (
+        remoteBranchExists &&
+        run("git", ["rev-parse", `refs/heads/${branch}`], { cwd: root }) !==
+          run("git", ["rev-parse", `refs/remotes/origin/${branch}`], {
+            cwd: root,
+          })
+      ) {
+        fail("local and remote release branches disagree");
+      }
+      run("git", ["switch", branch], { cwd: root, visible: true });
+    } else if (remoteBranchExists) {
+      run("git", ["switch", "--track", "-c", branch, `origin/${branch}`], {
+        cwd: root,
+        visible: true,
+      });
+    } else {
+      const head = run("git", ["rev-parse", "HEAD"], { cwd: root });
+      const main = run("git", ["rev-parse", "refs/remotes/origin/main"], {
+        cwd: root,
+      });
+      if (head !== main) {
+        fail("release preparation must start from up-to-date origin/main");
+      }
+      run("git", ["switch", "-c", branch], { cwd: root, visible: true });
+    }
+  }
+  assertClean(root);
+
+  const commitCount = Number(
+    run("git", ["rev-list", "--count", "refs/remotes/origin/main..HEAD"], {
+      cwd: root,
+    }),
+  );
+  if (commitCount === 0) {
+    const currentVersion = await checkVersions({ root });
+    if (compareSemver(version, currentVersion) <= 0) {
+      fail(`release version ${version} must be newer than ${currentVersion}`);
+    }
+    const date =
+      process.env.BERD_RELEASE_DATE || new Date().toISOString().slice(0, 10);
+    let originals;
+    try {
+      originals = await writeReleaseFiles(
+        root,
+        version,
+        notes,
+        date,
+        config.repository,
+      );
+      await validatePreparedFiles(root, version);
+      run("git", ["add", "--", ...RELEASE_FILES], { cwd: root });
+      const staged = run(
+        "git",
+        ["diff", "--cached", "--name-only", "--diff-filter=ACMRT"],
+        { cwd: root },
+      )
+        .split("\n")
+        .filter(Boolean)
+        .sort();
+      if (
+        JSON.stringify(staged) !== JSON.stringify([...RELEASE_FILES].sort())
+      ) {
+        fail(
+          `release preparation staged unexpected files:\n${staged.join("\n")}`,
+        );
+      }
+      run("git", ["commit", "-m", subject, "-m", RELEASE_COMMIT_BODY], {
+        cwd: root,
+        visible: true,
+      });
+      originals = undefined;
+    } catch (error) {
+      if (originals) await restoreReleaseFiles(root, originals);
+      throw error;
+    }
+  } else if (commitCount === 1) {
+    const parent = run("git", ["rev-parse", "HEAD^"], { cwd: root });
+    if (
+      !succeeds(
+        "git",
+        ["merge-base", "--is-ancestor", parent, "refs/remotes/origin/main"],
+        { cwd: root },
+      )
+    ) {
+      fail("existing release commit is not based on main");
+    }
+    validatePreparedCommit(root, version);
+    await checkVersions({ root, expected: version });
+  } else {
+    fail("release branch must contain exactly one release commit");
+  }
+
+  const head = run("git", ["rev-parse", "HEAD"], { cwd: root });
+  if (remoteBranchExists) {
+    const remoteHead = run(
+      "git",
+      ["rev-parse", `refs/remotes/origin/${branch}`],
+      { cwd: root },
+    );
+    if (remoteHead !== head)
+      fail("remote release branch has conflicting commits");
+  } else {
+    run("git", ["push", "--set-upstream", "origin", `refs/heads/${branch}`], {
+      cwd: root,
+      visible: true,
+    });
+  }
+
+  const prs = releasePrs(root, config.repository, branch);
+  if (prs.length > 1) fail(`multiple PRs exist for ${branch}`);
+  let url;
+  if (prs.length === 1) {
+    const pr = prs[0];
+    if (
+      pr.state !== "OPEN" ||
+      pr.mergedAt ||
+      pr.isDraft ||
+      pr.baseRefName !== "main" ||
+      pr.headRefName !== branch ||
+      pr.headRefOid !== head ||
+      pr.title !== subject
+    ) {
+      fail(`existing PR #${pr.number} conflicts with ${branch}`);
+    }
+    url = pr.url;
+  } else {
+    const body = `## Summary\n\n- synchronize Berd, berdctl, and tauri-plugin-berdctl at ${version}\n- add the reviewed v${version} changelog entry\n\n### Related issue\n\nN/A\n\n### Testing\n\n- \`just release-version-check ${version}\`\n- \`just release-validate ${version}\`\n`;
+    const dir = await mkdtemp(join(tmpdir(), "berd-release-pr-"));
+    const bodyPath = join(dir, "body.md");
+    try {
+      await writeFile(bodyPath, body);
+      url = run(
+        "gh",
+        [
+          "pr",
+          "create",
+          "--repo",
+          config.repository,
+          "--base",
+          "main",
+          "--head",
+          branch,
+          "--title",
+          subject,
+          "--body-file",
+          bodyPath,
+        ],
+        { cwd: root },
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+  console.log(`${url}\nstop here for human review and squash merge`);
+}
+
+async function publish(version) {
+  parseSemver(version, "release version");
+  const root = repoRoot();
+  const read = await fileReader(root);
+  const config = await releaseConfig(read);
+  const branch = `release/v${version}`;
+  const tag = `v${version}`;
+  const subject = `chore: release v${version}`;
+  assertClean(root);
+  run("gh", ["auth", "status", "--hostname", "github.com"], { cwd: root });
+  if (refExists(root, `refs/tags/${tag}`))
+    fail(`local tag already exists: ${tag}`);
+  const remoteTag = commandResult(
+    "git",
+    [
+      "ls-remote",
+      "--tags",
+      "origin",
+      `refs/tags/${tag}`,
+      `refs/tags/${tag}^{}`,
+    ],
+    { cwd: root },
+  );
+  if (remoteTag.status !== 0) fail("failed to inspect remote tags");
+  if (remoteTag.stdout.trim()) fail(`remote tag already exists: ${tag}`);
+  run(
+    "git",
+    [
+      "fetch",
+      "--no-tags",
+      "origin",
+      "refs/heads/main:refs/remotes/origin/main",
+    ],
+    { cwd: root },
+  );
+  run("git", ["fetch", "--tags", "origin"], { cwd: root });
+
+  const prs = releasePrs(root, config.repository, branch);
+  if (prs.length !== 1) fail(`expected exactly one PR for ${branch}`);
+  const pr = prs[0];
+  if (
+    !pr.mergedAt ||
+    pr.state !== "MERGED" ||
+    pr.baseRefName !== "main" ||
+    pr.headRefName !== branch ||
+    pr.title !== subject
+  ) {
+    fail(`PR #${pr.number} is not the merged ${subject} PR`);
+  }
+  const mergeSha = pr.mergeCommit?.oid;
+  if (!/^[0-9a-f]{40}$/.test(mergeSha ?? "")) {
+    fail(`PR #${pr.number} has no squash-merge commit SHA`);
+  }
+  if (
+    !succeeds(
+      "git",
+      ["merge-base", "--is-ancestor", mergeSha, "refs/remotes/origin/main"],
+      { cwd: root },
+    )
+  ) {
+    fail(`merge commit ${mergeSha} is not reachable from origin/main`);
+  }
+  const mergeTitle = run("git", ["show", "-s", "--format=%s", mergeSha], {
+    cwd: root,
+  });
+  if (mergeTitle !== subject) fail(`merge commit title is not '${subject}'`);
+  await checkVersions({ root, expected: version, ref: mergeSha });
+
+  run(
+    "git",
+    ["tag", "--annotate", "--no-sign", tag, mergeSha, "--message", subject],
+    { cwd: root },
+  );
+  if (
+    run("git", ["cat-file", "-t", `refs/tags/${tag}`], { cwd: root }) !== "tag"
+  ) {
+    fail(`created tag is not annotated: ${tag}`);
+  }
+  if (
+    run("git", ["rev-parse", `refs/tags/${tag}^{commit}`], { cwd: root }) !==
+    mergeSha
+  ) {
+    fail(`created tag does not target ${mergeSha}`);
+  }
+  run("git", ["push", "origin", `refs/tags/${tag}`], {
+    cwd: root,
+    visible: true,
+  });
+  console.log(
+    `https://github.com/${config.repository}/actions/workflows/release.yml\nwait for all platform assets, then approve the release environment promotion`,
+  );
+}
+
+async function notes(version, changelogPath) {
+  parseSemver(version, "release version");
+  const root = repoRoot();
+  const read = await fileReader(root);
+  const config = await releaseConfig(read);
+  const content = await readFile(
+    changelogPath || join(root, "CHANGELOG.md"),
+    "utf8",
+  );
+  process.stdout.write(
+    `${changelogEntry(content, version, config.repository).body}\n`,
+  );
+}
+
+function usage() {
+  console.error(`Usage:
+  release.mjs version-check [expected-version] [--ref <commit>]
+  release.mjs changelog-notes <version> [changelog-path]
+  release.mjs prepare <version> <notes-file>
+  release.mjs publish <version>`);
+  process.exit(2);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command === "version-check") {
+    if (args[0] === "") args.shift();
+    let expected;
+    let ref;
+    if (args[0] && args[0] !== "--ref") expected = args.shift();
+    if (args[0] === "--ref" && args[1] && args.length === 2) {
+      ref = args[1];
+      args.splice(0);
+    }
+    if (args.length) usage();
+    const actual = await checkVersions({ expected, ref });
+    console.log(`release versions are in lockstep at ${actual}`);
+    return;
+  }
+  if (command === "changelog-notes" && args.length >= 1 && args.length <= 2) {
+    await notes(args[0], args[1]);
+    return;
+  }
+  if (command === "prepare" && args.length === 2) {
+    await prepare(args[0], args[1]);
+    return;
+  }
+  if (command === "publish" && args.length === 1) {
+    await publish(args[0]);
+    return;
+  }
+  usage();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -16,7 +16,7 @@ import { parse as parseYaml } from "yaml";
 
 const repo = resolve(import.meta.dirname, "../../..");
 const tempDirs = [];
-const releaseRepositoryEnv = { BERD_REPO: "squareup/berd" };
+const releaseRepositoryEnv = { BERD_REPO: "block/berd" };
 
 async function tempDir() {
   const path = await mkdtemp(join(tmpdir(), "berd-release-test-"));
@@ -1226,12 +1226,24 @@ describe("ensure-versioned-release", () => {
     existing = false,
     annotated = false,
     resolvedSha = "a".repeat(40),
-    releaseJson = '{"tagName":"v1.2.3","isDraft":false}',
+    releaseJson,
   } = {}) {
     const dir = await tempDir();
     const bin = join(dir, "bin");
     const calls = join(dir, "calls");
+    const changelog = join(dir, "CHANGELOG.md");
     await mkdir(bin);
+    await writeFile(
+      changelog,
+      `# Changelog\n\n## [v1.2.3](https://github.com/block/berd/releases/tag/v1.2.3) - 2026-08-12\n\nstable notes\n\n## [v1.2.3-rc.1](https://github.com/block/berd/releases/tag/v1.2.3-rc.1) - 2026-08-11\n\nrc notes\n`,
+    );
+    const expectedBody = `stable notes\n\n---\n\nSource commit: \`${"a".repeat(40)}\`\n\nThe Windows NSIS installer and Linux packages lack platform-native code signatures; their updater archives remain minisign-authenticated.`;
+    releaseJson ??= JSON.stringify({
+      tagName: "v1.2.3",
+      isDraft: false,
+      name: "Berd v1.2.3",
+      body: expectedBody,
+    });
     await writeFile(
       join(bin, "gh"),
       `#!/usr/bin/env bash
@@ -1239,7 +1251,7 @@ set -euo pipefail
 printf '%s\\n' "$*" >> "$CALLS"
 if [[ "$1 $2" == "release view" ]]; then
   if [[ "$EXISTING" != true ]]; then exit 1; fi
-  if [[ "$*" == *"--json tagName,isDraft"* ]]; then
+  if [[ "$*" == *"--json tagName,isDraft,name,body"* ]]; then
     printf '%s' "$RELEASE_JSON"
   fi
 elif [[ "$1 $2" == "release create" ]]; then
@@ -1257,13 +1269,21 @@ fi
 `,
       { mode: 0o755 },
     );
-    return { bin, calls, existing, annotated, resolvedSha, releaseJson };
+    return {
+      bin,
+      calls,
+      changelog,
+      existing,
+      annotated,
+      resolvedSha,
+      releaseJson,
+    };
   }
 
   function ensure(f, version = "1.2.3") {
     return run(
       "scripts/release/github/ensure-versioned-release.sh",
-      ["squareup/berd", `v${version}`, version, "a".repeat(40)],
+      ["block/berd", `v${version}`, version, "a".repeat(40)],
       {
         PATH: `${f.bin}:${process.env.PATH}`,
         CALLS: f.calls,
@@ -1271,6 +1291,7 @@ fi
         ANNOTATED: String(f.annotated),
         RESOLVED_SHA: f.resolvedSha,
         RELEASE_JSON: f.releaseJson,
+        BERD_CHANGELOG_PATH: f.changelog,
         GH_TOKEN: "test-token",
         ...releaseRepositoryEnv,
       },
@@ -1316,6 +1337,21 @@ fi
     const result = ensure(f);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(error);
+  });
+
+  it("rejects existing GitHub release notes that drift from the changelog", async () => {
+    const f = await fixture({
+      existing: true,
+      releaseJson: JSON.stringify({
+        tagName: "v1.2.3",
+        isDraft: false,
+        name: "Berd v1.2.3",
+        body: "stale notes",
+      }),
+    });
+    const result = ensure(f);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("do not match CHANGELOG.md");
   });
 });
 
@@ -1378,7 +1414,7 @@ fi
   function reconcile(f) {
     return run(
       "scripts/release/github/reconcile-staged-assets.sh",
-      ["squareup/berd", "v1.2.3", "1.2.3", f.output],
+      ["block/berd", "v1.2.3", "1.2.3", f.output],
       {
         PATH: `${f.bin}:${process.env.PATH}`,
         CALLS: f.calls,
@@ -1462,7 +1498,7 @@ fi
   function upload(fixture, assets) {
     return run(
       "scripts/release/github/upload-immutable-assets.sh",
-      ["squareup/berd", "v1.2.3", ...assets],
+      ["block/berd", "v1.2.3", ...assets],
       {
         PATH: `${fixture.bin}:${process.env.PATH}`,
         REMOTE: fixture.remote,
@@ -1528,7 +1564,9 @@ describe("verify-release-ref", () => {
     await writeFile(join(checkout, "source"), "immutable");
     expect(git(["add", "source"]).status).toBe(0);
     expect(git(["commit", "-m", "source"]).status).toBe(0);
-    expect(git(["tag", "--no-sign", "v1.2.3"]).status).toBe(0);
+    expect(
+      git(["tag", "--annotate", "--no-sign", "v1.2.3", "-m", "release"]).status,
+    ).toBe(0);
     expect(git(["remote", "add", "origin", remote]).status).toBe(0);
     expect(git(["push", "origin", "HEAD", "refs/tags/v1.2.3"]).status).toBe(0);
     const verifyEnv = {
@@ -1666,7 +1704,7 @@ fi
         GH_PAGER: "/bin/cat",
         PAGER: "/bin/cat",
         GH_TOKEN: "test-token",
-        REPOSITORY: "squareup/berd",
+        REPOSITORY: "block/berd",
         VERSION: "1.2.3",
         PLATFORM: "darwin-aarch64",
       },
@@ -1817,8 +1855,9 @@ fi
     await writeFile(
       channelConfig,
       JSON.stringify({
-        repository: "squareup/berd",
+        repository: "block/berd",
         rollingTag: "berd-desktop-latest",
+        minimumPublicVersion: "0.6.0-rc.1",
         platforms: ["darwin-aarch64"],
       }),
     );
@@ -1846,7 +1885,7 @@ fi
         PATH: `${f.bin}:${process.env.PATH}`,
         GH_TOKEN: "test-token",
         BERD_UPDATER_PUBLIC_KEY: "test-public-key",
-        GITHUB_REPOSITORY: "squareup/berd",
+        GITHUB_REPOSITORY: "block/berd",
         STAGED_ARCHIVE: f.archive,
         CALLS: f.calls,
         PUBLISHED_MANIFEST: f.publishedManifest,

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -1165,7 +1165,6 @@ describe("write-provenance", () => {
       [
         "Berd_1.2.3_linux-x86_64.AppImage",
         "Berd_1.2.3_linux-x86_64.deb",
-        "Berd_1.2.3_linux-x86_64.rpm",
         "Berd_1.2.3_linux-x86_64.AppImage.tar.gz",
         "Berd_1.2.3_linux-x86_64.AppImage.tar.gz.sig",
         "Berd_1.2.3_linux-x86_64.AppImage.tar.gz.sha256",
@@ -1375,7 +1374,6 @@ describe("reconcile-staged-assets", () => {
     linux_ready: [
       "Berd_1.2.3_linux-x86_64.AppImage",
       "Berd_1.2.3_linux-x86_64.deb",
-      "Berd_1.2.3_linux-x86_64.rpm",
       "Berd_1.2.3_linux-x86_64.AppImage.tar.gz",
       "Berd_1.2.3_linux-x86_64.AppImage.tar.gz.sig",
       "Berd_1.2.3_linux-x86_64.AppImage.tar.gz.sha256",

--- a/scripts/release/tests/release-tooling.test.mjs
+++ b/scripts/release/tests/release-tooling.test.mjs
@@ -17,11 +17,12 @@ const sourceRepo = resolve(import.meta.dirname, "../../..");
 const releaseScript = join(sourceRepo, "scripts/release/release.mjs");
 const tempDirs = [];
 
-function run(command, args, { cwd, env = {} } = {}) {
+function run(command, args, { cwd, env = {}, input } = {}) {
   return spawnSync(command, args, {
     cwd,
     encoding: "utf8",
     env: { ...process.env, ...env },
+    input,
   });
 }
 
@@ -104,9 +105,19 @@ fi
       join(bin, "pnpm"),
       '#!/usr/bin/env bash\nexit "$' + '{PNPM_STATUS:-0}"\n',
     ),
+    writeFile(
+      join(bin, "just"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == "release-notes" ]]
+printf '%s\n' '## generated changes' '' '- generated release notes'
+`,
+    ),
   ]);
   await Promise.all(
-    ["gh", "cargo", "pnpm"].map((name) => chmod(join(bin, name), 0o755)),
+    ["gh", "cargo", "pnpm", "just"].map((name) =>
+      chmod(join(bin, name), 0o755),
+    ),
   );
   expect(run("git", ["init", "--bare", remote]).status).toBe(0);
   expect(run("git", ["init", "-b", "main", repo]).status).toBe(0);
@@ -128,12 +139,13 @@ fi
     GIT_CONFIG_GLOBAL: "/dev/null",
     PATH: `${bin}:${process.env.PATH}`,
   };
-  const release = (args, extraEnv = {}) =>
+  const release = (args, extraEnv = {}, input) =>
     run(process.execPath, [releaseScript, ...args], {
       cwd: repo,
       env: { ...env, ...extraEnv },
+      input,
     });
-  return { root, repo, remote, notes, calls, git, env, release };
+  return { repo, remote, notes, calls, git, release };
 }
 
 describe("release SemVer and changelog", () => {
@@ -176,6 +188,41 @@ describe("release SemVer and changelog", () => {
 });
 
 describe("release preparation", () => {
+  it("generates notes and requires explicit approval", async () => {
+    const declined = await fixture();
+    const cancelled = declined.release(["prepare", "0.6.0-rc.1"], {}, "n\n");
+    expect(cancelled.status).not.toBe(0);
+    expect(cancelled.stdout).toContain("generated release notes");
+    expect(cancelled.stderr).toContain("release preparation cancelled");
+    expect(declined.git(["branch", "--show-current"]).stdout.trim()).toBe(
+      "main",
+    );
+
+    const approved = await fixture();
+    const prepared = approved.release(["prepare", "0.6.0-rc.1"], {}, "y\n");
+    expect(prepared.status, `${prepared.stdout}\n${prepared.stderr}`).toBe(0);
+    expect(
+      await readFile(join(approved.repo, "CHANGELOG.md"), "utf8"),
+    ).toContain("generated release notes");
+  });
+
+  it("rejects versions below the configured public minimum", async () => {
+    const f = await fixture();
+    const prepared = f.release(["prepare", "0.5.0", f.notes]);
+    expect(prepared.status).not.toBe(0);
+    expect(prepared.stderr).toContain(
+      "0.5.0 is below minimum public version 0.6.0-rc.1",
+    );
+    expect(f.git(["branch", "--show-current"]).stdout.trim()).toBe("main");
+
+    const published = f.release(["publish", "0.5.0"]);
+    expect(published.status).not.toBe(0);
+    expect(published.stderr).toContain(
+      "0.5.0 is below minimum public version 0.6.0-rc.1",
+    );
+    expect(f.git(["tag", "--list"]).stdout.trim()).toBe("");
+  });
+
   it("creates one lockstep release commit, pushes it, opens a PR, and resumes", async () => {
     const f = await fixture();
     const prepared = f.release(["prepare", "0.6.0-rc.1", f.notes]);
@@ -282,5 +329,23 @@ describe("release publishing", () => {
         "refs/tags/v0.6.0-rc.1^{commit}",
       ]).stdout.trim(),
     ).toBe(mergeSha);
+
+    expect(
+      run("git", [
+        "--git-dir",
+        f.remote,
+        "update-ref",
+        "-d",
+        "refs/tags/v0.6.0-rc.1",
+      ]).status,
+    ).toBe(0);
+    const retried = f.release(["publish", "0.6.0-rc.1"], {
+      GH_PR_LIST_JSON: pr,
+    });
+    expect(retried.status, `${retried.stdout}\n${retried.stderr}`).toBe(0);
+    const resumed = f.release(["publish", "0.6.0-rc.1"], {
+      GH_PR_LIST_JSON: pr,
+    });
+    expect(resumed.status, `${resumed.stdout}\n${resumed.stderr}`).toBe(0);
   });
 });

--- a/scripts/release/tests/release-tooling.test.mjs
+++ b/scripts/release/tests/release-tooling.test.mjs
@@ -1,0 +1,317 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { updateChangelog } from "../release.mjs";
+import { compareSemver, parseSemver } from "../version.mjs";
+
+const sourceRepo = resolve(import.meta.dirname, "../../..");
+const releaseScript = join(sourceRepo, "scripts/release/release.mjs");
+const tempDirs = [];
+
+function run(command, args, { cwd, env = {} } = {}) {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "berd-release-tooling-"));
+  tempDirs.push(root);
+  const repo = join(root, "repo");
+  const remote = join(root, "origin.git");
+  const bin = join(root, "bin");
+  const notes = join(root, "notes.md");
+  const calls = join(root, "gh-calls");
+  await Promise.all([
+    mkdir(join(repo, "scripts/release"), { recursive: true }),
+    mkdir(join(repo, "src-tauri/crates/berdctl"), { recursive: true }),
+    mkdir(join(repo, "src-tauri/plugins/berdctl"), { recursive: true }),
+    mkdir(bin),
+  ]);
+  await Promise.all([
+    writeFile(join(repo, "package.json"), '{"version":"0.4.12"}\n'),
+    writeFile(
+      join(repo, "src-tauri/tauri.conf.json"),
+      '{"productName":"Berd","version":"0.4.12"}\n',
+    ),
+    writeFile(
+      join(repo, "src-tauri/Cargo.toml"),
+      '[package]\nname = "Berd"\nversion = "0.4.12"\nedition = "2021"\n',
+    ),
+    writeFile(
+      join(repo, "src-tauri/crates/berdctl/Cargo.toml"),
+      '[package]\nname = "berdctl"\nversion = "0.4.12"\nedition = "2021"\n',
+    ),
+    writeFile(
+      join(repo, "src-tauri/plugins/berdctl/Cargo.toml"),
+      '[package]\nname = "tauri-plugin-berdctl"\nversion = "0.4.12"\nedition = "2021"\n',
+    ),
+    writeFile(
+      join(repo, "src-tauri/Cargo.lock"),
+      `version = 4\n\n[[package]]\nname = "Berd"\nversion = "0.4.12"\n\n[[package]]\nname = "berdctl"\nversion = "0.4.12"\n\n[[package]]\nname = "tauri-plugin-berdctl"\nversion = "0.4.12"\n`,
+    ),
+    writeFile(join(repo, "CHANGELOG.md"), "# Changelog\n"),
+    writeFile(
+      join(repo, "scripts/release/release-channel.json"),
+      JSON.stringify({
+        repository: "block/berd",
+        rollingTag: "berd-desktop-latest",
+        minimumPublicVersion: "0.6.0-rc.1",
+        platforms: ["darwin-aarch64"],
+      }),
+    ),
+    writeFile(notes, "## changes\n\n- tested release tooling"),
+    writeFile(
+      join(bin, "gh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_CALLS"
+if [[ "$1 $2" == "auth status" ]]; then
+  exit 0
+elif [[ "$1 $2" == "pr list" ]]; then
+  printf '%s' "\${GH_PR_LIST_JSON:-[]}"
+elif [[ "$1 $2" == "pr create" ]]; then
+  printf '%s\n' 'https://github.com/block/berd/pull/123'
+else
+  exit 1
+fi
+`,
+    ),
+    writeFile(
+      join(bin, "cargo"),
+      '#!/usr/bin/env bash\nexit "$' + '{CARGO_STATUS:-0}"\n',
+    ),
+    writeFile(
+      join(bin, "pnpm"),
+      '#!/usr/bin/env bash\nexit "$' + '{PNPM_STATUS:-0}"\n',
+    ),
+  ]);
+  await Promise.all(
+    ["gh", "cargo", "pnpm"].map((name) => chmod(join(bin, name), 0o755)),
+  );
+  expect(run("git", ["init", "--bare", remote]).status).toBe(0);
+  expect(run("git", ["init", "-b", "main", repo]).status).toBe(0);
+  const git = (args) =>
+    run("git", args, {
+      cwd: repo,
+      env: { GIT_CONFIG_GLOBAL: "/dev/null" },
+    });
+  expect(git(["config", "user.name", "Release Test"]).status).toBe(0);
+  expect(git(["config", "user.email", "release@example.test"]).status).toBe(0);
+  expect(git(["add", "."]).status).toBe(0);
+  expect(git(["commit", "-m", "initial"]).status).toBe(0);
+  expect(git(["remote", "add", "origin", remote]).status).toBe(0);
+  expect(git(["push", "--set-upstream", "origin", "main"]).status).toBe(0);
+  const env = {
+    BERD_RELEASE_DATE: "2026-08-12",
+    BERD_RELEASE_REPO_ROOT: repo,
+    GH_CALLS: calls,
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    PATH: `${bin}:${process.env.PATH}`,
+  };
+  const release = (args, extraEnv = {}) =>
+    run(process.execPath, [releaseScript, ...args], {
+      cwd: repo,
+      env: { ...env, ...extraEnv },
+    });
+  return { root, repo, remote, notes, calls, git, env, release };
+}
+
+describe("release SemVer and changelog", () => {
+  it("uses canonical SemVer ordering for prereleases and stable releases", () => {
+    expect(compareSemver("0.6.0-rc.1", "0.6.0-rc.2")).toBeLessThan(0);
+    expect(compareSemver("0.6.0-rc.2", "0.6.0")).toBeLessThan(0);
+    expect(compareSemver("100000000000000000000.0.0", "9.0.0")).toBeGreaterThan(
+      0,
+    );
+    expect(() => parseSemver("v0.6.0")).toThrow(/without a leading v/);
+    expect(() => parseSemver("0.6.0+build.1")).toThrow(/build metadata/);
+  });
+
+  it("replaces only the top same-version RC during stable promotion", () => {
+    const rc1 = updateChangelog(
+      "# Changelog\n",
+      "0.6.0-rc.1",
+      "rc one",
+      "2026-08-10",
+      "block/berd",
+    );
+    const rc2 = updateChangelog(
+      rc1,
+      "0.6.0-rc.2",
+      "rc two",
+      "2026-08-11",
+      "block/berd",
+    );
+    const stable = updateChangelog(
+      rc2,
+      "0.6.0",
+      "cumulative stable notes",
+      "2026-08-12",
+      "block/berd",
+    );
+    expect(stable).toContain("[v0.6.0](https://github.com/block/berd");
+    expect(stable).not.toContain("v0.6.0-rc.2");
+    expect(stable).toContain("v0.6.0-rc.1");
+  });
+});
+
+describe("release preparation", () => {
+  it("creates one lockstep release commit, pushes it, opens a PR, and resumes", async () => {
+    const f = await fixture();
+    const prepared = f.release(["prepare", "0.6.0-rc.1", f.notes]);
+    expect(prepared.status, `${prepared.stdout}\n${prepared.stderr}`).toBe(0);
+    expect(f.git(["branch", "--show-current"]).stdout.trim()).toBe(
+      "release/v0.6.0-rc.1",
+    );
+    expect(f.git(["log", "-1", "--format=%s"]).stdout.trim()).toBe(
+      "chore: release v0.6.0-rc.1",
+    );
+    const checked = f.release(["version-check", "0.6.0-rc.1"]);
+    expect(checked.status, checked.stderr).toBe(0);
+    expect(await readFile(join(f.repo, "CHANGELOG.md"), "utf8")).toContain(
+      "https://github.com/block/berd/releases/tag/v0.6.0-rc.1",
+    );
+    expect(f.git(["tag", "--list"]).stdout.trim()).toBe("");
+    expect(await readFile(f.calls, "utf8")).toContain("pr create");
+
+    const head = f.git(["rev-parse", "HEAD"]).stdout.trim();
+    const pr = JSON.stringify([
+      {
+        number: 123,
+        url: "https://github.com/block/berd/pull/123",
+        state: "OPEN",
+        isDraft: false,
+        mergedAt: null,
+        headRefName: "release/v0.6.0-rc.1",
+        baseRefName: "main",
+        headRefOid: head,
+        title: "chore: release v0.6.0-rc.1",
+        mergeCommit: null,
+      },
+    ]);
+    const resumed = f.release(["prepare", "0.6.0-rc.1", f.notes], {
+      GH_PR_LIST_JSON: pr,
+    });
+    expect(resumed.status, resumed.stderr).toBe(0);
+    expect(resumed.stdout).toContain("https://github.com/block/berd/pull/123");
+    expect(
+      Number(
+        f
+          .git(["rev-list", "--count", "refs/remotes/origin/main..HEAD"])
+          .stdout.trim(),
+      ),
+    ).toBe(1);
+  });
+
+  it("restores every tracked file when focused validation fails", async () => {
+    const f = await fixture();
+    const failed = f.release(["prepare", "0.6.0-rc.1", f.notes], {
+      PNPM_STATUS: "1",
+    });
+    expect(failed.status).not.toBe(0);
+    expect(f.git(["status", "--porcelain"]).stdout).toBe("");
+    expect(
+      JSON.parse(await readFile(join(f.repo, "package.json"), "utf8")).version,
+    ).toBe("0.4.12");
+    expect(await readFile(join(f.repo, "CHANGELOG.md"), "utf8")).toBe(
+      "# Changelog\n",
+    );
+  });
+});
+
+describe("release publishing", () => {
+  it("creates an annotated tag and pushes only the squash-merge commit tag", async () => {
+    const f = await fixture();
+    const prepared = f.release(["prepare", "0.6.0-rc.1", f.notes]);
+    expect(prepared.status, prepared.stderr).toBe(0);
+    const releaseHead = f.git(["rev-parse", "HEAD"]).stdout.trim();
+    expect(f.git(["switch", "main"]).status).toBe(0);
+    expect(f.git(["merge", "--squash", "release/v0.6.0-rc.1"]).status).toBe(0);
+    expect(f.git(["commit", "-m", "chore: release v0.6.0-rc.1"]).status).toBe(
+      0,
+    );
+    const mergeSha = f.git(["rev-parse", "HEAD"]).stdout.trim();
+    expect(mergeSha).not.toBe(releaseHead);
+    expect(f.git(["push", "origin", "main"]).status).toBe(0);
+
+    const pr = JSON.stringify([
+      {
+        number: 123,
+        url: "https://github.com/block/berd/pull/123",
+        state: "MERGED",
+        isDraft: false,
+        mergedAt: "2026-08-12T00:00:00Z",
+        headRefName: "release/v0.6.0-rc.1",
+        baseRefName: "main",
+        headRefOid: releaseHead,
+        title: "chore: release v0.6.0-rc.1",
+        mergeCommit: { oid: mergeSha },
+      },
+    ]);
+    const published = f.release(["publish", "0.6.0-rc.1"], {
+      GH_PR_LIST_JSON: pr,
+    });
+    expect(published.status, `${published.stdout}\n${published.stderr}`).toBe(
+      0,
+    );
+    expect(published.stdout).toContain("actions/workflows/release.yml");
+    expect(
+      run("git", [
+        "--git-dir",
+        f.remote,
+        "cat-file",
+        "-t",
+        "refs/tags/v0.6.0-rc.1",
+      ]).stdout.trim(),
+    ).toBe("tag");
+    expect(
+      run("git", [
+        "--git-dir",
+        f.remote,
+        "rev-parse",
+        "refs/tags/v0.6.0-rc.1^{commit}",
+      ]).stdout.trim(),
+    ).toBe(mergeSha);
+  });
+});
+
+describe("release workflow source gate", () => {
+  it("requires main ancestry and annotated tags before release creation", async () => {
+    const [workflow, verifier, notesGenerator] = await Promise.all([
+      readFile(join(sourceRepo, ".github/workflows/release.yml"), "utf8"),
+      readFile(
+        join(sourceRepo, "scripts/release/github/verify-release-source.sh"),
+        "utf8",
+      ),
+      readFile(join(sourceRepo, "scripts/generate-release-notes.sh"), "utf8"),
+    ]);
+    expect(workflow.indexOf("Verify release source")).toBeLessThan(
+      workflow.indexOf("Ensure immutable versioned release"),
+    );
+    expect(workflow).toContain('just release-version-check "$VERSION"');
+    expect(verifier).toContain("git merge-base --is-ancestor");
+    expect(verifier).toContain('== "tag"');
+    expect(notesGenerator).not.toContain("gh release");
+    expect(notesGenerator).not.toContain("read -r -p");
+  });
+});

--- a/scripts/release/tests/release-tooling.test.mjs
+++ b/scripts/release/tests/release-tooling.test.mjs
@@ -188,9 +188,6 @@ describe("release preparation", () => {
     );
     const checked = f.release(["version-check", "0.6.0-rc.1"]);
     expect(checked.status, checked.stderr).toBe(0);
-    expect(await readFile(join(f.repo, "CHANGELOG.md"), "utf8")).toContain(
-      "https://github.com/block/berd/releases/tag/v0.6.0-rc.1",
-    );
     expect(f.git(["tag", "--list"]).stdout.trim()).toBe("");
     expect(await readFile(f.calls, "utf8")).toContain("pr create");
 
@@ -230,12 +227,6 @@ describe("release preparation", () => {
     });
     expect(failed.status).not.toBe(0);
     expect(f.git(["status", "--porcelain"]).stdout).toBe("");
-    expect(
-      JSON.parse(await readFile(join(f.repo, "package.json"), "utf8")).version,
-    ).toBe("0.4.12");
-    expect(await readFile(join(f.repo, "CHANGELOG.md"), "utf8")).toBe(
-      "# Changelog\n",
-    );
   });
 });
 
@@ -274,7 +265,6 @@ describe("release publishing", () => {
     expect(published.status, `${published.stdout}\n${published.stderr}`).toBe(
       0,
     );
-    expect(published.stdout).toContain("actions/workflows/release.yml");
     expect(
       run("git", [
         "--git-dir",
@@ -292,26 +282,5 @@ describe("release publishing", () => {
         "refs/tags/v0.6.0-rc.1^{commit}",
       ]).stdout.trim(),
     ).toBe(mergeSha);
-  });
-});
-
-describe("release workflow source gate", () => {
-  it("requires main ancestry and annotated tags before release creation", async () => {
-    const [workflow, verifier, notesGenerator] = await Promise.all([
-      readFile(join(sourceRepo, ".github/workflows/release.yml"), "utf8"),
-      readFile(
-        join(sourceRepo, "scripts/release/github/verify-release-source.sh"),
-        "utf8",
-      ),
-      readFile(join(sourceRepo, "scripts/generate-release-notes.sh"), "utf8"),
-    ]);
-    expect(workflow.indexOf("Verify release source")).toBeLessThan(
-      workflow.indexOf("Ensure immutable versioned release"),
-    );
-    expect(workflow).toContain('just release-version-check "$VERSION"');
-    expect(verifier).toContain("git merge-base --is-ancestor");
-    expect(verifier).toContain('== "tag"');
-    expect(notesGenerator).not.toContain("gh release");
-    expect(notesGenerator).not.toContain("read -r -p");
   });
 });

--- a/scripts/release/validate-manifest-promotion.mjs
+++ b/scripts/release/validate-manifest-promotion.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFile, writeFile } from "node:fs/promises";
+import { compareSemver, parseSemver } from "./version.mjs";
 
 const [candidatePath, currentPath] = process.argv.slice(2);
 if (!candidatePath || !currentPath) {
@@ -9,57 +10,6 @@ if (!candidatePath || !currentPath) {
   process.exit(2);
 }
 
-const semverPattern =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
-
-function parseSemver(value, label) {
-  const match = semverPattern.exec(value);
-  if (!match)
-    throw new Error(`${label} has invalid canonical SemVer: ${value}`);
-  return {
-    core: match.slice(1, 4),
-    prerelease: match[4]?.split(".") ?? [],
-  };
-}
-
-function compareDigitStrings(left, right) {
-  if (left.length !== right.length) return left.length < right.length ? -1 : 1;
-  return left === right ? 0 : left < right ? -1 : 1;
-}
-
-function compareIdentifiers(left, right) {
-  const leftNumeric = /^\d+$/.test(left);
-  const rightNumeric = /^\d+$/.test(right);
-  if (leftNumeric && rightNumeric) return compareDigitStrings(left, right);
-  if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
-  return left === right ? 0 : left < right ? -1 : 1;
-}
-
-function compareSemver(left, right) {
-  for (let index = 0; index < 3; index += 1) {
-    const compared = compareDigitStrings(left.core[index], right.core[index]);
-    if (compared !== 0) return compared;
-  }
-  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
-    return left.prerelease.length === right.prerelease.length
-      ? 0
-      : left.prerelease.length === 0
-        ? 1
-        : -1;
-  }
-  const length = Math.max(left.prerelease.length, right.prerelease.length);
-  for (let index = 0; index < length; index += 1) {
-    if (left.prerelease[index] === undefined) return -1;
-    if (right.prerelease[index] === undefined) return 1;
-    const compared = compareIdentifiers(
-      left.prerelease[index],
-      right.prerelease[index],
-    );
-    if (compared !== 0) return compared;
-  }
-  return 0;
-}
-
 try {
   const [candidateBytes, currentBytes] = await Promise.all([
     readFile(candidatePath),
@@ -67,10 +17,9 @@ try {
   ]);
   const candidate = JSON.parse(candidateBytes);
   const current = JSON.parse(currentBytes);
-  const compared = compareSemver(
-    parseSemver(candidate.version, "candidate manifest"),
-    parseSemver(current.version, "current manifest"),
-  );
+  parseSemver(candidate.version, "candidate manifest version");
+  parseSemver(current.version, "current manifest version");
+  const compared = compareSemver(candidate.version, current.version);
   if (compared < 0) {
     throw new Error(
       `refusing updater downgrade from ${current.version} to ${candidate.version}`,

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+export const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+
+export function parseSemver(value, label = "version") {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  const match = SEMVER_PATTERN.exec(value);
+  if (!match) {
+    throw new Error(
+      `${label} must be canonical SemVer without a leading v or build metadata: ${value}`,
+    );
+  }
+  return {
+    value,
+    core: match.slice(1, 4),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+}
+
+function compareDigitStrings(left, right) {
+  if (left.length !== right.length) return left.length < right.length ? -1 : 1;
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function compareIdentifiers(left, right) {
+  const leftNumeric = /^\d+$/.test(left);
+  const rightNumeric = /^\d+$/.test(right);
+  if (leftNumeric && rightNumeric) return compareDigitStrings(left, right);
+  if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+export function compareSemver(leftValue, rightValue) {
+  const left =
+    typeof leftValue === "string"
+      ? parseSemver(leftValue, "left version")
+      : leftValue;
+  const right =
+    typeof rightValue === "string"
+      ? parseSemver(rightValue, "right version")
+      : rightValue;
+
+  for (let index = 0; index < 3; index += 1) {
+    const compared = compareDigitStrings(left.core[index], right.core[index]);
+    if (compared !== 0) return compared;
+  }
+  if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+    if (left.prerelease.length === right.prerelease.length) return 0;
+    return left.prerelease.length === 0 ? 1 : -1;
+  }
+  const length = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    if (left.prerelease[index] === undefined) return -1;
+    if (right.prerelease[index] === undefined) return 1;
+    const compared = compareIdentifiers(
+      left.prerelease[index],
+      right.prerelease[index],
+    );
+    if (compared !== 0) return compared;
+  }
+  return 0;
+}
+
+export function sameNumericVersion(leftValue, rightValue) {
+  const left = parseSemver(leftValue, "left version");
+  const right = parseSemver(rightValue, "right version");
+  return left.core.join(".") === right.core.join(".");
+}
+
+function usage() {
+  console.error(
+    "Usage: version.mjs validate <version> | compare <left> <right> | at-least <version> <minimum>",
+  );
+  process.exit(2);
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  try {
+    if (command === "validate" && args.length === 1) {
+      parseSemver(args[0]);
+      return;
+    }
+    if (command === "compare" && args.length === 2) {
+      process.stdout.write(`${compareSemver(args[0], args[1])}\n`);
+      return;
+    }
+    if (command === "at-least" && args.length === 2) {
+      if (compareSemver(args[0], args[1]) < 0) {
+        throw new Error(`${args[0]} is below the minimum version ${args[1]}`);
+      }
+      return;
+    }
+    usage();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -2,7 +2,7 @@
 
 import { pathToFileURL } from "node:url";
 
-export const SEMVER_PATTERN =
+const SEMVER_PATTERN =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
 
 export function parseSemver(value, label = "version") {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -579,7 +579,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "berdctl"
-version = "0.1.0"
+version = "0.4.12"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.1.0"
+version = "0.4.12"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.1.0"
+version = "0.4.12"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.1.0"
+version = "0.4.12"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -64,7 +64,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg", "deb", "rpm", "appimage"],
+    "targets": ["app", "dmg", "deb", "appimage"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -87,9 +87,6 @@
     "linux": {
       "deb": {
         "depends": ["libvulkan1"]
-      },
-      "rpm": {
-        "depends": ["vulkan-loader"]
       }
     },
     "macOS": {


### PR DESCRIPTION
## implementation

This adds a maintainer-owned release state machine around the existing build, signing, staging, and promotion scripts.

- `just release-prepare X.Y.Z` generates notes through `just release-notes`, prints them for explicit `[y/N]` approval, creates `release/vX.Y.Z` from current `origin/main`, synchronizes the app/CLI/plugin versions and Cargo lock entries, updates `CHANGELOG.md`, runs focused validation, creates one conventional release commit, pushes the branch, and opens the release PR.
- `just release-publish X.Y.Z` resolves the merged release PR's squash commit through GitHub, verifies that commit is reachable from `origin/main`, revalidates its committed version/changelog state, creates an annotated tag on that exact commit, and pushes only the tag ref.
- tag publication is resumable after local or remote push ambiguity when the existing annotated tag resolves to the verified merge commit; conflicting tags fail closed.

## release invariants

- public versions must be canonical SemVer at or above `0.6.0-rc.1`
- `package.json`, Tauri config, the Berd/berdctl/plugin Cargo manifests, and their Cargo lock entries move in lockstep
- an immutable tag must be annotated, main-reachable, source-bound, and match the committed changelog entry before GitHub creates or resumes a release
- GitHub release notes are derived from the committed changelog and checked for drift on recovery
- updater public-key configuration is supplied as a repository secret

## failure and recovery behavior

- declining generated notes exits before creating a branch, commit, push, or PR
- failed preparation validation restores all tracked release files
- an existing release branch or PR is resumed only when its commit, metadata, and source boundary match the requested release
- a partially completed tag push can be retried without deleting a valid local tag
- release workflow recovery remains bound to the original tag and source commit

## validation

- `just check`
- `just release-validate`
- 78 release-script tests, including approval rejection, minimum-version enforcement, preparation rollback, publish retry, annotated-tag verification, and changelog/manifest SemVer behavior
