### PR TITLE
feat: publish a stable latest macOS installer

### DIFF
--- a/docs/release-and-updates.md
+++ b/docs/release-and-updates.md
@@ -10,6 +10,10 @@ The tag-bound release defaults are centralized in `scripts/release/release-chann
 
 `https://github.com/block/berd/releases/download/berd-desktop-latest/latest.json`
 
+The latest user-facing macOS installer is always available at:
+
+`https://github.com/block/berd/releases/download/berd-desktop-latest/Berd-latest-darwin-aarch64.dmg`
+
 Public releases must be at least `0.6.0-rc.1`. The app, bundled `berdctl`,
 internal `tauri-plugin-berdctl`, their Cargo lock entries, and the changelog are
 validated at the immutable tag before GitHub creates a release.

--- a/scripts/release/github/promote-updater.sh
+++ b/scripts/release/github/promote-updater.sh
@@ -40,6 +40,11 @@ archive_url() {
     "$(release_archive_name "$VERSION" "$platform")"
 }
 
+LATEST_MACOS_DMG_NAME="Berd-latest-darwin-aarch64.dmg"
+LATEST_MACOS_DMG_PATH="$WORK_DIR/$LATEST_MACOS_DMG_NAME"
+LATEST_MACOS_DMG_URL="https://github.com/${REPOSITORY}/releases/download/${ROLLING_TAG}/${LATEST_MACOS_DMG_NAME}"
+LATEST_MACOS_DMG_DIGEST=""
+
 staged_digest() {
   local platform="$1"
   awk 'NR == 1 {print $1}' "$(archive_path "$platform").sha256"
@@ -84,6 +89,18 @@ for PLATFORM in "${RELEASE_PLATFORMS[@]}"; do
   ARCHIVE_URL="$(archive_url "$PLATFORM")"
   MANIFEST_ARGS+=("$PLATFORM" "$WORK_DIR/$ARCHIVE_NAME.sig" "$ARCHIVE_URL")
   SUMMARY_LINES+=("- $PLATFORM updater SHA-256: \`$EXPECTED_DIGEST\`" "- $PLATFORM updater URL: $ARCHIVE_URL")
+  if [[ "$PLATFORM" == "darwin-aarch64" ]]; then
+    VERSIONED_DMG_NAME="Berd_${VERSION}_${PLATFORM}.dmg"
+    gh release download "$TAG" --repo "$REPOSITORY" --dir "$WORK_DIR" \
+      --pattern "$VERSIONED_DMG_NAME"
+    if [[ ! -s "$WORK_DIR/$VERSIONED_DMG_NAME" ]]; then
+      release_error "missing or empty staged input: $VERSIONED_DMG_NAME"
+      exit 1
+    fi
+    mv "$WORK_DIR/$VERSIONED_DMG_NAME" "$LATEST_MACOS_DMG_PATH"
+    LATEST_MACOS_DMG_DIGEST="$(shasum -a 256 "$LATEST_MACOS_DMG_PATH" | awk '{print $1}')"
+    SUMMARY_LINES+=("- macOS installer SHA-256: \`$LATEST_MACOS_DMG_DIGEST\`" "- macOS installer URL: $LATEST_MACOS_DMG_URL")
+  fi
 done
 
 if [[ -n "${BERD_RELEASE_CHANNEL_ID:-}" ]]; then
@@ -171,6 +188,9 @@ for PLATFORM in "${RELEASE_PLATFORMS[@]}"; do
   ARCHIVE_NAME="$(release_archive_name "$VERSION" "$PLATFORM")"
   UPLOADS+=("$WORK_DIR/$ARCHIVE_NAME" "$WORK_DIR/$ARCHIVE_NAME.sig" "$WORK_DIR/$ARCHIVE_NAME.sha256")
 done
+if [[ -n "$LATEST_MACOS_DMG_DIGEST" ]]; then
+  UPLOADS+=("$LATEST_MACOS_DMG_PATH")
+fi
 gh release upload "$ROLLING_TAG" --repo "$REPOSITORY" --clobber "${UPLOADS[@]}"
 
 # Confirm every updater payload is anonymously available before mutating the feed.
@@ -199,6 +219,29 @@ for PLATFORM in "${RELEASE_PLATFORMS[@]}"; do
     exit 1
   fi
 done
+
+if [[ -n "$LATEST_MACOS_DMG_DIGEST" ]]; then
+  accessible=false
+  for attempt in 1 2 3 4 5; do
+    if curl \
+      --fail \
+      --location \
+      --retry 2 \
+      --retry-all-errors \
+      -H 'Cache-Control: no-cache' \
+      -o "$WORK_DIR/public-$LATEST_MACOS_DMG_NAME" \
+      "${LATEST_MACOS_DMG_URL}?run=${GITHUB_RUN_ID:-manual}-${attempt}" \
+      && [[ "$(shasum -a 256 "$WORK_DIR/public-$LATEST_MACOS_DMG_NAME" | awk '{print $1}')" == "$LATEST_MACOS_DMG_DIGEST" ]]; then
+      accessible=true
+      break
+    fi
+    sleep "${BERD_PROMOTION_RETRY_DELAY_SECONDS:-10}"
+  done
+  if [[ "$accessible" != true ]]; then
+    release_error "rolling macOS installer was not publicly accessible: $LATEST_MACOS_DMG_URL"
+    exit 1
+  fi
+fi
 
 RECHECK_MANIFEST="$WORK_DIR/rechecked-latest.json"
 fetch_manifest "$RECHECK_MANIFEST" "${MANIFEST_URL}?run=${GITHUB_RUN_ID:-manual}-recheck" recheck

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -1879,6 +1879,7 @@ fi
 describe("promote-updater", () => {
   async function fixture({
     publishedDigestMatches = true,
+    publishedDmgMatches = true,
     signatureValid = true,
     currentVersion = null,
     recheckedVersion = currentVersion,
@@ -1902,6 +1903,8 @@ describe("promote-updater", () => {
       `${archive}.sha256`,
       `${digest}  ${archive.split("/").at(-1)}\n`,
     );
+    const dmg = join(dir, "Berd_1.2.3_darwin-aarch64.dmg");
+    await writeFile(dmg, "signed-notarized-dmg");
     await writeFile(
       join(bin, "gh"),
       `#!/usr/bin/env bash
@@ -1909,10 +1912,22 @@ set -euo pipefail
 printf '%s\\n' "$*" >> "$CALLS"
 if [[ "$1 $2" == "release download" ]]; then
   dir=""
+  download_dmg=false
   while [[ $# -gt 0 ]]; do
-    case "$1" in --dir) dir="$2"; shift 2 ;; *) shift ;; esac
+    case "$1" in
+      --dir) dir="$2"; shift 2 ;;
+      --pattern)
+        [[ "$2" != "Berd_1.2.3_darwin-aarch64.dmg" ]] || download_dmg=true
+        shift 2
+        ;;
+      *) shift ;;
+    esac
   done
-  cp "$STAGED_ARCHIVE" "$STAGED_ARCHIVE.sig" "$STAGED_ARCHIVE.sha256" "$dir/"
+  if [[ "$download_dmg" == true ]]; then
+    cp "$STAGED_DMG" "$dir/"
+  else
+    cp "$STAGED_ARCHIVE" "$STAGED_ARCHIVE.sig" "$STAGED_ARCHIVE.sha256" "$dir/"
+  fi
 elif [[ "$1 $2" == "release view" ]]; then
   exit 0
 elif [[ "$1 $2" == "release upload" ]]; then
@@ -1968,6 +1983,12 @@ elif [[ "$output" == *rechecked-latest.json ]]; then
   if [[ "$status" == 200 ]]; then cp "$REMOTE_RECHECKED_MANIFEST" "$output"; fi
 elif [[ "$output" == *published-latest.json ]]; then
   cp "$PUBLISHED_MANIFEST" "$output"
+elif [[ "$output" == *public-Berd-latest-darwin-aarch64.dmg ]]; then
+  if [[ "$PUBLISHED_DMG_MATCHES" == true ]]; then
+    cp "$STAGED_DMG" "$output"
+  else
+    printf tampered > "$output"
+  fi
 elif [[ "$PUBLISHED_DIGEST_MATCHES" == true ]]; then
   cp "$STAGED_ARCHIVE" "$output"
 else
@@ -1991,9 +2012,11 @@ fi
       dir,
       bin,
       archive,
+      dmg,
       calls,
       channelConfig,
       publishedDigestMatches,
+      publishedDmgMatches,
       signatureValid,
       preflightStatus,
       recheckStatus,
@@ -2013,11 +2036,13 @@ fi
         BERD_UPDATER_PUBLIC_KEY: "test-public-key",
         GITHUB_REPOSITORY: "block/berd",
         STAGED_ARCHIVE: f.archive,
+        STAGED_DMG: f.dmg,
         CALLS: f.calls,
         PUBLISHED_MANIFEST: f.publishedManifest,
         REMOTE_CURRENT_MANIFEST: f.currentManifest,
         REMOTE_RECHECKED_MANIFEST: f.recheckedManifest,
         PUBLISHED_DIGEST_MATCHES: String(f.publishedDigestMatches),
+        PUBLISHED_DMG_MATCHES: String(f.publishedDmgMatches),
         SIGNATURE_VALID: String(f.signatureValid),
         PREFLIGHT_STATUS: String(f.preflightStatus),
         RECHECK_STATUS: String(f.recheckStatus),
@@ -2033,6 +2058,7 @@ fi
     expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
     const calls = (await readFile(f.calls, "utf8")).trim().split("\n");
     expect(calls.at(-1)).toContain("latest.json");
+    expect(calls.join("\n")).toContain("Berd-latest-darwin-aarch64.dmg");
     expect(
       JSON.parse(await readFile(f.publishedManifest, "utf8")).version,
     ).toBe("1.2.3");
@@ -2091,7 +2117,20 @@ fi
     const f = await fixture({ publishedDigestMatches: false });
     const result = promote(f);
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("not publicly accessible");
+    expect(result.stderr).toContain(
+      "rolling archive was not publicly accessible",
+    );
+    const calls = await readFile(f.calls, "utf8");
+    expect(calls).not.toContain("latest.json");
+  });
+
+  it("leaves latest.json untouched when the rolling macOS installer does not match", async () => {
+    const f = await fixture({ publishedDmgMatches: false });
+    const result = promote(f);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "rolling macOS installer was not publicly accessible",
+    );
     const calls = await readFile(f.calls, "utf8");
     expect(calls).not.toContain("latest.json");
   });


### PR DESCRIPTION
**Category:** infrastructure
**User Impact:** People can always download the latest Berd macOS installer from one permanent URL.
**Problem:** The public DMG filename includes its release version, so website download links become stale after every release. The rolling release currently exposes only updater payloads, which are not appropriate for a manual install.
**Solution:** Publish the verified, notarized DMG to the rolling release under a stable filename, then anonymously verify its bytes before updating the release feed.

<details>
<summary>File changes</summary>

**docs/release-and-updates.md**
Documents the permanent URL for the latest user-facing macOS installer.

**scripts/release/github/promote-updater.sh**
Copies the immutable versioned DMG into the rolling release under a stable name, verifies its public bytes, and reports its URL and digest.

**scripts/release/tests/release-scripts.test.mjs**
Covers successful stable-DMG publication and ensures a mismatched public installer cannot advance the updater manifest.

</details>

### Validation

- `pnpm test:release-scripts` (85 tests passed; the full parallel invocation hit the existing 15s per-test timeout on two timing-sensitive cases, which both passed when rerun directly)
- `bash -n scripts/release/github/promote-updater.sh`
- `git diff --check`

### Laws

No product law applies; this changes release distribution infrastructure rather than in-app behavior.
