### PR TITLE
remove search from sidenav

### DIFF
--- a/src/app/views/NavigationPanesView.tsx
+++ b/src/app/views/NavigationPanesView.tsx
@@ -368,7 +368,7 @@ export function NavigationPanesView({
         onSettingsSectionChange={onSettingsSectionChange}
         renderInlineSessionList={
           !collapsed
-            ? (searchQuery) => (
+            ? () => (
                 <SessionListCapability
                   activeSessionId={activeSessionId}
                   collapsed={collapsed}
@@ -391,7 +391,6 @@ export function NavigationPanesView({
                   onSelectSession={onSelectSession}
                   onSessionSelectForScroll={handleSessionSelectForScroll}
                   projects={projects}
-                  searchQuery={searchQuery}
                   surface={{
                     renderDragHandle: () => null,
                     showTopDivider: true,

--- a/src/app/views/__tests__/NavigationPanesView.test.tsx
+++ b/src/app/views/__tests__/NavigationPanesView.test.tsx
@@ -630,57 +630,14 @@ describe("NavigationPanesView", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the sidebar search field by default", () => {
+  it("does not show a search field in the sidebar", () => {
     renderSidebar();
 
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
     expect(
-      screen.getByRole("searchbox", { name: "Jump to a chat" }),
-    ).toHaveAttribute("spellcheck", "false");
-    expect(
-      screen.getByRole("searchbox", { name: "Jump to a chat" }),
-    ).toHaveAttribute("autocorrect", "off");
-    expect(
-      screen.getByRole("searchbox", { name: "Jump to a chat" }),
-    ).toHaveAttribute("autocapitalize", "none");
-    expect(
-      screen.queryByRole("button", { name: "Clear" }),
+      screen.queryByRole("button", { name: "Jump to a chat" }),
     ).not.toBeInTheDocument();
     expect(screen.getByTestId("nav-settings")).toHaveAccessibleName("Settings");
-  });
-
-  it("clears the sidebar search query with the clear button", async () => {
-    const user = userEvent.setup();
-    renderSidebar();
-
-    const search = screen.getByRole("searchbox", { name: "Jump to a chat" });
-    await user.type(search, "profile");
-    await user.click(screen.getByRole("button", { name: "Clear" }));
-
-    expect(search).toHaveValue("");
-    expect(search).toHaveFocus();
-    expect(
-      screen.queryByRole("button", { name: "Clear" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("nav-settings")).toBeInTheDocument();
-  });
-
-  it("selects a filtered chat before search collapses on blur", async () => {
-    const user = userEvent.setup();
-    const onSelectSession = vi.fn();
-    seedSessions({
-      id: "profile-chat",
-      title: "Profile polish",
-      updatedAt: "2026-04-09T12:00:00.000Z",
-      messageCount: 3,
-    });
-
-    renderSidebar({ onSelectSession });
-
-    const search = screen.getByRole("searchbox", { name: "Jump to a chat" });
-    await user.type(search, "profile");
-    await user.click(screen.getByRole("button", { name: "Profile polish" }));
-
-    expect(onSelectSession).toHaveBeenCalledWith("profile-chat");
   });
 
   it("moves roving focus through main sidebar rows", () => {

--- a/src/features/navigation/ui/PrimaryNavigationSurface.tsx
+++ b/src/features/navigation/ui/PrimaryNavigationSurface.tsx
@@ -5,17 +5,9 @@ import {
   type KeyboardEventHandler,
   type ReactNode,
   type Ref,
-  useEffect,
-  useRef,
-  useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  IconArrowLeft,
-  IconSearch,
-  IconServer,
-  IconX,
-} from "@tabler/icons-react";
+import { IconArrowLeft, IconServer } from "@tabler/icons-react";
 import { ArrowUpCircle } from "lucide-react";
 import type { AppView } from "@/app/AppShell";
 import { PaneSurface } from "@/app/layout/panes/paneChrome";
@@ -25,7 +17,6 @@ import {
   type SectionId,
 } from "@/features/settings/ui/settingsSections";
 import { cn } from "@/shared/lib/cn";
-import { Button } from "@/shared/ui/button";
 import {
   SIDEBAR_PANEL_ELEVATED_SHADOW_CLASS,
   SIDEBAR_SECTION_DIVIDER_INSET_CLASS,
@@ -62,7 +53,7 @@ interface PrimaryNavigationSurfaceProps {
   onSettingsBack?: () => void;
   onSettingsClick?: () => void;
   onSettingsSectionChange?: (section: SectionId) => void;
-  renderInlineSessionList?: (searchQuery: string) => ReactNode;
+  renderInlineSessionList?: () => ReactNode;
   secondaryNavRef: Ref<HTMLElement>;
   settingsSections: readonly (typeof SETTINGS_SECTIONS)[number][];
   showBottomMask: boolean;
@@ -107,30 +98,7 @@ export const PrimaryNavigationSurface = forwardRef<
   },
   ref,
 ) {
-  const { t } = useTranslation(["sidebar", "common", "settings"]);
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const [searchExpanded, setSearchExpanded] = useState(!navCollapsed);
-  const [searchQuery, setSearchQuery] = useState("");
-  const expandSearch = () => {
-    setSearchExpanded(true);
-    window.requestAnimationFrame(() => searchInputRef.current?.focus());
-  };
-  useEffect(() => {
-    if (navCollapsed) {
-      setSearchQuery("");
-      return;
-    }
-    setSearchExpanded(true);
-  }, [navCollapsed]);
-  useEffect(() => {
-    const focusSearch = () => {
-      setSearchExpanded(true);
-      window.requestAnimationFrame(() => searchInputRef.current?.focus());
-    };
-    window.addEventListener("goose:focus-nav-search", focusSearch);
-    return () =>
-      window.removeEventListener("goose:focus-nav-search", focusSearch);
-  }, []);
+  const { t } = useTranslation(["sidebar", "settings"]);
   const mainNavItems: readonly {
     id: AppView;
     label: string;
@@ -169,7 +137,7 @@ export const PrimaryNavigationSurface = forwardRef<
       fullHeight
       width={width}
     >
-      <div className="flex-shrink-0 pt-1.5" aria-hidden="true" />
+      <div className="flex-shrink-0 pt-[3px]" aria-hidden="true" />
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <div
@@ -182,55 +150,6 @@ export const PrimaryNavigationSurface = forwardRef<
           inert={isSecondarySurface ? true : undefined}
           aria-hidden={isSecondarySurface}
         >
-          <div className="mb-1 flex h-7 flex-shrink-0 items-center px-1.5">
-            {navCollapsed ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label={t("search.jumpToChat")}
-                tooltip={t("search.jumpToChat")}
-                onClick={expandSearch}
-              >
-                <IconSearch aria-hidden="true" className="!size-4" />
-              </Button>
-            ) : searchExpanded ? (
-              <div className="group relative block w-full overflow-hidden rounded-sm">
-                <IconSearch
-                  aria-hidden="true"
-                  className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground/50 transition-colors group-hover:text-muted-foreground group-focus-within:text-muted-foreground"
-                />
-                <input
-                  ref={searchInputRef}
-                  type="search"
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="none"
-                  value={searchQuery}
-                  onChange={(event) => setSearchQuery(event.target.value)}
-                  placeholder={t("search.jumpToChat")}
-                  aria-label={t("search.jumpToChat")}
-                  className="h-7 w-full appearance-none rounded-sm border-0 bg-muted/40 pl-9 pr-8 text-sm font-normal text-muted-foreground/50 shadow-none outline-none ring-0 transition-colors placeholder:text-muted-foreground/50 hover:bg-muted/60 hover:text-muted-foreground focus:bg-muted/60 focus:text-muted-foreground focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 [&::-webkit-search-cancel-button]:appearance-none"
-                />
-                {searchQuery && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label={t("common:actions.clear")}
-                    title={t("common:actions.clear")}
-                    className="absolute right-1 top-1/2 -translate-y-1/2"
-                    onClick={() => {
-                      setSearchQuery("");
-                      searchInputRef.current?.focus();
-                    }}
-                  >
-                    <IconX aria-hidden="true" />
-                  </Button>
-                )}
-              </div>
-            ) : null}
-          </div>
           <nav
             ref={mainNavRef}
             onKeyDown={onKeyDown}
@@ -246,9 +165,7 @@ export const PrimaryNavigationSurface = forwardRef<
             }
             aria-label={t("navigation.main")}
           >
-            <div
-              className={cn("relative z-10 space-y-0", searchQuery && "hidden")}
-            >
+            <div className="relative z-10 space-y-0">
               <SidebarNavItem
                 testId="nav-home"
                 navId="home"
@@ -279,32 +196,30 @@ export const PrimaryNavigationSurface = forwardRef<
               })}
             </div>
 
-            {!navCollapsed && !searchQuery && <SidebarPinnedSection />}
+            {!navCollapsed && <SidebarPinnedSection />}
 
-            {renderInlineSessionList?.(searchQuery)}
+            {renderInlineSessionList?.()}
           </nav>
-          {(!searchQuery || navCollapsed) && (
-            <div className="flex-shrink-0 px-1.5 py-1.5">
-              <div
-                aria-hidden="true"
-                className={cn(
-                  "mb-1.5 h-px bg-border/70",
-                  SIDEBAR_SECTION_DIVIDER_INSET_CLASS,
-                )}
-              />
-              <SidebarNavItem
-                testId="nav-settings"
-                navId="settings"
-                icon={SidebarNavSettingsIcon}
-                label={t("settings:title")}
-                collapsed={navCollapsed}
-                labelTransition={labelTransition}
-                labelVisible={navLabelVisible}
-                isActive={activeView === "settings"}
-                onClick={() => onSettingsClick?.()}
-              />
-            </div>
-          )}
+          <div className="flex-shrink-0 px-1.5 py-1.5">
+            <div
+              aria-hidden="true"
+              className={cn(
+                "mb-1.5 h-px bg-border/70",
+                SIDEBAR_SECTION_DIVIDER_INSET_CLASS,
+              )}
+            />
+            <SidebarNavItem
+              testId="nav-settings"
+              navId="settings"
+              icon={SidebarNavSettingsIcon}
+              label={t("settings:title")}
+              collapsed={navCollapsed}
+              labelTransition={labelTransition}
+              labelVisible={navLabelVisible}
+              isActive={activeView === "settings"}
+              onClick={() => onSettingsClick?.()}
+            />
+          </div>
         </div>
 
         <div

--- a/src/features/navigation/ui/PrimaryNavigationSurface.tsx
+++ b/src/features/navigation/ui/PrimaryNavigationSurface.tsx
@@ -19,6 +19,7 @@ import {
 import { cn } from "@/shared/lib/cn";
 import {
   SIDEBAR_PANEL_ELEVATED_SHADOW_CLASS,
+  SIDEBAR_PRIMARY_NAV_TOP_INSET_CLASS,
   SIDEBAR_SECTION_DIVIDER_INSET_CLASS,
 } from "@/shared/ui/sidebar-tokens";
 import { SidebarNavItem } from "./SidebarNavItem";
@@ -137,7 +138,10 @@ export const PrimaryNavigationSurface = forwardRef<
       fullHeight
       width={width}
     >
-      <div className="flex-shrink-0 pt-[3px]" aria-hidden="true" />
+      <div
+        className={cn("flex-shrink-0", SIDEBAR_PRIMARY_NAV_TOP_INSET_CLASS)}
+        aria-hidden="true"
+      />
 
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <div

--- a/src/features/sessions/capabilities/SessionListCapability.tsx
+++ b/src/features/sessions/capabilities/SessionListCapability.tsx
@@ -162,7 +162,6 @@ export interface SessionListCapabilityProps {
   onSelectSession?: (sessionId: string) => void;
   onSessionSelectForScroll?: (sessionId: string) => void;
   projects: ProjectInfo[];
-  searchQuery?: string;
   surface: SessionListSurfaceOptions;
 }
 
@@ -481,7 +480,6 @@ export function SessionListCapability({
   onSelectSession,
   onSessionSelectForScroll,
   projects,
-  searchQuery = "",
   surface,
 }: SessionListCapabilityProps) {
   const { t } = useTranslation(["sidebar", "common"]);
@@ -575,29 +573,9 @@ export function SessionListCapability({
       sessions,
     ],
   );
-  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
-  const effectiveGroupChatsByProject =
-    normalizedSearchQuery.length > 0 ? false : groupChatsByProject;
-  const searchedVisibleSessions = useMemo(
-    () => ({
-      ...visibleSessions,
-      sessions: normalizedSearchQuery
-        ? visibleSessions.sessions.filter((session) => {
-            const projectName = session.projectId
-              ? projectsById.get(session.projectId)?.name
-              : undefined;
-            return [session.title, projectName].some((value) =>
-              value?.toLowerCase().includes(normalizedSearchQuery),
-            );
-          })
-        : visibleSessions.sessions,
-    }),
-    [normalizedSearchQuery, projectsById, visibleSessions],
-  );
   const activeSessions = useMemo(
-    () =>
-      searchedVisibleSessions.sessions.filter((session) => !session.archivedAt),
-    [searchedVisibleSessions],
+    () => visibleSessions.sessions.filter((session) => !session.archivedAt),
+    [visibleSessions],
   );
   const activeSessionIds = useMemo(
     () => new Set(activeSessions.map((session) => session.id)),
@@ -806,13 +784,13 @@ export function SessionListCapability({
   }, [activeSessionId, activeSessionIds]);
 
   useEffect(() => {
-    if (effectiveGroupChatsByProject) return;
+    if (groupChatsByProject) return;
     setFlatChatGroupNowMs(Date.now());
     const interval = window.setInterval(() => {
       setFlatChatGroupNowMs(Date.now());
     }, FLAT_CHAT_GROUP_REFRESH_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [effectiveGroupChatsByProject]);
+  }, [groupChatsByProject]);
 
   const pinnedChatProjectIds = useMemo(
     () =>
@@ -825,9 +803,9 @@ export function SessionListCapability({
   );
   const projectSessions = useMemo(
     () =>
-      effectiveGroupChatsByProject
+      groupChatsByProject
         ? getSessionListGroups(
-            searchedVisibleSessions.sessions.filter(
+            visibleSessions.sessions.filter(
               (session) => !pinnedHomeChatSessionIds.has(session.id),
             ),
             projectIds,
@@ -839,18 +817,17 @@ export function SessionListCapability({
         : EMPTY_SESSION_LIST_GROUPS,
     [
       branchNameBySessionId,
-      effectiveGroupChatsByProject,
+      groupChatsByProject,
       pinnedHomeChatSessionIds,
       projectIds,
       sessionStateById,
-      searchedVisibleSessions,
-      visibleSessions.placeholderSessionIds,
+      visibleSessions,
     ],
   );
   const flatSessionCandidates = useMemo(() => {
-    if (effectiveGroupChatsByProject) return [];
+    if (groupChatsByProject) return [];
     return getFlatSessionListItems(
-      searchedVisibleSessions.sessions.filter(
+      visibleSessions.sessions.filter(
         (session) => !pinnedHomeChatSessionIds.has(session.id),
       ),
       projectsById,
@@ -860,12 +837,11 @@ export function SessionListCapability({
     );
   }, [
     branchNameBySessionId,
-    effectiveGroupChatsByProject,
+    groupChatsByProject,
     pinnedHomeChatSessionIds,
     projectsById,
     sessionStateById,
-    searchedVisibleSessions,
-    visibleSessions.placeholderSessionIds,
+    visibleSessions,
   ]);
   const flatSessions = useMemo(
     () =>
@@ -882,7 +858,7 @@ export function SessionListCapability({
   );
   const flatChatGroups = useMemo(
     () =>
-      effectiveGroupChatsByProject
+      groupChatsByProject
         ? []
         : groupFlatChatsByActivityAge(
             flatSessions,
@@ -892,7 +868,7 @@ export function SessionListCapability({
     [
       flatChatGroupNowMs,
       flatSessions,
-      effectiveGroupChatsByProject,
+      groupChatsByProject,
       pinnedHomeChatSessionIds,
     ],
   );
@@ -900,7 +876,7 @@ export function SessionListCapability({
   const hasFlatChatOverflow =
     flatSessionCandidates.length > MAX_FLAT_SIDEBAR_CHATS ||
     (flatSessionCandidates.length >= MAX_FLAT_SIDEBAR_CHATS && hasMoreSessions);
-  const standaloneChatCount = effectiveGroupChatsByProject
+  const standaloneChatCount = groupChatsByProject
     ? projectSessions.standalone.length
     : flatSessionCandidates.length;
   const groupedChatCount = useMemo(
@@ -912,7 +888,7 @@ export function SessionListCapability({
       ),
     [projectSessions],
   );
-  const reachedAutoLoadLimit = effectiveGroupChatsByProject
+  const reachedAutoLoadLimit = groupChatsByProject
     ? standaloneChatCount >= MAX_FLAT_SIDEBAR_CHATS ||
       groupedChatCount >= MAX_AUTO_LOADED_GROUPED_CHATS
     : standaloneChatCount >= MAX_FLAT_SIDEBAR_CHATS;
@@ -1036,9 +1012,7 @@ export function SessionListCapability({
     hasVisibleChats: activeSessions.length > 0,
     flatChatGroups,
     hasFlatChatOverflow,
-    compactFlatGroups: normalizedSearchQuery.length > 0,
-    searchActive: normalizedSearchQuery.length > 0,
-    groupChatsByProject: effectiveGroupChatsByProject,
+    groupChatsByProject,
     onGroupChatsByProjectChange: setGroupChatsByProject,
     pinnedShowChatIcons: displayOptions.pinnedShowChatIcons,
     onPinnedShowChatIconsChange: setDisplayOption("pinnedShowChatIcons"),

--- a/src/features/sessions/ui/session-list/SidebarFlatChatsSection.tsx
+++ b/src/features/sessions/ui/session-list/SidebarFlatChatsSection.tsx
@@ -59,8 +59,6 @@ export function SidebarFlatChatsSection({
   showTimestamps,
   onShowTimestampsChange,
   showViewAllInHistory = false,
-  compactGroups = false,
-  compactHeader = false,
   showTopDivider: _showTopDivider = true,
 }: {
   groups: FlatChatGroup[];
@@ -97,8 +95,6 @@ export function SidebarFlatChatsSection({
   showTimestamps: boolean;
   onShowTimestampsChange: (show: boolean) => void;
   showViewAllInHistory?: boolean;
-  compactGroups?: boolean;
-  compactHeader?: boolean;
   showTopDivider?: boolean;
 }) {
   const { t } = useTranslation(["sidebar", "common"]);
@@ -127,7 +123,6 @@ export function SidebarFlatChatsSection({
           labelTransition={labelTransition}
           labelVisible={labelVisible}
           labelClassName={sectionHeaderTextClass}
-          className={compactHeader ? "pt-0" : undefined}
           actions={
             (onNavigate && showViewAllInHistory) ||
             onCreateProject ||
@@ -290,10 +285,7 @@ export function SidebarFlatChatsSection({
             {groups.map((group, groupIndex) => (
               <div
                 key={group.id}
-                className={cn(
-                  "space-y-0",
-                  !compactGroups && groupIndex > 0 && "mt-1 pt-1",
-                )}
+                className={cn("space-y-0", groupIndex > 0 && "mt-1 pt-1")}
                 data-sidebar-flat-chat-group={group.id}
               >
                 {group.sessions.map((session) => {

--- a/src/features/sessions/ui/session-list/SidebarProjectsInfoButton.tsx
+++ b/src/features/sessions/ui/session-list/SidebarProjectsInfoButton.tsx
@@ -72,9 +72,8 @@ export function useSidebarProjectsInfoMoment({
  * explains what projects are. Render only while the accompanying
  * `useSidebarProjectsInfoMoment` reports `visible`. Exposure is recorded
  * here, on mount, rather than in the hook: the hook also runs when the
- * sidebar is collapsed or in flat/search mode, where the header suppresses
- * the adornment, and those hidden passes must not consume the moment's
- * limited exposures.
+ * sidebar is hidden or the Projects header is not rendered, and those hidden
+ * passes must not consume the moment's limited exposures.
  */
 export function SidebarProjectsInfoButton({
   moment,

--- a/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
+++ b/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
@@ -61,8 +61,6 @@ export interface SidebarProjectsSectionProps {
   hasVisibleChats: boolean;
   flatChatGroups: FlatChatGroup[];
   hasFlatChatOverflow: boolean;
-  compactFlatGroups?: boolean;
-  searchActive?: boolean;
   groupChatsByProject: boolean;
   onGroupChatsByProjectChange?: (grouped: boolean) => void;
   pinnedShowChatIcons: boolean;
@@ -139,8 +137,6 @@ export function SidebarProjectsSection({
   hasVisibleChats,
   flatChatGroups,
   hasFlatChatOverflow,
-  compactFlatGroups = false,
-  searchActive = false,
   groupChatsByProject,
   onGroupChatsByProjectChange,
   pinnedShowChatIcons,
@@ -218,7 +214,6 @@ export function SidebarProjectsSection({
   // the link.
   const showGroupedHistoryLink =
     !collapsed &&
-    !searchActive &&
     ((projectSessions.standaloneOverflow ?? false) ||
       (hasMoreSessions && hasVisibleChats));
   const emptyActionClasses = cn(
@@ -304,9 +299,7 @@ export function SidebarProjectsSection({
           onMarkSelectedUnread={onMarkSelectedUnread}
           showTimestamps={chatShowTimestamps}
           onShowTimestampsChange={onChatShowTimestampsChange}
-          showViewAllInHistory={hasFlatChatOverflow && !searchActive}
-          compactGroups={compactFlatGroups}
-          compactHeader={searchActive}
+          showViewAllInHistory={hasFlatChatOverflow}
           showTopDivider={_showTopDivider}
         />
       </>

--- a/src/features/sessions/ui/session-list/__tests__/SidebarProjectsInfoButton.test.tsx
+++ b/src/features/sessions/ui/session-list/__tests__/SidebarProjectsInfoButton.test.tsx
@@ -31,8 +31,8 @@ function InfoMomentHarness({
 }
 
 /**
- * Mirrors call sites where the hook runs but the affordance never renders
- * (collapsed sidebar, flat/search mode suppressing the header adornment).
+ * Mirrors call sites where the hook runs but the Projects header—and therefore
+ * the affordance—does not render.
  */
 function HookWithoutButtonHarness({ hasProjects }: { hasProjects: boolean }) {
   useSidebarProjectsInfoMoment({ hasProjects, projectsReady: true });

--- a/src/shared/i18n/locales/en/sidebar.json
+++ b/src/shared/i18n/locales/en/sidebar.json
@@ -66,9 +66,7 @@
     "skills": "Skills"
   },
   "search": {
-    "closeJumpToChat": "Close chat search",
     "error": "Message search failed. Showing metadata matches only. Try again.",
-    "jumpToChat": "Jump to a chat",
     "loadingMore": "Searching more chats...",
     "placeholder": "Search chats...",
     "searchMore": "Search more chats",

--- a/src/shared/i18n/locales/es/sidebar.json
+++ b/src/shared/i18n/locales/es/sidebar.json
@@ -70,9 +70,7 @@
     "loadingMore": "Buscando más chats...",
     "placeholder": "Buscar chats...",
     "searchMore": "Buscar más chats",
-    "searching": "Buscando chats...",
-    "closeJumpToChat": "Cerrar búsqueda de chats",
-    "jumpToChat": "Ir a un chat"
+    "searching": "Buscando chats..."
   },
   "sections": {
     "projects": "Proyectos",

--- a/src/shared/ui/sidebar-tokens.ts
+++ b/src/shared/ui/sidebar-tokens.ts
@@ -65,6 +65,9 @@ export const SIDEBAR_GROUP_LABEL_TEXT_CLASS =
 export const SIDEBAR_PANEL_ELEVATED_HOVER_SHADOW_CLASS =
   "hover:shadow-sidebar-panel-elevated";
 
+/** Top inset for the primary navigation surface. */
+export const SIDEBAR_PRIMARY_NAV_TOP_INSET_CLASS = "pt-[3px]";
+
 /** Horizontal inset for sidebar section divider lines. */
 export const SIDEBAR_SECTION_DIVIDER_INSET_CLASS = "mx-3";
 


### PR DESCRIPTION
**Category:** improvement
**User Impact:** The sidenav now starts directly with navigation and chats instead of showing a search field.
**Problem:** The sidenav search field added visual weight to the primary navigation without supporting the intended streamlined layout.
**Solution:** Remove the search control and its now-unreachable filtering and presentation paths, tighten the top spacing, and preserve the normal chat and settings navigation behavior.

<details>
<summary>File changes</summary>

**src/app/views/NavigationPanesView.tsx**
Stops passing a search query into the inline session list now that the sidenav no longer owns search state.

**src/app/views/__tests__/NavigationPanesView.test.tsx**
Replaces obsolete search interaction coverage with an assertion that the sidenav no longer exposes the search control.

**src/features/navigation/ui/PrimaryNavigationSurface.tsx**
Removes the sidenav search field, associated state and event handling, and reduces the top inset to 3px.

**src/features/sessions/capabilities/SessionListCapability.tsx**
Removes the unused search-query API and unreachable filtering and search-mode grouping behavior.

**src/features/sessions/ui/session-list/SidebarFlatChatsSection.tsx**
Removes unused compact search presentation options.

**src/features/sessions/ui/session-list/SidebarProjectsInfoButton.tsx**
Updates documentation to describe the remaining hidden-header behavior without referencing removed search mode.

**src/features/sessions/ui/session-list/SidebarProjectsSection.tsx**
Removes stale search presentation controls while preserving history navigation for overflow chats.

**src/features/sessions/ui/session-list/__tests__/SidebarProjectsInfoButton.test.tsx**
Updates test documentation to match the current Projects-header lifecycle.

**src/shared/i18n/locales/en/sidebar.json**
Removes unused English strings for the deleted jump-to-chat control.

**src/shared/i18n/locales/es/sidebar.json**
Removes unused Spanish strings for the deleted jump-to-chat control.

</details>

## Verification

- `just check`
- `pnpm vitest run src/features/sessions/ui/session-list/__tests__ src/app/views/__tests__/NavigationPanesView.test.tsx` (169 passed, 1 skipped)
