### PR TITLE
chore(deps): bump doctor crate to block/builderbot a8174f6

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "doctor"
 version = "0.1.0"
-source = "git+https://github.com/block/builderbot?rev=73ff9a0521dcc784c9514911a655187e5dd3b6ca#73ff9a0521dcc784c9514911a655187e5dd3b6ca"
+source = "git+https://github.com/block/builderbot?rev=a8174f6d96749ade44f3618312624de627ce51c3#a8174f6d96749ade44f3618312624de627ce51c3"
 dependencies = [
  "dirs",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ buzz-voice = { git = "https://github.com/block/buzz", rev = "b1426cac2dcc24cfd1f
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 dunce = "1"
-doctor = { git = "https://github.com/block/builderbot", rev = "73ff9a0521dcc784c9514911a655187e5dd3b6ca" }
+doctor = { git = "https://github.com/block/builderbot", rev = "a8174f6d96749ade44f3618312624de627ce51c3" }
 etcetera = "0.11.0"
 flate2 = "1"
 hex = "0.4"


### PR DESCRIPTION
Bumps the pinned `doctor` crate from `block/builderbot` rev `73ff9a0` to `a8174f6` (latest builderbot main).

The `doctor` crate source itself is unchanged between the two revs — this only moves the pin forward. The upstream removal of the ineffective "Copy on Write Git Clones" check (git-clonefile, block/builderbot#906) landed before the previous pin, and a full-repo sweep confirms Berd carries no remaining references to the removed check, its id, or its fix command.

## Changes
- `src-tauri/Cargo.toml`: update `doctor` git rev
- `src-tauri/Cargo.lock`: corresponding lockfile update

## Validation
- `just tauri-check`