### PR TITLE
fix(chat): queue sends while sessions start

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -15,14 +15,12 @@ import { i18n } from "@/shared/i18n";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { getAppNavigationController } from "@/features/berdctl/navigation";
-import { placeholderAgentName } from "@/features/agents/lib/agentBuilderIdentity";
 import { resetAgentBuilderSourceLifecycleForTests } from "@/features/agents/lib/agentBuilderSourceLifecycle";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { ensureReplayBuffer } from "@/features/chat/hooks/replayBuffer";
 import { createUserMessage } from "@/shared/types/messages";
 import { useSessionWindowStore } from "@/features/chat/stores/sessionWindowStore";
-import { BackgroundQueuedMessageDrain } from "@/features/chat/ui/BackgroundQueuedMessageDrain";
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
 import type { Message } from "@/shared/types/messages";
 import type { GitState } from "@/shared/types/git";
@@ -97,10 +95,6 @@ const mockCreatePersonaSource = vi.hoisted(() => vi.fn());
 const mockListPersonaSources = vi.hoisted(() => vi.fn());
 const mockReadAgentSourceFile = vi.hoisted(() => vi.fn());
 const mockDeletePersonaSource = vi.hoisted(() => vi.fn());
-const mockUpdatePersonaSource = vi.hoisted(() => vi.fn());
-const mockSendQueuedPromptToExistingSessionInBackground = vi.hoisted(() =>
-  vi.fn(),
-);
 const mockListPersonas = vi.hoisted(() => vi.fn());
 const mockRepairBundledAgent = vi.hoisted(() => vi.fn());
 const mockAutomationBuilderSave = vi.hoisted(() => vi.fn());
@@ -151,10 +145,7 @@ function flushAfterNextPaintCallbacks() {
   }
 }
 
-function appShellWithTheme(
-  children?: ReactNode,
-  options?: { backgroundQueueDrain?: boolean },
-) {
+function appShellWithTheme(children?: ReactNode) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -162,19 +153,13 @@ function appShellWithTheme(
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <AppShell>{children}</AppShell>
-        {options?.backgroundQueueDrain ? (
-          <BackgroundQueuedMessageDrain />
-        ) : null}
       </ThemeProvider>
     </QueryClientProvider>
   );
 }
 
