### PR TITLE
fix(chat): stabilize virtual transcript measurement

### DIFF
--- a/src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.test.tsx
+++ b/src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TranscriptRowDescriptor } from "../../projection/transcriptItemTypes";
 import {
   createLoadedTranscriptState,
+  MEASUREMENT_FLUSH_FALLBACK_MS,
   useTranscriptVirtualTimeline,
 } from "./useTranscriptVirtualTimeline";
 
@@ -37,10 +38,12 @@ describe("useTranscriptVirtualTimeline", () => {
 
   afterEach(() => {
     document.body.replaceChildren();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("flushes visible measurements on the next animation frame instead of a microtask", async () => {
+  it("lets the animation frame flush once and cancel its timer fallback", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const container = createContainer();
     const containerRef = {
       current: container,
@@ -84,17 +87,66 @@ describe("useTranscriptVirtualTimeline", () => {
       runPendingFrames();
     });
 
-    await waitFor(() => {
-      expect(
-        result.current.snapshot.measurementStats.visibleMeasurementAttempts,
-      ).toBe(1);
-      expect(
-        result.current.snapshot.measurementStats.acceptedVisibleMeasurements,
-      ).toBe(1);
+    expect(
+      result.current.snapshot.measurementStats.visibleMeasurementAttempts,
+    ).toBe(1);
+    expect(
+      result.current.snapshot.measurementStats.acceptedVisibleMeasurements,
+    ).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+
+    // The losing delivery cannot flush the accepted measurement again.
+    await act(async () => {
+      vi.advanceTimersByTime(MEASUREMENT_FLUSH_FALLBACK_MS + 1);
     });
+    expect(
+      result.current.snapshot.measurementStats.visibleMeasurementAttempts,
+    ).toBe(1);
   });
 
-  it("cancels pending measurements when the loaded transcript unmounts", async () => {
+  it("flushes queued measurements when animation frames are withheld", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const container = createContainer();
+    const containerRef = {
+      current: container,
+    } satisfies RefObject<HTMLDivElement | null>;
+    const rows = [row("intro", 100), row("assistant-tail", 120)];
+
+    const { result } = renderHook(() =>
+      useTranscriptVirtualTimeline({
+        sessionId: SESSION_ID,
+        sessionEpoch: 1,
+        rows,
+        containerRef,
+        footerHeight: 0,
+      }),
+    );
+
+    act(() => {
+      result.current.measureRowElement(
+        "assistant-tail",
+        createMeasuredElement(240),
+      );
+    });
+
+    // The frame queue is intentionally never delivered, matching WKWebView
+    // while it considers the window occluded or in transition.
+    act(() => {
+      vi.advanceTimersByTime(MEASUREMENT_FLUSH_FALLBACK_MS + 1);
+    });
+
+    expect(
+      result.current.snapshot.measurementStats.visibleMeasurementAttempts,
+    ).toBe(1);
+    expect(
+      result.current.snapshot.measurementStats.acceptedVisibleMeasurements,
+    ).toBe(1);
+    expect(frameCallbacks).toHaveLength(0);
+    expect(cancelAnimationFrame).toHaveBeenCalled();
+  });
+
+  it("cancels pending frame and timer deliveries when the loaded transcript unmounts", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const container = createContainer();
     const containerRef = {
       current: container,
@@ -119,11 +171,13 @@ describe("useTranscriptVirtualTimeline", () => {
     });
     const pendingMeasurementFrameCount = frameCallbacks.length;
     expect(pendingMeasurementFrameCount).toBeGreaterThan(0);
+    expect(vi.getTimerCount()).toBe(1);
 
     unmount();
 
     expect(frameCallbacks.length).toBeLessThan(pendingMeasurementFrameCount);
     expect(cancelAnimationFrame).toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("replaces fallback runtime state when the session changes", async () => {

--- a/src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.ts
+++ b/src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.ts
@@ -235,6 +235,10 @@ const TANSTACK_UI_OVERSCAN_AFTER_PX = 1200;
 const MAX_CONTROLLER_MEASUREMENT_UPDATES_PER_BATCH = 24;
 const TRANSCRIPT_MEASUREMENT_STABILITY_EPSILON_PX = 2;
 const TRANSCRIPT_LAYOUT_SYNC_EPSILON_PX = 1;
+// Animation frames are the fast path, but WKWebView can withhold them while a
+// window is occluded or transitioning. This fallback guarantees delivery
+// without moving measurement work into a second scheduler.
+export const MEASUREMENT_FLUSH_FALLBACK_MS = 80;
 const EMPTY_PROTECTED_ROW_IDS: readonly string[] = [];
 let nextLoadedTranscriptStateId = 0;
 
@@ -270,6 +274,7 @@ export interface TranscriptVirtualTimelineState {
   readonly deferredMeasurementByToken: Set<string>;
   measurementFlushScheduled: boolean;
   visibleMeasurementFrame: number | null;
+  visibleMeasurementTimeout: number | null;
   deferDomCorrections: boolean;
   controllerScrollWritesSuspended: boolean;
   deferredCorrection: DeferredTranscriptCorrection | null;
@@ -298,6 +303,7 @@ function createTranscriptVirtualTimelineState(): TranscriptVirtualTimelineState 
     deferredMeasurementByToken: new Set(),
     measurementFlushScheduled: false,
     visibleMeasurementFrame: null,
+    visibleMeasurementTimeout: null,
     deferDomCorrections: false,
     controllerScrollWritesSuspended: false,
     deferredCorrection: null,
@@ -369,6 +375,10 @@ export function useTranscriptVirtualTimeline({
       if (runtime.visibleMeasurementFrame !== null) {
         cancelAnimationFrame(runtime.visibleMeasurementFrame);
         runtime.visibleMeasurementFrame = null;
+      }
+      if (runtime.visibleMeasurementTimeout !== null) {
+        window.clearTimeout(runtime.visibleMeasurementTimeout);
+        runtime.visibleMeasurementTimeout = null;
       }
       runtime.measurementFlushScheduled = false;
       runtime.measurementScheduler?.cancelPendingWork(sessionId, sessionEpoch);
@@ -999,10 +1009,20 @@ export function useTranscriptVirtualTimeline({
   ]);
 
   const flushPendingMeasurementsInner = useCallback(() => {
-    runtimeRef.current.measurementFlushScheduled = false;
-    runtimeRef.current.visibleMeasurementFrame = null;
+    const runtime = runtimeRef.current;
+    runtime.measurementFlushScheduled = false;
+    // Either delivery may win. Cancel both handles before reading queued work
+    // so a late callback cannot flush the same batch twice.
+    if (runtime.visibleMeasurementFrame !== null) {
+      cancelAnimationFrame(runtime.visibleMeasurementFrame);
+      runtime.visibleMeasurementFrame = null;
+    }
+    if (runtime.visibleMeasurementTimeout !== null) {
+      window.clearTimeout(runtime.visibleMeasurementTimeout);
+      runtime.visibleMeasurementTimeout = null;
+    }
 
-    const controller = runtimeRef.current.controller;
+    const controller = runtime.controller;
     if (!controller) {
       runtimeRef.current.pendingVisibleMeasurementElements.clear();
       runtimeRef.current.pendingOffscreenShellMeasurementElements.clear();
@@ -1296,6 +1316,10 @@ export function useTranscriptVirtualTimeline({
     runtimeRef.current.visibleMeasurementFrame = requestAnimationFrame(
       flushPendingMeasurements,
     );
+    runtimeRef.current.visibleMeasurementTimeout = window.setTimeout(
+      flushPendingMeasurements,
+      MEASUREMENT_FLUSH_FALLBACK_MS,
+    );
   }, [flushPendingMeasurements]);
 
   const measureRowElement = useCallback(
@@ -1344,11 +1368,8 @@ export function useTranscriptVirtualTimeline({
       return;
     }
 
-    if (runtimeRef.current.visibleMeasurementFrame !== null) {
-      cancelAnimationFrame(runtimeRef.current.visibleMeasurementFrame);
-      runtimeRef.current.visibleMeasurementFrame = null;
-    }
-    runtimeRef.current.measurementFlushScheduled = false;
+    // The synchronous flush cancels any pending frame and timer itself, using
+    // the same first-delivery-wins lifecycle as an async flush.
     flushPendingMeasurements();
   }, [flushPendingMeasurements]);
 

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -351,11 +351,15 @@ function TranscriptOffscreenShellMeasurementHost({
       data-virtual-offscreen-shell-row-count={rows.length}
       style={{
         contain: "layout style paint",
+        // A fixed transform can leak content taller than its hoist into the
+        // scroll range. A zero-height clipped host contains any content size
+        // while its children still lay out for measurement.
+        height: 0,
         insetInlineStart: 0,
+        overflow: "clip",
         pointerEvents: "none",
         position: "absolute",
         top: 0,
-        transform: "translateY(-100000px)",
         userSelect: "none",
         visibility: "hidden",
         WebkitUserSelect: "none",
@@ -392,11 +396,13 @@ function TranscriptOffscreenRealMeasurementHost({
       data-virtual-offscreen-real-row-count={rowCount}
       style={{
         contain: "layout style paint",
+        // Match the shell host's content-height-independent containment.
+        height: 0,
         insetInlineStart: 0,
+        overflow: "clip",
         pointerEvents: "none",
         position: "absolute",
         top: 0,
-        transform: "translateY(-100000px)",
         userSelect: "none",
         visibility: "hidden",
         WebkitUserSelect: "none",
@@ -3716,10 +3722,10 @@ function VirtualMessageTimelineSession({
 
     const handoff = liveTailHandoffRef.current;
     if (!handoff || streamingMessageId) {
-      if (
-        liveTailScrollHeightFloorPx > 0 &&
-        measuredEffectiveVirtualScrollHeight >= liveTailScrollHeightFloorPx
-      ) {
+      // Once no handoff remains, the temporary DOM-height floor has no owner
+      // and must not survive as permanent empty space. This also covers a
+      // handoff cleared by a prior restore before this effect runs again.
+      if (!handoff && liveTailScrollHeightFloorPx > 0) {
         setLiveTailScrollHeightFloorPx(0);
       }
       return;
@@ -3732,6 +3738,11 @@ function VirtualMessageTimelineSession({
     }
 
     liveTailHandoffRef.current = null;
+    // The restore below reads the still-floored DOM geometry in this layout
+    // pass. Release the floor for the next render after it has served that
+    // purpose; detached readers keep their restored scrollTop, while the
+    // existing height-change effect re-pins readers following latest.
+    setLiveTailScrollHeightFloorPx(0);
 
     const nextBottomScrollTop = getBottomScrollTop(container);
     const wasNearLatest =
@@ -3768,7 +3779,6 @@ function VirtualMessageTimelineSession({
     isBoundedVirtualMode,
     liveTailScrollHeightFloorPx,
     markPendingScrollOwnership,
-    measuredEffectiveVirtualScrollHeight,
     setDetachedFromLatest,
     streamingMessageId,
     syncJumpToLatestVisibility,

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.search.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.search.test.tsx
@@ -202,6 +202,15 @@ describe("VirtualMessageTimeline indexed search", () => {
     expect(initial?.indexing).toBe(true);
     expect(initial?.activeOrdinal).toBe(-1);
 
+    // Searchable rows remain rendered while harvesting, but the host contains
+    // any batch height without a fixed translateY hoist.
+    const harvestHost = screen.getByTestId("transcript-search-harvest-host");
+    expect(harvestHost.style.height).toBe("0px");
+    expect(harvestHost.style.overflow).toBe("clip");
+    expect(harvestHost.style.transform).toBe("");
+    expect(harvestHost.style.visibility).toBe("");
+    expect(harvestHost.style.display).toBe("");
+
     // The harvest host renders the missing rows offscreen, the count
     // converges to the full transcript, and the anchor lands on the
     // transcript-order FIRST match — not whatever was mounted.

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -12,7 +12,10 @@ import {
   type TranscriptDiagnostics,
 } from "../../transcript/diagnostics";
 import type { TranscriptRowDescriptor } from "../../transcript/projection";
-import { createLoadedTranscriptState } from "../../transcript/virtual/react/useTranscriptVirtualTimeline";
+import {
+  createLoadedTranscriptState,
+  MEASUREMENT_FLUSH_FALLBACK_MS,
+} from "../../transcript/virtual/react/useTranscriptVirtualTimeline";
 import {
   TRANSCRIPT_SELECTION_SURFACE_ATTRIBUTE,
   TRANSCRIPT_SELECTION_SURFACE_VALUE,
@@ -138,6 +141,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
@@ -365,6 +369,31 @@ function mockRequestAnimationFrame() {
   });
   vi.spyOn(window, "cancelAnimationFrame").mockImplementation((frameId) => {
     callbacks.delete(frameId);
+  });
+
+  // Timeline tests explicitly deliver animation frames. Swallow only the
+  // measurement scheduler's timer fallback so wall-clock stalls cannot flush
+  // rows at nondeterministic points; hook tests exercise the real fallback.
+  const realSetTimeout = window.setTimeout.bind(window);
+  const realClearTimeout = window.clearTimeout.bind(window);
+  const swallowedTimeoutIds = new Set<number>();
+  let nextSwallowedTimeoutId = 0x40000000;
+  vi.stubGlobal("setTimeout", (...args: Parameters<typeof realSetTimeout>) => {
+    if (args[1] === MEASUREMENT_FLUSH_FALLBACK_MS) {
+      nextSwallowedTimeoutId += 1;
+      swallowedTimeoutIds.add(nextSwallowedTimeoutId);
+      return nextSwallowedTimeoutId;
+    }
+    return realSetTimeout(...args);
+  });
+  vi.stubGlobal("clearTimeout", (timeoutId?: unknown) => {
+    if (
+      typeof timeoutId === "number" &&
+      swallowedTimeoutIds.delete(timeoutId)
+    ) {
+      return;
+    }
+    realClearTimeout(timeoutId as Parameters<typeof realClearTimeout>[0]);
   });
 
   return {
@@ -1575,6 +1604,86 @@ describe("VirtualMessageTimeline", () => {
     expect(animationFrame.run(1001)).toBe(true);
   });
 
+  it("releases the live-tail scroll-height floor after restoring a detached reader", async () => {
+    mockTranscriptElementMeasurements();
+    const messages = [
+      ...Array.from({ length: 160 }, (_, index) =>
+        textMessage(
+          `message-${index}`,
+          index % 2 === 0 ? "user" : "assistant",
+          `Message ${index}`,
+        ),
+      ),
+      textMessage(
+        "streaming-tail",
+        "assistant",
+        `${longText("streaming fragment", 120)}\n[height:650]`,
+      ),
+    ];
+    const { rerender } = renderWithProviders(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={messages}
+        streamingMessageId="streaming-tail"
+      />,
+    );
+    const list = screen.getByTestId("virtual-message-timeline-list");
+    await waitFor(() =>
+      expect(list).toHaveAttribute(
+        "data-virtual-render-mode",
+        "bounded-controller",
+      ),
+    );
+
+    const scroller = screen.getByTestId("message-timeline-scroll");
+    attachScrollTo(scroller);
+    const capturedDomScrollHeight = 80000;
+    setScrollMetrics(scroller, {
+      scrollTop: 100,
+      scrollHeight: capturedDomScrollHeight,
+      clientHeight: 300,
+    });
+    fireEvent.wheel(scroller, { deltaY: -120 });
+    fireEvent.scroll(scroller);
+
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={messages}
+        streamingMessageId={null}
+      />,
+    );
+
+    await waitFor(() => {
+      const trailingSpacer = screen
+        .getAllByTestId("virtual-message-timeline-flow-spacer")
+        .at(-1) as HTMLElement;
+      expect(readPixelStyleValue(trailingSpacer, "height")).toBeLessThan(
+        capturedDomScrollHeight / 2,
+      );
+      expect(scroller.scrollTop).toBeLessThan(capturedDomScrollHeight / 2);
+    });
+    const restoredDetachedScrollTop = scroller.scrollTop;
+
+    // Render the completed state once more. The restore cleared its handoff,
+    // so this explicitly exercises the no-handoff cleanup path and proves the
+    // released floor cannot return on a later render.
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={messages}
+        streamingMessageId={null}
+      />,
+    );
+    const trailingSpacer = screen
+      .getAllByTestId("virtual-message-timeline-flow-spacer")
+      .at(-1) as HTMLElement;
+    expect(readPixelStyleValue(trailingSpacer, "height")).toBeLessThan(
+      capturedDomScrollHeight / 2,
+    );
+    expect(scroller.scrollTop).toBe(restoredDetachedScrollTop);
+  });
+
   it("does not auto-scroll again for the same latest user message after detaching", async () => {
     mockTranscriptElementMeasurements();
     const latestUser = textMessage("user-latest", "user", "Follow up");
@@ -2214,6 +2323,9 @@ describe("VirtualMessageTimeline", () => {
     );
     expect(offscreenRealHost).toHaveAttribute("aria-hidden", "true");
     expect(offscreenRealHost.style.userSelect).toBe("none");
+    expect(offscreenRealHost.style.height).toBe("0px");
+    expect(offscreenRealHost.style.overflow).toBe("clip");
+    expect(offscreenRealHost.style.transform).toBe("");
     const offscreenRealRow = offscreenRealHost.querySelector<HTMLElement>(
       "[data-virtual-row-offscreen-real-id]",
     );
@@ -2223,9 +2335,13 @@ describe("VirtualMessageTimeline", () => {
       "false",
     );
     expect((offscreenRealRow as HTMLElement).style.userSelect).toBe("none");
-    expect(
-      screen.getByTestId("virtual-offscreen-measurement-host"),
-    ).toHaveAttribute("aria-hidden", "true");
+    const offscreenShellHost = screen.getByTestId(
+      "virtual-offscreen-measurement-host",
+    );
+    expect(offscreenShellHost).toHaveAttribute("aria-hidden", "true");
+    expect(offscreenShellHost.style.height).toBe("0px");
+    expect(offscreenShellHost.style.overflow).toBe("clip");
+    expect(offscreenShellHost.style.transform).toBe("");
     await waitFor(() =>
       expect(transcriptDiagnosticsSpy).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/features/chat/ui/useVirtualTranscriptSearch.tsx
+++ b/src/features/chat/ui/useVirtualTranscriptSearch.tsx
@@ -605,10 +605,10 @@ interface TranscriptSearchHarvestHostProps {
 
 /**
  * Renders unmounted rows offscreen — through the real message renderer — and
- * harvests their searchable text. Hidden via transform only: visibility or
- * display hiding would (correctly) make the collector treat the content as
- * unrendered. Each batch is released after its DOM settles, so async content
- * (code highlighting) lands in the harvested text.
+ * harvests their searchable text. The host collapses to zero height and clips
+ * overflow; visibility or display hiding would (correctly) make the collector
+ * treat the content as unrendered. Each batch is released after its DOM
+ * settles, so async content (code highlighting) lands in the harvested text.
  */
 export function TranscriptSearchHarvestHost({
   requests,
@@ -701,11 +701,14 @@ export function TranscriptSearchHarvestHost({
       data-testid="transcript-search-harvest-host"
       style={{
         contain: "layout style",
+        // Searchable content must remain rendered, but its height must never
+        // extend the transcript's scroll range.
+        height: 0,
         insetInlineStart: 0,
+        overflow: "clip",
         pointerEvents: "none",
         position: "absolute",
         top: 0,
-        transform: "translateY(-100000px)",
         width: "100%",
       }}
     >


### PR DESCRIPTION
**Category:** fix
**User Impact:** Long, tool-heavy transcripts stay visible and keep an accurate scroll range when windows transition, become occluded, or finish streaming.
**Problem:** A withheld animation frame could leave virtual row measurements queued indefinitely, while fixed offscreen hoists could leak very tall measurement content into the transcript's scroll range. The temporary live-tail height floor could also survive after its restore pass, leaving detached readers with permanent empty space below the conversation.
**Solution:** Keep measurement delivery in the existing scheduler but add a lifecycle-safe timer fallback whose first delivery cancels the other. Release the live-tail floor after handoff restoration, and contain all transcript measurement and search-harvest hosts with zero height plus clipped overflow instead of content-height-dependent transforms.

### Validation

- Targeted transcript virtualization tests: 73 passed
- `just check`
- `just test`: 6,221 passed, 1 skipped
- Reviewed `LAWS/README.md` and `LAWS/CHAT.md`; this changes transcript geometry and measurement internals without changing composer queue behavior.

<details>
<summary>File changes</summary>

**src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.ts**
Adds the timer fallback to the existing measurement-flush lifecycle, with shared first-delivery cancellation and unmount cleanup.

**src/features/chat/transcript/virtual/react/useTranscriptVirtualTimeline.test.tsx**
Covers timer delivery when animation frames never run, frame-first cancellation, and cleanup of both pending deliveries on unmount.

**src/features/chat/ui/VirtualMessageTimeline.tsx**
Releases the live-tail height floor after handoff restore and replaces fixed hoists on both offscreen measurement hosts with content-height-independent containment.

**src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx**
Covers detached-reader floor release, no-handoff cleanup stability, existing pinned behavior, and containment of both measurement hosts.

**src/features/chat/ui/useVirtualTranscriptSearch.tsx**
Contains search-harvest content without hiding it from text collection or extending transcript scroll geometry.

**src/features/chat/ui/__tests__/VirtualMessageTimeline.search.test.tsx**
Verifies search harvesting remains rendered and uses zero-height clipped containment without a transform.

</details>
