### PR TITLE
fix: rebuild workspace sdk before typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate:berdctl-contract": "node ./scripts/generate-berdctl-contract.mjs",
     "design-system:tokens": "node ./scripts/design-system-tokens.mjs",
     "build": "tsc && vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "pnpm --filter @aaif/goose-sdk build:ts && tsc --noEmit",
     "avatars:manifest": "node ./scripts/avatar-manifest.mjs manifest",
     "avatars:publish": "node ./scripts/avatar-manifest.mjs publish",
     "avatars:promote": "node ./scripts/avatar-manifest.mjs promote",


### PR DESCRIPTION
**Category:** fix
**User Impact:** Developers can run type checks after SDK updates without stale declarations causing false failures.
**Problem:** The root typecheck consumed ignored `sdk/dist` declarations without ensuring they matched the checked-in generated SDK source. After the ACP server ID rename, an older local SDK build made valid `serverId` usage fail type checking.
**Solution:** Build the vendored SDK TypeScript output before running the root application typecheck so workspace declarations are always current.

<details>
<summary>File changes</summary>

**package.json**
Build the workspace Goose SDK declarations before running the root TypeScript check, preventing stale ignored output from causing false failures.

</details>
