### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Changelog
 
-## [v0.6.0-rc.3](https://github.com/block/berd/releases/tag/v0.6.0-rc.3) - 2026-08-13
+## [v0.6.0](https://github.com/block/berd/releases/tag/v0.6.0) - 2026-08-14
 
-This release adds safer chat cleanup, clearer subagent activity, and improved guidance for getting started with Berd.
+This release makes project chats safer, improves chat organization and agent visibility, and refreshes the getting-started experience. Agent sharing is also now available to everyone.
 
-- **Automatic chat archiving:** Choose when inactive, unpinned chats are archived under Settings → Archive. Berd asks for confirmation before enabling it and protects active, running, pinned, or draft-bearing chats.
-- **Clearer subagent activity:** Chat activity now identifies known subagents and their assigned tasks, with more accurate labels for delegation, messages, waiting, interruptions, and cancellations.
-- **Experimental — Guided starter tasks:** Starter tasks now provide contextual guidance, take you directly to the relevant workflow, and can be restored from the Home widget picker after dismissal.
+- **Multi-folder project chats:** Choose worktree behavior for each Git folder when creating a project, with clearer setup prompts, progress, and recovery when starting a chat.
+- **Automatic chat archiving:** Choose when inactive, unpinned chats are archived under Settings → Archive. Active, running, pinned, and draft-bearing chats remain protected, and archived chats can be restored at any time.
+- **Clearer subagent activity:** Chat activity now identifies known subagents and their assigned tasks, with accurate labels for delegation, messages, waiting, interruptions, and cancellations.
+- **Agent share cards:** Share downloadable agent cards directly from the agent gallery or detail page without enabling an experiment.
+- **Message queue improvements:** Queued messages are grouped more clearly, and dismissing one no longer sends the next message unexpectedly.
+- **Streamlined navigation:** The sidebar now starts directly with navigation and chats, reducing visual clutter.
+- **Experimental — Guided starter tasks:** Starter tasks now provide contextual guidance, open the relevant workflow, and can be restored from the Home widget picker after dismissal.
+- **Experimental — Berdy onboarding:** A refreshed five-step tour introduces providers, chats, agents, and skills, then lets new users start chatting with Berdy directly from Home.
 
-**Full Changelog**: https://github.com/block/berd/compare/v0.6.0-rc.2...b2460b0
+**Full Changelog**: https://github.com/block/berd/compare/9b88cac3f72d09bb67cd4448029cc0fe17f6ad5c...39469b3
 
 ## [v0.6.0-rc.2](https://github.com/block/berd/releases/tag/v0.6.0-rc.2) - 2026-08-13
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "berd",
   "private": true,
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Berd"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",
@@ -579,7 +579,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "berdctl"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Berd"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 description = "Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.6.0-rc.3"
+version = "0.6.0"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Berd",
-  "version": "0.6.0-rc.3",
+  "version": "0.6.0",
   "identifier": "xyz.block.berd",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
## Summary

- synchronize Berd, berdctl, and tauri-plugin-berdctl at 0.6.0
- add the reviewed v0.6.0 changelog entry

### Related issue

N/A

### Testing

- `just release-version-check 0.6.0`
- `just release-validate 0.6.0`
