### PR TITLE
feat: improve macOS DMG installer artwork

### DIFF
--- a/scripts/package-macos-dmg.sh
+++ b/scripts/package-macos-dmg.sh
@@ -132,17 +132,6 @@ for y in stride(from: 16, through: 384, by: 32) {
   }
 }
 
-let heading = "Drag Berd into Applications" as NSString
-let headingAttributes: [NSAttributedString.Key: Any] = [
-  .font: NSFont.systemFont(ofSize: 20, weight: .semibold),
-  .foregroundColor: ink,
-]
-let headingSize = heading.size(withAttributes: headingAttributes)
-heading.draw(
-  at: NSPoint(x: (canvas.width - headingSize.width) / 2, y: 338),
-  withAttributes: headingAttributes
-)
-
 ink.setFill()
 
 // Keep the shaft and arrowhead as distinct brush gestures. The small paper gap

--- a/scripts/package-macos-dmg.sh
+++ b/scripts/package-macos-dmg.sh
@@ -64,60 +64,113 @@ func color(_ hex: UInt32) -> NSColor {
   )
 }
 
+func bezierPoint(
+  from start: NSPoint,
+  controlPoint1: NSPoint,
+  controlPoint2: NSPoint,
+  to end: NSPoint,
+  progress: CGFloat
+) -> NSPoint {
+  let inverse = 1 - progress
+  return NSPoint(
+    x: inverse * inverse * inverse * start.x
+      + 3 * inverse * inverse * progress * controlPoint1.x
+      + 3 * inverse * progress * progress * controlPoint2.x
+      + progress * progress * progress * end.x,
+    y: inverse * inverse * inverse * start.y
+      + 3 * inverse * inverse * progress * controlPoint1.y
+      + 3 * inverse * progress * progress * controlPoint2.y
+      + progress * progress * progress * end.y
+  )
+}
+
+func drawBrushStroke(
+  from start: NSPoint,
+  controlPoint1: NSPoint,
+  controlPoint2: NSPoint,
+  to end: NSPoint,
+  width: CGFloat,
+  seed: Int
+) {
+  let stampCount = 76
+  for index in 0..<stampCount {
+    let progress = CGFloat(index) / CGFloat(stampCount - 1)
+    let point = bezierPoint(
+      from: start,
+      controlPoint1: controlPoint1,
+      controlPoint2: controlPoint2,
+      to: end,
+      progress: progress
+    )
+    let edgeNoise = CGFloat((index * 37 + seed * 19) % 100) / 100
+    let sideNoise = CGFloat((index * 53 + seed * 31) % 100) / 100 - 0.5
+    let radius = width * (0.41 + edgeNoise * 0.11)
+    NSBezierPath(
+      ovalIn: NSRect(
+        x: point.x + sideNoise * 2.5 - radius,
+        y: point.y + (edgeNoise - 0.5) * 2.5 - radius,
+        width: radius * 2,
+        height: radius * 2
+      )
+    ).fill()
+  }
+}
+
 image.lockFocus()
-NSColor.white.setFill()
+
+let paper = color(0xe4e4e0)
+let ink = color(0x050505)
+let dot = color(0xc9cac4)
+
+paper.setFill()
 NSRect(origin: .zero, size: canvas).fill()
 
-let ink = color(0x050505)
-let gold = color(0xffd43b)
+dot.setFill()
+for y in stride(from: 16, through: 384, by: 32) {
+  for x in stride(from: 16, through: 784, by: 32) {
+    NSBezierPath(ovalIn: NSRect(x: x - 1, y: y - 1, width: 2, height: 2)).fill()
+  }
+}
 