-function renderAppShell(
-  children?: ReactNode,
-  options?: { backgroundQueueDrain?: boolean },
-) {
-  return render(appShellWithTheme(children, options));
+function renderAppShell(children?: ReactNode) {
+  return render(appShellWithTheme(children));
 }
 
 function managedWorktreeGitState(
@@ -465,11 +450,6 @@ vi.mock("@/shared/api/acpApi", () => ({
   updateSessionProject: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/features/chat/lib/queuedSessionSend", () => ({
-  sendQueuedPromptToExistingSessionInBackground: (...args: unknown[]) =>
-    mockSendQueuedPromptToExistingSessionInBackground(...args),
-}));
-
 vi.mock("@/shared/api/git", () => ({
   countBranchCommitsNotInBase: (...args: unknown[]) =>
     gitMocks.countBranchCommitsNotInBase(...args),
@@ -499,7 +479,6 @@ vi.mock("@/shared/api/agents", () => ({
   repairBundledAgent: (...args: unknown[]) => mockRepairBundledAgent(...args),
   readAgentSourceFile: (...args: unknown[]) => mockReadAgentSourceFile(...args),
   deletePersonaSource: (...args: unknown[]) => mockDeletePersonaSource(...args),
-  updatePersonaSource: (...args: unknown[]) => mockUpdatePersonaSource(...args),
   promotePersonaSource: vi.fn().mockResolvedValue(null),
 }));
 
@@ -1044,11 +1023,6 @@ describe("AppShell global navigation", () => {
     mockReadAgentSourceFile.mockRejectedValue(new Error("not found"));
     mockDeletePersonaSource.mockReset();
     mockDeletePersonaSource.mockResolvedValue(undefined);
-    mockUpdatePersonaSource.mockReset();
-    mockSendQueuedPromptToExistingSessionInBackground.mockReset();
-    mockSendQueuedPromptToExistingSessionInBackground.mockResolvedValue(
-      undefined,
-    );
     mockAutomationBuilderSave.mockReset();
     useChatStore.setState({
       messagesBySession: {},
@@ -3417,162 +3391,6 @@ describe("AppShell global navigation", () => {
       creationState: undefined,
       workingDir: draftWorkingDir,
     });
-  });
-
-  it("holds a queued builder prompt until draft identity migration completes", async () => {
-    const pendingSession = deferred<{ sessionId: string }>();
-    const pendingMigration = deferred<{
-      type: "agent";
-      path: string;
-      name: string;
-      description: string;
-      content: string;
-      global: boolean;
-      writable: boolean;
-      properties: { draft: true; builderSessionId: string };
-    }>();
-    mockAcpCreateSession.mockReturnValueOnce(pendingSession.promise);
-    const user = userEvent.setup();
-    renderAppShell(undefined, { backgroundQueueDrain: true });
-
-    await user.click(screen.getByRole("button", { name: "Sidebar new chat" }));
-    await waitFor(() => expect(mockAcpCreateSession).toHaveBeenCalled());
-
-    const draftSessionId = useChatSessionStore.getState().activeSessionId ?? "";
-    const targetAgentPath =
-      "/Users/test/.agents/agents/pending-builder-draft.md";
-    const localDraft = {
-      type: "agent" as const,
-      path: targetAgentPath,
-      name: placeholderAgentName(draftSessionId),
-      description: "Draft",
-      content: "Draft in progress.",
-      global: true,
-      writable: true,
-      properties: { draft: true, builderSessionId: draftSessionId },
-    };
-    useChatSessionStore.getState().patchSession(draftSessionId, {
-      intent: "build-agent",
-      agentBuilderOpen: true,
-      targetAgentPath,
-      targetAgentSlug: "pending-builder-draft",
-    });
-    mockListPersonaSources.mockResolvedValue([localDraft]);
-    mockReadAgentSourceFile.mockResolvedValue(localDraft);
-    mockUpdatePersonaSource.mockReturnValueOnce(pendingMigration.promise);
-    useChatStore.getState().enqueueTransportReadyMessage(draftSessionId, {
-      text: "make a reviewer",
-      persona: { kind: "inherit" },
-      sendOptions: {
-        assistantPrompt: `Use agent-builder at ${targetAgentPath}.`,
-      },
-    });
-    useChatSessionStore.setState({ hasHydratedSessions: true });
-
-    act(() => pendingSession.resolve({ sessionId: "created-session" }));
-
-    await waitFor(() => {
-      expect(mockUpdatePersonaSource).toHaveBeenCalledWith(targetAgentPath, {
-        name: placeholderAgentName("created-session"),
-        properties: {
-          draft: true,
-          builderSessionId: "created-session",
-        },
-      });
-    });
-    expect(
-      useChatSessionStore.getState().getSession(draftSessionId),
-    ).toMatchObject({ creationState: "pending" });
-    expect(
-      useChatStore.getState().queuedMessageBySession[draftSessionId]?.[0],
-    ).toMatchObject({ payload: { text: "make a reviewer" } });
-    expect(
-      mockSendQueuedPromptToExistingSessionInBackground,
-    ).not.toHaveBeenCalled();
-
-    act(() => {
-      pendingMigration.resolve({
-        ...localDraft,
-        name: placeholderAgentName("created-session"),
-        properties: {
-          draft: true,
-          builderSessionId: "created-session",
-        },
-      });
-    });
-
-    await waitFor(() => {
-      expect(
-        mockSendQueuedPromptToExistingSessionInBackground,
-      ).toHaveBeenCalledTimes(1);
-    });
-    expect(
-      mockSendQueuedPromptToExistingSessionInBackground.mock.calls[0]?.[0],
-    ).toBe("created-session");
-    expect(useChatSessionStore.getState().activeSessionId).toBe(
-      "created-session",
-    );
-  });
-
-  it("fails creation without dispatch when builder draft migration fails", async () => {
-    const pendingSession = deferred<{ sessionId: string }>();
-    mockAcpCreateSession.mockReturnValueOnce(pendingSession.promise);
-    const user = userEvent.setup();
-    renderAppShell(undefined, { backgroundQueueDrain: true });
-
-    await user.click(screen.getByRole("button", { name: "Sidebar new chat" }));
-    await waitFor(() => expect(mockAcpCreateSession).toHaveBeenCalled());
-
-    const draftSessionId = useChatSessionStore.getState().activeSessionId ?? "";
-    const targetAgentPath =
-      "/Users/test/.agents/agents/pending-builder-draft.md";
-    const localDraft = {
-      type: "agent" as const,
-      path: targetAgentPath,
-      name: placeholderAgentName(draftSessionId),
-      description: "Draft",
-      content: "Draft in progress.",
-      global: true,
-      writable: true,
-      properties: { draft: true, builderSessionId: draftSessionId },
-    };
-    useChatSessionStore.getState().patchSession(draftSessionId, {
-      intent: "build-agent",
-      agentBuilderOpen: true,
-      targetAgentPath,
-      targetAgentSlug: "pending-builder-draft",
-    });
-    mockListPersonaSources.mockResolvedValue([localDraft]);
-    mockReadAgentSourceFile.mockResolvedValue(localDraft);
-    mockUpdatePersonaSource.mockRejectedValueOnce(
-      new Error("draft identity update failed"),
-    );
-    useChatStore.getState().enqueueTransportReadyMessage(draftSessionId, {
-      text: "make a reviewer",
-      persona: { kind: "inherit" },
-    });
-    useChatSessionStore.setState({ hasHydratedSessions: true });
-
-    act(() => pendingSession.resolve({ sessionId: "created-session" }));
-
-    await waitFor(() => {
-      expect(mockAcpArchiveSession).toHaveBeenCalledWith("created-session");
-      expect(
-        useChatSessionStore.getState().getSession(draftSessionId),
-      ).toMatchObject({
-        creationState: "failed",
-        creationError: "draft identity update failed",
-      });
-    });
-    expect(
-      useChatStore.getState().queuedMessageBySession[draftSessionId]?.[0],
-    ).toMatchObject({ payload: { text: "make a reviewer" } });
-    expect(
-      useChatStore.getState().queuedMessageBySession["created-session"],
-    ).toBeUndefined();
-    expect(
-      mockSendQueuedPromptToExistingSessionInBackground,
-    ).not.toHaveBeenCalled();
   });
 
   it("applies the latest pending draft selection before promotion", async () => {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -114,7 +114,6 @@ import {
   setSettingsSectionUrl,
 } from "./lib/settingsSectionUrl";
 import { useAgentBuilderCoordinator } from "@/features/agents/hooks/useAgentBuilderCoordinator";
-import { migratePendingDraftAgent } from "@/features/agents/lib/agentBuilderSession";
 import {
   type ArchiveCleanupPolicy,
   MUTATION_DEADLINE_MARGIN_MS,
@@ -1973,13 +1972,6 @@ export function AppShell({
               clearCurrentModelSelectionIntent(
                 session.id,
                 pendingSelectionIntent.requestId,
-              );
-            }
-            if (latestSessionPatch.targetAgentPath) {
-              await migratePendingDraftAgent(
-                session.id,
-                sessionId,
-                latestSessionPatch.targetAgentPath,
               );
             }
             promoteChatSessionId(session.id, sessionId);

--- a/src/features/agents/lib/__tests__/agentBuilderSession.test.ts
+++ b/src/features/agents/lib/__tests__/agentBuilderSession.test.ts
@@ -29,7 +29,6 @@ const mocks = vi.hoisted(() => ({
   createPersonaSource: vi.fn(),
   deletePersonaSource: vi.fn(),
   promotePersonaSource: vi.fn(),
-  updatePersonaSource: vi.fn(),
   listPersonaSources: vi.fn(),
   readAgentSourceFile: vi.fn(),
 }));
@@ -90,7 +89,6 @@ vi.mock("@/shared/api/agents", () => ({
   createPersonaSource: mocks.createPersonaSource,
   deletePersonaSource: mocks.deletePersonaSource,
   promotePersonaSource: mocks.promotePersonaSource,
-  updatePersonaSource: mocks.updatePersonaSource,
   listPersonaSources: mocks.listPersonaSources,
   readAgentSourceFile: mocks.readAgentSourceFile,
 }));
@@ -105,7 +103,6 @@ import {
   discardDraftAgentSession,
   hasAgentBuilderSessionUserContent,
   isEmptyDraftAgentSession,
-  migratePendingDraftAgent,
   promoteDraft,
   recoverDraftAgent,
   reconcileAgentBuilderSessions,
@@ -172,17 +169,6 @@ describe("agentBuilderSession", () => {
     mocks.createPersonaSource.mockReset();
     mocks.deletePersonaSource.mockReset();
     mocks.promotePersonaSource.mockReset();
-    mocks.updatePersonaSource.mockReset();
-    mocks.updatePersonaSource.mockImplementation(async (path, patch) => {
-      const existing = await mocks.readAgentSourceFile(path, undefined);
-      return {
-        ...existing,
-        ...patch,
-        properties: patch.properties
-          ? { ...(existing?.properties ?? {}), ...patch.properties }
-          : existing?.properties,
-      };
-    });
     mocks.listPersonaSources.mockReset();
     mocks.readAgentSourceFile.mockReset();
     mocks.readAgentSourceFile.mockImplementation(
@@ -836,83 +822,6 @@ describe("agentBuilderSession", () => {
       slug: "draft-sess-1",
     });
     expect(mocks.createPersonaSource).toHaveBeenCalled();
-  });
-
-  it("migrates a pending builder draft to the promoted session id", async () => {
-    const localDraft = {
-      ...draftSource,
-      path: "/Users/x/.agents/agents/draft-local-session.md",
-      name: "Untitled agent local-sessio",
-      properties: { draft: true, builderSessionId: "local-session" },
-    };
-    chatState.sessions = [
-      {
-        id: "backend-session",
-        clientSessionId: "local-session",
-        intent: "build-agent",
-        targetAgentPath: localDraft.path,
-      },
-    ];
-    mocks.listPersonaSources.mockResolvedValue([localDraft]);
-    mocks.readAgentSourceFile.mockResolvedValue(localDraft);
-
-    await migratePendingDraftAgent("local-session", "backend-session");
-
-    expect(mocks.deletePersonaSource).not.toHaveBeenCalled();
-    expect(mocks.createPersonaSource).not.toHaveBeenCalled();
-    expect(mocks.patchSession).not.toHaveBeenCalled();
-    expect(mocks.promotePersonaSource).not.toHaveBeenCalled();
-    expect(mocks.updatePersonaSource).toHaveBeenCalledWith(localDraft.path, {
-      name: "Untitled agent backend-sess",
-      properties: {
-        draft: true,
-        builderSessionId: "backend-session",
-      },
-    });
-  });
-
-  it("rejects migration when the draft path belongs to another session", async () => {
-    const collidingDraft = {
-      ...draftSource,
-      path: "/Users/x/.agents/agents/colliding-draft.md",
-      name: "Collision",
-      properties: { draft: true, builderSessionId: "other-session" },
-    };
-    mocks.listPersonaSources.mockResolvedValue([collidingDraft]);
-    mocks.readAgentSourceFile.mockResolvedValue(collidingDraft);
-
-    await expect(
-      migratePendingDraftAgent(
-        "local-session",
-        "backend-session",
-        collidingDraft.path,
-      ),
-    ).rejects.toThrow(
-      "Pending Agent Builder draft belongs to a different session.",
-    );
-
-    expect(mocks.updatePersonaSource).not.toHaveBeenCalled();
-  });
-
-  it("does not rebind an existing non-draft agent target", async () => {
-    const existingAgent = {
-      ...draftSource,
-      path: "/Users/x/.agents/agents/reviewer.md",
-      name: "Reviewer",
-      properties: { draft: false },
-    };
-    mocks.listPersonaSources.mockResolvedValue([existingAgent]);
-    mocks.readAgentSourceFile.mockResolvedValue(existingAgent);
-
-    await expect(
-      migratePendingDraftAgent(
-        "local-session",
-        "backend-session",
-        existingAgent.path,
-      ),
-    ).resolves.toBeUndefined();
-
-    expect(mocks.updatePersonaSource).not.toHaveBeenCalled();
   });
 
   it("startup reconciliation patches loaded sessions from draft frontmatter", async () => {

--- a/src/features/agents/lib/agentBuilderSession.ts
+++ b/src/features/agents/lib/agentBuilderSession.ts
@@ -22,17 +22,13 @@ import {
   listAgentBuilderSources,
   promoteAgentBuilderDraftSource,
   readFreshAgentSource,
-  updateAgentBuilderSource,
   type DraftAgentDefaults,
-  type PersonaSourcePatch,
 } from "./agentBuilderSourceLifecycle";
 import type { AgentSourceEntry } from "@/shared/api/agents";
 import {
   deriveSlug,
   fileStem,
   isEmptyPlaceholderDraft,
-  isPlaceholderDraftForSession,
-  placeholderAgentName,
 } from "./agentBuilderIdentity";
 export {
   deriveSlug,
@@ -187,7 +183,7 @@ export async function startAgentBuilderSession(
   await deps.navigateChat(provisionalSessionId);
   void prepareProvisionalDraftTarget(sessionId).catch((error) => {
     console.error("Failed to prepare agent builder draft:", error);
-    markProvisionalDraftTargetFailed(sessionId);
+    markAgentBuilderSessionPreparationFailed(sessionId);
   });
   return sessionId;
 }
@@ -224,7 +220,9 @@ async function prepareProvisionalDraftTarget(
   });
 }
 
-function markProvisionalDraftTargetFailed(initialSessionId: string): void {
+export function markAgentBuilderSessionPreparationFailed(
+  initialSessionId: string,
+): void {
   const session = findSessionByInitialId(initialSessionId);
   if (
     !session ||
@@ -371,50 +369,6 @@ export async function preSeedDraftAgent(
     provider,
     modelSelection,
   });
-}
-
-export async function migratePendingDraftAgent(
-  draftSessionId: string,
-  backendSessionId: string,
-  targetPath?: string | null,
-): Promise<void> {
-  const resolvedTargetPath =
-    targetPath ??
-    useChatSessionStore.getState().getSession(backendSessionId)
-      ?.targetAgentPath;
-  if (!resolvedTargetPath) {
-    return;
-  }
-
-  const source = await findAgentBuilderSource(
-    draftSessionId,
-    resolvedTargetPath,
-  );
-  if (!source) {
-    throw new Error(
-      "Pending Agent Builder target could not be verified before session promotion.",
-    );
-  }
-  if (source.properties?.draft !== true) {
-    return;
-  }
-  if (source.properties.builderSessionId !== draftSessionId) {
-    throw new Error(
-      "Pending Agent Builder draft belongs to a different session.",
-    );
-  }
-
-  const patch: PersonaSourcePatch = {
-    properties: {
-      ...source.properties,
-      builderSessionId: backendSessionId,
-    },
-  };
-  if (isPlaceholderDraftForSession(source, draftSessionId)) {
-    patch.name = placeholderAgentName(backendSessionId);
-  }
-
-  await updateAgentBuilderSource(source.path, patch);
 }
 
 export async function recoverDraftAgent(

--- a/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -42,19 +42,11 @@ const mockUseChatSteerMessage = vi.fn();
 const mockTrackChatMessageSent = vi.fn();
 const mockTrackChatSessionStarted = vi.fn();
 const mockUseChatHook = vi.fn();
-const mockUseChatOptionsBySession = new Map<
-  string,
-  {
-    onMessageAccepted?: (
-      sessionId: string,
-      text: string,
-    ) => boolean | undefined;
-  }
->();
 const mockUseMessageQueue = vi.fn();
 const mockPickerOpen = vi.fn();
 const mockPreSeedDraftAgent = vi.fn();
-const mockMigratePendingDraftAgent = vi.fn();
+const mockClearBuilderSessionState = vi.fn();
+const mockMarkAgentBuilderSessionPreparationFailed = vi.fn();
 const mockDeletePersonaSource = vi.fn();
 const mockAcpCreateSession = vi.fn();
 const mockAcpSessionArchive = vi.fn();
@@ -170,7 +162,6 @@ vi.mock("../useChat", () => ({
       systemPromptOverride,
       personaInfo,
     );
-    mockUseChatOptionsBySession.set(sessionId, options ?? {});
     const optionsWithSessionId = { ...options, __sessionId: sessionId };
     return {
       messages: [],
@@ -204,8 +195,10 @@ vi.mock("../useAutoCompactPreferences", () => ({
 
 vi.mock("@/features/agents/lib/agentBuilderSession", () => ({
   preSeedDraftAgent: (...args: unknown[]) => mockPreSeedDraftAgent(...args),
-  migratePendingDraftAgent: (...args: unknown[]) =>
-    mockMigratePendingDraftAgent(...args),
+  clearBuilderSessionState: (...args: unknown[]) =>
+    mockClearBuilderSessionState(...args),
+  markAgentBuilderSessionPreparationFailed: (...args: unknown[]) =>
+    mockMarkAgentBuilderSessionPreparationFailed(...args),
 }));
 
 vi.mock("@/shared/api/agents", () => ({
@@ -307,29 +300,6 @@ function latestMessageQueueArgs() {
     boolean | undefined,
     boolean | undefined,
   ];
-}
-
-function mockQueueAdmissionWithoutDrain(): void {
-  mockUseMessageQueue.mockImplementation((sessionId: string) => ({
-    queuedMessage: null,
-    queuedRecords: [],
-    enqueue: (
-      text: string,
-      personaId?: string,
-      attachments?: ChatAttachmentDraft[],
-      sendOptions?: ChatSendOptions,
-      personaName?: string,
-    ) =>
-      useChatStore.getState().enqueueTransportReadyMessage(sessionId, {
-        text,
-        persona: personaId
-          ? { kind: "persona", id: personaId, name: personaName }
-          : { kind: "inherit" },
-        attachments,
-        sendOptions,
-      }),
-    dismiss: vi.fn(),
-  }));
 }
 
 function expectSessionPreparation({
@@ -436,7 +406,6 @@ describe("useChatSessionController", () => {
   beforeEach(() => {
     resetSessionTargetCoordinatorsForTests();
     vi.clearAllMocks();
-    mockUseChatOptionsBySession.clear();
     delete modelFixtures["legacy-v1-model"];
     resetManagedModelSelectionRepairCacheForTests();
     useRuntimeConfigStore.setState({
@@ -572,7 +541,6 @@ describe("useChatSessionController", () => {
       path: "/Users/x/.agents/agents/draft-from-chat.md",
       slug: "draft-from-chat",
     });
-    mockMigratePendingDraftAgent.mockResolvedValue(undefined);
     mockPickerState.selectedAgentId = "goose";
     mockPickerState.pickerAgents = [{ id: "goose", label: "Goose" }];
     mockPickerState.availableModels = [];
@@ -852,84 +820,6 @@ describe("useChatSessionController", () => {
     expect(sendResult).toBe(true);
   });
 
-  it("accepts a composer message into a pending draft session queue", () => {
-    mockQueueAdmissionWithoutDrain();
-    useChatSessionStore.setState({
-      sessions: [
-        sessionFixture({
-          id: "draft-session",
-          clientSessionId: "draft-session",
-          creationState: "pending",
-          executionTarget: {
-            harnessId: "goose",
-            modelProviderId: "openai",
-            modelId: "gpt-4o",
-            modelName: "GPT-4o",
-          },
-        }),
-      ],
-    });
-
-    const { result } = renderHook(() =>
-      useChatSessionController({ sessionId: "draft-session" }),
-    );
-
-    act(() => {
-      expect(result.current.handleSend("send when ready")).toBe(true);
-    });
-
-    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
-    expect(
-      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0],
-    ).toMatchObject({
-      kind: "transport-ready",
-      payload: {
-        text: "send when ready",
-        persona: { kind: "inherit" },
-      },
-    });
-  });
-
-  it("preserves a newer draft when a pending send drains during promotion", () => {
-    mockQueueAdmissionWithoutDrain();
-    useChatSessionStore.setState({
-      sessions: [
-        sessionFixture({
-          id: "draft-session",
-          clientSessionId: "draft-session",
-          creationState: "pending",
-          executionTarget: {
-            harnessId: "goose",
-            modelProviderId: "openai",
-            modelId: "gpt-4o",
-            modelName: "GPT-4o",
-          },
-        }),
-      ],
-    });
-
-    const { result } = renderHook(() =>
-      useChatSessionController({ sessionId: "draft-session" }),
-    );
-    const acceptMessage =
-      mockUseChatOptionsBySession.get("draft-session")?.onMessageAccepted;
-    let shouldClearDraft: boolean | undefined;
-
-    act(() => {
-      expect(result.current.handleSend("send when ready")).toBe(true);
-      result.current.handleDraftChange("newer draft");
-      useChatStore
-        .getState()
-        .promoteSessionId("draft-session", "backend-session");
-      useChatSessionStore
-        .getState()
-        .promoteDraftSession("draft-session", "backend-session");
-      shouldClearDraft = acceptMessage?.("backend-session", "send when ready");
-    });
-
-    expect(shouldClearDraft).toBe(false);
-  });
-
   it("preserves a newer draft when an older send is accepted later", async () => {
     vi.useFakeTimers();
     try {
@@ -1139,6 +1029,408 @@ describe("useChatSessionController", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("accepts a send into the queue while a draft session is pending", () => {
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          id: "draft-session",
+          clientSessionId: "draft-session",
+          executionTarget: {
+            harnessId: "goose",
+            modelProviderId: "openai",
+          },
+          creationState: "pending",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: "draft-session" }),
+    );
+
+    act(() => {
+      expect(result.current.handleSend("send when ready")).toBe(true);
+    });
+    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
+    expect(
+      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0],
+    ).toMatchObject({
+      kind: "transport-ready",
+      payload: { text: "send when ready" },
+    });
+  });
+
+  it("preserves a newer draft when a pending send drains after promotion", () => {
+    vi.useFakeTimers();
+    try {
+      let acceptCommittedMessage!: (sessionId: string, text: string) => void;
+      mockUseChatSendMessage.mockImplementationOnce(
+        (options?: {
+          onMessageAccepted?: (
+            sessionId: string,
+            text: string,
+          ) => boolean | undefined;
+        }) => {
+          acceptCommittedMessage = (sessionId, text) => {
+            if (options?.onMessageAccepted?.(sessionId, text) !== false) {
+              useChatStore.getState().clearDraft(sessionId);
+            }
+          };
+        },
+      );
+      useChatSessionStore.setState({
+        sessions: [
+          sessionFixture({
+            id: "draft-session",
+            clientSessionId: "draft-session",
+            executionTarget: {
+              harnessId: "goose",
+              modelProviderId: "openai",
+            },
+            creationState: "pending",
+          }),
+        ],
+      });
+
+      const { result, rerender } = renderHook(
+        ({ sessionId }: { sessionId: string }) =>
+          useChatSessionController({ sessionId }),
+        { initialProps: { sessionId: "draft-session" } },
+      );
+
+      act(() => {
+        expect(result.current.handleSend("send when ready")).toBe(true);
+        result.current.handleDraftChange("newer draft");
+        useChatStore
+          .getState()
+          .promoteSessionId("draft-session", "backend-session");
+        useChatSessionStore
+          .getState()
+          .promoteDraftSession("draft-session", "backend-session");
+      });
+      rerender({ sessionId: "backend-session" });
+      const [, , drainQueuedMessage] = latestMessageQueueArgs();
+      act(() => {
+        (drainQueuedMessage as (text: string) => void)("send when ready");
+      });
+
+      act(() => {
+        acceptCommittedMessage("backend-session", "send when ready");
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(useChatStore.getState().draftsBySession["backend-session"]).toBe(
+        "newer draft",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("queues an agent-builder send during session creation and prepares it after promotion", async () => {
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          id: "draft-session",
+          clientSessionId: "draft-session",
+          executionTarget: {
+            harnessId: "goose",
+            modelProviderId: "openai",
+          },
+          creationState: "pending",
+        }),
+      ],
+    });
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }: { sessionId: string }) =>
+        useChatSessionController({ sessionId }),
+      { initialProps: { sessionId: "draft-session" } },
+    );
+
+    act(() => {
+      expect(
+        result.current.handleSend("make a reviewer", undefined, undefined, {
+          chips: [{ label: "agent-builder", type: "skill" }],
+          assistantPrompt: "Use agent-builder.",
+        }),
+      ).toBe(true);
+    });
+
+    expect(mockPreSeedDraftAgent).not.toHaveBeenCalled();
+    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
+    expect(
+      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0],
+    ).toMatchObject({
+      kind: "transport-ready",
+      payload: {
+        text: "make a reviewer",
+        sendOptions: {
+          chips: [{ label: "agent-builder", type: "skill" }],
+        },
+      },
+    });
+
+    act(() => {
+      useChatStore
+        .getState()
+        .promoteSessionId("draft-session", "backend-session");
+      useChatSessionStore
+        .getState()
+        .promoteDraftSession("draft-session", "backend-session");
+    });
+    rerender({ sessionId: "backend-session" });
+
+    await waitFor(() => {
+      expect(mockPreSeedDraftAgent).toHaveBeenCalledWith("backend-session");
+    });
+  });
+
+  it("marks queued Agent Builder preparation as failed without dropping its send", async () => {
+    mockPreSeedDraftAgent.mockRejectedValueOnce(
+      new Error("draft creation failed"),
+    );
+    useChatStore.getState().enqueueTransportReadyMessage("session-1", {
+      persona: { kind: "inherit" },
+      text: "make a reviewer",
+      sendOptions: {
+        chips: [{ label: "agent-builder", type: "skill" }],
+      },
+    });
+
+    renderHook(() => useChatSessionController({ sessionId: "session-1" }));
+
+    await waitFor(() => {
+      expect(mockMarkAgentBuilderSessionPreparationFailed).toHaveBeenCalledWith(
+        "session-1",
+      );
+    });
+    expect(
+      useChatStore.getState().queuedMessageBySession["session-1"],
+    ).toHaveLength(1);
+  });
+
+  it("defers an eagerly selected Agent Builder draft until promotion", async () => {
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          id: "draft-session",
+          clientSessionId: "draft-session",
+          executionTarget: {
+            harnessId: "goose",
+            modelProviderId: "openai",
+          },
+          creationState: "pending",
+        }),
+      ],
+    });
+    useChatStore
+      .getState()
+      .setSkillDrafts("draft-session", [
+        { id: "builtin:agent-builder", name: "agent-builder" },
+      ]);
+
+    renderHook(() => useChatSessionController({ sessionId: "draft-session" }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockPreSeedDraftAgent).not.toHaveBeenCalled();
+  });
+
+  it("marks eagerly selected Agent Builder preparation as failed", async () => {
+    mockPreSeedDraftAgent.mockRejectedValueOnce(new Error("draft failed"));
+    useChatStore
+      .getState()
+      .setSkillDrafts("session-1", [
+        { id: "builtin:agent-builder", name: "agent-builder" },
+      ]);
+
+    renderHook(() => useChatSessionController({ sessionId: "session-1" }));
+
+    await waitFor(() => {
+      expect(mockMarkAgentBuilderSessionPreparationFailed).toHaveBeenCalledWith(
+        "session-1",
+      );
+    });
+  });
+
+  it("removing a deferred workspace send prevents Agent Builder preparation", () => {
+    useChatStore.getState().enqueueDeferredMessage(
+      "draft-session",
+      {
+        persona: { kind: "inherit" },
+        text: "make a reviewer",
+        sendOptions: {
+          chips: [{ label: "agent-builder", type: "skill" }],
+        },
+      },
+      { type: "workspace-first-send", status: "choice" },
+    );
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          id: "draft-session",
+          clientSessionId: "draft-session",
+          executionTarget: {
+            harnessId: "goose",
+            modelProviderId: "openai",
+          },
+          creationState: "pending",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: "draft-session" }),
+    );
+    const deferredRecord =
+      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0];
+
+    act(() => {
+      result.current.queue.dismiss(deferredRecord?.recordId);
+      useChatStore
+        .getState()
+        .promoteSessionId("draft-session", "backend-session");
+      useChatSessionStore
+        .getState()
+        .promoteDraftSession("draft-session", "backend-session");
+    });
+
+    expect(mockPreSeedDraftAgent).not.toHaveBeenCalled();
+  });
+
+  it("keeps a promoted builder send parked until its draft target is ready", () => {
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          intent: "build-agent",
+          agentBuilderOpen: true,
+          targetAgentPath: null,
+          targetAgentDraftState: "preparing",
+        }),
+      ],
+    });
+    useChatStore.getState().enqueueTransportReadyMessage("session-1", {
+      persona: { kind: "inherit" },
+      text: "make a reviewer",
+      sendOptions: {
+        chips: [{ label: "agent-builder", type: "skill" }],
+      },
+    });
+
+    const { rerender } = renderHook(() =>
+      useChatSessionController({ sessionId: "session-1" }),
+    );
+
+    expect(latestMessageQueueArgs()[1]).toBe("thinking");
+    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
+
+    act(() => {
+      useChatSessionStore.getState().patchSession("session-1", {
+        targetAgentPath: "/Users/x/.agents/agents/draft-session-1.md",
+        targetAgentSlug: "draft-session-1",
+        targetAgentDraftState: null,
+      });
+    });
+    rerender();
+
+    expect(latestMessageQueueArgs()[1]).toBe("idle");
+    const drainSend = latestMessageQueueArgs()[2] as (
+      text: string,
+      persona?: { id: string },
+      attachments?: ChatAttachmentDraft[],
+      sendOptions?: ChatSendOptions,
+    ) => boolean;
+    act(() => {
+      drainSend(
+        "make a reviewer",
+        undefined,
+        undefined,
+        useChatStore.getState().queuedMessageBySession["session-1"]?.[0]
+          ?.payload.sendOptions,
+      );
+    });
+
+    const sendOptions = mockUseChatSendMessage.mock.calls.at(-1)?.[4] as
+      | ChatSendOptions
+      | undefined;
+    expect(sendOptions?.assistantPrompt).toContain("draft-session-1.md");
+  });
+
+  it("routes a pending project first send through workspace startup", () => {
+    setMultiWorkspaceEnabled(true);
+    const onWorkspaceNameRequest = vi.fn();
+    useProjectStore.setState({
+      projects: [
+        {
+          id: "project-1",
+          path: "/tmp/project.md",
+          name: "Project",
+          description: "",
+          prompt: "",
+          icon: "",
+          color: "#22c55e",
+          projectWorkspaces: [
+            {
+              id: "workspace-1",
+              path: "/repo/project",
+              kind: "git-main-worktree",
+              source: "selected",
+              branch: "main",
+              usedByAgent: false,
+              repositoryPath: "/repo/project",
+              startupMode: "worktree",
+            },
+          ],
+          workingDirs: ["/repo/project"],
+          useWorktrees: true,
+          order: 0,
+          archivedAt: null,
+          artifact: null,
+        },
+      ],
+      loading: false,
+      activeProjectId: "project-1",
+    });
+    useChatSessionStore.setState({
+      sessions: [
+        sessionFixture({
+          id: "draft-session",
+          clientSessionId: "draft-session",
+          projectId: "project-1",
+          workingDir: "/repo/project",
+          workspaceAttachments: [],
+          executionTarget: {
+            harnessId: "goose",
+            modelProviderId: "openai",
+          },
+          creationState: "pending",
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useChatSessionController({
+        sessionId: "draft-session",
+        onWorkspaceNameRequest,
+      }),
+    );
+
+    act(() => {
+      expect(result.current.handleSend("send after setup")).toBe(true);
+    });
+
+    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
+    expect(
+      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0],
+    ).toMatchObject({
+      kind: "deferred",
+      payload: { text: "send after setup" },
+      state: { type: "workspace-first-send", status: "choice" },
+    });
   });
 
   it("keeps queued messages from draining while a project draft session is pending", () => {
@@ -2506,216 +2798,6 @@ describe("useChatSessionController", () => {
       | undefined;
     expect(sendOptions?.assistantPrompt).toContain("agent-builder");
     expect(sendOptions?.assistantPrompt).toContain("draft-from-chat.md");
-  });
-
-  it("queues agent-builder activation while draft session creation is pending", async () => {
-    mockQueueAdmissionWithoutDrain();
-    useChatSessionStore.setState({
-      sessions: [
-        sessionFixture({
-          id: "draft-session",
-          clientSessionId: "draft-session",
-          creationState: "pending",
-          executionTarget: {
-            harnessId: "goose",
-            modelProviderId: "openai",
-            modelId: "gpt-4o",
-            modelName: "GPT-4o",
-          },
-        }),
-      ],
-    });
-    const { result } = renderHook(() =>
-      useChatSessionController({ sessionId: "draft-session" }),
-    );
-
-    await act(async () => {
-      expect(
-        await result.current.handleSend(
-          "make a reviewer",
-          undefined,
-          undefined,
-          {
-            chips: [{ label: "agent-builder", type: "skill" }],
-            assistantPrompt: "Use agent-builder.",
-          },
-        ),
-      ).toBe(true);
-    });
-
-    expect(mockPreSeedDraftAgent).toHaveBeenCalledWith("draft-session");
-    expect(mockUseChatSendMessage).not.toHaveBeenCalled();
-    expect(
-      useChatSessionStore.getState().getSession("draft-session"),
-    ).toMatchObject({
-      intent: "build-agent",
-      agentBuilderOpen: true,
-      targetAgentPath: "/Users/x/.agents/agents/draft-from-chat.md",
-    });
-    expect(
-      useChatStore.getState().queuedMessageBySession["draft-session"]?.[0],
-    ).toMatchObject({
-      kind: "transport-ready",
-      payload: {
-        text: "make a reviewer",
-        sendOptions: {
-          assistantPrompt: expect.stringContaining("draft-from-chat.md"),
-        },
-      },
-    });
-  });
-
-  it("queues an in-flight builder activation against the promoted session", async () => {
-    mockQueueAdmissionWithoutDrain();
-    const pendingDraft = deferred<{ path: string; slug: string }>();
-    const pendingMigration = deferred<void>();
-    mockPreSeedDraftAgent.mockReturnValueOnce(pendingDraft.promise);
-    mockMigratePendingDraftAgent.mockReturnValueOnce(pendingMigration.promise);
-    useChatSessionStore.setState({
-      sessions: [
-        sessionFixture({
-          id: "draft-session",
-          clientSessionId: "draft-session",
-          creationState: "pending",
-          executionTarget: {
-            harnessId: "goose",
-            modelProviderId: "openai",
-            modelId: "gpt-4o",
-            modelName: "GPT-4o",
-          },
-        }),
-      ],
-    });
-    const { result } = renderHook(() =>
-      useChatSessionController({ sessionId: "draft-session" }),
-    );
-
-    const sendResult = result.current.handleSend(
-      "make a reviewer",
-      undefined,
-      undefined,
-      {
-        chips: [{ label: "agent-builder", type: "skill" }],
-        assistantPrompt: "Use agent-builder.",
-      },
-    );
-    expect(sendResult).toBeInstanceOf(Promise);
-    await waitFor(() => {
-      expect(mockPreSeedDraftAgent).toHaveBeenCalledWith("draft-session");
-    });
-
-    act(() => {
-      useChatStore
-        .getState()
-        .promoteSessionId("draft-session", "backend-session");
-      useChatSessionStore
-        .getState()
-        .promoteDraftSession("draft-session", "backend-session");
-    });
-    await act(async () => {
-      pendingDraft.resolve({
-        path: "/Users/x/.agents/agents/draft-from-chat.md",
-        slug: "draft-from-chat",
-      });
-      await pendingDraft.promise;
-    });
-
-    await waitFor(() => {
-      expect(mockMigratePendingDraftAgent).toHaveBeenCalledWith(
-        "draft-session",
-        "backend-session",
-        "/Users/x/.agents/agents/draft-from-chat.md",
-      );
-    });
-    expect(useChatStore.getState().queuedMessageBySession).toEqual({});
-
-    let accepted: boolean | undefined;
-    await act(async () => {
-      pendingMigration.resolve();
-      accepted = await sendResult;
-    });
-
-    expect(accepted).toBe(true);
-    expect(mockDeletePersonaSource).not.toHaveBeenCalled();
-    expect(
-      useChatSessionStore.getState().getSession("backend-session"),
-    ).toMatchObject({
-      intent: "build-agent",
-      agentBuilderOpen: true,
-      targetAgentPath: "/Users/x/.agents/agents/draft-from-chat.md",
-    });
-    expect(
-      useChatStore.getState().queuedMessageBySession["draft-session"],
-    ).toBeUndefined();
-    expect(
-      useChatStore.getState().queuedMessageBySession["backend-session"]?.[0],
-    ).toMatchObject({
-      kind: "transport-ready",
-      payload: {
-        text: "make a reviewer",
-        sendOptions: {
-          assistantPrompt: expect.stringContaining("draft-from-chat.md"),
-        },
-      },
-    });
-  });
-
-  it("does not queue an in-flight builder activation after creation fails", async () => {
-    mockQueueAdmissionWithoutDrain();
-    const pendingDraft = deferred<{ path: string; slug: string }>();
-    mockPreSeedDraftAgent.mockReturnValueOnce(pendingDraft.promise);
-    useChatSessionStore.setState({
-      sessions: [
-        sessionFixture({
-          id: "draft-session",
-          clientSessionId: "draft-session",
-          creationState: "pending",
-          executionTarget: {
-            harnessId: "goose",
-            modelProviderId: "openai",
-            modelId: "gpt-4o",
-            modelName: "GPT-4o",
-          },
-        }),
-      ],
-    });
-    const { result } = renderHook(() =>
-      useChatSessionController({ sessionId: "draft-session" }),
-    );
-
-    const sendResult = result.current.handleSend(
-      "make a reviewer",
-      undefined,
-      undefined,
-      {
-        chips: [{ label: "agent-builder", type: "skill" }],
-        assistantPrompt: "Use agent-builder.",
-      },
-    );
-    await waitFor(() => {
-      expect(mockPreSeedDraftAgent).toHaveBeenCalledWith("draft-session");
-    });
-    act(() => {
-      useChatSessionStore
-        .getState()
-        .markSessionCreationFailed("draft-session", "creation failed");
-    });
-
-    let accepted: boolean | undefined;
-    await act(async () => {
-      pendingDraft.resolve({
-        path: "/Users/x/.agents/agents/draft-from-chat.md",
-        slug: "draft-from-chat",
-      });
-      accepted = await sendResult;
-    });
-
-    expect(accepted).toBe(false);
-    expect(mockDeletePersonaSource).toHaveBeenCalledWith(
-      "/Users/x/.agents/agents/draft-from-chat.md",
-    );
-    expect(mockMigratePendingDraftAgent).not.toHaveBeenCalled();
-    expect(useChatStore.getState().queuedMessageBySession).toEqual({});
   });
 
   it("activates builder mode before appending an agent-builder send", async () => {
@@ -4729,6 +4811,54 @@ describe("useChatSessionController", () => {
       executionTarget: {
         harnessId: "goose",
         modelProviderId: "openai",
+      },
+    });
+    expect(mockAcpPrepareSession).not.toHaveBeenCalled();
+  });
+
+  it("keeps a provider-qualified persona target local while session creation is pending", () => {
+    useProviderCatalogStore.getState().mergeEntries([
+      {
+        id: "databricks_v2",
+        displayName: "Databricks",
+        category: "model",
+        description: "Databricks",
+        setupMethod: "single_api_key",
+        group: "default",
+      },
+    ]);
+    useAgentStore.setState({
+      personas: [
+        personaFixture({
+          provider: "goose",
+          modelProviderId: "databricks_v2",
+          model: "goose-claude-opus-4-8",
+        }),
+      ],
+    });
+    useChatSessionStore.setState((state) => ({
+      sessions: state.sessions.map((candidate) =>
+        candidate.id === "session-1"
+          ? { ...candidate, creationState: "pending" }
+          : candidate,
+      ),
+    }));
+    const { result } = renderHook(() =>
+      useChatSessionController({ sessionId: "session-1" }),
+    );
+
+    act(() => {
+      result.current.handlePersonaChange("persona-1");
+    });
+
+    expect(
+      useChatSessionStore.getState().getSession("session-1"),
+    ).toMatchObject({
+      personaId: "persona-1",
+      executionTarget: {
+        harnessId: "goose",
+        modelProviderId: "databricks_v2",
+        modelId: "goose-claude-opus-4-8",
       },
     });
     expect(mockAcpPrepareSession).not.toHaveBeenCalled();

--- a/src/features/chat/hooks/useChatSessionController.ts
+++ b/src/features/chat/hooks/useChatSessionController.ts
@@ -80,7 +80,7 @@ import { moveSessionToProject } from "../stores/chatSessionOperations";
 import { acpSetSessionConfigOption } from "@/shared/api/acp";
 import { updateSessionProject } from "@/shared/api/acpApi";
 import {
-  migratePendingDraftAgent,
+  markAgentBuilderSessionPreparationFailed,
   preSeedDraftAgent,
 } from "@/features/agents/lib/agentBuilderSession";
 import { personaExecutionTarget } from "@/features/agents/lib/personaExecutionTarget";
@@ -1735,23 +1735,9 @@ export function useChatSessionController({
           submittedDraftGeneration,
         );
       }
-      let wasSubmittedWithoutDraftOwnership =
+      const wasSubmittedWithoutDraftOwnership =
         submittedDraftGeneration === null &&
         takeDraftPreservingSubmission(acceptedSessionId, submittedText);
-      if (
-        submittedDraftGeneration === null &&
-        !wasSubmittedWithoutDraftOwnership
-      ) {
-        const clientSessionId = useChatSessionStore
-          .getState()
-          .getSession(acceptedSessionId)?.clientSessionId;
-        if (clientSessionId && clientSessionId !== acceptedSessionId) {
-          wasSubmittedWithoutDraftOwnership = takeDraftPreservingSubmission(
-            clientSessionId,
-            submittedText,
-          );
-        }
-      }
       const draftSnapshot = getDraftSnapshot(acceptedSessionId);
       const hasNewerDraftEdit =
         submittedDraftGeneration !== null &&
@@ -2102,9 +2088,10 @@ export function useChatSessionController({
         (s.messagesBySession[sessionId]?.length ?? 0) === 0
       : false,
   );
-  const hasQueuedMessages = useChatStore(
-    (state) => (state.queuedMessageBySession[stateSessionId]?.length ?? 0) > 0,
+  const queuedHead = useChatStore(
+    (state) => state.queuedMessageBySession[stateSessionId]?.[0] ?? null,
   );
+  const hasQueuedMessages = queuedHead !== null;
   const deferredWorkspaceRecord = useChatStore((state) => {
     const record = state.queuedMessageBySession[stateSessionId]?.[0];
     return record?.kind === "deferred" &&
@@ -2162,11 +2149,26 @@ export function useChatSessionController({
       null,
     );
   }, [deferredWorkspaceRecord, session?.executionTarget, stateSessionId]);
+  const queuedAgentBuilderSendNeedsPreparation = Boolean(
+    session?.creationState == null &&
+      queuedHead?.kind === "transport-ready" &&
+      isAgentBuilderSkillSendOptions(queuedHead.payload.sendOptions) &&
+      !session?.targetAgentPath,
+  );
   const isQueuePreparationReady = Boolean(
     sessionId &&
       session?.creationState == null &&
       workspaceContextReady &&
-      !deferredWorkspaceRecord,
+      !deferredWorkspaceRecord &&
+      !queuedAgentBuilderSendNeedsPreparation &&
+      // Agent Builder owns a draft file that is keyed to the final backend
+      // session id. Keep its accepted first send parked until that target is
+      // ready, then let the normal queue drain compose the path-bound prompt.
+      !(
+        session?.intent === "build-agent" &&
+        session.agentBuilderOpen !== false &&
+        !session.targetAgentPath
+      ),
   );
   const queueChatState = isQueuePreparationReady ? chatState : "thinking";
   const sendQueuedMessageWithAutoCompact = useCallback(
@@ -2241,11 +2243,7 @@ export function useChatSessionController({
 
       const activation = (async () => {
         const chatSessions = useChatSessionStore.getState();
-        const currentSession = chatSessions.sessions.find(
-          (candidate) =>
-            candidate.id === sessionId ||
-            candidate.clientSessionId === sessionId,
-        );
+        const currentSession = chatSessions.getSession(sessionId);
         if (!currentSession) {
           return null;
         }
@@ -2254,9 +2252,7 @@ export function useChatSessionController({
           currentSession.targetAgentPath
         ) {
           if (currentSession.agentBuilderOpen !== true) {
-            chatSessions.patchSession(currentSession.id, {
-              agentBuilderOpen: true,
-            });
+            chatSessions.patchSession(sessionId, { agentBuilderOpen: true });
             return { ...currentSession, agentBuilderOpen: true };
           }
           return currentSession;
@@ -2264,21 +2260,14 @@ export function useChatSessionController({
 
         const target = await preSeedDraftAgent(sessionId);
         const liveChatSessions = useChatSessionStore.getState();
-        const liveSession = liveChatSessions.sessions.find(
-          (candidate) =>
-            candidate.id === sessionId ||
-            candidate.clientSessionId === sessionId,
-        );
-        const liveSessionId = liveSession?.id;
+        const liveSession = liveChatSessions.getSession(sessionId);
         const liveSkills =
-          useChatStore.getState().skillDraftsBySession[
-            liveSessionId ?? stateSessionId
-          ] ?? EMPTY_SKILL_DRAFTS;
+          useChatStore.getState().skillDraftsBySession[stateSessionId] ??
+          EMPTY_SKILL_DRAFTS;
 
         if (
           !liveSession ||
           liveSession.archivedAt ||
-          liveSession.creationState === "failed" ||
           (options?.requireSelectedSkill &&
             !hasAgentBuilderSkillDraft(liveSkills))
         ) {
@@ -2286,14 +2275,6 @@ export function useChatSessionController({
             console.error("Failed to delete canceled agent draft:", error);
           });
           return null;
-        }
-
-        if (liveSession.id !== sessionId) {
-          await migratePendingDraftAgent(
-            sessionId,
-            liveSession.id,
-            target.path,
-          );
         }
 
         if (
@@ -2313,18 +2294,18 @@ export function useChatSessionController({
           targetAgentSlug: target.slug,
         };
 
-        liveChatSessions.patchSession(liveSession.id, patch);
+        liveChatSessions.patchSession(sessionId, patch);
 
         const chatStateNow = useChatStore.getState();
         const currentSkills =
-          chatStateNow.skillDraftsBySession[liveSession.id] ??
+          chatStateNow.skillDraftsBySession[stateSessionId] ??
           EMPTY_SKILL_DRAFTS;
         chatStateNow.setSkillDrafts(
-          liveSession.id,
+          stateSessionId,
           ensureAgentBuilderSkillDraft(currentSkills),
         );
 
-        return { ...liveSession, ...patch };
+        return { ...currentSession, ...patch };
       })();
 
       pendingBuilderActivationRef.current[sessionId] = activation;
@@ -2338,6 +2319,20 @@ export function useChatSessionController({
     },
     [sessionId, stateSessionId],
   );
+
+  useEffect(() => {
+    if (!queuedAgentBuilderSendNeedsPreparation || !sessionId) {
+      return;
+    }
+    void ensureCurrentSessionIsAgentBuilder().catch((error) => {
+      console.error("Failed to prepare queued agent builder:", error);
+      markAgentBuilderSessionPreparationFailed(sessionId);
+    });
+  }, [
+    ensureCurrentSessionIsAgentBuilder,
+    queuedAgentBuilderSendNeedsPreparation,
+    sessionId,
+  ]);
 
   const captureSessionSelection = useCallback(
     (payload: QueuedMessagePayload): QueuedMessagePayload => {
@@ -2442,24 +2437,17 @@ export function useChatSessionController({
           ? selectedPersona.displayName
           : useAgentStore.getState().getPersonaById(personaId)?.displayName
         : undefined;
-      const enqueueMessage = (
-        options = sendOptions,
-        targetSessionId = stateSessionId,
-      ) => {
-        const payload = captureSessionSelection({
-          text,
-          persona: personaIntentFromComposer(personaId, personaName),
-          attachments,
-          sendOptions: options,
-        });
-        const accepted =
-          targetSessionId === stateSessionId
-            ? enqueueCapturedMessage(payload)
-            : useChatStore
-                .getState()
-                .enqueueTransportReadyMessage(targetSessionId, payload);
+      const enqueueMessage = (options = sendOptions) => {
+        const accepted = enqueueCapturedMessage(
+          captureSessionSelection({
+            text,
+            persona: personaIntentFromComposer(personaId, personaName),
+            attachments,
+            sendOptions: options,
+          }),
+        );
         if (accepted && sessionId) {
-          recordDraftPreservingSubmission(targetSessionId, text);
+          recordDraftPreservingSubmission(sessionId, text);
         }
         return accepted;
       };
@@ -2474,6 +2462,38 @@ export function useChatSessionController({
         return false;
       }
 
+      // Draft sessions are interactive before backend creation finishes. Admit
+      // an ordinary first send through the same first-send path used by ready
+      // sessions, then let the queue's readiness gate hold it until promotion
+      // replaces the renderer-local id with the backend session id.
+      if (session?.creationState === "pending") {
+        const payload = captureSessionSelection({
+          text,
+          persona: personaIntentFromComposer(personaId, personaName),
+          attachments,
+          sendOptions,
+        });
+        const hasQueuedMessages =
+          (useChatStore.getState().queuedMessageBySession[stateSessionId]
+            ?.length ?? 0) > 0;
+        const accepted = hasQueuedMessages
+          ? enqueueCapturedMessage(payload)
+          : acceptFirstSend(sessionId, payload, {
+              queueReady: true,
+              startupName: preselectedWorkspaceStartupName,
+              onNeedsName: onWorkspaceNameRequest,
+            }).accepted;
+        if (!accepted) {
+          return false;
+        }
+        recordDraftPreservingSubmission(sessionId, text);
+        onMessageAccepted?.(sessionId);
+        if (personaId && personaId !== selectedPersonaId) {
+          handlePersonaChange(personaId);
+        }
+        return true;
+      }
+
       if (
         (session?.intent !== "build-agent" ||
           session.agentBuilderOpen === false) &&
@@ -2482,7 +2502,6 @@ export function useChatSessionController({
         return (async () => {
           const builderSession = await ensureCurrentSessionIsAgentBuilder();
           if (!builderSession) return false;
-          const builderSessionId = builderSession.id;
           const onBuilderWorkspaceNameRequest = onWorkspaceNameRequest
             ? (request: WorkspaceNameRequest) =>
                 onWorkspaceNameRequest({
@@ -2491,19 +2510,17 @@ export function useChatSessionController({
                     request.cancel();
                     const liveSession = useChatSessionStore
                       .getState()
-                      .getSession(builderSessionId);
+                      .getSession(sessionId);
                     if (
                       liveSession?.intent === "build-agent" &&
                       liveSession.targetAgentPath ===
                         builderSession.targetAgentPath
                     ) {
-                      useChatSessionStore
-                        .getState()
-                        .patchSession(builderSessionId, {
-                          intent: undefined,
-                          targetAgentPath: undefined,
-                          targetAgentSlug: undefined,
-                        });
+                      useChatSessionStore.getState().patchSession(sessionId, {
+                        intent: undefined,
+                        targetAgentPath: undefined,
+                        targetAgentSlug: undefined,
+                      });
                       if (builderSession.targetAgentPath) {
                         void deletePersonaSource(
                           builderSession.targetAgentPath,
@@ -2523,14 +2540,14 @@ export function useChatSessionController({
             sendOptions,
           );
           if (
-            (useChatStore.getState().queuedMessageBySession[builderSessionId]
+            (useChatStore.getState().queuedMessageBySession[stateSessionId]
               ?.length ?? 0) > 0
           ) {
-            enqueueMessage(deferredSendOptions, builderSessionId);
+            enqueueMessage(deferredSendOptions);
             return true;
           }
           const firstSend = acceptFirstSend(
-            builderSessionId,
+            sessionId,
             captureSessionSelection({
               text,
               persona: personaIntentFromComposer(personaId, personaName),
@@ -2545,8 +2562,8 @@ export function useChatSessionController({
             },
           );
           if (firstSend.accepted) {
-            recordDraftPreservingSubmission(builderSessionId, text);
-            onMessageAccepted?.(builderSessionId);
+            recordDraftPreservingSubmission(sessionId, text);
+            onMessageAccepted?.(sessionId);
             if (personaId && personaId !== selectedPersonaId) {
               handlePersonaChange(personaId);
             }
@@ -2554,20 +2571,17 @@ export function useChatSessionController({
           }
           if (firstSend.needsName || firstSend.occupied) return false;
           if (personaId && personaId !== selectedPersonaId) {
-            const accepted = enqueueMessage(
-              deferredSendOptions,
-              builderSessionId,
-            );
+            const accepted = enqueueMessage(deferredSendOptions);
             if (accepted) {
               handlePersonaChange(personaId);
             }
             return accepted;
           }
           if (!workspaceContextReady) {
-            enqueueMessage(deferredSendOptions, builderSessionId);
+            enqueueMessage(deferredSendOptions);
             return true;
           }
-          return enqueueMessage(deferredSendOptions, builderSessionId);
+          return enqueueMessage(deferredSendOptions);
         })();
       }
 
@@ -2652,6 +2666,7 @@ export function useChatSessionController({
       readOnly,
       recordDraftPreservingSubmission,
       session?.agentBuilderOpen,
+      session?.creationState,
       session?.intent,
       sessionId,
       selectedPersona,
@@ -2845,6 +2860,7 @@ export function useChatSessionController({
     if (
       !sessionId ||
       !skillWasJustSelected ||
+      session?.creationState === "pending" ||
       (session?.intent === "build-agent" && session.agentBuilderOpen !== false)
     ) {
       return;
@@ -2852,24 +2868,30 @@ export function useChatSessionController({
 
     void ensureCurrentSessionIsAgentBuilder({
       requireSelectedSkill: true,
-    }).then((builderSession) => {
-      if (!builderSession) {
-        return;
-      }
+    })
+      .then((builderSession) => {
+        if (!builderSession) {
+          return;
+        }
 
-      const chatState = useChatStore.getState();
-      if (
-        isAgentBuilderMentionOnlyDraft(
-          chatState.draftsBySession[stateSessionId] ?? "",
-        )
-      ) {
-        chatState.clearDraft(stateSessionId);
-      }
-    });
+        const chatState = useChatStore.getState();
+        if (
+          isAgentBuilderMentionOnlyDraft(
+            chatState.draftsBySession[stateSessionId] ?? "",
+          )
+        ) {
+          chatState.clearDraft(stateSessionId);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to prepare selected agent builder:", error);
+        markAgentBuilderSessionPreparationFailed(sessionId);
+      });
   }, [
     ensureCurrentSessionIsAgentBuilder,
     hasSelectedAgentBuilderSkill,
     session?.agentBuilderOpen,
+    session?.creationState,
     session?.intent,
     sessionId,
     stateSessionId,

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -355,8 +355,6 @@ export function ChatView({
     : `${1 - builderFraction}fr ${builderFraction}fr`;
   const isAgentBuilderTargetFailed =
     isAgentBuilderOpen && effectiveSession?.targetAgentDraftState === "failed";
-  const isAgentBuilderTargetPending =
-    isAgentBuilderOpen && !effectiveSession?.targetAgentPath;
   const hasVisibleRightRail =
     isAgentBuilderOpen ||
     Boolean(
@@ -676,8 +674,6 @@ export function ChatView({
       effectiveSession.creationError ?? t("toolbar.sessionStartFailed");
   } else if (isAgentBuilderTargetFailed) {
     sendDisabledReason = t("toolbar.agentBuilderPrepareFailed");
-  } else if (isAgentBuilderTargetPending) {
-    sendDisabledReason = t("toolbar.agentBuilderPreparing");
   }
 
   // The composer is owned by the timeline so it stays mounted across loading,
@@ -791,7 +787,7 @@ export function ChatView({
             sendDisabled:
               isReadOnly ||
               effectiveSession?.creationState === "failed" ||
-              isAgentBuilderTargetPending ||
+              isAgentBuilderTargetFailed ||
               controller.workspaceSetupInProgress,
             sendDisabledReason,
             queuedMessage: composerHandoffInProgress

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -587,7 +587,7 @@ describe("ChatView MCP app messaging", () => {
     expect(timelineProps.showPlaceholder).toBe(false);
   });
 
-  it("keeps the composer enabled while a blank draft session is pending", () => {
+  it("keeps Send available while a blank draft session is pending", () => {
     mocks.useChatSessionController.mockReturnValue({
       ...mocks.useChatSessionController(),
       messages: [],
@@ -606,45 +606,14 @@ describe("ChatView MCP app messaging", () => {
 
     const chatInputProps = mocks.chatInputSpy.mock.calls.at(-1)?.[0] as {
       composerActions?: {
-        onSend?: (text: string) => boolean;
+        onSend?: unknown;
         sendDisabled?: boolean;
         sendDisabledReason?: string;
       };
     };
+    expect(chatInputProps.composerActions?.onSend).toBe(mocks.handleSend);
     expect(chatInputProps.composerActions?.sendDisabled).toBe(false);
     expect(chatInputProps.composerActions?.sendDisabledReason).toBeUndefined();
-
-    act(() => {
-      expect(
-        chatInputProps.composerActions?.onSend?.("queue while starting"),
-      ).toBe(true);
-    });
-    expect(mocks.handleSend).toHaveBeenCalledWith("queue while starting");
-  });
-
-  it("keeps the composer blocked after draft session creation fails", () => {
-    render(
-      <ChatView
-        sessionId="draft-session"
-        activeSession={{
-          ...chatSessionWithWorkingDir("~/goose artifacts"),
-          id: "draft-session",
-          creationState: "failed",
-          creationError: "Session failed to start",
-        }}
-      />,
-    );
-
-    const chatInputProps = mocks.chatInputSpy.mock.calls.at(-1)?.[0] as {
-      composerActions?: {
-        sendDisabled?: boolean;
-        sendDisabledReason?: string;
-      };
-    };
-    expect(chatInputProps.composerActions?.sendDisabled).toBe(true);
-    expect(chatInputProps.composerActions?.sendDisabledReason).toBe(
-      "Session failed to start",
-    );
   });
 
   it("keeps the empty-state placeholder visible while a blank draft session is pending", () => {
@@ -1167,6 +1136,32 @@ describe("ChatView MCP app messaging", () => {
     expect(chatInputProps.controls).toEqual({ skills: false });
     expect(chatInputProps.placeholder).toBeUndefined();
     expect(document.querySelector(".agent-builder-column-enter")).toBeTruthy();
+  });
+
+  it("keeps Send available while an agent builder draft target is preparing", () => {
+    const activeSession = {
+      id: "session-1",
+      title: "Build agent",
+      createdAt: "2026-05-27T00:00:00.000Z",
+      updatedAt: "2026-05-27T00:00:00.000Z",
+      messageCount: 0,
+      intent: "build-agent",
+      agentBuilderOpen: true,
+      targetAgentPath: null,
+      targetAgentSlug: null,
+      targetAgentDraftState: "preparing",
+    } satisfies ChatSession;
+
+    render(<ChatView sessionId="session-1" activeSession={activeSession} />);
+
+    const chatInputProps = mocks.chatInputSpy.mock.calls.at(-1)?.[0] as {
+      composerActions?: {
+        sendDisabled?: boolean;
+        sendDisabledReason?: string;
+      };
+    };
+    expect(chatInputProps.composerActions?.sendDisabled).toBe(false);
+    expect(chatInputProps.composerActions?.sendDisabledReason).toBeUndefined();
   });
 
   it("uses failed draft copy when an agent builder draft target fails", () => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users can send a message immediately while a new chat is starting, and Berd will deliver it once the session is ready.

**Problem:** New chats briefly disabled Send while their backend session was being created, which became a noticeable blocker on slower startup paths. Nearby queue and preparation fixes prevented premature dispatch, but did not let the composer admit the message during that waiting period.

**Solution:** Keep the composer available and admit pending-session sends through the existing queue, while one readiness gate holds dispatch until session creation, workspace setup, and Agent Builder preparation are complete. Agent Builder preparation follows the authoritative queued record so canceling workspace setup cannot leave an orphaned draft.

<details>
<summary>File changes</summary>

**src/features/agents/lib/agentBuilderSession.ts**
Exports the existing Agent Builder preparation-failure transition so every asynchronous caller can move preparation into its recoverable failed state.

**src/features/chat/hooks/useChatSessionController.ts**
Admits messages while session creation is pending, preserves captured persona/model/workspace intent, and keeps queued Agent Builder requests parked until their final-session draft target is ready. Builder preparation now follows queue and workspace admission rather than racing ahead of it.

**src/features/chat/hooks/__tests__/useChatSessionController.test.ts**
Adds regression coverage for pending admission, ID promotion, draft preservation, workspace setup and cancellation, persona/model intent, and Agent Builder readiness and failure paths.

**src/features/chat/ui/ChatView.tsx**
Keeps Send available during session and Agent Builder preparation while continuing to block failed creation or failed Builder setup.

**src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx**
Protects composer availability during pending session creation and Agent Builder preparation, while preserving failed-state behavior.

</details>
