### PR TITLE
ci: synchronize release configuration across builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,20 @@ concurrency:
 
 env:
   RELEASE_CHANNEL_CONFIG: scripts/release/release-channel.json
+  # One public product-build contract for every platform lane. Platform
+  # scripts may derive matching native features, but must not choose different
+  # renderer capabilities.
+  VITE_ENVIRONMENT: production
+  VITE_AUTH_GATE: "0"
+  VITE_AGENT_TOOLS: "0"
+  VITE_AUTOMATIONS: "0"
+  VITE_BUILDERBOT: "0"
+  VITE_FEEDBACK: "0"
+  VITE_MANAGED_CONNECTIONS: "0"
+  VITE_VOICE_DICTATION: "0"
+  VITE_BYO_KEY_PROVIDERS: "1"
+  VITE_SECURITY_ML: "0"
+  VITE_UPDATER_ENABLED: "true"
 
 jobs:
   setup:
@@ -447,11 +461,10 @@ jobs:
           GOOSE_BUILD_PROFILE=release scripts/prepare-goose-sidecar.sh
           CARGO_TARGET_DIR="$BERD_TAURI_CARGO_TARGET_DIR" scripts/prepare-berdctl-sidecar.sh x86_64-unknown-linux-gnu
           scripts/prepare-catch-sidecar.sh x86_64-unknown-linux-gnu
+          CARGO_FEATURES="$(scripts/block-feature-gates.sh berdctl)"
           BERD_APP_VERSION="$VERSION" \
           VITE_APP_VERSION="$VERSION" \
-          VITE_ENVIRONMENT=production \
-          VITE_UPDATER_ENABLED=true \
-          pnpm tauri build --bundles appimage,deb --features berdctl \
+          pnpm tauri build --bundles appimage,deb --features "$CARGO_FEATURES" \
             --config src-tauri/tauri.release.conf.json
 
       - name: Package and sign Linux updater archive

--- a/release-agents/README.md
+++ b/release-agents/README.md
@@ -2,8 +2,8 @@
 
 This directory holds agent Markdown files available to Berd release builds.
 Selected files are staged into `distro/agents/` only for the duration of the
-build. Official and custom builds default to the public-safe `builderbot`
-selection.
+build. Official and custom builds do not select any release-only agents by
+default. Berdy is always bundled from `distro/agents/berdy.md`.
 
 ## Adding an agent
 
@@ -33,10 +33,9 @@ Requirements:
 
 ## Selecting bundled agents
 