-let arrow = NSBezierPath()
-arrow.move(to: NSPoint(x: 326, y: 178))
-arrow.curve(
-  to: NSPoint(x: 464, y: 178),
-  controlPoint1: NSPoint(x: 372, y: 202),
-  controlPoint2: NSPoint(x: 420, y: 202)
+let heading = "Drag Berd into Applications" as NSString
+let headingAttributes: [NSAttributedString.Key: Any] = [
+  .font: NSFont.systemFont(ofSize: 20, weight: .semibold),
+  .foregroundColor: ink,
+]
+let headingSize = heading.size(withAttributes: headingAttributes)
+heading.draw(
+  at: NSPoint(x: (canvas.width - headingSize.width) / 2, y: 338),
+  withAttributes: headingAttributes
 )
-arrow.lineCapStyle = .round
-arrow.lineJoinStyle = .round
-arrow.lineWidth = 6
-ink.setStroke()
-arrow.stroke()
 
-let head = NSBezierPath()
-head.move(to: NSPoint(x: 464, y: 178))
-head.line(to: NSPoint(x: 438, y: 155))
-head.move(to: NSPoint(x: 464, y: 178))
-head.line(to: NSPoint(x: 438, y: 201))
-head.lineCapStyle = .round
-head.lineJoinStyle = .round
-head.lineWidth = 6
-ink.setStroke()
-head.stroke()
+ink.setFill()
 
-let burstA = NSBezierPath(roundedRect: NSRect(x: 642, y: 250, width: 10, height: 28), xRadius: 3, yRadius: 3)
-var transformA = AffineTransform()
-transformA.translate(x: 647, y: 264)
-transformA.rotate(byDegrees: -6)
-transformA.translate(x: -647, y: -264)
-burstA.transform(using: transformA)
-gold.setFill()
-burstA.fill()
-ink.setStroke()
-burstA.lineWidth = 3
-burstA.stroke()
-
-let burstB = NSBezierPath(roundedRect: NSRect(x: 664, y: 236, width: 10, height: 32), xRadius: 3, yRadius: 3)
-var transformB = AffineTransform()
-transformB.translate(x: 669, y: 252)
-transformB.rotate(byDegrees: 42)
-transformB.translate(x: -669, y: -252)
-burstB.transform(using: transformB)
-gold.setFill()
-burstB.fill()
-ink.setStroke()
-burstB.lineWidth = 3
-burstB.stroke()
+// Keep the shaft and arrowhead as distinct brush gestures. The small paper gap
+// stops the upper arrowhead stroke from visually merging into the curved line.
+drawBrushStroke(
+  from: NSPoint(x: 285, y: 184),
+  controlPoint1: NSPoint(x: 340, y: 222),
+  controlPoint2: NSPoint(x: 420, y: 222),
+  to: NSPoint(x: 473, y: 188),
+  width: 13,
+  seed: 2
+)
+drawBrushStroke(
+  from: NSPoint(x: 489, y: 211),
+  controlPoint1: NSPoint(x: 496, y: 202),
+  controlPoint2: NSPoint(x: 503, y: 193),
+  to: NSPoint(x: 510, y: 184),
+  width: 13,
+  seed: 3
+)
+drawBrushStroke(
+  from: NSPoint(x: 466, y: 154),
+  controlPoint1: NSPoint(x: 480, y: 163),
+  controlPoint2: NSPoint(x: 495, y: 174),
+  to: NSPoint(x: 510, y: 184),
+  width: 13,
+  seed: 4
+)
 
 image.unlockFocus()
 
@@ -189,7 +242,7 @@ on run argv
     set text size of opts to 12
     set background picture of opts to file ".background:background.png" of dmgRoot
     set position of item appName of dmgRoot to {190, 210}
-    set position of item "Applications" of dmgRoot to {590, 210}
+    set position of item "Applications" of dmgRoot to {610, 210}
     set the extension hidden of item appName of dmgRoot to true
     delay 1
     close dmgWindow

--- a/scripts/package-macos-dmg.sh
+++ b/scripts/package-macos-dmg.sh
@@ -137,26 +137,26 @@ ink.setFill()
 // Keep the shaft and arrowhead as distinct brush gestures. The small paper gap
 // stops the upper arrowhead stroke from visually merging into the curved line.
 drawBrushStroke(
-  from: NSPoint(x: 285, y: 184),
-  controlPoint1: NSPoint(x: 340, y: 222),
-  controlPoint2: NSPoint(x: 420, y: 222),
-  to: NSPoint(x: 473, y: 188),
+  from: NSPoint(x: 285, y: 232),
+  controlPoint1: NSPoint(x: 340, y: 270),
+  controlPoint2: NSPoint(x: 420, y: 270),
+  to: NSPoint(x: 473, y: 236),
   width: 13,
   seed: 2
 )
 drawBrushStroke(
-  from: NSPoint(x: 489, y: 211),
-  controlPoint1: NSPoint(x: 496, y: 202),
-  controlPoint2: NSPoint(x: 503, y: 193),
-  to: NSPoint(x: 510, y: 184),
+  from: NSPoint(x: 489, y: 259),
+  controlPoint1: NSPoint(x: 496, y: 250),
+  controlPoint2: NSPoint(x: 503, y: 241),
+  to: NSPoint(x: 510, y: 232),
   width: 13,
   seed: 3
 )
 drawBrushStroke(
-  from: NSPoint(x: 466, y: 154),
-  controlPoint1: NSPoint(x: 480, y: 163),
-  controlPoint2: NSPoint(x: 495, y: 174),
-  to: NSPoint(x: 510, y: 184),
+  from: NSPoint(x: 466, y: 202),
+  controlPoint1: NSPoint(x: 480, y: 211),
+  controlPoint2: NSPoint(x: 495, y: 222),
+  to: NSPoint(x: 510, y: 232),
   width: 13,
   seed: 4
 )
@@ -230,8 +230,8 @@ on run argv
     set icon size of opts to 128
     set text size of opts to 12
     set background picture of opts to file ".background:background.png" of dmgRoot
-    set position of item appName of dmgRoot to {190, 210}
-    set position of item "Applications" of dmgRoot to {610, 210}
+    set position of item appName of dmgRoot to {190, 170}
+    set position of item "Applications" of dmgRoot to {610, 170}
     set the extension hidden of item appName of dmgRoot to true
     delay 1
     close dmgWindow


### PR DESCRIPTION
**Category:** improvement
**User Impact:** People downloading Berd on macOS now see a clearer, distinctly Berd installation window when moving the app into Applications.

**Problem:** The existing DMG used a generic white background and conventional arrow that did not reflect Berd’s visual identity. The installation action was recognizable, but the first product moment felt disconnected from the rest of the experience.

**Solution:** Rework the generated DMG artwork around Berd’s dotted-paper field and a hand-drawn brush arrow. The arrowhead remains a separate gesture so its direction stays legible, while the native app and Applications icons preserve the familiar macOS installation model.

## Preview

![Redesigned Berd macOS installer](https://d24qwcpro867f5.cloudfront.net/repos/berd/prs/52/berd-dmg-installer-centered.png)

<details>
<summary>File changes</summary>

**scripts/package-macos-dmg.sh**
Replaces the generic DMG background with generated dotted-paper artwork, an explicit installation instruction, and deterministic brush-stamped arrow geometry. It also adjusts the Applications icon position to balance the composition.

</details>

## Validation

- `bash -n scripts/package-macos-dmg.sh`
- `pnpm vitest run --config vitest.release-scripts.config.ts` — 84 tests passed
- Built, mounted, and visually inspected a production-shaped DMG
