### PR TITLE
chore: pin Goose app tool permission fix

### DIFF
--- a/goose-backend.lock.json
+++ b/goose-backend.lock.json
@@ -1,7 +1,7 @@
 {
   "repo": "https://github.com/aaif-goose/goose.git",
-  "ref": "main",
-  "commit": "11deb564d09db782a17878af7cfafd299d9fa461",
+  "ref": "9573440da0c649f827537bc67f412eb23d40a002",
+  "commit": "9573440da0c649f827537bc67f412eb23d40a002",
   "package": "goose-cli",
   "bin": "goose"
 }


### PR DESCRIPTION
## Summary

- pin Berd's managed Goose backend to `9573440da0c649f827537bc67f412eb23d40a002`
- pick up the fail-closed authorization gate for MCP app-initiated tool calls
- preserve normal approved and `AlwaysAllow` dispatch behavior

**Draft dependency blocker:** this PR depends on aaif-goose/goose#11275. The current SHA is the reviewed draft-branch commit and is not yet permanently reachable from upstream `main`. Do **not** mark this PR ready or merge it as-is. After the Goose PR lands, update both `ref` and `commit` to the exact landed upstream SHA, rerun the managed-backend build and full Berd gate, and obtain fresh exact-SHA review.

### Related issue

- Depends on https://github.com/aaif-goose/goose/pull/11275
- No separate Berd issue; this is the lock-only integration step for the upstream security fix.

### Testing

At Berd `89ee77381707f41ecdd080c3c05c4f9f4c1aef18`:

- `just setup` built the managed Goose backend at exactly `9573440da0c649f827537bc67f412eb23d40a002`
- `GIT_CONFIG_GLOBAL=/dev/null just ci` passed
- pre-push `fmt-check`, `check`, `tauri-check`, and `clippy` passed
- two independent exact-SHA reviews found no defects in the Goose change or lock-only Berd diff; one independently fetched the pinned SHA and confirmed it is resolvable today

The `GIT_CONFIG_GLOBAL` isolation avoids a machine-local setting that forces annotated tags and breaks a release fixture's intentionally plain `git tag`; the full gate passed under normal Git defaults.
