### PR TITLE
feat(berdctl): expose automations as a gated `automation` noun

### DIFF
--- a/justfile
+++ b/justfile
@@ -511,7 +511,8 @@ dev:
     # member needs an explicit build, resolved at runtime via BERDCTL_BIN
     # because tauri.dev.conf.json blanks externalBin.
     BERDCTL_FEATURES=()
-    [[ "${VITE_FEEDBACK:-0}" == "1" || "${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)
+    [[ "${VITE_FEEDBACK:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)
+    [[ "${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-automations)
     # ${arr[@]+...} guards the empty-array expansion, which bash 3.2 (stock
     # macOS) treats as an unbound variable under `set -u`.
     (cd src-tauri && cargo build -p berdctl ${BERDCTL_FEATURES[@]+"${BERDCTL_FEATURES[@]}"})

--- a/justfile
+++ b/justfile
@@ -331,7 +331,7 @@ _bundle-unix:
       GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=release ./scripts/ensure-local-goose.sh
     fi
     GOOSE_BUILD_PROFILE=release ./scripts/prepare-goose-sidecar.sh
-    VITE_FEEDBACK="${VITE_FEEDBACK:-0}" CARGO_TARGET_DIR="$TAURI_CARGO_TARGET_DIR" ./scripts/prepare-berdctl-sidecar.sh
+    VITE_FEEDBACK="${VITE_FEEDBACK:-0}" VITE_AUTOMATIONS="${VITE_AUTOMATIONS:-0}" CARGO_TARGET_DIR="$TAURI_CARGO_TARGET_DIR" ./scripts/prepare-berdctl-sidecar.sh
     ./scripts/prepare-catch-sidecar.sh
 
     CARGO_FEATURES=(berdctl)
@@ -421,7 +421,7 @@ _bundle-debug-unix:
       GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=debug ./scripts/ensure-local-goose.sh
     fi
     GOOSE_BUILD_PROFILE=debug ./scripts/prepare-goose-sidecar.sh
-    VITE_FEEDBACK="${VITE_FEEDBACK:-0}" CARGO_TARGET_DIR="$TAURI_CARGO_TARGET_DIR" ./scripts/prepare-berdctl-sidecar.sh
+    VITE_FEEDBACK="${VITE_FEEDBACK:-0}" VITE_AUTOMATIONS="${VITE_AUTOMATIONS:-0}" CARGO_TARGET_DIR="$TAURI_CARGO_TARGET_DIR" ./scripts/prepare-berdctl-sidecar.sh
     ./scripts/prepare-catch-sidecar.sh
 
     CARGO_FEATURES=(berdctl devtools)
@@ -511,7 +511,7 @@ dev:
     # member needs an explicit build, resolved at runtime via BERDCTL_BIN
     # because tauri.dev.conf.json blanks externalBin.
     BERDCTL_FEATURES=()
-    [[ "${VITE_FEEDBACK:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)
+    [[ "${VITE_FEEDBACK:-0}" == "1" || "${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)
     # ${arr[@]+...} guards the empty-array expansion, which bash 3.2 (stock
     # macOS) treats as an unbound variable under `set -u`.
     (cd src-tauri && cargo build -p berdctl ${BERDCTL_FEATURES[@]+"${BERDCTL_FEATURES[@]}"})

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -53,6 +53,7 @@ export VITE_APP_VERSION="$BERD_APP_VERSION_RICH"
 
 BERDCTL_FEATURES=()
 [[ "${VITE_FEEDBACK:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)
+[[ "${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-automations)
 # ${arr[@]+...} guards the empty-array expansion, which bash 3.2 (stock
 # macOS) treats as an unbound variable under `set -u`.
 (cd src-tauri && cargo build -p berdctl ${BERDCTL_FEATURES[@]+"${BERDCTL_FEATURES[@]}"})

--- a/scripts/generate-berdctl-contract.mjs
+++ b/scripts/generate-berdctl-contract.mjs
@@ -35,7 +35,7 @@ const packageJson = JSON.parse(
   fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
 );
 
-async function loadContracts(feedbackEnabled) {
+async function loadContracts({ feedbackEnabled, automationsEnabled }) {
   // Mirror the app's vite resolution (the `@` alias and build-feature defines)
   // so each generated projection comes from the exact renderer registry that
   // its build will dispatch.
@@ -50,6 +50,9 @@ async function loadContracts(feedbackEnabled) {
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(packageJson.version),
       "import.meta.env.VITE_FEEDBACK": JSON.stringify(
         feedbackEnabled ? "1" : "0",
+      ),
+      "import.meta.env.VITE_AUTOMATIONS": JSON.stringify(
+        automationsEnabled ? "1" : "0",
       ),
     },
     server: { middlewareMode: true, hmr: false },
@@ -69,8 +72,16 @@ async function loadContracts(feedbackEnabled) {
   }
 }
 
-const publicContracts = await loadContracts(false);
-const feedbackContracts = await loadContracts(true);
+const publicContracts = await loadContracts({
+  feedbackEnabled: false,
+  automationsEnabled: false,
+});
+// The Block distribution enables Feedback and Automations together, so one
+// "block" variant carries both gated groups; a public build carries neither.
+const blockContracts = await loadContracts({
+  feedbackEnabled: true,
+  automationsEnabled: true,
+});
 
 // Resolve the repo's biome binary (same pattern as
 // scripts/design-system-manifest.mjs) so the emitted JSON matches the
@@ -104,8 +115,8 @@ let stale = false;
 for (const [fileName, contract] of [
   ["api-surface.json", publicContracts.api],
   ["cli-surface.json", publicContracts.surface],
-  ["api-surface-feedback.json", feedbackContracts.api],
-  ["cli-surface-feedback.json", feedbackContracts.surface],
+  ["api-surface-feedback.json", blockContracts.api],
+  ["cli-surface-feedback.json", blockContracts.surface],
 ]) {
   const target = path.join(crateDir, fileName);
   const rendered = render(fileName, contract);

--- a/scripts/generate-berdctl-contract.mjs
+++ b/scripts/generate-berdctl-contract.mjs
@@ -72,12 +72,21 @@ async function loadContracts({ feedbackEnabled, automationsEnabled }) {
   }
 }
 
+// One variant per gate combination: the gates are independent renderer
+// build flags, and the embedded CLI artifacts must never advertise a group
+// the matching renderer build filters out of TOOL_GROUPS.
 const publicContracts = await loadContracts({
   feedbackEnabled: false,
   automationsEnabled: false,
 });
-// The Block distribution enables Feedback and Automations together, so one
-// "block" variant carries both gated groups; a public build carries neither.
+const feedbackContracts = await loadContracts({
+  feedbackEnabled: true,
+  automationsEnabled: false,
+});
+const automationsContracts = await loadContracts({
+  feedbackEnabled: false,
+  automationsEnabled: true,
+});
 const blockContracts = await loadContracts({
   feedbackEnabled: true,
   automationsEnabled: true,
@@ -115,8 +124,12 @@ let stale = false;
 for (const [fileName, contract] of [
   ["api-surface.json", publicContracts.api],
   ["cli-surface.json", publicContracts.surface],
-  ["api-surface-feedback.json", blockContracts.api],
-  ["cli-surface-feedback.json", blockContracts.surface],
+  ["api-surface-feedback.json", feedbackContracts.api],
+  ["cli-surface-feedback.json", feedbackContracts.surface],
+  ["api-surface-automations.json", automationsContracts.api],
+  ["cli-surface-automations.json", automationsContracts.surface],
+  ["api-surface-block.json", blockContracts.api],
+  ["cli-surface-block.json", blockContracts.surface],
 ]) {
   const target = path.join(crateDir, fileName);
   const rendered = render(fileName, contract);

--- a/scripts/prepare-berdctl-sidecar.sh
+++ b/scripts/prepare-berdctl-sidecar.sh
@@ -30,7 +30,11 @@ fi
 
 EXPLICIT_TRIPLE="${1:-${BERDCTL_TRIPLE:-}}"
 CARGO_ARGS=(build -p berdctl --release)
-if [[ "${VITE_FEEDBACK:-0}" == "1" ]]; then
+# The berdctl contract ships as two variants: public, and one "block"
+# variant carrying both gated groups (feedback + automations). Either
+# renderer flag therefore selects the block artifacts; the renderer
+# registry still refuses per-flag at dispatch (the trust boundary).
+if [[ "${VITE_FEEDBACK:-0}" == "1" || "${VITE_AUTOMATIONS:-0}" == "1" ]]; then
   CARGO_ARGS+=(--features block-feedback)
 fi
 if [[ -n "$EXPLICIT_TRIPLE" ]]; then

--- a/scripts/prepare-berdctl-sidecar.sh
+++ b/scripts/prepare-berdctl-sidecar.sh
@@ -30,12 +30,14 @@ fi
 
 EXPLICIT_TRIPLE="${1:-${BERDCTL_TRIPLE:-}}"
 CARGO_ARGS=(build -p berdctl --release)
-# The berdctl contract ships as two variants: public, and one "block"
-# variant carrying both gated groups (feedback + automations). Either
-# renderer flag therefore selects the block artifacts; the renderer
-# registry still refuses per-flag at dispatch (the trust boundary).
-if [[ "${VITE_FEEDBACK:-0}" == "1" || "${VITE_AUTOMATIONS:-0}" == "1" ]]; then
-  CARGO_ARGS+=(--features block-feedback)
+# Each renderer gate maps to its own cargo feature so the embedded CLI
+# contract always matches the renderer registry variant it ships with; the
+# renderer registry still refuses at dispatch (the trust boundary).
+BERDCTL_FEATURE_LIST=()
+[[ "${VITE_FEEDBACK:-0}" == "1" ]] && BERDCTL_FEATURE_LIST+=(block-feedback)
+[[ "${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURE_LIST+=(block-automations)
+if [[ ${#BERDCTL_FEATURE_LIST[@]} -gt 0 ]]; then
+  CARGO_ARGS+=(--features "$(IFS=,; echo "${BERDCTL_FEATURE_LIST[*]}")")
 fi
 if [[ -n "$EXPLICIT_TRIPLE" ]]; then
   TRIPLE="$EXPLICIT_TRIPLE"

--- a/scripts/release/build-macos.sh
+++ b/scripts/release/build-macos.sh
@@ -453,7 +453,7 @@ echo "+++ :hammer: pnpm tauri build (unsigned)"
 GOOSE_BUILD_PROFILE=release ./scripts/prepare-goose-sidecar.sh
 # ACP bridges are installed into the managed Node runtime on demand; they are
 # no longer staged as build resources.
-VITE_FEEDBACK="$VITE_FEEDBACK_VALUE" ./scripts/prepare-berdctl-sidecar.sh "$TARGET_TRIPLE"
+VITE_FEEDBACK="$VITE_FEEDBACK_VALUE" VITE_AUTOMATIONS="$VITE_AUTOMATIONS_VALUE" ./scripts/prepare-berdctl-sidecar.sh "$TARGET_TRIPLE"
 if [[ "$VITE_AGENT_TOOLS_VALUE" == "1" ]]; then
   ./scripts/prepare-bb-cli-resource.sh "$TARGET_TRIPLE"
   tmp="$(mktemp)"

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -495,10 +495,28 @@ describe("development Block-feature resources", () => {
       `[[ "\${VITE_FEEDBACK:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-feedback)`,
     );
     expect(source).toContain(
+      `[[ "\${VITE_AUTOMATIONS:-0}" == "1" ]] && BERDCTL_FEATURES+=(--features block-automations)`,
+    );
+    expect(source).toContain(
       `cargo build -p berdctl \${BERDCTL_FEATURES[@]+"\${BERDCTL_FEATURES[@]}"}`,
     );
     expect(source).toContain(`[[ "\${VITE_AGENT_TOOLS:-0}" == "1" ]]`);
     expect(source).toContain("prepare-bb-cli-resource.sh");
+  });
+});
+
+describe("Windows sidecar staging Block-feature seam", () => {
+  it("maps each gated CLI family onto the berdctl.exe build args", async () => {
+    const script = await readFile(
+      join(repo, "scripts/windows/Stage-Sidecar-Windows.ps1"),
+      "utf8",
+    );
+    expect(script).toContain('if ($env:VITE_FEEDBACK -eq "1") {');
+    expect(script).toContain('$cargoArgs += @("--features", "block-feedback")');
+    expect(script).toContain('if ($env:VITE_AUTOMATIONS -eq "1") {');
+    expect(script).toContain(
+      '$cargoArgs += @("--features", "block-automations")',
+    );
   });
 });
 

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -535,7 +535,7 @@ describe("build-macos Block-service feature seam", () => {
       'jq \'.bundle.resources["../resources/bb"] = "bb"\'',
     );
     expect(script).toContain(
-      'VITE_FEEDBACK="$VITE_FEEDBACK_VALUE" ./scripts/prepare-berdctl-sidecar.sh',
+      'VITE_FEEDBACK="$VITE_FEEDBACK_VALUE" VITE_AUTOMATIONS="$VITE_AUTOMATIONS_VALUE" ./scripts/prepare-berdctl-sidecar.sh',
     );
   });
 

--- a/scripts/windows/Stage-Sidecar-Windows.ps1
+++ b/scripts/windows/Stage-Sidecar-Windows.ps1
@@ -75,6 +75,9 @@ $cargoArgs = @("build", "-p", "berdctl", "--release")
 if ($env:VITE_FEEDBACK -eq "1") {
     $cargoArgs += @("--features", "block-feedback")
 }
+if ($env:VITE_AUTOMATIONS -eq "1") {
+    $cargoArgs += @("--features", "block-automations")
+}
 if (-not [string]::IsNullOrWhiteSpace($hostTriple) -and $Triple -ne $hostTriple) {
     $cargoArgs += @("--target", $Triple)
     $berdctlReleaseDir = Join-Path (Join-Path $tauriTargetDir $Triple) "release"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -21,3 +21,4 @@ ureq = { version = "3", features = ["json"] }
 [features]
 default = []
 block-feedback = []
+block-automations = []

--- a/src-tauri/crates/berdctl/api-surface-automations.json
+++ b/src-tauri/crates/berdctl/api-surface-automations.json
@@ -970,85 +970,100 @@
         }
       }
     },
-    "feedback": {
-      "description": "Open an approved report in Berd's feedback form or submit it directly after explicit user approval.",
+    "automations": {
+      "description": "Manage the user's scheduled automations: list, get, create, run now.",
       "actions": {
-        "open": {
-          "description": "Open Berd's existing feedback form with the supplied title and description ready for optional hand editing. Nothing is submitted. Logs and Doctor diagnostics are selected only when --include-logs is explicitly passed.",
+        "list": {
+          "description": "List the user's scheduled automations (id, title, schedule, status, and last-run info) as the Automations view shows them; does not change anything on screen. Read one automation's full detail with action \"get\".",
           "fields": [
             {
-              "name": "title",
-              "required": true,
+              "name": "query",
+              "required": false,
               "kind": "string",
-              "description": "Report title to prefill in the feedback form (1-200 chars).",
+              "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
               "min": 1,
               "max": 200
-            },
-            {
-              "name": "description",
-              "required": true,
-              "kind": "string",
-              "description": "Report description to prefill in the feedback form (1-50000 chars).",
-              "min": 1,
-              "max": 50000
-            },
-            {
-              "name": "include_logs",
-              "required": false,
-              "kind": "boolean",
-              "description": "Prefill the explicit opt-in to attach sanitized logs and Doctor diagnostics; omitted means false."
             }
           ],
           "schema": {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
             "properties": {
-              "title": {
+              "query": {
+                "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 200,
-                "description": "Report title to prefill in the feedback form (1-200 chars)."
-              },
-              "description": {
-                "type": "string",
-                "minLength": 1,
-                "maxLength": 50000,
-                "description": "Report description to prefill in the feedback form (1-50000 chars)."
-              },
-              "include_logs": {
-                "default": false,
-                "description": "Prefill the explicit opt-in to attach sanitized logs and Doctor diagnostics; omitted means false.",
-                "type": "boolean"
+                "maxLength": 200
               }
             },
-            "required": ["title", "description"],
             "additionalProperties": false
           }
         },
-        "submit": {
-          "description": "Submit the supplied approved report without opening the feedback form. Use this only after the user explicitly asks to file, send, or submit it. Berd immediately shows success or failure in the app. Logs and Doctor diagnostics are attached only when --include-logs is explicitly passed.",
+        "get": {
+          "description": "Read one automation's full detail — title, schedule, time zone, status, pause state, instructions, and latest-run wiring — exactly as the Automations view shows it; does not change anything on screen.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
+            "additionalProperties": false
+          }
+        },
+        "create": {
+          "description": "Create a scheduled automation that runs the given instruction steps on the given cron cadence. The new automation appears in the Automations view immediately and can be edited, paused, or deleted there.",
           "fields": [
             {
               "name": "title",
               "required": true,
               "kind": "string",
-              "description": "Approved report title to submit (1-200 chars).",
+              "description": "Automation title, shown in the Automations view (1-200 chars).",
               "min": 1,
               "max": 200
             },
             {
-              "name": "description",
+              "name": "schedule",
               "required": true,
               "kind": "string",
-              "description": "Approved report description to submit (1-50000 chars).",
+              "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone.",
               "min": 1,
-              "max": 50000
+              "max": 100
             },
             {
-              "name": "include_logs",
+              "name": "instruction",
+              "required": true,
+              "kind": "string_array",
+              "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+            },
+            {
+              "name": "time_zone",
+              "required": false,
+              "kind": "string",
+              "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+              "min": 1,
+              "max": 100
+            },
+            {
+              "name": "enable_notifications",
               "required": false,
               "kind": "boolean",
-              "description": "Explicitly opt in to attach sanitized logs and Doctor diagnostics; omitted means false."
+              "description": "Notify the user when runs complete; omitted means no notifications."
             }
           ],
           "schema": {
@@ -1059,21 +1074,65 @@
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 200,
-                "description": "Approved report title to submit (1-200 chars)."
+                "description": "Automation title, shown in the Automations view (1-200 chars)."
               },
-              "description": {
+              "schedule": {
                 "type": "string",
                 "minLength": 1,
-                "maxLength": 50000,
-                "description": "Approved report description to submit (1-50000 chars)."
+                "maxLength": 100,
+                "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone."
               },
-              "include_logs": {
+              "instruction": {
+                "minItems": 1,
+                "maxItems": 50,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 10000
+                },
+                "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+              },
+              "time_zone": {
+                "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "enable_notifications": {
                 "default": false,
-                "description": "Explicitly opt in to attach sanitized logs and Doctor diagnostics; omitted means false.",
+                "description": "Notify the user when runs complete; omitted means no notifications.",
                 "type": "boolean"
               }
             },
-            "required": ["title", "description"],
+            "required": ["title", "schedule", "instruction"],
+            "additionalProperties": false
+          }
+        },
+        "run": {
+          "description": "Trigger one immediate run of an automation without changing its schedule. The run and its output appear in the Automations view like any scheduled run.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
             "additionalProperties": false
           }
         }

--- a/src-tauri/crates/berdctl/api-surface-block.json
+++ b/src-tauri/crates/berdctl/api-surface-block.json
@@ -970,6 +970,174 @@
         }
       }
     },
+    "automations": {
+      "description": "Manage the user's scheduled automations: list, get, create, run now.",
+      "actions": {
+        "list": {
+          "description": "List the user's scheduled automations (id, title, schedule, status, and last-run info) as the Automations view shows them; does not change anything on screen. Read one automation's full detail with action \"get\".",
+          "fields": [
+            {
+              "name": "query",
+              "required": false,
+              "kind": "string",
+              "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "query": {
+                "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "get": {
+          "description": "Read one automation's full detail — title, schedule, time zone, status, pause state, instructions, and latest-run wiring — exactly as the Automations view shows it; does not change anything on screen.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
+            "additionalProperties": false
+          }
+        },
+        "create": {
+          "description": "Create a scheduled automation that runs the given instruction steps on the given cron cadence. The new automation appears in the Automations view immediately and can be edited, paused, or deleted there.",
+          "fields": [
+            {
+              "name": "title",
+              "required": true,
+              "kind": "string",
+              "description": "Automation title, shown in the Automations view (1-200 chars).",
+              "min": 1,
+              "max": 200
+            },
+            {
+              "name": "schedule",
+              "required": true,
+              "kind": "string",
+              "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone.",
+              "min": 1,
+              "max": 100
+            },
+            {
+              "name": "instruction",
+              "required": true,
+              "kind": "string_array",
+              "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+            },
+            {
+              "name": "time_zone",
+              "required": false,
+              "kind": "string",
+              "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+              "min": 1,
+              "max": 100
+            },
+            {
+              "name": "enable_notifications",
+              "required": false,
+              "kind": "boolean",
+              "description": "Notify the user when runs complete; omitted means no notifications."
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation title, shown in the Automations view (1-200 chars)."
+              },
+              "schedule": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100,
+                "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone."
+              },
+              "instruction": {
+                "minItems": 1,
+                "maxItems": 50,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 10000
+                },
+                "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+              },
+              "time_zone": {
+                "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "enable_notifications": {
+                "default": false,
+                "description": "Notify the user when runs complete; omitted means no notifications.",
+                "type": "boolean"
+              }
+            },
+            "required": ["title", "schedule", "instruction"],
+            "additionalProperties": false
+          }
+        },
+        "run": {
+          "description": "Trigger one immediate run of an automation without changing its schedule. The run and its output appear in the Automations view like any scheduled run.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
     "feedback": {
       "description": "Open an approved report in Berd's feedback form or submit it directly after explicit user approval.",
       "actions": {

--- a/src-tauri/crates/berdctl/api-surface-feedback.json
+++ b/src-tauri/crates/berdctl/api-surface-feedback.json
@@ -970,6 +970,174 @@
         }
       }
     },
+    "automations": {
+      "description": "Manage the user's scheduled automations: list, get, create, run now.",
+      "actions": {
+        "list": {
+          "description": "List the user's scheduled automations (id, title, schedule, status, and last-run info) as the Automations view shows them; does not change anything on screen. Read one automation's full detail with action \"get\".",
+          "fields": [
+            {
+              "name": "query",
+              "required": false,
+              "kind": "string",
+              "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "query": {
+                "description": "Case-insensitive substring filter on the automation title (1-200 chars).",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "get": {
+          "description": "Read one automation's full detail — title, schedule, time zone, status, pause state, instructions, and latest-run wiring — exactly as the Automations view shows it; does not change anything on screen.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
+            "additionalProperties": false
+          }
+        },
+        "create": {
+          "description": "Create a scheduled automation that runs the given instruction steps on the given cron cadence. The new automation appears in the Automations view immediately and can be edited, paused, or deleted there.",
+          "fields": [
+            {
+              "name": "title",
+              "required": true,
+              "kind": "string",
+              "description": "Automation title, shown in the Automations view (1-200 chars).",
+              "min": 1,
+              "max": 200
+            },
+            {
+              "name": "schedule",
+              "required": true,
+              "kind": "string",
+              "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone.",
+              "min": 1,
+              "max": 100
+            },
+            {
+              "name": "instruction",
+              "required": true,
+              "kind": "string_array",
+              "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+            },
+            {
+              "name": "time_zone",
+              "required": false,
+              "kind": "string",
+              "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+              "min": 1,
+              "max": 100
+            },
+            {
+              "name": "enable_notifications",
+              "required": false,
+              "kind": "boolean",
+              "description": "Notify the user when runs complete; omitted means no notifications."
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation title, shown in the Automations view (1-200 chars)."
+              },
+              "schedule": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100,
+                "description": "Cron schedule for the run cadence (e.g. \"0 */30 * * * *\"); the backend interprets it in --time-zone."
+              },
+              "instruction": {
+                "minItems": 1,
+                "maxItems": 50,
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 10000
+                },
+                "description": "One instruction step the automation runs each time (repeat the flag for multiple steps; 1-50 steps, each 1-10000 chars)."
+              },
+              "time_zone": {
+                "description": "IANA time zone for the schedule (e.g. \"America/New_York\"); defaults to the app's current time zone.",
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "enable_notifications": {
+                "default": false,
+                "description": "Notify the user when runs complete; omitted means no notifications.",
+                "type": "boolean"
+              }
+            },
+            "required": ["title", "schedule", "instruction"],
+            "additionalProperties": false
+          }
+        },
+        "run": {
+          "description": "Trigger one immediate run of an automation without changing its schedule. The run and its output appear in the Automations view like any scheduled run.",
+          "fields": [
+            {
+              "name": "automation_id",
+              "required": true,
+              "kind": "string",
+              "description": "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+              "min": 1,
+              "max": 200
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "automation_id": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Automation id, as returned by `berdctl automation list` (1-200 chars)."
+              }
+            },
+            "required": ["automation_id"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
     "feedback": {
       "description": "Open an approved report in Berd's feedback form or submit it directly after explicit user approval.",
       "actions": {

--- a/src-tauri/crates/berdctl/cli-surface-automations.json
+++ b/src-tauri/crates/berdctl/cli-surface-automations.json
@@ -161,19 +161,29 @@
         }
       }
     },
-    "feedback": {
-      "group": "feedback",
-      "about": "Open or submit an approved Berd feedback report",
+    "automation": {
+      "group": "automations",
+      "about": "Manage scheduled automations: list, get, create, run",
       "verbs": {
-        "open": {
-          "action": "open",
-          "about": "Open the feedback form with a report prefilled",
-          "afterHelp": "Example:\n  berdctl feedback open --title \"Composer loses draft\" \\\n    --description \"Steps to reproduce...\" --include-logs --json\n\nResult:\n  {\"opened\":true,\"include_logs\":true} — the existing feedback form is visible\n  for review and optional image attachments; nothing was submitted."
+        "list": {
+          "action": "list",
+          "about": "List the user's automations",
+          "afterHelp": "Example:\n  berdctl automation list --json\n  berdctl automation list --query \"review\" --json\n\nResult:\n  {\"automations\": [{\"automation_id\": \"...\", \"title\": \"...\",\n                    \"schedule\": \"0 */30 * * * *\", \"time_zone\": \"...\",\n                    \"status\": \"...\", \"latest_run_status\": \"...\",\n                    \"schedule_paused\": false, \"last_success_at\": \"...\"}, ...]}\n  Read one automation's instructions with `berdctl automation get`."
         },
-        "submit": {
-          "action": "submit",
-          "about": "Submit an approved report directly to the Berd team",
-          "afterHelp": "Example:\n  berdctl feedback submit --title \"Composer loses draft\" \\\n    --description \"Steps to reproduce...\" --include-logs --json\n\nResult:\n  {\"submitted\":true,\"include_logs\":true,\"issue_url\":\"https://...\"}\n  issue_url is omitted when the feedback service does not return one."
+        "get": {
+          "action": "get",
+          "about": "Read one automation's full detail",
+          "afterHelp": "Example:\n  berdctl automation get --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"...\", \"schedule\": \"0 */30 * * * *\",\n   \"time_zone\": \"...\", \"status\": \"...\", \"latest_run_status\": \"...\",\n   \"schedule_paused\": false, \"instructions\": [\"...\"],\n   \"human_readable_instructions\": [\"...\"],\n   \"latest_chat_session_id\": \"...\", \"created\": \"...\", \"updated\": \"...\"}\n  Find ids with `berdctl automation list`."
+        },
+        "create": {
+          "action": "create",
+          "about": "Create a scheduled automation",
+          "afterHelp": "Example:\n  berdctl automation create --title \"Morning digest\" \\\n    --schedule \"0 0 9 * * *\" --time-zone \"America/New_York\" \\\n    --instruction \"Summarize my unread Slack messages\" \\\n    --instruction \"Post the summary to my notes\" --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"Morning digest\",\n   \"schedule\": \"0 0 9 * * *\"} — visible in the Automations view.\n  Inspect it with `berdctl automation get`; run it now with\n  `berdctl automation run`."
+        },
+        "run": {
+          "action": "run",
+          "about": "Run an automation now, off schedule",
+          "afterHelp": "Example:\n  berdctl automation run --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"run_session_id\": \"...\"} — the run's session id,\n  when the backend reports one. Watch progress in the Automations view or\n  read the result later with `berdctl automation get`."
         }
       }
     },

--- a/src-tauri/crates/berdctl/cli-surface-block.json
+++ b/src-tauri/crates/berdctl/cli-surface-block.json
@@ -161,6 +161,32 @@
         }
       }
     },
+    "automation": {
+      "group": "automations",
+      "about": "Manage scheduled automations: list, get, create, run",
+      "verbs": {
+        "list": {
+          "action": "list",
+          "about": "List the user's automations",
+          "afterHelp": "Example:\n  berdctl automation list --json\n  berdctl automation list --query \"review\" --json\n\nResult:\n  {\"automations\": [{\"automation_id\": \"...\", \"title\": \"...\",\n                    \"schedule\": \"0 */30 * * * *\", \"time_zone\": \"...\",\n                    \"status\": \"...\", \"latest_run_status\": \"...\",\n                    \"schedule_paused\": false, \"last_success_at\": \"...\"}, ...]}\n  Read one automation's instructions with `berdctl automation get`."
+        },
+        "get": {
+          "action": "get",
+          "about": "Read one automation's full detail",
+          "afterHelp": "Example:\n  berdctl automation get --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"...\", \"schedule\": \"0 */30 * * * *\",\n   \"time_zone\": \"...\", \"status\": \"...\", \"latest_run_status\": \"...\",\n   \"schedule_paused\": false, \"instructions\": [\"...\"],\n   \"human_readable_instructions\": [\"...\"],\n   \"latest_chat_session_id\": \"...\", \"created\": \"...\", \"updated\": \"...\"}\n  Find ids with `berdctl automation list`."
+        },
+        "create": {
+          "action": "create",
+          "about": "Create a scheduled automation",
+          "afterHelp": "Example:\n  berdctl automation create --title \"Morning digest\" \\\n    --schedule \"0 0 9 * * *\" --time-zone \"America/New_York\" \\\n    --instruction \"Summarize my unread Slack messages\" \\\n    --instruction \"Post the summary to my notes\" --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"Morning digest\",\n   \"schedule\": \"0 0 9 * * *\"} — visible in the Automations view.\n  Inspect it with `berdctl automation get`; run it now with\n  `berdctl automation run`."
+        },
+        "run": {
+          "action": "run",
+          "about": "Run an automation now, off schedule",
+          "afterHelp": "Example:\n  berdctl automation run --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"run_session_id\": \"...\"} — the run's session id,\n  when the backend reports one. Watch progress in the Automations view or\n  read the result later with `berdctl automation get`."
+        }
+      }
+    },
     "feedback": {
       "group": "feedback",
       "about": "Open or submit an approved Berd feedback report",

--- a/src-tauri/crates/berdctl/cli-surface-feedback.json
+++ b/src-tauri/crates/berdctl/cli-surface-feedback.json
@@ -161,6 +161,32 @@
         }
       }
     },
+    "automation": {
+      "group": "automations",
+      "about": "Manage scheduled automations: list, get, create, run",
+      "verbs": {
+        "list": {
+          "action": "list",
+          "about": "List the user's automations",
+          "afterHelp": "Example:\n  berdctl automation list --json\n  berdctl automation list --query \"review\" --json\n\nResult:\n  {\"automations\": [{\"automation_id\": \"...\", \"title\": \"...\",\n                    \"schedule\": \"0 */30 * * * *\", \"time_zone\": \"...\",\n                    \"status\": \"...\", \"latest_run_status\": \"...\",\n                    \"schedule_paused\": false, \"last_success_at\": \"...\"}, ...]}\n  Read one automation's instructions with `berdctl automation get`."
+        },
+        "get": {
+          "action": "get",
+          "about": "Read one automation's full detail",
+          "afterHelp": "Example:\n  berdctl automation get --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"...\", \"schedule\": \"0 */30 * * * *\",\n   \"time_zone\": \"...\", \"status\": \"...\", \"latest_run_status\": \"...\",\n   \"schedule_paused\": false, \"instructions\": [\"...\"],\n   \"human_readable_instructions\": [\"...\"],\n   \"latest_chat_session_id\": \"...\", \"created\": \"...\", \"updated\": \"...\"}\n  Find ids with `berdctl automation list`."
+        },
+        "create": {
+          "action": "create",
+          "about": "Create a scheduled automation",
+          "afterHelp": "Example:\n  berdctl automation create --title \"Morning digest\" \\\n    --schedule \"0 0 9 * * *\" --time-zone \"America/New_York\" \\\n    --instruction \"Summarize my unread Slack messages\" \\\n    --instruction \"Post the summary to my notes\" --json\n\nResult:\n  {\"automation_id\": \"...\", \"title\": \"Morning digest\",\n   \"schedule\": \"0 0 9 * * *\"} — visible in the Automations view.\n  Inspect it with `berdctl automation get`; run it now with\n  `berdctl automation run`."
+        },
+        "run": {
+          "action": "run",
+          "about": "Run an automation now, off schedule",
+          "afterHelp": "Example:\n  berdctl automation run --automation-id <automation-id> --json\n\nResult:\n  {\"automation_id\": \"...\", \"run_session_id\": \"...\"} — the run's session id,\n  when the backend reports one. Watch progress in the Automations view or\n  read the result later with `berdctl automation get`."
+        }
+      }
+    },
     "feedback": {
       "group": "feedback",
       "about": "Open or submit an approved Berd feedback report",

--- a/src-tauri/crates/berdctl/src/contract.rs
+++ b/src-tauri/crates/berdctl/src/contract.rs
@@ -102,6 +102,9 @@ pub struct Contract {
     pub surface: Surface,
 }
 
+// `block-feedback` selects the Block-variant artifacts, which carry BOTH
+// gated groups (feedback and automations); the renderer's per-flag registry
+// filter remains the trust boundary for whichever is actually enabled.
 pub(crate) const API_SURFACE: &str = if cfg!(feature = "block-feedback") {
     include_str!("../api-surface-feedback.json")
 } else {

--- a/src-tauri/crates/berdctl/src/contract.rs
+++ b/src-tauri/crates/berdctl/src/contract.rs
@@ -102,16 +102,31 @@ pub struct Contract {
     pub surface: Surface,
 }
 
-// `block-feedback` selects the Block-variant artifacts, which carry BOTH
-// gated groups (feedback and automations); the renderer's per-flag registry
-// filter remains the trust boundary for whichever is actually enabled.
-pub(crate) const API_SURFACE: &str = if cfg!(feature = "block-feedback") {
+// One artifact variant per gate combination, so the CLI never advertises a
+// group the matching renderer build filters out of TOOL_GROUPS (each VITE_*
+// flag maps to exactly one cargo feature; the renderer registry remains the
+// trust boundary).
+pub(crate) const API_SURFACE: &str = if cfg!(all(
+    feature = "block-feedback",
+    feature = "block-automations"
+)) {
+    include_str!("../api-surface-block.json")
+} else if cfg!(feature = "block-feedback") {
     include_str!("../api-surface-feedback.json")
+} else if cfg!(feature = "block-automations") {
+    include_str!("../api-surface-automations.json")
 } else {
     include_str!("../api-surface.json")
 };
-pub(crate) const CLI_SURFACE: &str = if cfg!(feature = "block-feedback") {
+pub(crate) const CLI_SURFACE: &str = if cfg!(all(
+    feature = "block-feedback",
+    feature = "block-automations"
+)) {
+    include_str!("../cli-surface-block.json")
+} else if cfg!(feature = "block-feedback") {
     include_str!("../cli-surface-feedback.json")
+} else if cfg!(feature = "block-automations") {
+    include_str!("../cli-surface-automations.json")
 } else {
     include_str!("../cli-surface.json")
 };

--- a/src-tauri/crates/berdctl/src/main.rs
+++ b/src-tauri/crates/berdctl/src/main.rs
@@ -772,8 +772,8 @@ Result:
         );
         assert_eq!(
             rendered.contains("automation"),
-            cfg!(feature = "block-feedback"),
-            "the block variant artifacts carry feedback and automations together"
+            cfg!(feature = "block-automations"),
+            "the automation noun tracks its own gate, independent of feedback"
         );
         for command in ["session", "folder", "project", "agent", "skill", "info"] {
             assert!(

--- a/src-tauri/crates/berdctl/src/main.rs
+++ b/src-tauri/crates/berdctl/src/main.rs
@@ -307,6 +307,17 @@ mod tests {
             ("feedback", "open") | ("feedback", "submit") => {
                 vec!["--title", "t", "--description", "d"]
             }
+            ("automation", "list") => vec![],
+            ("automation", "get") => vec!["--automation-id", "a"],
+            ("automation", "create") => vec![
+                "--title",
+                "t",
+                "--schedule",
+                "0 0 9 * * *",
+                "--instruction",
+                "step",
+            ],
+            ("automation", "run") => vec!["--automation-id", "a"],
             ("info", "harnesses") => vec![],
             ("info", "models") => vec![],
             ("info", "context") => vec![],
@@ -758,6 +769,11 @@ Result:
         assert_eq!(
             rendered.contains("feedback"),
             cfg!(feature = "block-feedback")
+        );
+        assert_eq!(
+            rendered.contains("automation"),
+            cfg!(feature = "block-feedback"),
+            "the block variant artifacts carry feedback and automations together"
         );
         for command in ["session", "folder", "project", "agent", "skill", "info"] {
             assert!(

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -581,6 +581,14 @@ describe("action schemas", () => {
       "skills.get": { skill_id: "global:/skills/x" },
       "feedback.open": { title: "Bug", description: "Details" },
       "feedback.submit": { title: "Bug", description: "Details" },
+      "automations.list": {},
+      "automations.get": { automation_id: "auto-1" },
+      "automations.create": {
+        title: "Morning digest",
+        schedule: "0 0 9 * * *",
+        instruction: ["Summarize unread messages"],
+      },
+      "automations.run": { automation_id: "auto-1" },
       "info.list_harnesses": {},
       "info.list_models": {},
       "info.get_context": {},
@@ -4062,6 +4070,41 @@ describe("info", () => {
     expect(result.active_session_id).toBe("session-2");
     expect(result.active_project_id).toBe("project-9");
     expect(result.app_version.length).toBeGreaterThan(0);
+  });
+});
+
+describe("automation schemas", () => {
+  it("bounds ids, titles, schedules, and instruction steps", () => {
+    const create = ALL_TOOL_GROUPS.automations.actions.create.schema;
+    expect(
+      create.safeParse({
+        title: "Morning digest",
+        schedule: "0 0 9 * * *",
+        instruction: ["Summarize unread messages"],
+      }),
+    ).toMatchObject({ success: true, data: { enable_notifications: false } });
+    expect(
+      create.safeParse({
+        title: "",
+        schedule: "0 0 9 * * *",
+        instruction: ["x"],
+      }).success,
+    ).toBe(false);
+    expect(
+      create.safeParse({
+        title: "T",
+        schedule: "0 0 9 * * *",
+        instruction: [],
+      }).success,
+    ).toBe(false);
+
+    const get = ALL_TOOL_GROUPS.automations.actions.get.schema;
+    expect(get.safeParse({ automation_id: "auto-1" }).success).toBe(true);
+    expect(get.safeParse({ automation_id: "" }).success).toBe(false);
+
+    const run = ALL_TOOL_GROUPS.automations.actions.run.schema;
+    expect(run.safeParse({ automation_id: "auto-1" }).success).toBe(true);
+    expect(run.safeParse({}).success).toBe(false);
   });
 });
 

--- a/src/features/berdctl/commands/impl/automationCommands.test.ts
+++ b/src/features/berdctl/commands/impl/automationCommands.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAutomationTile,
+  getAutomationTile,
+  getAutomationTiles,
+  refreshAutomationTile,
+} from "@/features/automations/api/kgooseAutomations";
+import { getProfileCapabilitySnapshot } from "@/shared/profile/capabilities";
+
+import { createAutomationCommand } from "./createAutomation";
+import { getAutomationCommand } from "./getAutomation";
+import { listAutomationsCommand } from "./listAutomations";
+import { runAutomationCommand } from "./runAutomation";
+
+vi.mock("@/shared/profile/capabilities", () => ({
+  getProfileCapabilitySnapshot: vi.fn(),
+}));
+vi.mock("@/features/automations/api/kgooseAutomations", () => ({
+  createAutomationTile: vi.fn(),
+  getAutomationTile: vi.fn(),
+  getAutomationTiles: vi.fn(),
+  refreshAutomationTile: vi.fn(),
+}));
+
+const reviewTile = {
+  id: "auto-1",
+  title: "Review sweep",
+  schedule: "0 */30 * * * *",
+  timeZone: "America/New_York",
+  status: "active",
+  latestRunStatus: "success",
+  schedulePaused: false,
+  instructions: ["Run the review driver"],
+  humanReadableInstructions: ["Run the review driver"],
+  enableNotifications: true,
+  latestChatSessionId: "session-9",
+  created: "2026-08-01T00:00:00Z",
+  updated: "2026-08-17T00:00:00Z",
+};
+
+describe("automation commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getProfileCapabilitySnapshot).mockReturnValue(true);
+  });
+
+  it("lists automations as wire summaries, filtered by --query", async () => {
+    vi.mocked(getAutomationTiles).mockResolvedValue({
+      tiles: [reviewTile, { id: "auto-2", title: "Daily digest" }],
+    });
+
+    await expect(
+      listAutomationsCommand.execute({ query: "review" }, {}),
+    ).resolves.toEqual({
+      automations: [
+        {
+          automation_id: "auto-1",
+          title: "Review sweep",
+          schedule: "0 */30 * * * *",
+          time_zone: "America/New_York",
+          status: "active",
+          latest_run_status: "success",
+          schedule_paused: false,
+        },
+      ],
+    });
+  });
+
+  it("refuses every action when the automations capability is off", async () => {
+    vi.mocked(getProfileCapabilitySnapshot).mockReturnValue(false);
+
+    await expect(listAutomationsCommand.execute({}, {})).rejects.toMatchObject({
+      code: "automations_disabled",
+    });
+    await expect(
+      getAutomationCommand.execute({ automation_id: "auto-1" }, {}),
+    ).rejects.toMatchObject({ code: "automations_disabled" });
+    await expect(
+      createAutomationCommand.execute(
+        {
+          title: "T",
+          schedule: "0 0 9 * * *",
+          instruction: ["step"],
+          enable_notifications: false,
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({ code: "automations_disabled" });
+    await expect(
+      runAutomationCommand.execute({ automation_id: "auto-1" }, {}),
+    ).rejects.toMatchObject({ code: "automations_disabled" });
+    expect(getAutomationTiles).not.toHaveBeenCalled();
+    expect(createAutomationTile).not.toHaveBeenCalled();
+    expect(refreshAutomationTile).not.toHaveBeenCalled();
+  });
+
+  it("gets one automation's full detail", async () => {
+    vi.mocked(getAutomationTile).mockResolvedValue({ tileInfo: reviewTile });
+
+    await expect(
+      getAutomationCommand.execute({ automation_id: "auto-1" }, {}),
+    ).resolves.toEqual({
+      automation_id: "auto-1",
+      title: "Review sweep",
+      schedule: "0 */30 * * * *",
+      time_zone: "America/New_York",
+      status: "active",
+      latest_run_status: "success",
+      schedule_paused: false,
+      instructions: ["Run the review driver"],
+      human_readable_instructions: ["Run the review driver"],
+      enable_notifications: true,
+      latest_chat_session_id: "session-9",
+      created: "2026-08-01T00:00:00Z",
+      updated: "2026-08-17T00:00:00Z",
+    });
+  });
+
+  it("reports an unknown automation id with the fixing command", async () => {
+    vi.mocked(getAutomationTile).mockResolvedValue({});
+
+    await expect(
+      getAutomationCommand.execute({ automation_id: "nope" }, {}),
+    ).rejects.toMatchObject({
+      code: "automation_not_found",
+      message: expect.stringContaining("berdctl automation list"),
+    });
+  });
+
+  it("creates an automation and returns the backend id", async () => {
+    vi.mocked(createAutomationTile).mockResolvedValue({
+      success: true,
+      automationId: "auto-3",
+    });
+
+    await expect(
+      createAutomationCommand.execute(
+        {
+          title: "Morning digest",
+          schedule: "0 0 9 * * *",
+          instruction: ["Summarize unread messages"],
+          time_zone: "America/New_York",
+          enable_notifications: true,
+        },
+        {},
+      ),
+    ).resolves.toEqual({
+      automation_id: "auto-3",
+      title: "Morning digest",
+      schedule: "0 0 9 * * *",
+    });
+    expect(createAutomationTile).toHaveBeenCalledWith({
+      type: 4,
+      title: "Morning digest",
+      schedule: "0 0 9 * * *",
+      instructions: ["Summarize unread messages"],
+      timeZone: "America/New_York",
+      enableNotifications: true,
+    });
+  });
+
+  it("surfaces a backend create rejection as a stable command error", async () => {
+    vi.mocked(createAutomationTile).mockResolvedValue({
+      success: false,
+      errorMsg: "invalid cron",
+    });
+
+    await expect(
+      createAutomationCommand.execute(
+        {
+          title: "T",
+          schedule: "not-cron",
+          instruction: ["step"],
+          enable_notifications: false,
+        },
+        {},
+      ),
+    ).rejects.toMatchObject({
+      code: "automation_create_failed",
+      message: "invalid cron",
+    });
+  });
+
+  it("runs an automation now and returns the run session id", async () => {
+    vi.mocked(getAutomationTile).mockResolvedValue({ tileInfo: reviewTile });
+    vi.mocked(refreshAutomationTile).mockResolvedValue({
+      success: true,
+      refreshSessionId: "run-42",
+    });
+
+    await expect(
+      runAutomationCommand.execute({ automation_id: "auto-1" }, {}),
+    ).resolves.toEqual({ automation_id: "auto-1", run_session_id: "run-42" });
+    expect(refreshAutomationTile).toHaveBeenCalledWith("auto-1");
+  });
+
+  it("resolves the automation before running so bad ids read as not-found", async () => {
+    vi.mocked(getAutomationTile).mockResolvedValue({});
+
+    await expect(
+      runAutomationCommand.execute({ automation_id: "nope" }, {}),
+    ).rejects.toMatchObject({ code: "automation_not_found" });
+    expect(refreshAutomationTile).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a backend run refusal as a stable command error", async () => {
+    vi.mocked(getAutomationTile).mockResolvedValue({ tileInfo: reviewTile });
+    vi.mocked(refreshAutomationTile).mockResolvedValue({
+      success: false,
+      errorMsg: "backend busy",
+    });
+
+    await expect(
+      runAutomationCommand.execute({ automation_id: "auto-1" }, {}),
+    ).rejects.toMatchObject({
+      code: "automation_run_failed",
+      message: "backend busy",
+    });
+  });
+});

--- a/src/features/berdctl/commands/impl/createAutomation.ts
+++ b/src/features/berdctl/commands/impl/createAutomation.ts
@@ -1,0 +1,113 @@
+import { z } from "zod/v4";
+
+import { CommandError, defineCommand } from "../types";
+
+const createAutomationSchema = z
+  .object({
+    title: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .describe(
+        "Automation title, shown in the Automations view (1-200 chars).",
+      ),
+    schedule: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .describe(
+        'Cron schedule for the run cadence (e.g. "0 */30 * * * *"); the ' +
+          "backend interprets it in --time-zone.",
+      ),
+    instruction: z
+      .array(z.string().trim().min(1).max(10_000))
+      .min(1)
+      .max(50)
+      .describe(
+        "One instruction step the automation runs each time (repeat the flag " +
+          "for multiple steps; 1-50 steps, each 1-10000 chars).",
+      ),
+    time_zone: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        'IANA time zone for the schedule (e.g. "America/New_York"); defaults ' +
+          "to the app's current time zone.",
+      ),
+    enable_notifications: z
+      .boolean()
+      .default(false)
+      .describe(
+        "Notify the user when runs complete; omitted means no notifications.",
+      ),
+  })
+  .strict();
+
+interface CreateAutomationResult {
+  automation_id: string;
+  title: string;
+  schedule: string;
+}
+
+export const createAutomationCommand = defineCommand({
+  effect: "create",
+  visibility: "immediate",
+  destructive: false,
+  bridgeTimeoutMs: 60_000,
+  summary: "Create a scheduled automation",
+  description:
+    "Create a scheduled automation that runs the given instruction steps on " +
+    "the given cron cadence. The new automation appears in the Automations " +
+    "view immediately and can be edited, paused, or deleted there.",
+  helpFooter: `Example:
+  berdctl automation create --title "Morning digest" \\
+    --schedule "0 0 9 * * *" --time-zone "America/New_York" \\
+    --instruction "Summarize my unread Slack messages" \\
+    --instruction "Post the summary to my notes" --json
+
+Result:
+  {"automation_id": "...", "title": "Morning digest",
+   "schedule": "0 0 9 * * *"} — visible in the Automations view.
+  Inspect it with \`berdctl automation get\`; run it now with
+  \`berdctl automation run\`.`,
+  schema: createAutomationSchema,
+  execute: async (args): Promise<CreateAutomationResult> => {
+    const [{ requireAutomationsCapability }, api] = await Promise.all([
+      import("../runtime/automations"),
+      import("@/features/automations/api/kgooseAutomations"),
+    ]);
+    requireAutomationsCapability();
+    const timeZone =
+      args.time_zone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const response = await api.createAutomationTile({
+      // 4 is the generic "summary" automation tile type the Automations
+      // builder creates (automationBuilder.ts SUMMARY_TILE_TYPE); dashboard
+      // and Builderbot tile types are deliberately out of scope here.
+      type: 4,
+      title: args.title,
+      schedule: args.schedule,
+      instructions: args.instruction,
+      timeZone,
+      enableNotifications: args.enable_notifications,
+    });
+    const automationId = response.automationId ?? response.tileId;
+    if (response.success === false || !automationId) {
+      throw new CommandError(
+        "automation_create_failed",
+        response.errorMsg?.trim() ||
+          "The backend rejected the automation; check the schedule cron " +
+            "expression and try again.",
+      );
+    }
+    return {
+      automation_id: automationId,
+      title: args.title,
+      schedule: args.schedule,
+    };
+  },
+});

--- a/src/features/berdctl/commands/impl/getAutomation.ts
+++ b/src/features/berdctl/commands/impl/getAutomation.ts
@@ -1,0 +1,46 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+import type { AutomationDetail } from "../runtime/automations";
+
+const getAutomationSchema = z
+  .object({
+    automation_id: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .describe(
+        "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+      ),
+  })
+  .strict();
+
+export const getAutomationCommand = defineCommand({
+  effect: "read",
+  visibility: "none",
+  destructive: false,
+  summary: "Read one automation's full detail",
+  description:
+    "Read one automation's full detail — title, schedule, time zone, status, " +
+    "pause state, instructions, and latest-run wiring — exactly as the " +
+    "Automations view shows it; does not change anything on screen.",
+  helpFooter: `Example:
+  berdctl automation get --automation-id <automation-id> --json
+
+Result:
+  {"automation_id": "...", "title": "...", "schedule": "0 */30 * * * *",
+   "time_zone": "...", "status": "...", "latest_run_status": "...",
+   "schedule_paused": false, "instructions": ["..."],
+   "human_readable_instructions": ["..."],
+   "latest_chat_session_id": "...", "created": "...", "updated": "..."}
+  Find ids with \`berdctl automation list\`.`,
+  schema: getAutomationSchema,
+  execute: async (args): Promise<AutomationDetail> => {
+    const { findAutomationOrThrow, detailAutomationTile } = await import(
+      "../runtime/automations"
+    );
+    const tile = await findAutomationOrThrow(args.automation_id);
+    return detailAutomationTile(tile);
+  },
+});

--- a/src/features/berdctl/commands/impl/listAutomations.ts
+++ b/src/features/berdctl/commands/impl/listAutomations.ts
@@ -1,0 +1,58 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+import type { AutomationSummary } from "../runtime/automations";
+
+const listAutomationsSchema = z
+  .object({
+    query: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe(
+        "Case-insensitive substring filter on the automation title (1-200 chars).",
+      ),
+  })
+  .strict();
+
+interface ListAutomationsResult {
+  automations: AutomationSummary[];
+}
+
+export const listAutomationsCommand = defineCommand({
+  effect: "read",
+  visibility: "none",
+  destructive: false,
+  summary: "List the user's automations",
+  description:
+    "List the user's scheduled automations (id, title, schedule, status, and " +
+    "last-run info) as the Automations view shows them; does not change " +
+    'anything on screen. Read one automation\'s full detail with action "get".',
+  helpFooter: `Example:
+  berdctl automation list --json
+  berdctl automation list --query "review" --json
+
+Result:
+  {"automations": [{"automation_id": "...", "title": "...",
+                    "schedule": "0 */30 * * * *", "time_zone": "...",
+                    "status": "...", "latest_run_status": "...",
+                    "schedule_paused": false, "last_success_at": "..."}, ...]}
+  Read one automation's instructions with \`berdctl automation get\`.`,
+  schema: listAutomationsSchema,
+  execute: async (args): Promise<ListAutomationsResult> => {
+    const { fetchAutomationTiles, summarizeAutomationTile } = await import(
+      "../runtime/automations"
+    );
+    const tiles = await fetchAutomationTiles();
+    const query = args.query?.toLowerCase();
+    const automations = tiles
+      .map(summarizeAutomationTile)
+      .filter(
+        (automation) =>
+          !query || automation.title.toLowerCase().includes(query),
+      );
+    return { automations };
+  },
+});

--- a/src/features/berdctl/commands/impl/runAutomation.ts
+++ b/src/features/berdctl/commands/impl/runAutomation.ts
@@ -1,0 +1,64 @@
+import { z } from "zod/v4";
+
+import { CommandError, defineCommand } from "../types";
+
+const runAutomationSchema = z
+  .object({
+    automation_id: z
+      .string()
+      .trim()
+      .min(1)
+      .max(200)
+      .describe(
+        "Automation id, as returned by `berdctl automation list` (1-200 chars).",
+      ),
+  })
+  .strict();
+
+interface RunAutomationResult {
+  automation_id: string;
+  run_session_id?: string;
+}
+
+export const runAutomationCommand = defineCommand({
+  effect: "update",
+  visibility: "discoverable",
+  destructive: false,
+  bridgeTimeoutMs: 60_000,
+  summary: "Run an automation now, off schedule",
+  description:
+    "Trigger one immediate run of an automation without changing its " +
+    "schedule. The run and its output appear in the Automations view like " +
+    "any scheduled run.",
+  helpFooter: `Example:
+  berdctl automation run --automation-id <automation-id> --json
+
+Result:
+  {"automation_id": "...", "run_session_id": "..."} — the run's session id,
+  when the backend reports one. Watch progress in the Automations view or
+  read the result later with \`berdctl automation get\`.`,
+  schema: runAutomationSchema,
+  execute: async (args): Promise<RunAutomationResult> => {
+    const [{ findAutomationOrThrow }, api] = await Promise.all([
+      import("../runtime/automations"),
+      import("@/features/automations/api/kgooseAutomations"),
+    ]);
+    // Resolve first so a bad id reads as automation_not_found, not a
+    // backend refresh failure.
+    const tile = await findAutomationOrThrow(args.automation_id);
+    const response = await api.refreshAutomationTile(tile.id ?? "");
+    if (response.success === false) {
+      throw new CommandError(
+        "automation_run_failed",
+        response.errorMsg?.trim() ||
+          "The backend refused to start the run; try again from the " +
+            "Automations view.",
+      );
+    }
+    const result: RunAutomationResult = { automation_id: tile.id ?? "" };
+    if (response.refreshSessionId) {
+      result.run_session_id = response.refreshSessionId;
+    }
+    return result;
+  },
+});

--- a/src/features/berdctl/commands/registry.ts
+++ b/src/features/berdctl/commands/registry.ts
@@ -8,16 +8,19 @@ import { listSessionFoldersCommand } from "./impl/listSessionFolders";
 import { replaceSessionFolderCommand } from "./impl/replaceSessionFolder";
 import { setSessionFolderCwdCommand } from "./impl/setSessionFolderCwd";
 import { clearSessionProjectCommand } from "./impl/clearSessionProject";
+import { createAutomationCommand } from "./impl/createAutomation";
 import { createAgentCommand } from "./impl/createAgent";
 import { createProjectCommand } from "./impl/createProject";
 import { createSessionCommand } from "./impl/createSession";
 import { createSkillCommand } from "./impl/createSkill";
 import { forkSessionCommand } from "./impl/forkSession";
+import { getAutomationCommand } from "./impl/getAutomation";
 import { getContextCommand } from "./impl/getContext";
 import { getProjectCommand } from "./impl/getProject";
 import { getSessionCommand } from "./impl/getSession";
 import { getSkillCommand } from "./impl/getSkill";
 import { listAgentsCommand } from "./impl/listAgents";
+import { listAutomationsCommand } from "./impl/listAutomations";
 import { listHarnessesCommand } from "./impl/listHarnesses";
 import { listModelsCommand } from "./impl/listModels";
 import { listProjectsCommand } from "./impl/listProjects";
@@ -28,6 +31,7 @@ import { moveSessionToGroupCommand } from "./impl/moveSessionToGroup";
 import { openFeedbackCommand } from "./impl/openFeedback";
 import { openSessionCommand } from "./impl/openSession";
 import { renameSessionCommand } from "./impl/renameSession";
+import { runAutomationCommand } from "./impl/runAutomation";
 import { sendSessionCommand } from "./impl/sendSession";
 import { setProjectStartupModeCommand } from "./impl/setProjectStartupMode";
 import { submitFeedbackCommand } from "./impl/submitFeedback";
@@ -150,6 +154,20 @@ export const ALL_TOOL_GROUPS = {
       get: getSkillCommand,
     },
   },
+  automations: {
+    description:
+      "Manage the user's scheduled automations: list, get, create, run now.",
+    cli: {
+      noun: "automation",
+      about: "Manage scheduled automations: list, get, create, run",
+    },
+    actions: {
+      list: listAutomationsCommand,
+      get: getAutomationCommand,
+      create: createAutomationCommand,
+      run: runAutomationCommand,
+    },
+  },
   feedback: {
     description:
       "Open an approved report in Berd's feedback form or submit it directly after explicit user approval.",
@@ -185,13 +203,19 @@ export const ALL_TOOL_GROUPS = {
 } as const satisfies Record<string, ToolGroup>;
 
 /**
- * Build-owned command registry. Public builds omit Feedback entirely; an
- * enabled distribution opts it back in with the same VITE_FEEDBACK boolean
- * that owns the renderer and backend surfaces.
+ * Build-owned command registry. Public builds omit the Block-only groups
+ * (Feedback, Automations) entirely; an enabled distribution opts each back
+ * in with the same VITE_* boolean that owns its renderer and backend
+ * surfaces.
  */
+const GROUP_BUILD_GATES: Record<string, boolean> = {
+  feedback: import.meta.env.VITE_FEEDBACK === "1",
+  automations: import.meta.env.VITE_AUTOMATIONS === "1",
+};
+
 export const TOOL_GROUPS: Record<string, ToolGroup> = Object.fromEntries(
   Object.entries(ALL_TOOL_GROUPS).filter(
-    ([name]) => name !== "feedback" || import.meta.env.VITE_FEEDBACK === "1",
+    ([name]) => GROUP_BUILD_GATES[name] ?? true,
   ),
 );
 

--- a/src/features/berdctl/commands/runtime/automations.ts
+++ b/src/features/berdctl/commands/runtime/automations.ts
@@ -1,0 +1,105 @@
+import {
+  getAutomationTile,
+  getAutomationTiles,
+  type AutomationTile,
+} from "@/features/automations/api/kgooseAutomations";
+import { getProfileCapabilitySnapshot } from "@/shared/profile/capabilities";
+
+import { CommandError } from "../types";
+
+/** Wire summary of one automation, as `automation list` returns it. */
+export interface AutomationSummary {
+  automation_id: string;
+  title: string;
+  schedule: string;
+  time_zone: string;
+  status: string;
+  latest_run_status: string;
+  schedule_paused: boolean;
+  paused_reason?: string;
+  last_success_at?: string;
+}
+
+/** `automation get`'s detail: the summary plus instructions and run wiring. */
+export interface AutomationDetail extends AutomationSummary {
+  instructions: string[];
+  human_readable_instructions: string[];
+  allow_human_input?: boolean;
+  enable_notifications?: boolean;
+  latest_chat_session_id?: string;
+  created?: string;
+  updated?: string;
+}
+
+/** Refuse before touching KGoose when the build/runtime has no Automations
+ *  surface — the same capability that gates the Automations view. */
+export function requireAutomationsCapability(): void {
+  if (!getProfileCapabilitySnapshot("automations")) {
+    throw new CommandError(
+      "automations_disabled",
+      "Automations are disabled in this build or runtime configuration.",
+    );
+  }
+}
+
+export async function fetchAutomationTiles(): Promise<AutomationTile[]> {
+  requireAutomationsCapability();
+  const { tiles } = await getAutomationTiles();
+  return tiles;
+}
+
+export async function findAutomationOrThrow(
+  automationId: string,
+): Promise<AutomationTile> {
+  requireAutomationsCapability();
+  const { tileInfo } = await getAutomationTile(automationId);
+  if (!tileInfo?.id) {
+    throw new CommandError(
+      "automation_not_found",
+      `No automation "${automationId}"; list automations with ` +
+        "`berdctl automation list`.",
+    );
+  }
+  return tileInfo;
+}
+
+function asWireString(value: string | number | undefined): string {
+  return value === undefined ? "" : String(value);
+}
+
+export function summarizeAutomationTile(
+  tile: AutomationTile,
+): AutomationSummary {
+  const summary: AutomationSummary = {
+    automation_id: tile.id ?? "",
+    title: tile.title ?? "",
+    schedule: tile.schedule ?? "",
+    time_zone: tile.timeZone ?? "",
+    status: asWireString(tile.status),
+    latest_run_status: asWireString(tile.latestRunStatus),
+    schedule_paused: tile.schedulePaused === true,
+  };
+  if (tile.pausedReason) summary.paused_reason = tile.pausedReason;
+  if (tile.lastSuccessAt) summary.last_success_at = tile.lastSuccessAt;
+  return summary;
+}
+
+export function detailAutomationTile(tile: AutomationTile): AutomationDetail {
+  const detail: AutomationDetail = {
+    ...summarizeAutomationTile(tile),
+    instructions: tile.instructions ?? [],
+    human_readable_instructions: tile.humanReadableInstructions ?? [],
+  };
+  if (typeof tile.allowHumanInput === "boolean") {
+    detail.allow_human_input = tile.allowHumanInput;
+  }
+  if (typeof tile.enableNotifications === "boolean") {
+    detail.enable_notifications = tile.enableNotifications;
+  }
+  if (tile.latestChatSessionId) {
+    detail.latest_chat_session_id = tile.latestChatSessionId;
+  }
+  if (tile.created) detail.created = tile.created;
+  if (tile.updated) detail.updated = tile.updated;
+  return detail;
+}

--- a/src/features/berdctl/commands/types.ts
+++ b/src/features/berdctl/commands/types.ts
@@ -87,6 +87,10 @@ export const COMMAND_ERROR_CODES = [
   "feedback_disabled",
   "feedback_form_busy",
   "feedback_submission_failed",
+  "automations_disabled",
+  "automation_not_found",
+  "automation_create_failed",
+  "automation_run_failed",
   "timed_out",
   "internal_error",
 ] as const;


### PR DESCRIPTION
## What

Adds a berdctl `automation` noun (registry group `automations`) with four verbs:

| verb | effect / visibility | what it does |
|---|---|---|
| `automation list` | read / none | Summaries (id, title, schedule, status, pause state, last success), `--query` title filter |
| `automation get` | read / none | One automation's full detail, including instructions and latest-run wiring |
| `automation create` | create / immediate | Create a scheduled automation (generic summary tile type) |
| `automation run` | update / discoverable | Trigger one immediate run, off schedule |

```
$ berdctl automation --help
Manage scheduled automations: list, get, create, run
```

## Why

Agents running inside Berd can already manage sessions/projects/skills via berdctl, but automations were UI-only. This lets an agent set up and operate recurring jobs (for example a scheduled PR-review sweep) through the app instead of ad-hoc local cron/schedulers.

## How it is gated

Follows the `feedback` precedent for gated distribution surfaces, since Automations depend on a backing service:

- **Renderer registry** (the trust boundary) includes the group only when `VITE_AUTOMATIONS === "1"`.
- **Every action** also refuses at `execute()` via the `automations` profile capability (`automations_disabled`), mirroring how the Automations view is gated at runtime.
- **Contract artifacts**: one variant per gate combination (public / feedback / automations / block), selected by matching cargo features (`block-feedback`, `block-automations`). The embedded CLI can never advertise a noun its renderer build filters out of `TOOL_GROUPS`, in any flag combination. Public artifacts are byte-identical to before.
- **Every berdctl build path** maps `VITE_AUTOMATIONS` → `block-automations`: dev justfile, `dev-e2e.sh`, `prepare-berdctl-sidecar.sh`, `Stage-Sidecar-Windows.ps1`, and the macOS release build. Release-script tests pin each seam.

## Scope decisions

- **No `delete` / `pause` verbs.** Delete is destructive and outside the v1 no-auth model; pause/resume is not currently a first-class single mutation in the UI API surface (`schedulePaused` is read-only on the tile). Both stay in the UI for now.
- `create` pins the generic summary tile type (`4`, same as the Automations builder); dashboard/Builderbot tile types are deliberately out of scope, matching the view's own filtering.
- `run` resolves the automation first so a bad id reads as `automation_not_found` rather than a backend refresh failure.

## Tests

- Behavior tests for all four commands: capability refusal before any backend call, not-found with the fixing command named, backend rejections surfaced as stable command errors, run session id passthrough.
- Schema-bounds coverage plus valid-args fixtures (strict-parse totality).
- Rust: wire-mapping minimal invocations for the new verbs; top-level help asserts `automation` appears iff `block-automations` (independent of feedback).
- `just check` green; `cargo test -p berdctl` green on **all four** feature combinations; clippy/fmt green; contracts regenerated byte-stable; release-script seam tests green (85).

## Review

Builderbot local review loop: round 1 flagged variant coupling + a missed release-build gate (both fixed: per-combination artifacts, full build-path propagation); round 2 asked for seam test coverage (added); final round: **0 findings, "patch is correct."**

🤖 Authored by Nick's AI agent; built against the berdctl-new-command SKILL and docs/berdctl-architecture.md.

