### PR TITLE
chore: release v0.6.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.6.0-rc.2](https://github.com/block/berd/releases/tag/v0.6.0-rc.2) - 2026-08-13
+
+This release improves platform support and keeps Berd’s built-in agent runtime current.
+
+- **More reliable releases:** Improved Windows packaging and signed update delivery across Windows and Linux.
+- **Extension compatibility:** Updated the bundled Goose runtime while maintaining support for existing ACP extensions.
+
+**Full Changelog**: https://github.com/block/berd/compare/v0.6.0-rc.1...f12536b
+
 ## [v0.6.0-rc.1](https://github.com/block/berd/releases/tag/v0.6.0-rc.1) - 2026-08-13
 
 This release improves project chat setup and refreshes the getting-started experience.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "berd",
   "private": true,
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0-rc.2",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Berd"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",
@@ -579,7 +579,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "berdctl"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Berd"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 description = "Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Berd",
-  "version": "0.6.0-rc.1",
+  "version": "0.6.0-rc.2",
   "identifier": "xyz.block.berd",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
## Summary

- synchronize Berd, berdctl, and tauri-plugin-berdctl at 0.6.0-rc.2
- add the reviewed v0.6.0-rc.2 changelog entry

### Related issue

N/A

### Testing

- `just release-version-check 0.6.0-rc.2`
- `just release-validate 0.6.0-rc.2`
