### PR TITLE
fix: bind oauth callbacks to login attempts

### DIFF
--- a/bb-cli/Cargo.lock
+++ b/bb-cli/Cargo.lock
@@ -180,14 +180,18 @@ name = "builderbot-auth"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "core-foundation",
+ "getrandom 0.4.3",
  "reqwest",
  "security-framework-sys",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
+ "subtle",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/bb-cli/docs/bb-auth-flow.md
+++ b/bb-cli/docs/bb-auth-flow.md
@@ -10,21 +10,22 @@ sequenceDiagram
     participant Auth0
     participant Store as Backend Data Store
 
-    CLI->>CLI: Start localhost callback server
-    CLI->>Browser: Open /v1/auth/login?type=cli&returnTo=http://127.0.0.1:<port>/callback
-    Browser->>Backend: Begin CLI login
-    Backend->>Store: Store AuthTransaction with type=cli and loopback returnTo
+    CLI->>CLI: Start 127.0.0.1 callback server and generate state + PKCE verifier
+    CLI->>Browser: Open /v1/auth/login?type=cli&returnTo=...&state=...&code_challenge=...&code_challenge_method=S256
+    Browser->>Backend: Begin correlated CLI login
+    Backend->>Store: Store AuthTransaction with client state + PKCE challenge
     Backend-->>Browser: Set oauth state cookie, 302 to Auth0 authorize
     Browser->>Auth0: Complete Auth0 login
     Auth0-->>Browser: 302 to configured /v1/auth/callback with code and state
     Browser->>Backend: GET /v1/auth/callback with oauth state cookie
     Backend->>Auth0: Exchange code using stored PKCE verifier
     Auth0-->>Backend: ID/access token response
-    Backend->>Store: Create short-lived one-time code for CLI login
-    Backend-->>Browser: 302 to localhost callback with code
-    Browser->>CLI: GET /callback?code=...
-    CLI->>Backend: POST /v1/auth/login/exchange { code }
-    Backend->>Store: Verify code is valid, unused, unexpired, and type=cli
+    Backend->>Store: Create short-lived code bound to client PKCE challenge
+    Backend-->>Browser: 302 to 127.0.0.1 callback with code + client state
+    Browser->>CLI: GET /callback?code=...&state=...
+    CLI->>CLI: Compare state before accepting code
+    CLI->>Backend: POST /v1/auth/login/exchange { code, code_verifier }
+    Backend->>Store: Atomically verify challenge, expiry, and one-time use
     Backend->>Store: Create cli session credential
     Backend-->>CLI: Return cli session credential
     CLI->>Backend: API request with X-BB-Session-Credential: <cli session>
@@ -36,4 +37,8 @@ Security constraints:
 - CLI sessions are returned by the exchange endpoint and accepted only via the `X-BB-Session-Credential` header.
 - Durable session credentials are never placed in redirect URLs.
 - The localhost redirect carries only a short-lived, single-use exchange code.
-- CLI `returnTo` targets must be loopback URLs.
+- The loopback callback accepts only `GET` requests to the exact callback path.
+- Every CLI attempt uses independent high-entropy state and PKCE S256 material.
+- Missing, malformed, wrong, stale, replayed, and cross-attempt callbacks are rejected without stopping the valid listener.
+- The verifier is sent only to the exchange endpoint and is cleared with the attempt on success, failure, or cancellation.
+- CLI `returnTo` targets must be `http://127.0.0.1:<port>` URLs without userinfo, query, or fragment.