-Official and custom release builds bundle `builderbot` by default. Block-only
-agents are supplied by the private distribution rather than this public catalog.
-Either build kind can override its default by setting `CUSTOM_BUNDLED_AGENTS`.
-Provide a comma-separated list of basenames without the `.md` extension.
+Release builds select no agents from this directory by default. Either build
+kind can opt into agents by setting `CUSTOM_BUNDLED_AGENTS`. Provide a
+comma-separated list of basenames without the `.md` extension.
 
 ```json
 {"CUSTOM_BUNDLED_AGENTS":"support-bot,oncall-captain"}

--- a/scripts/release/build-macos.sh
+++ b/scripts/release/build-macos.sh
@@ -36,10 +36,8 @@
 #                     trust roots build-bundled
 #   - BERD_RELEASE_CHANNEL_ID: current binary channel ID inside that catalog
 #
-# An official build — the default, with all of the above unset — is byte-for-
-# byte the build this script ran before custom builds existed: features =
-# berdctl, no extra VITE_* overrides, no version suffix, and the committed
-# runtime-config.json shipped as-is.
+# Official builds enable BYO-key providers, add no release-only agents or
+# version suffix, and ship the committed runtime-config.json as-is.
 
 set -euo pipefail
 
@@ -105,7 +103,7 @@ VITE_BUILDERBOT_VALUE="${VITE_BUILDERBOT:-0}"
 VITE_FEEDBACK_VALUE="${VITE_FEEDBACK:-0}"
 VITE_MANAGED_CONNECTIONS_VALUE="${VITE_MANAGED_CONNECTIONS:-0}"
 VITE_VOICE_DICTATION_VALUE="${VITE_VOICE_DICTATION:-0}"
-VITE_BYO_KEY_PROVIDERS_VALUE=0
+VITE_BYO_KEY_PROVIDERS_VALUE=1
 # Public builds have no external security classifier. Internal distributions may
 # opt in by supplying their implementation and setting VITE_SECURITY_ML=1.
 VITE_SECURITY_ML_VALUE="${VITE_SECURITY_ML:-0}"
@@ -421,8 +419,8 @@ if [[ "$BUILD_KIND" == "custom" && "$DISABLE_BB_CLI" == "true" ]]; then
   CARGO_FEATURES="$CARGO_FEATURES,no-bb-cli-install"
 fi
 
-# Stage the selected bundled agents into distro/agents/ for the Tauri resource
-# bundle. Official and custom builds use the default builderbot selection.
+# Stage explicitly selected release-only agents into distro/agents/ for the
+# Tauri resource bundle. Berdy is already present in that directory.
 stage_custom_bundled_agents
 
 # Generate the channel-specific release overlay. The generator validates the

--- a/scripts/release/lib.sh
+++ b/scripts/release/lib.sh
@@ -236,11 +236,10 @@ default_bundled_agents() {
   [[ -n "$build_kind" ]] || build_kind="$(release_build_kind)"
 
   case "$build_kind" in
-    official)
-      printf '%s' "builderbot"
-      ;;
-    custom)
-      printf '%s' "builderbot"
+    official|custom)
+      # Berdy already lives under distro/agents and is bundled on every
+      # platform. Release-only agents must be selected explicitly.
+      return 0
       ;;
     *)
       echo "invalid build_kind '${build_kind}' (expected official or custom)" >&2

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -707,6 +707,40 @@ describe("generate-latest-json", () => {
 });
 
 describe("desktop release workflow platform gate", () => {
+  it("uses one public build profile across all platform lanes", async () => {
+    const workflow = parseYaml(
+      await readFile(join(repo, ".github/workflows/release.yml"), "utf8"),
+    );
+
+    expect(workflow.env).toMatchObject({
+      VITE_ENVIRONMENT: "production",
+      VITE_AUTH_GATE: "0",
+      VITE_AGENT_TOOLS: "0",
+      VITE_AUTOMATIONS: "0",
+      VITE_BUILDERBOT: "0",
+      VITE_FEEDBACK: "0",
+      VITE_MANAGED_CONNECTIONS: "0",
+      VITE_VOICE_DICTATION: "0",
+      VITE_BYO_KEY_PROVIDERS: "1",
+      VITE_SECURITY_ML: "0",
+      VITE_UPDATER_ENABLED: "true",
+    });
+
+    const linuxBuild = workflow.jobs["stage-linux"].steps.find(
+      (step) => step.name === "Build Linux packages",
+    ).run;
+    expect(linuxBuild).toContain(
+      'CARGO_FEATURES="$(scripts/block-feature-gates.sh berdctl)"',
+    );
+    expect(linuxBuild).toContain('--features "$CARGO_FEATURES"');
+
+    const macosBuild = await readFile(
+      join(repo, "scripts/release/build-macos.sh"),
+      "utf8",
+    );
+    expect(macosBuild).toContain("VITE_BYO_KEY_PROVIDERS_VALUE=1");
+  });
+
   it("does not interpolate GitHub expressions into executable shell", async () => {
     const workflow = parseYaml(
       await readFile(join(repo, ".github/workflows/release.yml"), "utf8"),

--- a/src/scripts/__tests__/releaseDefaults.test.ts
+++ b/src/scripts/__tests__/releaseDefaults.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -19,10 +20,23 @@ function runDefaultBundledAgents(buildKind: string) {
 
 describe("release bundled-agent defaults", () => {
   it.each([
-    ["official", "builderbot"],
-    ["custom", "builderbot"],
-  ])("uses the %s build default", (buildKind, expected) => {
-    expect(runDefaultBundledAgents(buildKind)).toBe(expected);
+    "official",
+    "custom",
+  ])("does not add release-only agents to %s builds by default", (buildKind) => {
+    expect(runDefaultBundledAgents(buildKind)).toBe("");
+  });
+
+  it("always bundles Berdy from the distro resources", () => {
+    const tauriConfig = JSON.parse(
+      readFileSync(resolve(repoRoot, "src-tauri/tauri.conf.json"), "utf8"),
+    );
+    const berdy = readFileSync(
+      resolve(repoRoot, "distro/agents/berdy.md"),
+      "utf8",
+    );
+
+    expect(tauriConfig.bundle.resources["../distro"]).toBe("distro");
+    expect(berdy).toContain("berdBundled: true");
   });
 
   it("rejects an invalid build kind", () => {


### PR DESCRIPTION
Synchronizes the public release capability configuration across macOS, Windows, and Linux.

The workflow now exports one shared Vite flag set for every platform lane, including BYO-key providers. Linux derives its native feature list through the same feature-gate helper used by the other release paths, keeping renderer and Tauri capabilities aligned.

Official and custom releases no longer stage BuilderBot by default. Berdy remains bundled from the committed distro resources, while release-only agents require an explicit selection.

Regression coverage verifies the workflow capability profile, Linux feature derivation, BYO-key default, and Berdy resource contract. Validated with the release-script suites, the full Vitest suite, `just check`, and the commit/push hooks.
