### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.6.1](https://github.com/block/berd/releases/tag/v0.6.1) - 2026-08-17
+
+Berd 0.6.0 improves queued messaging, long-chat reliability, agent cards, and the Home experience, alongside smoother installation and updates.
+
+- **Reliable queued messages:** Follow-ups now send automatically when an agent is ready, even after you navigate away. Messages also wait for new chats to finish starting before sending.
+- **Cleaner chat controls:** Normal sends no longer briefly flash a queued indicator. While an agent is working, pressing `Enter` with an empty composer steers the first queued message.
+- **Safer transcript refreshes:** Long, tool-heavy chats retain accurate scrolling and visible history. If reloading or compaction returns incomplete data, Berd preserves the existing transcript and shows a recoverable error.
+- **Improved agent cards:** Shared and imported agents now use a consistent collectible-card design with avatar-aware colors, motion, and more dependable PNG exports. Agent cards also show their actual descriptions, which can now be edited during manual setup.
+- **Polished Home canvas:** New Home layouts use better-sized widgets and a more balanced starting view, with smoother project cube and avatar movement. Existing layouts and user edits remain preserved.
+- **Refined chat context rail:** Cards, menus, dropdowns, and selected states are clearer and more consistent across light and dark modes.
+- **Better Windows link launching:** Berd now opens links directly in Chrome when available, with a reliable fallback to the default browser.
+- **Improved macOS installation:** The installer has refreshed Berd artwork, and the latest macOS installer is now available through a permanent download link.
+- **More reliable updates:** Release metadata compatibility fixes help older Berd versions install future desktop updates without false verification failures.
+
+**Full Changelog**: https://github.com/block/berd/compare/v0.6.0...f5b4b55b
+
 ## [v0.6.0](https://github.com/block/berd/releases/tag/v0.6.0) - 2026-08-14
 
 This release makes project chats safer, improves chat organization and agent visibility, and refreshes the getting-started experience. Agent sharing is also now available to everyone.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "berd",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Berd"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",
@@ -579,7 +579,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "berdctl"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Berd"
-version = "0.6.0"
+version = "0.6.1"
 description = "Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.6.0"
+version = "0.6.1"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Berd",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "xyz.block.berd",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
## Summary

- synchronize Berd, berdctl, and tauri-plugin-berdctl at 0.6.1
- add the reviewed v0.6.1 changelog entry

### Related issue

N/A

### Testing

- `just release-version-check 0.6.1`
- `just release-validate 0.6.1`
