### PR TITLE
fix(release): forward unix provenance arguments

### DIFF
--- a/justfile
+++ b/justfile
@@ -277,7 +277,7 @@ release-reconcile-assets repository tag version output_file:
 [unix]
 [positional-arguments]
 release-write-provenance source_sha version platform output_dir *ASSETS:
-    bash -euo pipefail -c 'scripts/release/write-provenance.sh "$@"' _ "$1" "$2" "$3" "$4" "${@:5}"
+    bash -euo pipefail -c 'scripts/release/write-provenance.sh "$@"' _ "$@"
 
 # On Windows, run the shared Bash script as one generated recipe so argv remains
 # positional and is not interpolated into shell source.

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -777,8 +777,7 @@ describe("desktop release workflow platform gate", () => {
       2,
     );
     expect(provenanceRecipes).toContain(
-      'bash -euo pipefail -c \'scripts/release/write-provenance.sh "$@"\' _ "$1" "$2" "$3" "$4" "$' +
-        '{@:5}"',
+      'bash -euo pipefail -c \'scripts/release/write-provenance.sh "$@"\' _ "$@"',
     );
     expect(provenanceRecipes).toContain(
       'scripts/release/write-provenance.sh "$1" "$2" "$3" "$4" "$' + '{@:5}"',


### PR DESCRIPTION
Fixes Linux and macOS release provenance generation under Ubuntu `/bin/sh`.

Technical changes:
- forwards the complete positional argument list with POSIX-compatible `"$@"` before invoking the nested Bash process
- removes the `${@:5}` expansion that fails under `dash`
- updates the release recipe assertion to match the corrected command

Validation:
- focused Ubuntu `act` job generated and validated Linux and macOS provenance receipts without running application builds
- `just release-scripts-test` (78 tests passed)
