### PR TITLE
fix: preserve transcripts after invalid replay refreshes

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -18,6 +18,8 @@ import { getAppNavigationController } from "@/features/berdctl/navigation";
 import { resetAgentBuilderSourceLifecycleForTests } from "@/features/agents/lib/agentBuilderSourceLifecycle";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { ensureReplayBuffer } from "@/features/chat/hooks/replayBuffer";
+import { createUserMessage } from "@/shared/types/messages";
 import { useSessionWindowStore } from "@/features/chat/stores/sessionWindowStore";
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
 import type { Message } from "@/shared/types/messages";
@@ -1770,6 +1772,11 @@ describe("AppShell global navigation", () => {
       activeSessionId: null,
     });
     mockCheckDirectoriesExist.mockResolvedValue(["/missing/session"]);
+    mockAcpLoadSession.mockImplementationOnce(async () => {
+      ensureReplayBuffer("missing-session").push(
+        createUserMessage("Existing history"),
+      );
+    });
 
     renderAppShell();
 
@@ -1787,8 +1794,8 @@ describe("AppShell global navigation", () => {
 
     const messages =
       useChatStore.getState().messagesBySession["missing-session"] ?? [];
-    expect(messages).toHaveLength(1);
-    expect(messages[0]?.content[0]).toMatchObject({
+    expect(messages).toHaveLength(2);
+    expect(messages[1]?.content[0]).toMatchObject({
       type: "systemNotification",
       notificationType: "warning",
       action: { type: "openContextPanel" },

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -142,9 +142,9 @@ import {
 } from "@/features/chat/stores/chatSessionOperations";
 import {
   activateSession as activateChatSession,
-  hasConversationMessages,
   loadSessionMessagesAndPrepare,
 } from "@/features/chat/lib/sessionActivation";
+import { hasConversationMessages } from "@/features/chat/lib/sessionReplayReplacement";
 import {
   focusSessionWindow,
   releaseSession,

--- a/src/features/chat/hooks/__tests__/useChat.compaction.test.ts
+++ b/src/features/chat/hooks/__tests__/useChat.compaction.test.ts
@@ -171,6 +171,53 @@ describe("useChat compaction", () => {
     ).toBe(false);
   });
 
+  it("keeps the transcript and reports failure when compacted replay is invalid", async () => {
+    mockAcpLoadSession.mockImplementation(async (sessionId: string) => {
+      ensureReplayBuffer(sessionId).push(
+        createTextMessage("compact-1", "user", "/compact/compact"),
+      );
+    });
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        createTextMessage("user-1", "user", "Before compact"),
+        createTextMessage("assistant-1", "assistant", "A long answer"),
+      ]);
+
+    const { result } = renderHook(() => useChat("session-1"));
+    let compactResult: unknown;
+    await act(async () => {
+      compactResult = await result.current.compactConversation();
+    });
+
+    expect(compactResult).toBe("failed");
+    const messages = useChatStore.getState().messagesBySession["session-1"];
+    expect(messages.map((message) => message.id)).toEqual([
+      "user-1",
+      "assistant-1",
+      expect.any(String),
+    ]);
+    expect(
+      messages.some((message) =>
+        message.content.some(
+          (block) =>
+            block.type === "systemNotification" &&
+            block.notificationType === "compaction",
+        ),
+      ),
+    ).toBe(false);
+    expect(messages[2].content).toEqual([
+      {
+        type: "systemNotification",
+        notificationType: "error",
+        text: "Couldn't verify the compacted conversation because refreshed history wasn't received. Your previous messages are still shown. Try reloading the session.",
+      },
+    ]);
+    expect(useChatStore.getState().getSessionRuntime("session-1").error).toBe(
+      "Couldn't verify the compacted conversation because refreshed history wasn't received. Your previous messages are still shown. Try reloading the session.",
+    );
+  });
+
   it("prepares and compacts the override persona session", async () => {
     let preparedPersonaId: string | undefined;
     const ensurePrepared = vi.fn(async (personaId?: string) => {

--- a/src/features/chat/hooks/__tests__/useChat.compaction.test.ts
+++ b/src/features/chat/hooks/__tests__/useChat.compaction.test.ts
@@ -171,7 +171,7 @@ describe("useChat compaction", () => {
     ).toBe(false);
   });
 
-  it("keeps the transcript and reports failure when compacted replay is invalid", async () => {
+  it("keeps the transcript and warns when compacted replay is invalid", async () => {
     mockAcpLoadSession.mockImplementation(async (sessionId: string) => {
       ensureReplayBuffer(sessionId).push(
         createTextMessage("compact-1", "user", "/compact/compact"),
@@ -190,7 +190,7 @@ describe("useChat compaction", () => {
       compactResult = await result.current.compactConversation();
     });
 
-    expect(compactResult).toBe("failed");
+    expect(compactResult).toBe("completed-with-refresh-warning");
     const messages = useChatStore.getState().messagesBySession["session-1"];
     expect(messages.map((message) => message.id)).toEqual([
       "user-1",
@@ -213,9 +213,38 @@ describe("useChat compaction", () => {
         text: "Couldn't verify the compacted conversation because refreshed history wasn't received. Your previous messages are still shown. Try reloading the session.",
       },
     ]);
-    expect(useChatStore.getState().getSessionRuntime("session-1").error).toBe(
-      "Couldn't verify the compacted conversation because refreshed history wasn't received. Your previous messages are still shown. Try reloading the session.",
-    );
+    expect(
+      useChatStore.getState().getSessionRuntime("session-1").error,
+    ).toBeNull();
+  });
+
+  it("warns but reports committed when transcript refresh throws after compaction", async () => {
+    mockAcpLoadSession.mockRejectedValue(new Error("refresh failed"));
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        createTextMessage("user-1", "user", "Before compact"),
+      ]);
+
+    const { result } = renderHook(() => useChat("session-1"));
+    let compactResult: unknown;
+    await act(async () => {
+      compactResult = await result.current.compactConversation();
+    });
+
+    expect(compactResult).toBe("completed-with-refresh-warning");
+    expect(
+      useChatStore
+        .getState()
+        .messagesBySession["session-1"].map((message) =>
+          message.content[0]?.type === "systemNotification"
+            ? message.content[0].notificationType
+            : message.id,
+        ),
+    ).toEqual(["user-1", "error"]);
+    expect(
+      useChatStore.getState().getSessionRuntime("session-1").error,
+    ).toBeNull();
   });
 
   it("prepares and compacts the override persona session", async () => {

--- a/src/features/chat/hooks/__tests__/useChatSessionController.compaction.test.ts
+++ b/src/features/chat/hooks/__tests__/useChatSessionController.compaction.test.ts
@@ -376,6 +376,28 @@ describe("useChatSessionController compaction behavior", () => {
     );
   });
 
+  it("continues the queued send when compaction commits but transcript refresh is incomplete", async () => {
+    mockTokenState = {
+      ...INITIAL_TOKEN_STATE,
+      accumulatedTotal: 8_500,
+      contextLimit: 10_000,
+    };
+    useChatStore
+      .getState()
+      .replaceTokenState("session-1", mockTokenState, true);
+    mockCompactConversation.mockResolvedValue("completed-with-refresh-warning");
+
+    renderHook(() => useChatSessionController({ sessionId: "session-1" }));
+
+    expect(capturedQueuedSend).not.toBeNull();
+    await act(async () => {
+      await capturedQueuedSend?.("hello");
+    });
+
+    expect(mockCompactConversation).toHaveBeenCalledOnce();
+    expect(mockSendMessage).toHaveBeenCalledWith("hello", undefined, undefined);
+  });
+
   it("keeps compaction enabled for goose agent sessions backed by model providers", async () => {
     mockTokenState = {
       ...INITIAL_TOKEN_STATE,

--- a/src/features/chat/hooks/__tests__/useChatSessionController.targetLeaseCompaction.test.ts
+++ b/src/features/chat/hooks/__tests__/useChatSessionController.targetLeaseCompaction.test.ts
@@ -4,6 +4,8 @@ import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { useChatStore } from "../../stores/chatStore";
 import { useChatSessionStore } from "../../stores/chatSessionStore";
+import { ensureReplayBuffer } from "../replayBuffer";
+import { createUserMessage } from "@/shared/types/messages";
 import { beginModelSelectionIntent } from "../../model-selection/modelSelectionIntent";
 import {
   resetSessionTargetCoordinatorsForTests,
@@ -212,7 +214,11 @@ describe("controller/useChat queued target lease during compaction", () => {
     transportProviders.length = 0;
     selectedAgentId = "goose";
     mockAcpPrepareSession.mockResolvedValue(undefined);
-    mockAcpLoadSession.mockResolvedValue(undefined);
+    mockAcpLoadSession.mockImplementation(async (sessionId: string) => {
+      ensureReplayBuffer(sessionId).push(
+        createUserMessage("Compacted history"),
+      );
+    });
     mockAcpSendMessage.mockResolvedValue(undefined);
     mockResolveSessionCwd.mockResolvedValue("/tmp/project");
     useAgentStore.setState({

--- a/src/features/chat/hooks/useChat.ts
+++ b/src/features/chat/hooks/useChat.ts
@@ -38,7 +38,11 @@ const MANUAL_COMPACT_TRIGGER = "/compact";
 const EMPTY_MESSAGES: Message[] = [];
 const cancellationOwnerBySession = new Map<string, symbol>();
 const cancellationPromiseBySession = new Map<string, Promise<boolean>>();
-type CompactConversationResult = "completed" | "failed" | "skipped";
+type CompactConversationResult =
+  | "completed"
+  | "completed-with-refresh-warning"
+  | "failed"
+  | "skipped";
 type EnsurePrepared = (
   personaId?: string,
   sessionSelection?: ChatSendOptions["sessionSelection"],
@@ -436,11 +440,13 @@ export function useChat(
       setSessionLoading(sessionId, true);
       clearReplayBuffer(sessionId);
 
+      let compactionCommitted = false;
       try {
         const sendOptions = effectivePersonaInfo?.id
           ? { personaId: effectivePersonaInfo.id }
           : undefined;
         await acpSendMessage(sessionId, MANUAL_COMPACT_TRIGGER, sendOptions);
+        compactionCommitted = true;
 
         // Command responses are streamed via prompt notifications, but the ACP
         // layer does not currently forward history replacement events. Drop those
@@ -453,7 +459,7 @@ export function useChat(
         setSessionLoading(sessionId, false);
 
         const replayResult = replaceMessagesFromSessionReplay(sessionId, {
-          conversationRequired: true,
+          historyExpectation: "nonempty",
           trailingMessages: [createCompactionConfirmationMessage()],
         });
         if (replayResult.status === "invalid") {
@@ -464,13 +470,23 @@ export function useChat(
             sessionId,
             createSystemNotificationMessage(errorMessage, "error"),
           );
-          setError(sessionId, errorMessage);
-          return "failed" as CompactConversationResult;
+          return "completed-with-refresh-warning" as CompactConversationResult;
         }
         return "completed" as CompactConversationResult;
       } catch (err) {
         clearReplayBuffer(sessionId);
         setSessionLoading(sessionId, false);
+
+        if (compactionCommitted) {
+          const errorMessage = i18n.t(
+            "chat:notifications.compactionReplayIncomplete",
+          );
+          addMessage(
+            sessionId,
+            createSystemNotificationMessage(errorMessage, "error"),
+          );
+          return "completed-with-refresh-warning" as CompactConversationResult;
+        }
 
         const errorMessage = formatAcpErrorMessage(err);
         addMessage(

--- a/src/features/chat/hooks/useChat.ts
+++ b/src/features/chat/hooks/useChat.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from "react";
 import { useChatStore } from "../stores/chatStore";
 import { useChatSessionStore } from "../stores/chatSessionStore";
-import { clearReplayBuffer, getAndDeleteReplayBuffer } from "./replayBuffer";
+import { clearReplayBuffer } from "./replayBuffer";
 import {
   type ChatAttachmentDraft,
   type Message,
@@ -22,7 +22,7 @@ import {
   resolveAssistantCancellation,
 } from "../lib/sendCore";
 import { perfLog } from "@/shared/lib/perfLog";
-import { sanitizeReplayMessages } from "../lib/replaySanitizer";
+import { replaceMessagesFromSessionReplay } from "../lib/sessionReplayReplacement";
 import { i18n } from "@/shared/i18n";
 import type { ChatSendOptions } from "../types";
 import { formatAcpErrorMessage } from "@/shared/api/acpErrors";
@@ -119,7 +119,6 @@ export function useChat(
   );
   const setActiveSession = useChatStore((s) => s.setActiveSession);
   const addMessage = useChatStore((s) => s.addMessage);
-  const setMessages = useChatStore((s) => s.setMessages);
   const clearMessages = useChatStore((s) => s.clearMessages);
   const setChatState = useChatStore((s) => s.setChatState);
   const setError = useChatStore((s) => s.setError);
@@ -453,14 +452,20 @@ export function useChat(
 
         setSessionLoading(sessionId, false);
 
-        const buffer = getAndDeleteReplayBuffer(sessionId);
-        if (buffer) {
-          setMessages(sessionId, [
-            ...sanitizeReplayMessages(buffer),
-            createCompactionConfirmationMessage(),
-          ]);
-        } else {
-          addMessage(sessionId, createCompactionConfirmationMessage());
+        const replayResult = replaceMessagesFromSessionReplay(sessionId, {
+          conversationRequired: true,
+          trailingMessages: [createCompactionConfirmationMessage()],
+        });
+        if (replayResult.status === "invalid") {
+          const errorMessage = i18n.t(
+            "chat:notifications.compactionReplayIncomplete",
+          );
+          addMessage(
+            sessionId,
+            createSystemNotificationMessage(errorMessage, "error"),
+          );
+          setError(sessionId, errorMessage);
+          return "failed" as CompactConversationResult;
         }
         return "completed" as CompactConversationResult;
       } catch (err) {
@@ -492,7 +497,6 @@ export function useChat(
       setError,
       addMessage,
       setSessionLoading,
-      setMessages,
       setPendingAssistantProvider,
     ],
   );

--- a/src/features/chat/hooks/useChatSessionController.ts
+++ b/src/features/chat/hooks/useChatSessionController.ts
@@ -1952,7 +1952,10 @@ export function useChatSessionController({
               }
             : undefined,
         );
-        if (compactionResult !== "completed") {
+        if (
+          compactionResult !== "completed" &&
+          compactionResult !== "completed-with-refresh-warning"
+        ) {
           return false;
         }
 

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -281,6 +281,54 @@ describe("loadSessionMessages", () => {
     ).toBe("assistant-1");
   });
 
+  it("preserves a populated transcript when a forced replay is invalid", async () => {
+    seedSession(
+      { id: "empty-forced-replay", messageCount: 2 },
+      { replay: false },
+    );
+    useChatStore
+      .getState()
+      .setMessages("empty-forced-replay", [replayUserMessage("existing-1")]);
+    ensureReplayBuffer("empty-forced-replay");
+
+    await expect(
+      loadSessionMessages("empty-forced-replay", { force: true }),
+    ).resolves.toBe(false);
+
+    expect(
+      messagesFor("empty-forced-replay").map((message) => message.id),
+    ).toEqual(["existing-1", "session-load-error:empty-forced-replay"]);
+    expect(notificationFromLastMessage("empty-forced-replay")).toMatchObject({
+      notificationType: "error",
+      text: "Couldn't refresh this conversation. Your previous messages are still shown.",
+    });
+    expect(
+      useChatSessionStore.getState().getSession("empty-forced-replay")
+        ?.messageCount,
+    ).toBe(2);
+    expect(
+      useChatStore.getState().loadingSessionIds.has("empty-forced-replay"),
+    ).toBe(false);
+  });
+
+  it("rejects an empty cold replay when session metadata expects history", async () => {
+    seedSession(
+      { id: "cold-empty-replay", messageCount: 3 },
+      { replay: false },
+    );
+    ensureReplayBuffer("cold-empty-replay");
+
+    await expect(loadSessionMessages("cold-empty-replay")).resolves.toBe(false);
+
+    expect(notificationFromLastMessage("cold-empty-replay")).toMatchObject({
+      notificationType: "error",
+    });
+    expect(
+      useChatSessionStore.getState().getSession("cold-empty-replay")
+        ?.messageCount,
+    ).toBe(3);
+  });
+
   it("clears replay loading before publishing error-to-idle", async () => {
     seedSession({ id: "error-replay" });
     useChatStore.getState().setError("error-replay", "stale error");

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -578,8 +578,8 @@ describe("loadSessionMessages", () => {
     );
   });
 
-  it("loads a session without a stored session record", async () => {
-    await expect(loadSessionMessages("unknown-session")).resolves.toBe(true);
+  it("rejects missing replay when session history is unknown", async () => {
+    await expect(loadSessionMessages("unknown-session")).resolves.toBe(false);
 
     expect(checkDirectoriesExist).not.toHaveBeenCalled();
     expect(acpLoadSession).toHaveBeenCalledWith(
@@ -874,9 +874,72 @@ describe("loadSessionMessages", () => {
         workingDir: "/Users/morganm/goose artifacts",
         updatedAt: "2026-06-25T00:45:04.000Z",
         lastMessageAt: "2026-06-19T06:59:21.000Z",
+        messageCount: 1143,
         pinnedLoadState: undefined,
       },
     );
+  });
+
+  it("rejects empty pinned replay when authoritative metadata refresh fails", async () => {
+    acpGetSessionInfo.mockRejectedValue(new Error("metadata unavailable"));
+    seedSession(
+      {
+        id: "s-pinned-unknown",
+        messageCount: 0,
+        pinnedLoadState: "loading",
+      },
+      { replay: false },
+    );
+    acpLoadSession.mockImplementation(async (sessionId: string) => {
+      ensureReplayBuffer(sessionId);
+    });
+
+    await expect(loadSessionMessages("s-pinned-unknown")).resolves.toBe(false);
+    expect(notificationFromLastMessage("s-pinned-unknown")).toMatchObject({
+      notificationType: "error",
+    });
+  });
+
+  it("keeps refreshed pinned history metadata across invalid replay retries", async () => {
+    acpGetSessionInfo.mockResolvedValue({
+      sessionId: "s-pinned-empty",
+      title: "Existing session",
+      updatedAt: "2026-06-25T00:45:04.000Z",
+      createdAt: "2026-06-19T03:43:17.000Z",
+      lastMessageAt: "2026-06-19T06:59:21.000Z",
+      archivedAt: null,
+      userSetName: false,
+      messageCount: 9,
+      subtitle: null,
+      workingDir: null,
+      projectId: null,
+      providerId: "goose",
+      modelId: "claude-sonnet-4",
+      personaId: null,
+    });
+    seedSession(
+      {
+        id: "s-pinned-empty",
+        messageCount: 0,
+        pinnedLoadState: "loading",
+      },
+      { replay: false },
+    );
+    acpLoadSession.mockImplementation(async (sessionId: string) => {
+      ensureReplayBuffer(sessionId);
+    });
+
+    await expect(loadSessionMessages("s-pinned-empty")).resolves.toBe(false);
+    expect(
+      useChatSessionStore.getState().getSession("s-pinned-empty")?.messageCount,
+    ).toBe(9);
+
+    await expect(loadSessionMessages("s-pinned-empty")).resolves.toBe(false);
+    expect(acpGetSessionInfo).toHaveBeenCalledTimes(1);
+    expect(
+      useChatSessionStore.getState().getSession("s-pinned-empty")?.messageCount,
+    ).toBe(9);
+    expect(messagesFor("s-pinned-empty")).toHaveLength(1);
   });
 
   it("does not let pinned metadata replace a newer UI model selection", async () => {

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -895,6 +895,13 @@ describe("loadSessionMessages", () => {
     });
 
     await expect(loadSessionMessages("s-pinned-unknown")).resolves.toBe(false);
+    await expect(loadSessionMessages("s-pinned-unknown")).resolves.toBe(false);
+
+    expect(acpGetSessionInfo).toHaveBeenCalledTimes(2);
+    expect(
+      useChatSessionStore.getState().getSession("s-pinned-unknown")
+        ?.pinnedLoadState,
+    ).toBe("failed");
     expect(notificationFromLastMessage("s-pinned-unknown")).toMatchObject({
       notificationType: "error",
     });

--- a/src/features/chat/lib/sessionActivation.ts
+++ b/src/features/chat/lib/sessionActivation.ts
@@ -1,5 +1,8 @@
 import { clearReplayBuffer } from "@/features/chat/hooks/replayBuffer";
-import { replaceMessagesFromSessionReplay } from "@/features/chat/lib/sessionReplayReplacement";
+import {
+  hasConversationMessages,
+  replaceMessagesFromSessionReplay,
+} from "@/features/chat/lib/sessionReplayReplacement";
 import { completeReplayAssistantMessage } from "@/features/chat/acp/acpReplayAssistant";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import {
@@ -202,18 +205,6 @@ export function clearSessionLoadWarningNotice(sessionId: string): void {
     .removeMessage(sessionId, loaderNoticeMessageId(sessionId, "warning"));
 }
 
-/**
- * True when the session holds replayed conversation history. Loader-added
- * system notifications don't count: treating them as "loaded" would make a
- * single failed load (whose error notification is the only message)
- * permanently block retries through the has-messages skip guard.
- */
-export function hasConversationMessages(
-  messages: Message[] | undefined,
-): boolean {
-  return messages?.some((message) => message.role !== "system") ?? false;
-}
-
 const sessionLoadPromises = new Map<string, Promise<boolean>>();
 
 export async function loadSessionMessagesAndPrepare(
@@ -304,7 +295,6 @@ async function performSessionMessagesLoad(
 
   const sessionStore = useChatSessionStore.getState();
   const sessionAtRequest = sessionStore.getSession(sessionId);
-  const messageCountAtRequest = sessionAtRequest?.messageCount;
   if (sessionAtRequest?.creationState === "pending") {
     perfLog(`[perf:load] ${sid} skip — session creation pending`);
     useChatStore.getState().setSessionLoading(sessionId, false);
@@ -401,8 +391,19 @@ async function performSessionMessagesLoad(
     const latestSessionBeforeReplay = useChatSessionStore
       .getState()
       .getSession(sessionId);
+    const historyExpectation = sessionAtRequest?.pinnedLoadState
+      ? sessionInfo
+        ? sessionInfo.messageCount > 0
+          ? "nonempty"
+          : "empty"
+        : "unknown"
+      : latestSessionBeforeReplay?.messageCount === undefined
+        ? "unknown"
+        : latestSessionBeforeReplay.messageCount > 0
+          ? "nonempty"
+          : "empty";
     const replayResult = replaceMessagesFromSessionReplay(sessionId, {
-      conversationRequired: (latestSessionBeforeReplay?.messageCount ?? 0) > 0,
+      historyExpectation,
     });
     const replayStats = getReplayPerf(sessionId);
     clearReplayPerf(sessionId);
@@ -418,12 +419,9 @@ async function performSessionMessagesLoad(
         ...createSystemNotificationMessage(errorMessage, "error"),
         id: loaderNoticeMessageId(sessionId, "error"),
       });
-      useChatSessionStore.getState().patchSession(sessionId, {
-        pinnedLoadState: undefined,
-        ...(messageCountAtRequest !== undefined
-          ? { messageCount: messageCountAtRequest }
-          : {}),
-      });
+      useChatSessionStore
+        .getState()
+        .patchSession(sessionId, { pinnedLoadState: undefined });
       clearIdleStreamingMessageAfterReplay(sessionId);
       perfLog(
         `[perf:load] ${sid} replay invalid: reason=${replayResult.reason} notifs=${replayStats?.count ?? 0}`,
@@ -436,9 +434,7 @@ async function performSessionMessagesLoad(
       completeReplayAssistantMessage(sessionId);
     }
     const latestSession = useChatSessionStore.getState().getSession(sessionId);
-    const sessionPatch: Partial<ChatSession> = {
-      messageCount: replayMessages.length,
-    };
+    const sessionPatch: Partial<ChatSession> = {};
     if (
       latestSession &&
       !latestSession.userSetName &&

--- a/src/features/chat/lib/sessionActivation.ts
+++ b/src/features/chat/lib/sessionActivation.ts
@@ -419,9 +419,12 @@ async function performSessionMessagesLoad(
         ...createSystemNotificationMessage(errorMessage, "error"),
         id: loaderNoticeMessageId(sessionId, "error"),
       });
-      useChatSessionStore
-        .getState()
-        .patchSession(sessionId, { pinnedLoadState: undefined });
+      useChatSessionStore.getState().patchSession(sessionId, {
+        pinnedLoadState:
+          sessionAtRequest?.pinnedLoadState && !sessionInfo
+            ? "failed"
+            : undefined,
+      });
       clearIdleStreamingMessageAfterReplay(sessionId);
       perfLog(
         `[perf:load] ${sid} replay invalid: reason=${replayResult.reason} notifs=${replayStats?.count ?? 0}`,

--- a/src/features/chat/lib/sessionActivation.ts
+++ b/src/features/chat/lib/sessionActivation.ts
@@ -1,8 +1,5 @@
-import {
-  clearReplayBuffer,
-  getAndDeleteReplayBuffer,
-} from "@/features/chat/hooks/replayBuffer";
-import { sanitizeReplayMessages } from "@/features/chat/lib/replaySanitizer";
+import { clearReplayBuffer } from "@/features/chat/hooks/replayBuffer";
+import { replaceMessagesFromSessionReplay } from "@/features/chat/lib/sessionReplayReplacement";
 import { completeReplayAssistantMessage } from "@/features/chat/acp/acpReplayAssistant";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import {
@@ -307,6 +304,7 @@ async function performSessionMessagesLoad(
 
   const sessionStore = useChatSessionStore.getState();
   const sessionAtRequest = sessionStore.getSession(sessionId);
+  const messageCountAtRequest = sessionAtRequest?.messageCount;
   if (sessionAtRequest?.creationState === "pending") {
     perfLog(`[perf:load] ${sid} skip — session creation pending`);
     useChatStore.getState().setSessionLoading(sessionId, false);
@@ -400,34 +398,58 @@ async function performSessionMessagesLoad(
       hydrateSessionTarget(sessionId, loadedTarget);
     }
     const tFlush = performance.now();
-    const buffer = getAndDeleteReplayBuffer(sessionId);
-    const replayMessages = buffer ? sanitizeReplayMessages(buffer) : undefined;
+    const latestSessionBeforeReplay = useChatSessionStore
+      .getState()
+      .getSession(sessionId);
+    const replayResult = replaceMessagesFromSessionReplay(sessionId, {
+      conversationRequired: (latestSessionBeforeReplay?.messageCount ?? 0) > 0,
+    });
     const replayStats = getReplayPerf(sessionId);
     clearReplayPerf(sessionId);
-    if (replayMessages) {
-      useChatStore.getState().setMessages(sessionId, replayMessages);
-      if (sessionInfo?.activeRunId === null) {
-        completeReplayAssistantMessage(sessionId);
-      }
-      const latestSession = useChatSessionStore
-        .getState()
-        .getSession(sessionId);
-      const sessionPatch: Partial<ChatSession> = {
-        messageCount: replayMessages.length,
-      };
-      if (
-        latestSession &&
-        !latestSession.userSetName &&
-        isDefaultChatTitle(latestSession.title)
-      ) {
-        const fallbackTitle = fallbackTitleFromReplay(replayMessages);
-        if (fallbackTitle) {
-          sessionPatch.title = fallbackTitle;
-        }
-      }
-      useChatSessionStore.getState().patchSession(sessionId, sessionPatch);
-    }
     const chatStore = useChatStore.getState();
+    if (replayResult.status === "invalid") {
+      const errorMessage = i18n.t("chat:toolbar.sessionReplayIncomplete");
+      chatStore.setSessionLoading(sessionId, false);
+      chatStore.removeMessage(
+        sessionId,
+        loaderNoticeMessageId(sessionId, "error"),
+      );
+      chatStore.addMessage(sessionId, {
+        ...createSystemNotificationMessage(errorMessage, "error"),
+        id: loaderNoticeMessageId(sessionId, "error"),
+      });
+      useChatSessionStore.getState().patchSession(sessionId, {
+        pinnedLoadState: undefined,
+        ...(messageCountAtRequest !== undefined
+          ? { messageCount: messageCountAtRequest }
+          : {}),
+      });
+      clearIdleStreamingMessageAfterReplay(sessionId);
+      perfLog(
+        `[perf:load] ${sid} replay invalid: reason=${replayResult.reason} notifs=${replayStats?.count ?? 0}`,
+      );
+      return false;
+    }
+
+    const replayMessages = replayResult.messages;
+    if (sessionInfo?.activeRunId === null) {
+      completeReplayAssistantMessage(sessionId);
+    }
+    const latestSession = useChatSessionStore.getState().getSession(sessionId);
+    const sessionPatch: Partial<ChatSession> = {
+      messageCount: replayMessages.length,
+    };
+    if (
+      latestSession &&
+      !latestSession.userSetName &&
+      isDefaultChatTitle(latestSession.title)
+    ) {
+      const fallbackTitle = fallbackTitleFromReplay(replayMessages);
+      if (fallbackTitle) {
+        sessionPatch.title = fallbackTitle;
+      }
+    }
+    useChatSessionStore.getState().patchSession(sessionId, sessionPatch);
     const sessionStore = useChatSessionStore.getState();
     chatStore.removeMessage(
       sessionId,

--- a/src/features/chat/lib/sessionReplayReplacement.ts
+++ b/src/features/chat/lib/sessionReplayReplacement.ts
@@ -8,8 +8,10 @@ export type SessionReplayReplacementResult =
   | { status: "not-required"; messages: [] }
   | { status: "invalid"; reason: "missing" | "empty" };
 
-function hasConversationMessages(messages: Message[]): boolean {
-  return messages.some((message) => message.role !== "system");
+export function hasConversationMessages(
+  messages: Message[] | undefined,
+): boolean {
+  return messages?.some((message) => message.role !== "system") ?? false;
 }
 
 /**
@@ -21,16 +23,19 @@ function hasConversationMessages(messages: Message[]): boolean {
 export function replaceMessagesFromSessionReplay(
   sessionId: string,
   options: {
-    conversationRequired?: boolean;
+    historyExpectation?: "empty" | "nonempty" | "unknown";
     trailingMessages?: Message[];
   } = {},
 ): SessionReplayReplacementResult {
   const existingMessages =
     useChatStore.getState().messagesBySession[sessionId] ?? [];
   const existingConversation = hasConversationMessages(existingMessages);
+  const historyExpectation = options.historyExpectation ?? "unknown";
+  const replacementRequired =
+    historyExpectation !== "empty" || existingConversation;
   const buffer = getAndDeleteReplayBuffer(sessionId);
   if (!buffer) {
-    if (options.conversationRequired || existingConversation) {
+    if (replacementRequired) {
       return { status: "invalid", reason: "missing" };
     }
     useChatStore.getState().setMessages(sessionId, []);
@@ -39,7 +44,7 @@ export function replaceMessagesFromSessionReplay(
 
   const messages = sanitizeReplayMessages(buffer);
   if (!hasConversationMessages(messages)) {
-    if (options.conversationRequired || existingConversation) {
+    if (replacementRequired) {
       return { status: "invalid", reason: "empty" };
     }
     useChatStore.getState().setMessages(sessionId, []);

--- a/src/features/chat/lib/sessionReplayReplacement.ts
+++ b/src/features/chat/lib/sessionReplayReplacement.ts
@@ -1,0 +1,53 @@
+import { getAndDeleteReplayBuffer } from "@/features/chat/hooks/replayBuffer";
+import { sanitizeReplayMessages } from "@/features/chat/lib/replaySanitizer";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import type { Message } from "@/shared/types/messages";
+
+export type SessionReplayReplacementResult =
+  | { status: "replaced"; messages: Message[] }
+  | { status: "not-required"; messages: [] }
+  | { status: "invalid"; reason: "missing" | "empty" };
+
+function hasConversationMessages(messages: Message[]): boolean {
+  return messages.some((message) => message.role !== "system");
+}
+
+/**
+ * Consumes a session replay and replaces the visible transcript only when the
+ * replay is authoritative for the current operation. Empty history is valid
+ * for an empty transcript, but cannot replace conversation messages already
+ * on screen or satisfy an operation that requires replacement history.
+ */
+export function replaceMessagesFromSessionReplay(
+  sessionId: string,
+  options: {
+    conversationRequired?: boolean;
+    trailingMessages?: Message[];
+  } = {},
+): SessionReplayReplacementResult {
+  const existingMessages =
+    useChatStore.getState().messagesBySession[sessionId] ?? [];
+  const existingConversation = hasConversationMessages(existingMessages);
+  const buffer = getAndDeleteReplayBuffer(sessionId);
+  if (!buffer) {
+    if (options.conversationRequired || existingConversation) {
+      return { status: "invalid", reason: "missing" };
+    }
+    useChatStore.getState().setMessages(sessionId, []);
+    return { status: "not-required", messages: [] };
+  }
+
+  const messages = sanitizeReplayMessages(buffer);
+  if (!hasConversationMessages(messages)) {
+    if (options.conversationRequired || existingConversation) {
+      return { status: "invalid", reason: "empty" };
+    }
+    useChatStore.getState().setMessages(sessionId, []);
+    return { status: "not-required", messages: [] };
+  }
+
+  useChatStore
+    .getState()
+    .setMessages(sessionId, [...messages, ...(options.trailingMessages ?? [])]);
+  return { status: "replaced", messages };
+}

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -345,6 +345,7 @@
   },
   "notifications": {
     "compactionComplete": "Conversation compacted. Older context was summarized.",
+    "compactionReplayIncomplete": "Couldn't verify the compacted conversation because refreshed history wasn't received. Your previous messages are still shown. Try reloading the session.",
     "modelSwitchError": "Could not switch to {{model}}. This chat is still using {{fallbackModel}}.",
     "modelSwitchErrorWithoutFallback": "Could not switch to {{model}}.",
     "archiveError": "Failed to archive chat",
@@ -518,6 +519,7 @@
     "sessionLoadMissingProjectDir": "This session's project folder no longer exists: {{missingPath}}. Loaded the conversation using {{fallbackPath}} instead.",
     "sessionLoadMissingWorkingDir": "This session's folder no longer exists: {{missingPath}}. Loaded the conversation using {{fallbackPath}} instead.",
     "sessionLoadFailed": "Couldn't load this session.",
+    "sessionReplayIncomplete": "Couldn't refresh this conversation. Your previous messages are still shown.",
     "editProjectFolders": "Edit project",
     "changeFolder": "Change folder",
     "stopGeneration": "Stop generation",

--- a/src/shared/i18n/locales/es/chat.json
+++ b/src/shared/i18n/locales/es/chat.json
@@ -344,6 +344,7 @@
   },
   "notifications": {
     "compactionComplete": "Conversacion compactada. El contexto anterior se resumio.",
+    "compactionReplayIncomplete": "No se pudo verificar la conversación compactada porque no se recibió el historial actualizado. Tus mensajes anteriores siguen visibles. Intenta volver a cargar la sesión.",
     "modelSwitchError": "No se pudo cambiar a {{model}}. Este chat sigue usando {{fallbackModel}}.",
     "modelSwitchErrorWithoutFallback": "No se pudo cambiar a {{model}}.",
     "archiveError": "No se pudo archivar el chat",
@@ -515,6 +516,7 @@
     "sessionLoadMissingProjectDir": "La carpeta del proyecto de esta sesión ya no existe: {{missingPath}}. Se cargó la conversación usando {{fallbackPath}} en su lugar.",
     "sessionLoadMissingWorkingDir": "La carpeta de esta sesión ya no existe: {{missingPath}}. Se cargó la conversación usando {{fallbackPath}} en su lugar.",
     "sessionLoadFailed": "No se pudo cargar esta sesión.",
+    "sessionReplayIncomplete": "No se pudo actualizar esta conversación. Tus mensajes anteriores siguen visibles.",
     "editProjectFolders": "Editar proyecto",
     "changeFolder": "Cambiar carpeta",
     "stopGeneration": "Detener generación",


### PR DESCRIPTION
**Category:** fix
**User Impact:** Chats keep their visible history and show a recoverable error when a reload or compaction refresh does not return usable conversation messages.

**Problem:** A replay buffer could exist but sanitize to an empty transcript, causing reload and compaction flows to replace visible history with nothing. Compaction could also claim success even though replacement history was never received.

**Solution:** Centralize replay replacement validation at the session replay boundary. Empty replay data can represent a genuinely empty session only when no history is expected; otherwise the prior transcript and message metadata are preserved, the operation reports failure, and the existing inline error-notification pattern explains that refresh history was not received.

<details>
<summary>File changes</summary>

**src/features/chat/lib/sessionReplayReplacement.ts**
Adds the shared replay consumption and replacement policy used by session loading and compaction.

**src/features/chat/lib/sessionActivation.ts**
Treats unusable replay data as a failed refresh, preserves prior message metadata, and surfaces a recoverable inline error.

**src/features/chat/lib/__tests__/sessionActivation.test.ts**
Covers populated forced reloads and cold loads whose metadata indicates expected history.

**src/features/chat/hooks/useChat.ts**
Requires usable replacement history before reporting compaction success or adding its success notice.

**src/features/chat/hooks/__tests__/useChat.compaction.test.ts**
Verifies invalid post-compaction replay keeps prior messages, returns failure, and does not add a false success notice.

**src/features/chat/hooks/__tests__/useChatSessionController.targetLeaseCompaction.test.ts**
Makes successful auto-compaction fixtures emit truthful replacement history.

**src/app/AppShell.navigation.test.tsx**
Makes the missing-folder recovery fixture provide the history its session metadata declares.

**src/shared/i18n/locales/en/chat.json**
Adds user-facing recovery copy for incomplete load and compaction replay results.

**src/shared/i18n/locales/es/chat.json**
Adds Spanish recovery copy for incomplete load and compaction replay results.

</details>

### Validation

- `pnpm vitest run src/features/chat/lib/__tests__/sessionActivation.test.ts src/features/chat/hooks/__tests__/useChat.compaction.test.ts src/features/chat/hooks/__tests__/useChatSessionController.targetLeaseCompaction.test.ts`
- `just check`
- `just test` (532 files, 6,226 passed, 1 skipped)

### Laws

Reviewed `LAWS/README.md`, `LAWS/CHAT.md`, and `LAWS/AGENTS.md`. This change does not alter composer queue or agent invocation laws.