### PR TITLE
fix: keep agent work expansions anchored

### DIFF
--- a/src/features/chat/ui/AgentWorkPanel.tsx
+++ b/src/features/chat/ui/AgentWorkPanel.tsx
@@ -27,6 +27,7 @@ import type {
   ToolCallStatus,
 } from "@/shared/types/messages";
 import type { TranscriptAgentWorkPayload } from "@/features/chat/transcript/projection/transcriptItemTypes";
+import { useTranscriptRowStateAdapter } from "@/features/chat/transcript/row-state";
 import { ToolCallAdapter } from "./ToolCallAdapter";
 
 interface ToolTimelineItem {
@@ -351,6 +352,7 @@ export function AgentWorkPanel({
 }) {
   const { t } = useTranslation("chat");
   const prefersReducedMotion = useReducedMotion();
+  const { markRowInteracted, pinScrollAnchor } = useTranscriptRowStateAdapter();
   const items = useMemo(
     () => buildAgentWorkTimeline(payload.content),
     [payload.content],
@@ -423,7 +425,12 @@ export function AgentWorkPanel({
   return (
     <Collapsible
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={(nextOpen) => {
+        markRowInteracted("agent-work-disclosure");
+        pinScrollAnchor();
+        setOpen(nextOpen);
+      }}
+      data-role="agent-work-panel"
       className="mt-3 w-full min-w-0 max-w-full"
     >
       <div>
@@ -484,7 +491,11 @@ export function AgentWorkPanel({
               >
                 <Collapsible
                   open={previousStepsOpen}
-                  onOpenChange={setPreviousStepsOpen}
+                  onOpenChange={(nextOpen) => {
+                    markRowInteracted("agent-work-previous-steps");
+                    pinScrollAnchor();
+                    setPreviousStepsOpen(nextOpen);
+                  }}
                 >
                   <CollapsibleTrigger asChild>
                     <Button

--- a/src/features/chat/ui/ToolCallAdapter.tsx
+++ b/src/features/chat/ui/ToolCallAdapter.tsx
@@ -8,6 +8,7 @@ import { CodeBlock } from "@/shared/ui/ai-elements/code-block";
 import {
   Tool,
   ToolContent,
+  ToolDetailsViewport,
   ToolHeader,
   ToolInput,
   ToolOutput,
@@ -593,8 +594,9 @@ export function ToolCallAdapter({
           className="text-muted-foreground [&_button]:text-muted-foreground [&_code]:text-muted-foreground [&_dd]:text-muted-foreground [&_dt]:text-muted-foreground [&_span]:text-muted-foreground"
         >
           {agentWorkLayout ? (
-            <div
+            <ToolDetailsViewport
               data-role="agent-work-tool-details"
+              aria-label={t("tools.details")}
               className="max-h-48 space-y-3 overflow-y-auto overscroll-contain py-1"
             >
               <AgentWorkToolSection
@@ -614,7 +616,7 @@ export function ToolCallAdapter({
                 label={t("tools.structuredContent")}
                 value={structuredDetails}
               />
-            </div>
+            </ToolDetailsViewport>
           ) : showCombinedSurface ? (
             <ToolSurface tone="muted" className="bg-muted">
               <ToolInput

--- a/src/features/chat/ui/ToolCallAdapter.tsx
+++ b/src/features/chat/ui/ToolCallAdapter.tsx
@@ -593,7 +593,10 @@ export function ToolCallAdapter({
           className="text-muted-foreground [&_button]:text-muted-foreground [&_code]:text-muted-foreground [&_dd]:text-muted-foreground [&_dt]:text-muted-foreground [&_span]:text-muted-foreground"
         >
           {agentWorkLayout ? (
-            <div className="space-y-3 py-1">
+            <div
+              data-role="agent-work-tool-details"
+              className="max-h-48 space-y-3 overflow-y-auto overscroll-contain py-1"
+            >
               <AgentWorkToolSection
                 label={t("tools.inputSummary.command")}
                 value={commandRow?.value ?? null}

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -3799,7 +3799,11 @@ function VirtualMessageTimelineSession({
     ) {
       return;
     }
-    if (resolvedScrollTargetMessageId || userDetachedRef.current) {
+    if (
+      resolvedScrollTargetMessageId ||
+      userDetachedRef.current ||
+      virtualTimelineSnapshot.controllerState.anchor.type !== "bottom"
+    ) {
       return;
     }
     requestBottomScroll();
@@ -3809,6 +3813,7 @@ function VirtualMessageTimelineSession({
     requestBottomScroll,
     resolvedScrollTargetMessageId,
     streamingMessageId,
+    virtualTimelineSnapshot.controllerState.anchor.type,
   ]);
 
   const messageList = (

--- a/src/features/chat/ui/__tests__/ToolCallAdapter.test.tsx
+++ b/src/features/chat/ui/__tests__/ToolCallAdapter.test.tsx
@@ -409,6 +409,25 @@ describe("ToolCallAdapter — expanded body", () => {
     renderAdapter({ open: true, isError: true, result: "Boom" });
     expect(screen.getByText("Boom")).toHaveClass("text-destructive");
   });
+
+  it("caps and scrolls an inner details viewport in the agent work layout", () => {
+    const { container } = renderAdapter({ open: true, agentWorkLayout: true });
+
+    expect(
+      container.querySelector('[data-role="agent-work-tool-details"]'),
+    ).toHaveClass("max-h-48", "overflow-y-auto", "overscroll-contain");
+    expect(
+      container.querySelector('[data-role="tool-call-content"]'),
+    ).not.toHaveClass("max-h-48", "overflow-y-auto");
+  });
+
+  it("does not add a capped details viewport outside the agent work layout", () => {
+    const { container } = renderAdapter({ open: true });
+
+    expect(
+      container.querySelector('[data-role="agent-work-tool-details"]'),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("ToolCallAdapter — text + structured de-dupe matrix", () => {

--- a/src/features/chat/ui/__tests__/ToolCallAdapter.test.tsx
+++ b/src/features/chat/ui/__tests__/ToolCallAdapter.test.tsx
@@ -413,9 +413,13 @@ describe("ToolCallAdapter — expanded body", () => {
   it("caps and scrolls an inner details viewport in the agent work layout", () => {
     const { container } = renderAdapter({ open: true, agentWorkLayout: true });
 
-    expect(
-      container.querySelector('[data-role="agent-work-tool-details"]'),
-    ).toHaveClass("max-h-48", "overflow-y-auto", "overscroll-contain");
+    const details = screen.getByRole("region", { name: "Tool details" });
+    expect(details).toHaveAttribute("tabindex", "0");
+    expect(details).toHaveClass(
+      "max-h-48",
+      "overflow-y-auto",
+      "overscroll-contain",
+    );
     expect(
       container.querySelector('[data-role="tool-call-content"]'),
     ).not.toHaveClass("max-h-48", "overflow-y-auto");

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -1104,6 +1104,54 @@ describe("VirtualMessageTimeline", () => {
     expect(screen.queryByTestId("message-assistant-work:answer")).toBeNull();
   });
 
+  it("keeps a revealed agent-work row anchored as its measured height grows", () => {
+    mockTranscriptElementMeasurements();
+    const animationFrame = mockRequestAnimationFrame();
+    const assistant: Message = {
+      id: "assistant-work",
+      role: "assistant",
+      created: Date.UTC(2026, 5, 4, 12, 1, 0),
+      metadata: { userVisible: true },
+      content: [
+        { type: "thinking", text: "Planning" },
+        {
+          type: "toolRequest",
+          id: "tool-1",
+          name: "scan",
+          arguments: {},
+          status: "completed",
+        },
+        { type: "text", text: "Final answer" },
+      ],
+    };
+    renderWithProviders(
+      <VirtualMessageTimeline sessionId="session-1" messages={[assistant]} />,
+    );
+    const scroller = screen.getByTestId("message-timeline-scroll");
+    const scrollTo = attachScrollTo(scroller);
+    setScrollMetrics(scroller, {
+      scrollTop: 500,
+      scrollHeight: 1000,
+      clientHeight: 500,
+    });
+    animationFrame.runAll(0);
+    scrollTo.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /previous steps?/ }));
+    animationFrame.runAll(100);
+    scrollTo.mockClear();
+
+    const agentWorkRow = screen.getByTestId(
+      "virtual-transcript-row-message:assistant-work:agent-work",
+    );
+    agentWorkRow.setAttribute("data-mock-row-height", "480");
+    triggerResizeObservers();
+    animationFrame.runAll(200);
+
+    expect(scroller.scrollTop).toBe(500);
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("mounts a just-settled agent-work row open before collapsing", async () => {
     const animationFrame = mockRequestAnimationFrame();
     const user = textMessage("user-1", "user", "Please inspect");

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -547,6 +547,7 @@
   },
   "tools": {
     "content": "Content",
+    "details": "Tool details",
     "error": "Error",
     "input": "Input",
     "result": "Result",

--- a/src/shared/i18n/locales/es/chat.json
+++ b/src/shared/i18n/locales/es/chat.json
@@ -544,6 +544,7 @@
   },
   "tools": {
     "content": "Contenido",
+    "details": "Detalles de la herramienta",
     "error": "Error",
     "input": "Entrada",
     "result": "Resultado",

--- a/src/shared/ui/ai-elements/tool.tsx
+++ b/src/shared/ui/ai-elements/tool.tsx
@@ -256,6 +256,25 @@ export const ToolContent = ({ className, ...props }: ToolContentProps) => (
   />
 );
 
+export type ToolDetailsViewportProps = ComponentProps<"div">;
+
+export const ToolDetailsViewport = ({
+  className,
+  ...props
+}: ToolDetailsViewportProps) => (
+  // Scrollable regions need a tab stop so keyboard users can operate them.
+  <div
+    role="region"
+    // biome-ignore lint/a11y/noNoninteractiveTabindex: focus transfers keyboard scrolling to this overflow viewport.
+    tabIndex={0}
+    className={cn(
+      "rounded-sm outline-none transition-[color,box-shadow] focus-visible:ring-1 focus-visible:ring-ring/50",
+      className,
+    )}
+    {...props}
+  />
+);
+
 export type ToolSectionProps = ComponentProps<"div"> & {
   label: string;
 };


### PR DESCRIPTION
**Category:** fix
**User Impact:** Expanded agent work stays visually anchored, while long tool details remain compact and can be scrolled with a pointer or keyboard.
**Problem:** Long tool-call details made Agent Work difficult to scan, and opening the surrounding Previous steps disclosure could make the virtual transcript jump toward the bottom. The compact details region also needed an accessible keyboard-scrolling path.
**Solution:** Cap Agent Work tool details in a labeled, focusable scroll viewport, pin user-opened Agent Work disclosures to their transcript row, and only auto-follow measured height changes while the virtualizer still owns a bottom anchor.

<details>
<summary>File changes</summary>

**src/features/chat/ui/AgentWorkPanel.tsx**
Pins the virtual transcript anchor before either Agent Work disclosure changes height, preserving the reader’s position.

**src/features/chat/ui/ToolCallAdapter.tsx**
Places Agent Work tool details inside the shared compact scroll viewport and supplies its localized accessible label.

**src/features/chat/ui/VirtualMessageTimeline.tsx**
Prevents measured-height bottom-follow from overriding a row anchor established by user interaction.

**src/features/chat/ui/__tests__/ToolCallAdapter.test.tsx**
Covers the Agent Work-only height cap, scrolling behavior, region label, and keyboard focusability.

**src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx**
Protects the regression where expanding and remeasuring an Agent Work row forced the transcript toward the bottom.

**src/shared/i18n/locales/en/chat.json**
Adds the English accessible label for tool details.

**src/shared/i18n/locales/es/chat.json**
Adds the Spanish accessible label for tool details.

**src/shared/ui/ai-elements/tool.tsx**
Adds a reusable focusable tool-details viewport with the shared focus treatment.

</details>


## Screenshots

### Before

Long tool output expands the Agent Work row beyond the viewport.

![Before: expanded Agent Work tool output fills the transcript](https://d24qwcpro867f5.cloudfront.net/repos/berd/prs/72/agent-work-before.png)

### After

Tool details stay compact in a keyboard-accessible scroll region while the expanded Agent Work row remains anchored.

![After: expanded Agent Work tool output is capped and scrollable](https://d24qwcpro867f5.cloudfront.net/repos/berd/prs/72/agent-work-after.png)
