### PR TITLE
fix: accept github squash release titles

### DIFF
--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -774,7 +774,10 @@ async function publish(version) {
   const mergeTitle = run("git", ["show", "-s", "--format=%s", mergeSha], {
     cwd: root,
   });
-  if (mergeTitle !== subject) fail(`merge commit title is not '${subject}'`);
+  const githubMergeTitle = `${subject} (#${pr.number})`;
+  if (mergeTitle !== subject && mergeTitle !== githubMergeTitle) {
+    fail(`merge commit title does not match PR #${pr.number}`);
+  }
   await checkVersions({ root, expected: version, ref: mergeSha });
   const sourceConfig = await releaseConfig(gitReader(root, mergeSha));
   validateMinimumPublicVersion(version, sourceConfig);

--- a/scripts/release/tests/release-tooling.test.mjs
+++ b/scripts/release/tests/release-tooling.test.mjs
@@ -285,9 +285,9 @@ describe("release publishing", () => {
     const releaseHead = f.git(["rev-parse", "HEAD"]).stdout.trim();
     expect(f.git(["switch", "main"]).status).toBe(0);
     expect(f.git(["merge", "--squash", "release/v0.6.0-rc.1"]).status).toBe(0);
-    expect(f.git(["commit", "-m", "chore: release v0.6.0-rc.1"]).status).toBe(
-      0,
-    );
+    expect(
+      f.git(["commit", "-m", "chore: release v0.6.0-rc.1 (#123)"]).status,
+    ).toBe(0);
     const mergeSha = f.git(["rev-parse", "HEAD"]).stdout.trim();
     expect(mergeSha).not.toBe(releaseHead);
     expect(f.git(["push", "origin", "main"]).status).toBe(0);


### PR DESCRIPTION
## context

GitHub created the merged release commit as `chore: release v0.6.0-rc.1 (#11)`. `release-publish` required the subject without the PR-number suffix, so it rejected the valid merged release PR before tagging.

## implementation

- accept either the exact release subject or GitHub's canonical ` (#<pr-number>)` suffix
- bind the accepted suffix to the already validated merged release PR number
- keep version, ancestry, source commit, and tag-target validation unchanged
- exercise the publish path with a GitHub-style squash commit subject

## validation

- `just release-scripts-test` (78 passed)
