### PR TITLE
fix: hide the queued pill while an ordinary send passes through the queue

### DIFF
--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -196,6 +196,76 @@ function getAgentToolsTipPresentation({
   };
 }
 
+const QUEUED_MESSAGE_VISIBILITY_DELAY_MS = 200;
+
+/**
+ * Presentation-only gate for queued-message pills. Every composer send passes
+ * through the queue (LAWS/CHAT.md), so an ordinary send on an idle session
+ * briefly exists as a queue record before dispatch. Holding new records back
+ * for a short grace period keeps that pass-through invisible, while records
+ * queued during an active response (`revealImmediately`) and records that
+ * already exist on mount show at once. Records that leave the queue during
+ * the grace period never render. Queue behavior itself is unaffected.
+ */
+function useVisibleQueuedMessageIds(
+  recordIds: string[],
+  revealImmediately: boolean,
+): ReadonlySet<string> {
+  const [visibleIds, setVisibleIds] = useState<ReadonlySet<string>>(
+    () => new Set(recordIds),
+  );
+  const timersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+
+  useEffect(() => {
+    const currentIds = new Set(recordIds);
+
+    for (const [recordId, timer] of timersRef.current) {
+      if (!currentIds.has(recordId)) {
+        clearTimeout(timer);
+        timersRef.current.delete(recordId);
+      }
+    }
+
+    setVisibleIds((current) => {
+      const retained = new Set(
+        [...current].filter((recordId) => currentIds.has(recordId)),
+      );
+      const unchanged =
+        retained.size === current.size &&
+        [...retained].every((recordId) => current.has(recordId));
+      return unchanged ? current : retained;
+    });
+
+    for (const recordId of recordIds) {
+      if (visibleIds.has(recordId)) continue;
+      // A record already inside its grace period keeps its timer even if the
+      // session starts responding: an ordinary idle send often flips the
+      // session to streaming while its record is still being dismissed, and
+      // upgrading it to immediate visibility would reintroduce the flash.
+      if (timersRef.current.has(recordId)) continue;
+      if (revealImmediately) {
+        setVisibleIds((current) => new Set(current).add(recordId));
+        continue;
+      }
+      const timer = setTimeout(() => {
+        timersRef.current.delete(recordId);
+        setVisibleIds((current) => new Set(current).add(recordId));
+      }, QUEUED_MESSAGE_VISIBILITY_DELAY_MS);
+      timersRef.current.set(recordId, timer);
+    }
+  }, [recordIds, revealImmediately, visibleIds]);
+
+  useEffect(
+    () => () => {
+      for (const timer of timersRef.current.values()) clearTimeout(timer);
+      timersRef.current.clear();
+    },
+    [],
+  );
+
+  return visibleIds;
+}
+
 export function ChatInput({
   composerActions,
   initialValue = "",
@@ -486,13 +556,24 @@ export function ChatInput({
   const allQueuedMessages =
     queuedMessages ??
     (queuedMessage ? [{ recordId: "legacy", payload: queuedMessage }] : []);
+  const queuedRecordIds = useMemo(
+    () => allQueuedMessages.map(({ recordId }) => recordId),
+    [allQueuedMessages],
+  );
+  const visibleQueuedMessageIds = useVisibleQueuedMessageIds(
+    queuedRecordIds,
+    isStreaming,
+  );
   const visibleQueuedMessages = allQueuedMessages.filter(
     ({ payload }) => payload.showInComposer !== false,
+  );
+  const presentedQueuedMessages = visibleQueuedMessages.filter(({ recordId }) =>
+    visibleQueuedMessageIds.has(recordId),
   );
   // A record being edited lives in the composer, so its pill is hidden to
   // avoid showing the same message both queued and in the composer. Queue
   // positions (head-only actions) still come from the unfiltered list.
-  const queuedMessagePills = visibleQueuedMessages
+  const queuedMessagePills = presentedQueuedMessages
     .map((entry, index) => ({ ...entry, index }))
     .filter(({ recordId }) => recordId !== editingQueuedRecordId);
   useLayoutEffect(() => {

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -2407,6 +2407,160 @@ describe("ChatInput", () => {
     expect(onSteerQueuedMessage).not.toHaveBeenCalled();
   });
 
+  it("does not flash a newly queued message that sends during the visibility grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      const queueProps = {
+        onEditQueue: vi.fn(() => true),
+        onCancelQueueEdit: vi.fn(() => true),
+        onDismissQueue: vi.fn(),
+        onUpdateQueue: vi.fn(() => true),
+      };
+      const { rerender } = render(
+        <ChatInput onSend={vi.fn()} queuedMessages={[]} {...queueProps} />,
+      );
+
+      rerender(
+        <ChatInput
+          onSend={vi.fn()}
+          queuedMessages={[
+            {
+              recordId: "immediate-send",
+              payload: { persona: { kind: "none" }, text: "send now" },
+            },
+          ]}
+          {...queueProps}
+        />,
+      );
+      expect(screen.queryByText("send now")).not.toBeInTheDocument();
+
+      rerender(
+        <ChatInput onSend={vi.fn()} queuedMessages={[]} {...queueProps} />,
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(screen.queryByText("send now")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps an idle send hidden when its dispatch flips the session to streaming", async () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <ChatInput onSend={vi.fn()} queuedMessages={[]} />,
+      );
+
+      // The record enters the queue while idle, then dispatch starts the run
+      // before the record is dismissed. Streaming must not upgrade a record
+      // already in its grace period to immediate visibility.
+      rerender(
+        <ChatInput
+          onSend={vi.fn()}
+          queuedMessages={[
+            {
+              recordId: "dispatching",
+              payload: { persona: { kind: "none" }, text: "on its way" },
+            },
+          ]}
+        />,
+      );
+      rerender(
+        <ChatInput
+          onSend={vi.fn()}
+          isStreaming
+          queuedMessages={[
+            {
+              recordId: "dispatching",
+              payload: { persona: { kind: "none" }, text: "on its way" },
+            },
+          ]}
+        />,
+      );
+      expect(screen.queryByText("on its way")).not.toBeInTheDocument();
+
+      rerender(<ChatInput onSend={vi.fn()} isStreaming queuedMessages={[]} />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      expect(screen.queryByText("on its way")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a newly queued message immediately while the agent is responding", () => {
+    const { rerender } = render(
+      <ChatInput onSend={vi.fn()} queuedMessages={[]} isStreaming />,
+    );
+
+    rerender(
+      <ChatInput
+        onSend={vi.fn()}
+        isStreaming
+        queuedMessages={[
+          {
+            recordId: "responding-queue",
+            payload: { persona: { kind: "none" }, text: "queue this" },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("queue this")).toBeInTheDocument();
+  });
+
+  it("reveals a newly queued message when it remains after the grace period", async () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <ChatInput onSend={vi.fn()} queuedMessages={[]} />,
+      );
+
+      rerender(
+        <ChatInput
+          onSend={vi.fn()}
+          queuedMessages={[
+            {
+              recordId: "waiting",
+              payload: { persona: { kind: "none" }, text: "still waiting" },
+            },
+          ]}
+        />,
+      );
+      expect(screen.queryByText("still waiting")).not.toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(199);
+      });
+      expect(screen.queryByText("still waiting")).not.toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(screen.getByText("still waiting")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a queue that already exists when the composer mounts", () => {
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        queuedMessages={[
+          {
+            recordId: "existing",
+            payload: { persona: { kind: "none" }, text: "already waiting" },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("already waiting")).toBeInTheDocument();
+  });
+
   it("hides the queued pill for the record being edited", async () => {
     const onUpdateQueue = vi.fn(() => true);
     const user = userEvent.setup();


### PR DESCRIPTION
**Category:** fix
**User Impact:** Sending a message no longer briefly flashes a "queued" state; the queued pill now appears only when a message is genuinely waiting.

**Problem:** Every composer send passes through the message queue by design (LAWS/CHAT.md), and since that architecture landed, every ordinary send briefly rendered the queued-message pill for a fraction of a second before dispatching. The flash implied the message was waiting when it was not, making sends feel hesitant and the queued state meaningless.

**Solution:** Add a presentation-only grace period in the composer: a new queue record stays hidden for 200ms, so records that dispatch immediately never render a pill. Messages queued while the agent is already responding show instantly (they are genuinely waiting), queues that already exist when a chat opens show instantly, and a blocked idle send reveals its pill once the grace period passes. Queue behavior, ordering, persistence, and dispatch are untouched — this only gates what the pill list renders.

<details>
<summary>File changes</summary>

**src/features/chat/ui/ChatInput.tsx**
Adds a `useVisibleQueuedMessageIds` hook that tracks which queue records have earned visibility: new records wait 200ms before rendering, records present at mount or queued during an active response render immediately, and records that leave the queue during the grace period never render. A record already in its grace period keeps its timer when the session flips to streaming, since an ordinary idle send starts the run before its record is dismissed. Only the pill list reads the gated set; steering, editing, and head-only actions still read the unfiltered queue so hidden records cannot misdirect them.

**src/features/chat/ui/__tests__/ChatInput.test.tsx**
Adds five regression tests: a fast idle send never flashes, a message queued mid-response appears immediately, an idle send whose dispatch flips the session to streaming stays hidden, a genuinely blocked message reveals after the grace period, and a queue that exists at mount renders immediately.

</details>