--- a/bb-cli/src/bb/auth_login.rs
+++ b/bb-cli/src/bb/auth_login.rs
@@ -2,12 +2,12 @@
 
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use builderbot_auth::auth_login::{
-    build_auth_http_client, exchange_login_code_and_verify, login_url, logout_session_credential,
-    verify_session_credential, AuthMeResponse,
+    build_auth_http_client, logout_session_credential, verify_session_credential, AuthMeResponse,
+    OAuthCallback, OAuthLoginAttempt,
 };
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -18,6 +18,8 @@ use super::auth_storage::{session_storage_key_from_config, SessionCredentialStor
 use super::skills_config::{kgoose_service_url, SkillsConfig};
 
 const CALLBACK_PATH: &str = "/callback";
+const LOGIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const CALLBACK_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Copy)]
 enum AuthCallbackPage {
@@ -103,17 +105,14 @@ pub fn run_browser_login(
     let server = Server::http("127.0.0.1:0")
         .map_err(|error| anyhow!("listen on loopback callback port: {error}"))?;
     let callback_url = format!("http://{}{}", server.server_addr(), CALLBACK_PATH);
-    let login_url = login_url(&service_url, &callback_url)?;
+    let oauth_attempt = OAuthLoginAttempt::generate()?;
+    let login_url = oauth_attempt.login_url(&service_url, &callback_url)?;
 
     let (tx, rx) = mpsc::channel();
-    thread::spawn(move || {
-        let result = receive_exchange_code(server);
-        let _ = tx.send(result);
-    });
 
     if !config.json {
         println!("Opening BuilderBot auth login in your browser:");
-        println!("{login_url}");
+        println!("{}", login_url.as_str());
     }
     if let Err(error) = webbrowser::open(login_url.as_str()) {
         if config.json {
@@ -124,11 +123,20 @@ pub fn run_browser_login(
         println!("Could not open a browser automatically. Open the URL above manually.");
     }
 
-    let code = rx
+    thread::spawn(move || {
+        let result = receive_exchange_code(server, oauth_attempt);
+        let _ = tx.send(result);
+    });
+
+    let (code, mut oauth_attempt) = rx
         .recv()
         .context("loopback auth server stopped before login completed")??;
-    let verified =
-        exchange_login_code_and_verify(&client, config.playpen.as_deref(), &service_url, &code)?;
+    let verified = oauth_attempt.exchange_login_code_and_verify(
+        &client,
+        config.playpen.as_deref(),
+        &service_url,
+        &code,
+    )?;
     let stored = verified.credential;
     let me = verified.me;
     let workspace_name = me.active_workspace_name()?.to_string();
@@ -181,42 +189,71 @@ pub fn logout_stored_session(
     logout_session_credential(&client, config.playpen.as_deref(), &service_url, &stored)
 }
 
-fn receive_exchange_code(server: Server) -> Result<String> {
-    for request in server.incoming_requests() {
+fn receive_exchange_code(
+    server: Server,
+    mut attempt: OAuthLoginAttempt,
+) -> Result<(String, OAuthLoginAttempt)> {
+    let deadline = Instant::now() + LOGIN_ATTEMPT_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(anyhow!(
+                "BuilderBot CLI auth login expired before receiving a valid callback"
+            ));
+        }
+        let Some(request) = server
+            .recv_timeout(remaining.min(CALLBACK_POLL_INTERVAL))
+            .context("receive loopback auth callback")?
+        else {
+            continue;
+        };
         let url = request.url().to_string();
-        let parsed =
-            Url::parse(&format!("http://127.0.0.1{url}")).context("parse loopback callback URL")?;
+        let parsed = match Url::parse(&format!("http://127.0.0.1{url}")) {
+            Ok(parsed) => parsed,
+            Err(_) => {
+                let _ = respond_text(
+                    request,
+                    StatusCode(400),
+                    "BuilderBot CLI auth ignored an invalid callback request. The valid login is still waiting.",
+                );
+                continue;
+            }
+        };
         if parsed.path() != CALLBACK_PATH {
-            respond_text(
+            let _ = respond_text(
                 request,
                 StatusCode(404),
                 "BuilderBot CLI auth is waiting for the callback.",
-            )?;
+            );
+            continue;
+        }
+        if request.method() != &tiny_http::Method::Get {
+            let _ = respond_text(
+                request,
+                StatusCode(400),
+                "BuilderBot CLI auth ignored an invalid callback request. The valid login is still waiting.",
+            );
             continue;
         }
 
-        let error = parsed
-            .query_pairs()
-            .find(|(key, _)| key == "error")
-            .map(|(_, value)| value.into_owned());
-        if let Some(error) = error {
-            respond_auth_page(request, StatusCode(400), AuthCallbackPage::Failure)?;
-            return Err(anyhow!("auth callback returned error: {error}"));
+        match attempt.parse_callback(&parsed) {
+            OAuthCallback::Code(code) => {
+                let _ = respond_auth_page(request, StatusCode(200), AuthCallbackPage::Success);
+                return Ok((code, attempt));
+            }
+            OAuthCallback::Error(error) => {
+                respond_auth_page(request, StatusCode(400), AuthCallbackPage::Failure)?;
+                return Err(anyhow!("auth callback returned error: {error}"));
+            }
+            OAuthCallback::Rejected(_) => {
+                let _ = respond_text(
+                    request,
+                    StatusCode(400),
+                    "BuilderBot CLI auth ignored an uncorrelated callback. The valid login is still waiting.",
+                );
+            }
         }
-
-        let code = parsed
-            .query_pairs()
-            .find(|(key, _)| key == "code")
-            .map(|(_, value)| value.into_owned())
-            .filter(|value| !value.trim().is_empty())
-            .ok_or_else(|| anyhow!("auth callback did not include an exchange code"))?;
-        respond_auth_page(request, StatusCode(200), AuthCallbackPage::Success)?;
-        return Ok(code);
     }
-
-    Err(anyhow!(
-        "loopback auth server stopped without receiving a callback"
-    ))
 }
 
 fn respond_text(request: tiny_http::Request, status: StatusCode, body: &str) -> Result<()> {

--- a/crates/builderbot-auth/Cargo.toml
+++ b/crates/builderbot-auth/Cargo.toml
@@ -12,12 +12,16 @@ blocking-client = ["dep:reqwest"]
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
+getrandom = "0.4"
 reqwest = { version = "0.12", optional = true, default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+subtle = "2.6"
 url = "2.5"
+zeroize = "1.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"

--- a/crates/builderbot-auth/src/auth_login.rs
+++ b/crates/builderbot-auth/src/auth_login.rs
@@ -1,12 +1,17 @@
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use reqwest::blocking::{Client, ClientBuilder};
 use reqwest::header::{ACCEPT, USER_AGENT};
 use reqwest::redirect::Policy;
 use reqwest::StatusCode as HttpStatusCode;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
 use url::Url;
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::auth::SESSION_CREDENTIAL_HEADER;
 use crate::auth_storage::StoredSessionCredential;
@@ -54,9 +59,192 @@ pub struct VerifiedLoginSession {
     pub me: AuthMeResponse,
 }
 
+/// Per-login correlation and PKCE material. Keep this value in memory only and
+/// drop it as soon as the login attempt completes, fails, or is canceled.
+pub struct OAuthLoginAttempt {
+    state: Zeroizing<String>,
+    code_verifier: Zeroizing<String>,
+    code_challenge: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum OAuthCallback {
+    Code(String),
+    Error(String),
+    Rejected(OAuthCallbackRejection),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthCallbackRejection {
+    MissingState,
+    StateMismatch,
+    MissingCode,
+    InvalidState,
+    InvalidCode,
+    InvalidError,
+    DuplicateParameter,
+    ConflictingOutcome,
+}
+
+impl OAuthLoginAttempt {
+    pub fn generate() -> Result<Self> {
+        let mut state_bytes = [0_u8; 32];
+        let mut verifier_bytes = [0_u8; 64];
+        getrandom::fill(&mut state_bytes).context("generate OAuth state")?;
+        getrandom::fill(&mut verifier_bytes).context("generate PKCE code verifier")?;
+
+        let state = URL_SAFE_NO_PAD.encode(state_bytes);
+        let code_verifier = URL_SAFE_NO_PAD.encode(verifier_bytes);
+        state_bytes.zeroize();
+        verifier_bytes.zeroize();
+
+        Ok(Self::from_parts(state, code_verifier))
+    }
+
+    fn from_parts(state: String, code_verifier: String) -> Self {
+        let code_challenge = pkce_s256_challenge(&code_verifier);
+        Self {
+            state: Zeroizing::new(state),
+            code_verifier: Zeroizing::new(code_verifier),
+            code_challenge,
+        }
+    }
+
+    #[cfg(test)]
+    fn test_state(&self) -> &str {
+        &self.state
+    }
+
+    pub fn login_url(&self, server_url: &str, callback_url: &str) -> Result<Zeroizing<String>> {
+        let callback_url = Url::parse(callback_url).context("callback URL must be absolute")?;
+        if callback_url.scheme() != "http"
+            || callback_url.host_str() != Some("127.0.0.1")
+            || callback_url.port().is_none()
+            || callback_url.cannot_be_a_base()
+            || !callback_url.username().is_empty()
+            || callback_url.password().is_some()
+            || callback_url.query().is_some()
+            || callback_url.fragment().is_some()
+        {
+            return Err(anyhow!(
+                "callback URL must be an absolute HTTP URL on 127.0.0.1 with an explicit port and no userinfo, query, or fragment"
+            ));
+        }
+
+        let mut url = auth_url(server_url, "/v1/auth/login")?;
+        let callback_url = Zeroizing::new(String::from(callback_url));
+        let state = Zeroizing::new(self.state.to_string());
+        url.query_pairs_mut()
+            .append_pair("type", "cli")
+            .append_pair("returnTo", &callback_url)
+            .append_pair("state", &state)
+            .append_pair("code_challenge", &self.code_challenge)
+            .append_pair("code_challenge_method", "S256");
+        Ok(Zeroizing::new(String::from(url)))
+    }
+
+    pub fn state_matches(&self, returned_state: &str) -> bool {
+        if self.state.len() != returned_state.len() {
+            return false;
+        }
+        bool::from(self.state.as_bytes().ct_eq(returned_state.as_bytes()))
+    }
+
+    /// Parse one callback for this attempt. Rejections leave the attempt
+    /// usable; a correlated success or authorization error consumes state.
+    pub fn parse_callback(&mut self, callback_url: &Url) -> OAuthCallback {
+        if self.state.is_empty() {
+            return OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch);
+        }
+
+        let mut state = None;
+        let mut code = None;
+        let mut error = None;
+        for (key, value) in callback_url.query_pairs() {
+            let slot = match key.as_ref() {
+                "state" => &mut state,
+                "code" => &mut code,
+                "error" => &mut error,
+                _ => continue,
+            };
+            if slot.replace(value.into_owned()).is_some() {
+                return OAuthCallback::Rejected(OAuthCallbackRejection::DuplicateParameter);
+            }
+        }
+
+        let Some(state) = state.filter(|state| !state.is_empty()) else {
+            return OAuthCallback::Rejected(OAuthCallbackRejection::MissingState);
+        };
+        if state.len() > 128 {
+            return OAuthCallback::Rejected(OAuthCallbackRejection::InvalidState);
+        }
+        if !self.state_matches(&state) {
+            return OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch);
+        }
+        if code.is_some() && error.is_some() {
+            return OAuthCallback::Rejected(OAuthCallbackRejection::ConflictingOutcome);
+        }
+        if let Some(error) = error.filter(|error| !error.trim().is_empty()) {
+            if error.len() > 1024 {
+                return OAuthCallback::Rejected(OAuthCallbackRejection::InvalidError);
+            }
+            self.consume_state();
+            return OAuthCallback::Error(error);
+        }
+        match code.filter(|code| !code.trim().is_empty()) {
+            Some(code) if code.len() <= 1024 => {
+                self.consume_state();
+                OAuthCallback::Code(code)
+            }
+            Some(_) => OAuthCallback::Rejected(OAuthCallbackRejection::InvalidCode),
+            None => OAuthCallback::Rejected(OAuthCallbackRejection::MissingCode),
+        }
+    }
+
+    fn consume_state(&mut self) {
+        self.state.zeroize();
+    }
+
+    pub fn exchange_login_code_and_verify(
+        &mut self,
+        client: &Client,
+        playpen: Option<&str>,
+        server_url: &str,
+        code: &str,
+    ) -> Result<VerifiedLoginSession> {
+        if self.code_verifier.is_empty() {
+            return Err(anyhow!("OAuth login attempt has already been exchanged"));
+        }
+        let result =
+            exchange_login_code_and_verify(client, playpen, server_url, code, &self.code_verifier);
+        self.code_verifier.zeroize();
+        self.code_challenge.zeroize();
+        result
+    }
+}
+
+impl Drop for OAuthLoginAttempt {
+    fn drop(&mut self) {
+        self.state.zeroize();
+        self.code_verifier.zeroize();
+        self.code_challenge.zeroize();
+    }
+}
+
+impl std::fmt::Debug for OAuthLoginAttempt {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("OAuthLoginAttempt { .. }")
+    }
+}
+
+fn pkce_s256_challenge(code_verifier: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()))
+}
+
 #[derive(Debug, Serialize)]
 struct LoginExchangeRequest<'a> {
     code: &'a str,
+    code_verifier: &'a str,
 }
 
 pub fn build_auth_http_client(timeout: Duration) -> Result<Client> {
@@ -72,13 +260,17 @@ pub fn exchange_login_code(
     playpen: Option<&str>,
     server_url: &str,
     code: &str,
+    code_verifier: &str,
 ) -> Result<LoginExchangeResponse> {
     let url = auth_url(server_url, "/v1/auth/login/exchange")?;
     let mut request = client
         .post(url)
         .header(USER_AGENT, CLI_USER_AGENT)
         .header(ACCEPT, "application/json")
-        .json(&LoginExchangeRequest { code });
+        .json(&LoginExchangeRequest {
+            code,
+            code_verifier,
+        });
     if let Some(baggage) = playpen_baggage(playpen) {
         request = request.header("Baggage", baggage);
     }
@@ -98,8 +290,9 @@ pub fn exchange_login_code_and_verify(
     playpen: Option<&str>,
     server_url: &str,
     code: &str,
+    code_verifier: &str,
 ) -> Result<VerifiedLoginSession> {
-    let exchange = exchange_login_code(client, playpen, server_url, code)?;
+    let exchange = exchange_login_code(client, playpen, server_url, code, code_verifier)?;
     let credential = StoredSessionCredential {
         session_credential: exchange.session_credential,
         expires_at: Some(exchange.expires_at),
@@ -176,14 +369,6 @@ pub fn logout_session_credential(
     Ok(true)
 }
 
-pub fn login_url(server_url: &str, callback_url: &str) -> Result<Url> {
-    let mut url = auth_url(server_url, "/v1/auth/login")?;
-    url.query_pairs_mut()
-        .append_pair("type", "cli")
-        .append_pair("returnTo", callback_url);
-    Ok(url)
-}
-
 pub fn auth_url(server_url: &str, path: &str) -> Result<Url> {
     let base = Url::parse(server_url).context("server URL must be absolute")?;
     let path = format!(
@@ -210,6 +395,19 @@ mod tests {
     use std::thread;
 
     use super::*;
+
+    const TEST_STATE: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const TEST_CODE_VERIFIER: &str =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const TEST_CODE_CHALLENGE: &str = "_-BU_nrgy23GXDr5th1SCfQ5hR20PQulmXM33xVGaOs";
+
+    fn test_attempt() -> OAuthLoginAttempt {
+        OAuthLoginAttempt::from_parts(TEST_STATE.to_string(), TEST_CODE_VERIFIER.to_string())
+    }
+
+    fn request_json(request: &RecordedRequest) -> serde_json::Value {
+        serde_json::from_str(&request.body).expect("JSON request body")
+    }
 
     #[test]
     fn verify_session_credential_treats_unauthorized_as_invalid() {
@@ -321,31 +519,187 @@ mod tests {
     }
 
     #[test]
-    fn login_url_uses_v1_route() {
-        let url = login_url(
-            "https://example.com/cash-app/goose",
-            "http://127.0.0.1:1234/callback",
-        )
-        .expect("login URL");
+    fn oauth_login_attempt_builds_correlated_s256_request() {
+        let mut attempt = test_attempt();
+        let url = attempt
+            .login_url(
+                "https://example.com/cash-app/goose",
+                "http://127.0.0.1:1234/callback",
+            )
+            .expect("login URL");
+        let url = Url::parse(&url).expect("parse login URL");
+        let query: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
 
         assert_eq!(url.path(), "/cash-app/goose/v1/auth/login");
+        assert_eq!(query.get("type").map(String::as_str), Some("cli"));
+        assert_eq!(
+            query.get("returnTo").map(String::as_str),
+            Some("http://127.0.0.1:1234/callback")
+        );
+        assert_eq!(query.get("state").map(String::as_str), Some(TEST_STATE));
+        assert_eq!(
+            query.get("code_challenge").map(String::as_str),
+            Some(TEST_CODE_CHALLENGE)
+        );
+        assert_eq!(
+            query.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        assert!(attempt.state_matches(TEST_STATE));
+        assert!(!attempt.state_matches(&"c".repeat(43)));
+        assert_eq!(
+            attempt.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1/callback?code=exchange&state={TEST_STATE}"
+                ))
+                .expect("callback URL")
+            ),
+            OAuthCallback::Code("exchange".to_string())
+        );
+        assert_eq!(
+            attempt.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1/callback?code=replay&state={TEST_STATE}"
+                ))
+                .expect("replay callback URL")
+            ),
+            OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch)
+        );
+        assert_eq!(
+            attempt.parse_callback(
+                &Url::parse("http://127.0.0.1/callback?code=empty-state-replay&state=")
+                    .expect("empty-state replay callback URL")
+            ),
+            OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch)
+        );
+        assert!(attempt.test_state().is_empty());
     }
 
     #[test]
-    fn exchange_login_code_uses_v1_route() {
+    fn oauth_login_attempt_rejects_non_loopback_callback_urls() {
+        let attempt = test_attempt();
+
+        for callback_url in [
+            "https://127.0.0.1:1234/callback",
+            "http://localhost:1234/callback",
+            "http://127.0.0.1/callback",
+            "http://user@127.0.0.1:1234/callback",
+            "http://user:password@127.0.0.1:1234/callback",
+            "http://127.0.0.1:1234/callback?existing=query",
+            "http://127.0.0.1:1234/callback#fragment",
+        ] {
+            assert!(
+                attempt
+                    .login_url("https://example.com/cash-app/goose", callback_url)
+                    .is_err(),
+                "accepted invalid callback URL {callback_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth_callback_parser_requires_exact_unambiguous_state() {
+        let mut attempt = test_attempt();
+        for (query, expected) in [
+            (
+                "code=exchange",
+                OAuthCallback::Rejected(OAuthCallbackRejection::MissingState),
+            ),
+            (
+                "code=exchange&state=ccccccccccccccccccccccccccccccccccccccccccc",
+                OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch),
+            ),
+            (
+                &format!("state={TEST_STATE}"),
+                OAuthCallback::Rejected(OAuthCallbackRejection::MissingCode),
+            ),
+            (
+                &format!("code={}&state={TEST_STATE}", "x".repeat(1025)),
+                OAuthCallback::Rejected(OAuthCallbackRejection::InvalidCode),
+            ),
+            (
+                &format!("code=exchange&state={}", "x".repeat(129)),
+                OAuthCallback::Rejected(OAuthCallbackRejection::InvalidState),
+            ),
+            (
+                &format!("error={}&state={TEST_STATE}", "x".repeat(1025)),
+                OAuthCallback::Rejected(OAuthCallbackRejection::InvalidError),
+            ),
+            (
+                &format!("code=first&code=second&state={TEST_STATE}"),
+                OAuthCallback::Rejected(OAuthCallbackRejection::DuplicateParameter),
+            ),
+            (
+                &format!("code=exchange&error=denied&state={TEST_STATE}"),
+                OAuthCallback::Rejected(OAuthCallbackRejection::ConflictingOutcome),
+            ),
+        ] {
+            let callback =
+                Url::parse(&format!("http://127.0.0.1/callback?{query}")).expect("callback URL");
+            assert_eq!(attempt.parse_callback(&callback), expected);
+        }
+
+        let error_callback = Url::parse(&format!(
+            "http://127.0.0.1/callback?error=access_denied&state={TEST_STATE}"
+        ))
+        .expect("error callback URL");
+        assert_eq!(
+            attempt.parse_callback(&error_callback),
+            OAuthCallback::Error("access_denied".to_string())
+        );
+    }
+
+    #[test]
+    fn generated_oauth_login_attempt_uses_high_entropy_url_safe_material() {
+        let first = OAuthLoginAttempt::generate().expect("first OAuth attempt");
+        let second = OAuthLoginAttempt::generate().expect("second OAuth attempt");
+
+        for attempt in [&first, &second] {
+            assert_eq!(attempt.state.len(), 43);
+            assert_eq!(attempt.code_verifier.len(), 86);
+            assert_eq!(attempt.code_challenge.len(), 43);
+            assert!(attempt
+                .state
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'));
+            assert!(attempt
+                .code_verifier
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'));
+        }
+        assert_ne!(first.state, second.state);
+        assert_ne!(first.code_verifier, second.code_verifier);
+        assert_eq!(format!("{first:?}"), "OAuthLoginAttempt { .. }");
+    }
+
+    #[test]
+    fn exchange_login_code_sends_code_and_verifier() {
         let server = SingleResponseServer::start(
             200,
             r#"{"session_credential":"session","expires_at":"2026-06-15T00:00:00Z"}"#,
         );
         let client = build_auth_http_client(Duration::from_secs(5)).expect("client");
 
-        let exchange = exchange_login_code(&client, None, &server.base_url, "one-time-code")
-            .expect("exchange");
+        let exchange = exchange_login_code(
+            &client,
+            None,
+            &server.base_url,
+            "one-time-code",
+            TEST_CODE_VERIFIER,
+        )
+        .expect("exchange");
         let request = server.finish();
 
         assert_eq!(exchange.session_credential, "session");
         assert_eq!(exchange.expires_at, "2026-06-15T00:00:00Z");
         assert_eq!(request.path, "/v1/auth/login/exchange");
+        assert_eq!(
+            request_json(&request),
+            serde_json::json!({
+                "code": "one-time-code",
+                "code_verifier": TEST_CODE_VERIFIER,
+            })
+        );
     }
 
     #[test]
@@ -362,9 +716,14 @@ mod tests {
         ]);
         let client = build_auth_http_client(Duration::from_secs(5)).expect("client");
 
-        let verified =
-            exchange_login_code_and_verify(&client, None, &server.base_url, "one-time-code")
-                .expect("verified login");
+        let verified = exchange_login_code_and_verify(
+            &client,
+            None,
+            &server.base_url,
+            "one-time-code",
+            TEST_CODE_VERIFIER,
+        )
+        .expect("verified login");
         let requests = server.finish();
 
         assert_eq!(verified.credential.session_credential, "session");
@@ -400,9 +759,14 @@ mod tests {
         ]);
         let client = build_auth_http_client(Duration::from_secs(5)).expect("client");
 
-        let error =
-            exchange_login_code_and_verify(&client, None, &server.base_url, "one-time-code")
-                .expect_err("auth/me rejection fails login");
+        let error = exchange_login_code_and_verify(
+            &client,
+            None,
+            &server.base_url,
+            "one-time-code",
+            TEST_CODE_VERIFIER,
+        )
+        .expect_err("auth/me rejection fails login");
         let requests = server.finish();
 
         assert!(
@@ -416,6 +780,7 @@ mod tests {
 
     struct RecordedRequest {
         path: String,
+        body: String,
         bb_session_credential: Option<String>,
     }
 
@@ -496,6 +861,7 @@ mod tests {
             .to_string();
 
         let mut bb_session_credential = None;
+        let mut content_length = 0;
         loop {
             let mut line = String::new();
             reader.read_line(&mut line).expect("request header");
@@ -505,11 +871,17 @@ mod tests {
             if let Some((name, value)) = line.split_once(':') {
                 if name.eq_ignore_ascii_case(SESSION_CREDENTIAL_HEADER) {
                     bb_session_credential = Some(value.trim().to_string());
+                } else if name.eq_ignore_ascii_case("content-length") {
+                    content_length = value.trim().parse().expect("content length");
                 }
             }
         }
+        let mut request_body = vec![0_u8; content_length];
+        std::io::Read::read_exact(&mut reader, &mut request_body).expect("request body");
+        let request_body = String::from_utf8(request_body).expect("UTF-8 request body");
         *request.lock().expect("request mutex") = Some(RecordedRequest {
             path,
+            body: request_body,
             bb_session_credential,
         });
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -694,14 +694,18 @@ name = "builderbot-auth"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "core-foundation 0.10.1",
+ "getrandom 0.4.3",
  "reqwest 0.12.28",
  "security-framework-sys",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2",
+ "subtle",
  "url",
+ "zeroize",
 ]
 
 [[package]]

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use builderbot_auth::auth_login::{
-    build_auth_http_client, exchange_login_code_and_verify, login_url, logout_session_credential,
-    verify_session_credential, AuthMeResponse,
+    build_auth_http_client, logout_session_credential, verify_session_credential, AuthMeResponse,
+    OAuthCallback, OAuthCallbackRejection, OAuthLoginAttempt,
 };
 use builderbot_auth::auth_storage::{
     default_session_storage_for_bb_home,
@@ -40,9 +40,12 @@ const KGOOSE_PLAYPEN_ENV_VAR: &str = "KGOOSE_PLAYPEN";
 const BB_SKILLS_CONFIG_ENV_VAR: &str = "BB_SKILLS_CONFIG";
 const SKILLS_CONFIG_FILE_NAME: &str = "skills.yaml";
 const CALLBACK_PATH: &str = "/callback";
-const CANCEL_CALLBACK_PATH: &str = "/cancel";
 const AUTH_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
-const LOOPBACK_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+const LOGIN_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const LOOPBACK_IO_TIMEOUT: Duration = Duration::from_secs(1);
+const MAX_LOOPBACK_REQUEST_LINE_BYTES: usize = 4 * 1024;
+const MAX_LOOPBACK_HEADER_LINE_BYTES: usize = 8 * 1024;
+const MAX_LOOPBACK_HEADER_COUNT: usize = 64;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -123,8 +126,15 @@ struct SkillsFileConfig {
 struct LoginAttempt {
     id: u64,
     callback_addr: SocketAddr,
-    callback_received: bool,
     canceled: bool,
+}
+
+struct LoginAttemptGuard(u64);
+
+impl Drop for LoginAttemptGuard {
+    fn drop(&mut self) {
+        clear_login_attempt_if_current(self.0);
+    }
 }
 
 fn login_attempt_state() -> &'static Mutex<Option<LoginAttempt>> {
@@ -213,17 +223,20 @@ fn auth_status_blocking() -> Result<AuthStatus> {
     status_for_context(&context)
 }
 
-fn register_login_attempt(callback_addr: SocketAddr) -> u64 {
+fn register_login_attempt(callback_addr: SocketAddr) -> Result<u64> {
     let id = next_login_attempt_id();
-    *login_attempt_state()
+    let mut current = login_attempt_state()
         .lock()
-        .expect("login attempt state mutex poisoned") = Some(LoginAttempt {
+        .expect("login attempt state mutex poisoned");
+    if current.is_some() {
+        return Err(anyhow!("BuilderBot auth login is already in progress"));
+    }
+    *current = Some(LoginAttempt {
         id,
         callback_addr,
-        callback_received: false,
         canceled: false,
     });
-    id
+    Ok(id)
 }
 
 fn clear_login_attempt_if_current(id: u64) {
@@ -235,20 +248,19 @@ fn clear_login_attempt_if_current(id: u64) {
     }
 }
 
-fn mark_login_attempt_callback_received(id: u64) {
-    let mut current = login_attempt_state()
-        .lock()
-        .expect("login attempt state mutex poisoned");
-    if let Some(attempt) = current.as_mut().filter(|attempt| attempt.id == id) {
-        attempt.callback_received = true;
-    }
-}
-
 fn is_login_attempt_canceled(id: u64) -> bool {
     login_attempt_state()
         .lock()
         .expect("login attempt state mutex poisoned")
         .is_some_and(|attempt| attempt.id == id && attempt.canceled)
+}
+
+fn current_login_attempt_id_for(callback_addr: SocketAddr) -> Option<u64> {
+    login_attempt_state()
+        .lock()
+        .expect("login attempt state mutex poisoned")
+        .filter(|attempt| attempt.callback_addr == callback_addr)
+        .map(|attempt| attempt.id)
 }
 
 fn complete_login_attempt_if_not_canceled(id: u64) -> bool {
@@ -267,20 +279,10 @@ fn complete_login_attempt_if_not_canceled(id: u64) -> bool {
 }
 
 fn cancel_login_blocking() -> Result<()> {
-    let Some(attempt) = mark_login_attempt_canceled() else {
-        return Ok(());
-    };
-
-    if attempt.callback_received {
-        return Ok(());
-    }
-
-    let stream = TcpStream::connect_timeout(&attempt.callback_addr, LOOPBACK_CONNECT_TIMEOUT)
-        .with_context(|| format!("connect to auth callback at {}", attempt.callback_addr))?;
-    stream
-        .set_write_timeout(Some(LOOPBACK_CONNECT_TIMEOUT))
-        .context("set auth cancel write timeout")?;
-    write_cancel_request(stream)
+    // Cancellation is an in-process command, not a loopback HTTP capability.
+    // The nonblocking login worker polls this state at least every 25 ms.
+    mark_login_attempt_canceled();
+    Ok(())
 }
 
 fn mark_login_attempt_canceled() -> Option<LoginAttempt> {
@@ -314,10 +316,15 @@ fn login_blocking(app_handle: AppHandle, org: Option<String>) -> Result<AuthStat
     }
 
     let listener = TcpListener::bind("127.0.0.1:0").context("listen on loopback callback port")?;
+    listener
+        .set_nonblocking(true)
+        .context("configure loopback callback listener")?;
     let callback_addr = listener.local_addr()?;
-    let attempt_id = register_login_attempt(callback_addr);
+    let mut oauth_attempt = OAuthLoginAttempt::generate()?;
     let callback_url = format!("http://{}{}", callback_addr, CALLBACK_PATH);
-    let login_url = login_url(&context.kgoose_service_url, &callback_url)?;
+    let login_url = oauth_attempt.login_url(&context.kgoose_service_url, &callback_url)?;
+    let attempt_id = register_login_attempt(callback_addr)?;
+    let _attempt_guard = LoginAttemptGuard(attempt_id);
     if let Err(error) = app_handle
         .opener()
         .open_url(login_url.as_str(), None::<&str>)
@@ -327,19 +334,18 @@ fn login_blocking(app_handle: AppHandle, org: Option<String>) -> Result<AuthStat
         return Err(error);
     }
 
-    let code = match receive_exchange_code(listener) {
+    let code = match receive_exchange_code(listener, &mut oauth_attempt) {
         Ok(code) => code,
         Err(error) => {
             clear_login_attempt_if_current(attempt_id);
             return Err(error);
         }
     };
-    mark_login_attempt_callback_received(attempt_id);
     if is_login_attempt_canceled(attempt_id) {
         clear_login_attempt_if_current(attempt_id);
         return Err(anyhow!("BuilderBot auth login was canceled"));
     }
-    let verified = match exchange_login_code_and_verify(
+    let verified = match oauth_attempt.exchange_login_code_and_verify(
         &client,
         context.playpen.as_deref(),
         &context.kgoose_service_url,
@@ -659,84 +665,209 @@ fn session_storage_key(context: &AuthContext) -> SessionStorageKey {
     )
 }
 
-fn receive_exchange_code(listener: TcpListener) -> Result<String> {
-    for stream in listener.incoming() {
-        let stream = stream.context("accept loopback auth callback")?;
-        if let Some(code) = handle_callback_stream(stream)? {
-            return Ok(code);
+fn receive_exchange_code(listener: TcpListener, attempt: &mut OAuthLoginAttempt) -> Result<String> {
+    let deadline = std::time::Instant::now() + LOGIN_ATTEMPT_TIMEOUT;
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(anyhow!(
+                "BuilderBot auth login expired before receiving a valid callback"
+            ));
+        }
+        if let Some(attempt_id) = current_login_attempt_id_for(listener.local_addr()?) {
+            if is_login_attempt_canceled(attempt_id) {
+                return Err(anyhow!("BuilderBot auth login was canceled"));
+            }
+        } else {
+            return Err(anyhow!("BuilderBot auth login attempt is no longer active"));
+        }
+
+        match listener.accept() {
+            Ok((stream, _)) => {
+                if let Some(code) = handle_callback_stream(stream, attempt)? {
+                    return Ok(code);
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Err(error) => return Err(error).context("accept loopback auth callback"),
         }
     }
-
-    Err(anyhow!(
-        "loopback auth server stopped without receiving a callback"
-    ))
 }
 
-fn handle_callback_stream(mut stream: TcpStream) -> Result<Option<String>> {
-    let mut reader = BufReader::new(stream.try_clone().context("clone callback stream")?);
-    let mut request_line = String::new();
-    reader
-        .read_line(&mut request_line)
-        .context("read callback request line")?;
-    while {
-        let mut header = String::new();
-        reader
-            .read_line(&mut header)
-            .context("read callback header")?;
-        header != "\r\n" && !header.is_empty()
-    } {}
+fn handle_callback_stream(
+    mut stream: TcpStream,
+    attempt: &mut OAuthLoginAttempt,
+) -> Result<Option<String>> {
+    if let Err(error) = stream.set_read_timeout(Some(LOOPBACK_IO_TIMEOUT)) {
+        log::debug!("ignoring loopback auth connection with no read timeout: {error}");
+        return Ok(None);
+    }
+    if let Err(error) = stream.set_write_timeout(Some(LOOPBACK_IO_TIMEOUT)) {
+        log::debug!("ignoring loopback auth connection with no write timeout: {error}");
+        return Ok(None);
+    }
+    let outcome = read_callback_stream(&stream, attempt);
+    match outcome {
+        Err(error) => {
+            let _ = write_loopback_response(
+                &mut stream,
+                400,
+                "BuilderBot auth ignored an invalid callback request. The valid login is still waiting.",
+            );
+            log::debug!("ignoring invalid loopback auth connection: {error:#}");
+            Ok(None)
+        }
+        Ok(CallbackReadOutcome::WrongPath) => {
+            let _ = write_loopback_response(
+                &mut stream,
+                404,
+                "BuilderBot auth is waiting for the callback.",
+            );
+            Ok(None)
+        }
+        Ok(CallbackReadOutcome::InvalidMethod) => {
+            let _ = write_loopback_response(
+                &mut stream,
+                400,
+                "BuilderBot auth ignored an invalid callback request. The valid login is still waiting.",
+            );
+            Ok(None)
+        }
+        Ok(CallbackReadOutcome::Callback(OAuthCallback::Code(code))) => {
+            let _ = write_loopback_response(
+                &mut stream,
+                200,
+                "BuilderBot auth complete. Return to Goose.",
+            );
+            Ok(Some(code))
+        }
+        Ok(CallbackReadOutcome::Callback(OAuthCallback::Error(error))) => {
+            let _ = write_loopback_response(
+                &mut stream,
+                400,
+                "BuilderBot auth failed. Return to Goose.",
+            );
+            Err(anyhow!("auth callback returned error: {error}"))
+        }
+        Ok(CallbackReadOutcome::Callback(OAuthCallback::Rejected(rejection))) => {
+            let _ =
+                write_loopback_response(&mut stream, 400, callback_rejection_message(rejection));
+            Ok(None)
+        }
+    }
+}
 
-    let request_target = request_line
-        .split_whitespace()
-        .nth(1)
+enum CallbackReadOutcome {
+    Callback(OAuthCallback),
+    WrongPath,
+    InvalidMethod,
+}
+
+fn read_callback_stream(
+    stream: &TcpStream,
+    attempt: &mut OAuthLoginAttempt,
+) -> Result<CallbackReadOutcome> {
+    let mut reader = BufReader::new(stream.try_clone().context("clone callback stream")?);
+    let request_line = read_bounded_http_line(
+        &mut reader,
+        MAX_LOOPBACK_REQUEST_LINE_BYTES,
+        "callback request line",
+    )?;
+    if request_line.is_empty() {
+        return Err(anyhow!("auth callback request line was empty"));
+    }
+
+    let mut headers_complete = false;
+    for _ in 0..MAX_LOOPBACK_HEADER_COUNT {
+        let header = read_bounded_http_line(
+            &mut reader,
+            MAX_LOOPBACK_HEADER_LINE_BYTES,
+            "callback header",
+        )?;
+        if header == "\r\n" {
+            headers_complete = true;
+            break;
+        }
+        if header.is_empty() {
+            return Err(anyhow!("auth callback request ended before its headers"));
+        }
+    }
+    if !headers_complete {
+        return Err(anyhow!(
+            "auth callback request exceeded {MAX_LOOPBACK_HEADER_COUNT} headers"
+        ));
+    }
+
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts
+        .next()
+        .ok_or_else(|| anyhow!("auth callback request did not include a method"))?;
+    let request_target = request_parts
+        .next()
         .ok_or_else(|| anyhow!("auth callback request did not include a path"))?;
+    let version = request_parts
+        .next()
+        .ok_or_else(|| anyhow!("auth callback request did not include an HTTP version"))?;
+    if request_parts.next().is_some() || !matches!(version, "HTTP/1.0" | "HTTP/1.1") {
+        return Err(anyhow!("auth callback request line was malformed"));
+    }
+
     let parsed = Url::parse(&format!("http://127.0.0.1{request_target}"))
         .context("parse loopback callback URL")?;
 
-    if parsed.path() == CANCEL_CALLBACK_PATH {
-        write_loopback_response(&mut stream, 200, "BuilderBot auth canceled.")?;
-        return Err(anyhow!("BuilderBot auth login was canceled"));
-    }
-
     if parsed.path() != CALLBACK_PATH {
-        write_loopback_response(
-            &mut stream,
-            404,
-            "BuilderBot auth is waiting for the callback.",
-        )?;
-        return Ok(None);
+        return Ok(CallbackReadOutcome::WrongPath);
     }
 
-    if let Some(error) = parsed
-        .query_pairs()
-        .find(|(key, _)| key == "error")
-        .map(|(_, value)| value.into_owned())
-    {
-        write_loopback_response(&mut stream, 400, "BuilderBot auth failed. Return to Goose.")?;
-        return Err(anyhow!("auth callback returned error: {error}"));
+    if method != "GET" {
+        return Ok(CallbackReadOutcome::InvalidMethod);
     }
 
-    let code = parsed
-        .query_pairs()
-        .find(|(key, _)| key == "code")
-        .map(|(_, value)| value.into_owned())
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| anyhow!("auth callback did not include an exchange code"))?;
-    write_loopback_response(
-        &mut stream,
-        200,
-        "BuilderBot auth complete. Return to Goose.",
-    )?;
-    Ok(Some(code))
+    Ok(CallbackReadOutcome::Callback(
+        attempt.parse_callback(&parsed),
+    ))
 }
 
-fn write_cancel_request(mut stream: TcpStream) -> Result<()> {
-    let request = format!(
-        "GET {CANCEL_CALLBACK_PATH} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
-    );
-    stream
-        .write_all(request.as_bytes())
-        .context("write auth cancel request")
+fn read_bounded_http_line(
+    reader: &mut BufReader<TcpStream>,
+    max_bytes: usize,
+    description: &str,
+) -> Result<String> {
+    let mut bytes = Vec::new();
+    let read = reader
+        .take((max_bytes + 1) as u64)
+        .read_until(b'\n', &mut bytes)
+        .with_context(|| format!("read {description}"))?;
+    if read == 0 {
+        return Ok(String::new());
+    }
+    if bytes.len() > max_bytes || !bytes.ends_with(b"\n") {
+        return Err(anyhow!("{description} exceeded {max_bytes} bytes"));
+    }
+    String::from_utf8(bytes).with_context(|| format!("{description} was not valid UTF-8"))
+}
+
+fn callback_rejection_message(rejection: OAuthCallbackRejection) -> &'static str {
+    match rejection {
+        OAuthCallbackRejection::MissingState => {
+            "BuilderBot auth ignored a callback with missing state. The valid login is still waiting."
+        }
+        OAuthCallbackRejection::StateMismatch => {
+            "BuilderBot auth ignored a callback for another login. The valid login is still waiting."
+        }
+        OAuthCallbackRejection::MissingCode => {
+            "BuilderBot auth ignored a callback with no exchange code. The valid login is still waiting."
+        }
+        OAuthCallbackRejection::InvalidState
+        | OAuthCallbackRejection::InvalidCode
+        | OAuthCallbackRejection::InvalidError => {
+            "BuilderBot auth ignored a callback with an invalid parameter. The valid login is still waiting."
+        }
+        OAuthCallbackRejection::DuplicateParameter | OAuthCallbackRejection::ConflictingOutcome => {
+            "BuilderBot auth ignored an ambiguous callback. The valid login is still waiting."
+        }
+    }
 }
 
 fn write_loopback_response(stream: &mut TcpStream, status: u16, body: &str) -> Result<()> {
@@ -993,12 +1124,173 @@ mod tests {
     }
 
     #[test]
-    fn receive_exchange_code_stops_on_cancel_callback() {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback server");
-        let addr = listener.local_addr().expect("local addr");
-        let handle = thread::spawn(move || receive_exchange_code(listener));
+    fn concurrent_login_attempt_is_rejected_without_replacing_the_active_attempt() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        let first_listener = TcpListener::bind("127.0.0.1:0").expect("bind first callback server");
+        let first_addr = first_listener.local_addr().expect("first local addr");
+        let first_attempt_id =
+            register_login_attempt(first_addr).expect("register first login attempt");
+        let second_listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind second callback server");
+        let second_addr = second_listener.local_addr().expect("second local addr");
 
-        send_cancel_request(addr);
+        let error =
+            register_login_attempt(second_addr).expect_err("reject concurrent login attempt");
+
+        assert!(
+            format!("{error:#}").contains("already in progress"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(
+            current_login_attempt_id_for(first_addr),
+            Some(first_attempt_id)
+        );
+        assert_eq!(current_login_attempt_id_for(second_addr), None);
+        clear_login_attempt_if_current(first_attempt_id);
+    }
+
+    #[test]
+    fn rejected_callbacks_do_not_terminate_the_valid_attempt() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback server");
+        listener
+            .set_nonblocking(true)
+            .expect("configure callback server");
+        let addr = listener.local_addr().expect("local addr");
+        let attempt_id = register_login_attempt(addr).expect("register login attempt");
+        let mut attempt = OAuthLoginAttempt::generate().expect("OAuth attempt");
+        let login_url = attempt
+            .login_url(
+                "https://example.com/cash-app/goose",
+                &format!("http://{addr}{CALLBACK_PATH}"),
+            )
+            .expect("login URL");
+        let login_url = Url::parse(&login_url).expect("parse login URL");
+        let expected_state = login_url
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.into_owned())
+            .expect("state query parameter");
+        let handle = thread::spawn(move || receive_exchange_code(listener, &mut attempt));
+
+        for target in [
+            format!("{CALLBACK_PATH}?code=missing-state"),
+            format!("{CALLBACK_PATH}?code=wrong-state&state={}", "x".repeat(43)),
+            format!("{CALLBACK_PATH}?state={expected_state}"),
+            format!("{CALLBACK_PATH}?code=first&code=second&state={expected_state}"),
+        ] {
+            assert_eq!(send_callback_request(addr, "GET", &target), 400);
+        }
+        assert_eq!(
+            send_callback_request(
+                addr,
+                "GET",
+                &format!("{CALLBACK_PATH}?code=valid-code&state={expected_state}"),
+            ),
+            200
+        );
+
+        assert_eq!(
+            handle
+                .join()
+                .expect("join callback server")
+                .expect("valid callback"),
+            "valid-code"
+        );
+        clear_login_attempt_if_current(attempt_id);
+    }
+
+    #[test]
+    fn cross_attempt_and_replayed_callbacks_are_rejected() {
+        let mut first = OAuthLoginAttempt::generate().expect("first OAuth attempt");
+        let mut second = OAuthLoginAttempt::generate().expect("second OAuth attempt");
+        let first_state = attempt_state(&first);
+        let second_state = attempt_state(&second);
+
+        assert_eq!(
+            second.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1{CALLBACK_PATH}?code=cross-attempt&state={first_state}"
+                ))
+                .expect("cross-attempt callback")
+            ),
+            OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch)
+        );
+        assert_eq!(
+            first.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1{CALLBACK_PATH}?code=valid&state={first_state}"
+                ))
+                .expect("valid callback")
+            ),
+            OAuthCallback::Code("valid".to_string())
+        );
+        assert_eq!(
+            first.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1{CALLBACK_PATH}?code=replay&state={first_state}"
+                ))
+                .expect("replayed callback")
+            ),
+            OAuthCallback::Rejected(OAuthCallbackRejection::StateMismatch)
+        );
+        assert_eq!(
+            second.parse_callback(
+                &Url::parse(&format!(
+                    "http://127.0.0.1{CALLBACK_PATH}?code=second&state={second_state}"
+                ))
+                .expect("second valid callback")
+            ),
+            OAuthCallback::Code("second".to_string())
+        );
+    }
+
+    #[test]
+    fn unsolicited_cancel_path_does_not_terminate_the_valid_attempt() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback server");
+        listener
+            .set_nonblocking(true)
+            .expect("configure callback server");
+        let addr = listener.local_addr().expect("local addr");
+        let attempt_id = register_login_attempt(addr).expect("register login attempt");
+        let mut attempt = OAuthLoginAttempt::generate().expect("OAuth attempt");
+        let expected_state = attempt_state(&attempt);
+        let handle = thread::spawn(move || receive_exchange_code(listener, &mut attempt));
+
+        assert_eq!(send_callback_request(addr, "GET", "/cancel"), 404);
+        assert_eq!(
+            send_callback_request(
+                addr,
+                "GET",
+                &format!("{CALLBACK_PATH}?code=valid-code&state={expected_state}"),
+            ),
+            200
+        );
+
+        assert_eq!(
+            handle
+                .join()
+                .expect("join callback server")
+                .expect("valid callback"),
+            "valid-code"
+        );
+        clear_login_attempt_if_current(attempt_id);
+    }
+
+    #[test]
+    fn cancel_login_command_stops_the_registered_attempt() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback server");
+        listener
+            .set_nonblocking(true)
+            .expect("configure callback server");
+        let addr = listener.local_addr().expect("local addr");
+        let attempt_id = register_login_attempt(addr).expect("register login attempt");
+        let mut attempt = OAuthLoginAttempt::generate().expect("OAuth attempt");
+        let handle = thread::spawn(move || receive_exchange_code(listener, &mut attempt));
+
+        cancel_login_blocking().expect("cancel login");
 
         let error = handle
             .join()
@@ -1008,6 +1300,57 @@ mod tests {
             format!("{error:#}").contains("canceled"),
             "unexpected error: {error:#}"
         );
+        clear_login_attempt_if_current(attempt_id);
+    }
+
+    #[test]
+    fn malformed_and_slow_connections_do_not_terminate_the_valid_attempt() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback server");
+        listener
+            .set_nonblocking(true)
+            .expect("configure callback server");
+        let addr = listener.local_addr().expect("local addr");
+        let attempt_id = register_login_attempt(addr).expect("register login attempt");
+        let mut attempt = OAuthLoginAttempt::generate().expect("OAuth attempt");
+        let expected_state = attempt_state(&attempt);
+        let handle = thread::spawn(move || receive_exchange_code(listener, &mut attempt));
+
+        let mut slow_stream = TcpStream::connect(addr).expect("connect slow callback request");
+        slow_stream
+            .write_all(b"GET /callback")
+            .expect("write incomplete callback request");
+        let mut status_line = String::new();
+        BufReader::new(slow_stream)
+            .read_line(&mut status_line)
+            .expect("read slow callback response");
+        assert!(status_line.starts_with("HTTP/1.1 400 "), "{status_line:?}");
+
+        let oversized_target = format!("/{}", "x".repeat(MAX_LOOPBACK_REQUEST_LINE_BYTES));
+        assert_eq!(send_callback_request(addr, "GET", &oversized_target), 400);
+        assert_eq!(
+            send_callback_request(
+                addr,
+                "GET",
+                &format!("{CALLBACK_PATH}?code=valid-code&state={expected_state}"),
+            ),
+            200
+        );
+
+        assert_eq!(
+            handle
+                .join()
+                .expect("join callback server")
+                .expect("valid callback"),
+            "valid-code"
+        );
+        clear_login_attempt_if_current(attempt_id);
+    }
+
+    #[test]
+    fn cancel_login_without_an_active_attempt_is_a_no_op() {
+        let _guard = env_lock().lock().expect("login attempt lock");
+        cancel_login_blocking().expect("cancel without active login");
     }
 
     #[test]
@@ -1116,9 +1459,38 @@ mod tests {
         clear_auth_env();
     }
 
-    fn send_cancel_request(addr: SocketAddr) {
-        let stream = TcpStream::connect(addr).expect("connect cancel request");
-        write_cancel_request(stream).expect("write cancel request");
+    fn attempt_state(attempt: &OAuthLoginAttempt) -> String {
+        let login_url = attempt
+            .login_url(
+                "https://example.com/cash-app/goose",
+                "http://127.0.0.1:49152/callback",
+            )
+            .expect("login URL");
+        let login_url = Url::parse(&login_url).expect("parse login URL");
+        login_url
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.into_owned())
+            .expect("state query parameter")
+    }
+
+    fn send_callback_request(addr: SocketAddr, method: &str, target: &str) -> u16 {
+        let mut stream = TcpStream::connect(addr).expect("connect callback request");
+        write!(
+            stream,
+            "{method} {target} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+        )
+        .expect("write callback request");
+        let mut status_line = String::new();
+        BufReader::new(stream)
+            .read_line(&mut status_line)
+            .expect("read callback response");
+        status_line
+            .split_whitespace()
+            .nth(1)
+            .expect("callback response status")
+            .parse()
+            .expect("numeric callback response status")
     }
 
     struct RecordedAuthRequest {


### PR DESCRIPTION
## Summary

Binds each loopback OAuth callback to the specific login attempt that initiated it, closing a local auth-code injection vector against the ephemeral CLI callback listener. A callback that does not match the in-flight attempt's expected state/correlation is rejected without terminating the listener, so a competing local process cannot inject or replay an authorization code into an unrelated login.

## Changes

- `crates/builderbot-auth/src/auth_login.rs` — callback/state correlation, exchange, replay/malformed/timeout handling, and cleanup for the shared login flow.
- `bb-cli/src/bb/auth_login.rs` — CLI ephemeral callback listener binding to the initiating attempt.
- `src-tauri/src/commands/auth.rs` — desktop auth command wiring for the correlated callback contract.
- `bb-cli/docs/bb-auth-flow.md` — documents the correlated callback behavior.
- `crates/builderbot-auth/Cargo.toml`, `bb-cli/Cargo.lock`, `src-tauri/Cargo.lock` — four new dependency edges (`base64`, `getrandom`, `subtle`, `zeroize`).

Diffstat: 7 files, +980/-182.

## Validation

At exact HEAD `3179d159`:
- `cargo fmt --check` clean in both `src-tauri` and `bb-cli`.
- `just clippy` (all four invocations, `-D warnings`) passed.
- `cargo test -p builderbot-auth`: 36 passed (OAuth correlation/state/PKCE/callback-parser).
- `src-tauri` auth suite: 15 passed (cross-attempt/replay, rejected-callback survival, malformed/slow-connection survival, unsolicited-cancel 404, in-process cancel).

## Notes

- Base: `block/berd` `main` at `a3078aeb`. This change was transplanted onto the live upstream; the effective source patch is byte-identical to the reviewed content across the five source/doc files, with only the four dependency edges added to the two lockfiles.
- The pre-commit `design-system-manifest-check` frontend hook does not run in this worktree (no `node_modules`); no frontend files are in this diff.

Draft — not for merge until coordinated release is authorized.
