### PR TITLE
fix(ci): bootstrap windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
     needs: setup
     if: needs.setup.outputs.staged_windows_assets_ready != 'true'
     runs-on: windows-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     permissions:
       contents: write
       id-token: write
@@ -300,14 +300,35 @@ jobs:
         with:
           tool: just@1.40.0
 
+      - name: Install pinned Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.10.0
+
+      - name: Install pinned pnpm
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
+          if ((pnpm --version) -ne '10.33.0') { throw 'pnpm 10.33.0 was not activated' }
+
+      - name: Resolve managed Goose Cargo target
+        shell: pwsh
+        run: |
+          $target = Join-Path $env:LOCALAPPDATA 'berd-dev\cargo-target'
+          "GOOSE_DEV_CARGO_TARGET_DIR=$target" >> $env:GITHUB_ENV
+
+      - name: Cache managed Goose Cargo target
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ env.GOOSE_DEV_CARGO_TARGET_DIR }}
+          key: goose-cargo-${{ runner.os }}-rust-1.94.1-${{ hashFiles('goose-backend.lock.json') }}
+
       - name: Require updater public key
         shell: pwsh
         run: |
           if ([string]::IsNullOrWhiteSpace($env:BERD_UPDATER_PUBLIC_KEY)) { throw 'BERD_UPDATER_PUBLIC_KEY repository secret is required' }
-
-      - name: Set up Windows build dependencies
-        shell: pwsh
-        run: just setup-windows release
 
       - name: Generate updater-enabled Tauri configuration
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing immutable v<semver> tag to recover; select this same tag as the run ref
+        description: Existing immutable v<semver> tag to recover; run from main
         required: true
         type: string
 
@@ -18,7 +18,7 @@ permissions:
 # incomplete platform payload before rebuilding it, so concurrent runs for the
 # same immutable tag would otherwise race against each other's uploads.
 concurrency:
-  group: berd-release-${{ github.ref }}
+  group: berd-release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -47,7 +47,7 @@ jobs:
       - name: Check out requested immutable ref
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -70,8 +70,8 @@ jobs:
             echo "::error::Expected an existing v<semver> tag without build metadata; got '$TAG'"
             exit 1
           }
-          if [[ "$EVENT_NAME" == "workflow_dispatch" && "${GITHUB_REF:-}" != "refs/tags/$TAG" ]]; then
-            echo "::error::Recovery dispatch must run from refs/tags/$TAG; got '${GITHUB_REF:-<unset>}'"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "${GITHUB_REF:-}" != "refs/heads/main" ]]; then
+            echo "::error::Recovery dispatch must use the workflow from main; got '${GITHUB_REF:-<unset>}'"
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.10.0
+          package-manager-cache: false
 
       - name: Install pinned pnpm
         shell: pwsh
@@ -312,18 +313,6 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.33.0 --activate
           if ((pnpm --version) -ne '10.33.0') { throw 'pnpm 10.33.0 was not activated' }
-
-      - name: Resolve managed Goose Cargo target
-        shell: pwsh
-        run: |
-          $target = Join-Path $env:LOCALAPPDATA 'berd-dev\cargo-target'
-          "GOOSE_DEV_CARGO_TARGET_DIR=$target" >> $env:GITHUB_ENV
-
-      - name: Cache managed Goose Cargo target
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ${{ env.GOOSE_DEV_CARGO_TARGET_DIR }}
-          key: goose-cargo-${{ runner.os }}-rust-1.94.1-${{ hashFiles('goose-backend.lock.json') }}
 
       - name: Require updater public key
         shell: pwsh

--- a/scripts/release/package-signed-updater-linux.sh
+++ b/scripts/release/package-signed-updater-linux.sh
@@ -58,10 +58,6 @@ tar -tzf "$OUTPUT_DIR/$ARCHIVE_NAME" | grep -Fxq "$APPIMAGE_NAME"
 )
 SIGNATURE="$OUTPUT_DIR/$ARCHIVE_NAME.sig"
 [[ -s "$SIGNATURE" ]] || { release_error "tauri signer produced no $SIGNATURE"; exit 1; }
-grep -Fq "untrusted comment: signature from minisign secret key" "$SIGNATURE" || {
-  release_error "tauri signer produced an invalid minisign envelope"
-  exit 1
-}
 "$REPO_ROOT/scripts/release/verify-updater-signature.sh" \
   "$OUTPUT_DIR/$ARCHIVE_NAME" "$SIGNATURE" "$BERD_UPDATER_PUBLIC_KEY"
 unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD

--- a/scripts/release/package-signed-updater-windows.sh
+++ b/scripts/release/package-signed-updater-windows.sh
@@ -115,10 +115,6 @@ if [[ ! -s "$SIGNATURE" ]]; then
   release_error "tauri signer produced no $SIGNATURE"
   exit 1
 fi
-if ! grep -Fq "untrusted comment: signature from minisign secret key" "$SIGNATURE"; then
-  release_error "tauri signer produced an invalid minisign envelope"
-  exit 1
-fi
 "$REPO_ROOT/scripts/release/verify-updater-signature.sh" \
   "$ARCHIVE" "$SIGNATURE" "$BERD_UPDATER_PUBLIC_KEY"
 unset TAURI_SIGNING_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY_PASSWORD

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -88,7 +88,7 @@ describe("managed Goose build profile", () => {
       '$gooseBuildProfile = if ($Debug) { "debug" } else { "release" }',
     );
     expect(bundle).toContain("$env:GOOSE_BUILD_PROFILE = $gooseBuildProfile");
-    expect(workflow).toContain("run: just setup-windows release");
+    expect(workflow).toContain("just bundle-windows nsis");
     expect(windowsSetup).toContain(
       '[ValidateSet("debug", "release")][string]$GooseBuildProfile = "debug"',
     );
@@ -754,7 +754,9 @@ describe("desktop release workflow platform gate", () => {
     expect(workflow).not.toContain(`${expressionStart} env.asset_dir }}`);
     expect(workflow).not.toContain("release delete-asset");
     expect(workflow).toContain("release-reconcile-assets");
-    expect(workflow).toContain("group: berd-release-$" + "{{ github.ref }}");
+    expect(workflow).toContain(
+      "group: berd-release-$" + "{{ inputs.tag || github.ref_name }}",
+    );
     expect(workflow).toContain("pnpm install --frozen-lockfile");
     expect(workflow).toContain("release-write-provenance");
     expect(workflow).not.toContain("jq -n");


### PR DESCRIPTION
updates release recovery, windows packaging, and updater signature verification.

- runs recovery dispatches from main while checking out the requested immutable tag, with push and recovery runs serialized by tag
- aligns the windows release job with the proven unsigned build using node 24.10.0, pnpm 10.33.0, disabled package-manager caching, direct bundle-windows invocation, and a 240-minute timeout
- removes plaintext minisign-envelope checks that rejected tauri cli base64 signature files while retaining non-empty output checks and cryptographic verification on linux and windows
- updates release workflow assertions for direct windows bundling and tag-based concurrency