### PR TITLE
add a first-run landing experience

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ dunce = "1"
 doctor = { git = "https://github.com/block/builderbot", rev = "73ff9a0521dcc784c9514911a655187e5dd3b6ca" }
 etcetera = "0.11.0"
 flate2 = "1"
+tempfile = "3"
 hex = "0.4"
 ignore = "0.4.25"
 infer = "0.19.0"
@@ -142,7 +143,6 @@ block-voice-dictation = []
 admin-runtime-config = []
 
 [dev-dependencies]
-tempfile = "3"
 # Mirrors goose's bare-name command resolver (crates/goose Cargo.toml): the
 # native Windows gate resolves the bridge launcher through the exact
 # `which_in_global` path goosed uses, so PATHEXT resolution is under test.

--- a/src-tauri/src/commands/installation.rs
+++ b/src-tauri/src/commands/installation.rs
@@ -9,7 +9,6 @@ pub async fn get_installation_cohort(
     state: State<'_, InstallationCohortState>,
 ) -> Result<InstallationCohort, String> {
     let mut receiver = state.0.clone();
-    drop(state);
     loop {
         let readiness = *receiver.borrow_and_update();
         if let InstallationCohortReadiness::Ready(cohort) = readiness {

--- a/src-tauri/src/commands/installation.rs
+++ b/src-tauri/src/commands/installation.rs
@@ -1,8 +1,22 @@
 use tauri::State;
 
-use crate::services::installation_cohort::{InstallationCohort, InstallationCohortState};
+use crate::services::installation_cohort::{
+    InstallationCohort, InstallationCohortReadiness, InstallationCohortState,
+};
 
 #[tauri::command]
-pub fn get_installation_cohort(state: State<'_, InstallationCohortState>) -> InstallationCohort {
-    state.0
+pub async fn get_installation_cohort(
+    state: State<'_, InstallationCohortState>,
+) -> Result<InstallationCohort, String> {
+    let mut receiver = state.0.clone();
+    drop(state);
+    loop {
+        let readiness = *receiver.borrow_and_update();
+        if let InstallationCohortReadiness::Ready(cohort) = readiness {
+            return Ok(cohort);
+        }
+        if receiver.changed().await.is_err() {
+            return Ok(InstallationCohort::Unknown);
+        }
+    }
 }

--- a/src-tauri/src/commands/installation.rs
+++ b/src-tauri/src/commands/installation.rs
@@ -1,0 +1,8 @@
+use tauri::State;
+
+use crate::services::installation_cohort::{InstallationCohort, InstallationCohortState};
+
+#[tauri::command]
+pub fn get_installation_cohort(state: State<'_, InstallationCohortState>) -> InstallationCohort {
+    state.0
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -25,6 +25,7 @@ pub mod git;
 pub mod git_changes;
 pub mod global_shortcut;
 pub mod home_widget_media;
+pub mod installation;
 pub mod layout;
 pub mod message_queues;
 pub mod migration;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -211,6 +211,13 @@ pub fn run() {
             app.manage(commands::pocket_voice::PocketVoiceState::default());
             app.manage(commands::native_voice::NativeVoiceState::default());
             app.manage(commands::voice_capture::VoiceCaptureState::default());
+            let installation_cohort =
+                services::installation_cohort::initialize_installation_cohort(
+                    &app_data_dir,
+                    services::app_data_migration::legacy_layout_database_exists(app.handle()),
+                )
+                .map_err(std::io::Error::other)?;
+            app.manage(installation_cohort);
             let release_channel_state = commands::updates::ReleaseChannelState::load(app.handle())?;
             app.manage(release_channel_state);
 
@@ -510,6 +517,7 @@ pub fn run() {
             commands::git::git_create_worktree,
             commands::git::git_remove_worktree,
             commands::home_widget_media::import_home_widget_photo,
+            commands::installation::get_installation_cohort,
             commands::layout::get_layout,
             commands::layout::save_layout_items,
             commands::layout::save_layout_camera,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -211,13 +211,23 @@ pub fn run() {
             app.manage(commands::pocket_voice::PocketVoiceState::default());
             app.manage(commands::native_voice::NativeVoiceState::default());
             app.manage(commands::voice_capture::VoiceCaptureState::default());
+            let (installation_cohort_sender, installation_cohort_state) =
+                services::installation_cohort::installation_cohort_channel();
+            app.manage(installation_cohort_state);
             let installation_cohort =
                 services::installation_cohort::initialize_installation_cohort(
                     &app_data_dir,
                     services::app_data_migration::legacy_layout_database_exists(app.handle()),
                 )
-                .map_err(std::io::Error::other)?;
-            app.manage(installation_cohort);
+                .unwrap_or_else(|error| {
+                    log::warn!("Failed to initialize installation cohort: {error}");
+                    services::installation_cohort::InstallationCohort::Unknown
+                });
+            installation_cohort_sender.send_replace(
+                services::installation_cohort::InstallationCohortReadiness::Ready(
+                    installation_cohort,
+                ),
+            );
             let release_channel_state = commands::updates::ReleaseChannelState::load(app.handle())?;
             app.manage(release_channel_state);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,10 +214,18 @@ pub fn run() {
             let (installation_cohort_sender, installation_cohort_state) =
                 services::installation_cohort::installation_cohort_channel();
             app.manage(installation_cohort_state);
+            let current_layout_exists =
+                services::installation_cohort::layout_database_exists(&app_data_dir);
+            let legacy_layout_exists = if app.try_state::<services::e2e_mode::E2eMode>().is_some() {
+                Ok(false)
+            } else {
+                services::app_data_migration::legacy_layout_database_exists(app.handle())
+            };
             let installation_cohort =
                 services::installation_cohort::initialize_installation_cohort(
                     &app_data_dir,
-                    services::app_data_migration::legacy_layout_database_exists(app.handle()),
+                    current_layout_exists,
+                    legacy_layout_exists,
                 )
                 .unwrap_or_else(|error| {
                     log::warn!("Failed to initialize installation cohort: {error}");

--- a/src-tauri/src/services/app_data_migration.rs
+++ b/src-tauri/src/services/app_data_migration.rs
@@ -74,14 +74,12 @@ struct AppDataMigrationSummary {
 /// Copy old app-owned local data before Berd services open files in the new
 /// location. Failures are logged and non-fatal so a single locked/cache file
 /// does not prevent app startup.
-pub(crate) fn legacy_layout_database_exists<R: Runtime>(app: &AppHandle<R>) -> bool {
-    legacy_directory_pairs(app)
-        .ok()
-        .into_iter()
-        .flatten()
-        .any(|pair| {
-            pair.kind == AppDirectoryKind::Data && pair.old.join(OLD_LAYOUT_DATABASE).is_file()
-        })
+pub(crate) fn legacy_layout_database_exists<R: Runtime>(
+    app: &AppHandle<R>,
+) -> Result<bool, String> {
+    Ok(legacy_directory_pairs(app)?.into_iter().any(|pair| {
+        pair.kind == AppDirectoryKind::Data && pair.old.join(OLD_LAYOUT_DATABASE).is_file()
+    }))
 }
 
 pub(crate) fn migrate_legacy_app_data<R: Runtime>(app: &AppHandle<R>) {

--- a/src-tauri/src/services/app_data_migration.rs
+++ b/src-tauri/src/services/app_data_migration.rs
@@ -77,9 +77,11 @@ struct AppDataMigrationSummary {
 pub(crate) fn legacy_layout_database_exists<R: Runtime>(
     app: &AppHandle<R>,
 ) -> Result<bool, String> {
-    Ok(legacy_directory_pairs(app)?.into_iter().any(|pair| {
-        pair.kind == AppDirectoryKind::Data && pair.old.join(OLD_LAYOUT_DATABASE).is_file()
-    }))
+    let pair = legacy_directory_pairs(app)?
+        .into_iter()
+        .find(|pair| pair.kind == AppDirectoryKind::Data)
+        .ok_or_else(|| "Legacy app data directory is unavailable".to_string())?;
+    crate::services::installation_cohort::file_exists(&pair.old.join(OLD_LAYOUT_DATABASE))
 }
 
 pub(crate) fn migrate_legacy_app_data<R: Runtime>(app: &AppHandle<R>) {

--- a/src-tauri/src/services/app_data_migration.rs
+++ b/src-tauri/src/services/app_data_migration.rs
@@ -74,6 +74,16 @@ struct AppDataMigrationSummary {
 /// Copy old app-owned local data before Berd services open files in the new
 /// location. Failures are logged and non-fatal so a single locked/cache file
 /// does not prevent app startup.
+pub(crate) fn legacy_layout_database_exists<R: Runtime>(app: &AppHandle<R>) -> bool {
+    legacy_directory_pairs(app)
+        .ok()
+        .into_iter()
+        .flatten()
+        .any(|pair| {
+            pair.kind == AppDirectoryKind::Data && pair.old.join(OLD_LAYOUT_DATABASE).is_file()
+        })
+}
+
 pub(crate) fn migrate_legacy_app_data<R: Runtime>(app: &AppHandle<R>) {
     if app
         .try_state::<crate::services::e2e_mode::E2eMode>()

--- a/src-tauri/src/services/installation_cohort.rs
+++ b/src-tauri/src/services/installation_cohort.rs
@@ -31,6 +31,18 @@ struct InstallationCohortRecord {
     cohort: InstallationCohort,
 }
 
+pub fn layout_database_exists(app_data_dir: &Path) -> Result<bool, String> {
+    file_exists(&app_data_dir.join(CURRENT_LAYOUT_DATABASE))
+}
+
+pub(crate) fn file_exists(path: &Path) -> Result<bool, String> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!("Failed to inspect {}: {error}", path.display())),
+    }
+}
+
 pub fn installation_cohort_channel() -> (
     watch::Sender<InstallationCohortReadiness>,
     InstallationCohortState,
@@ -41,6 +53,7 @@ pub fn installation_cohort_channel() -> (
 
 pub fn initialize_installation_cohort(
     app_data_dir: &Path,
+    current_layout_exists: Result<bool, String>,
     legacy_layout_exists: Result<bool, String>,
 ) -> Result<InstallationCohort, String> {
     fs::create_dir_all(app_data_dir)
@@ -59,8 +72,9 @@ pub fn initialize_installation_cohort(
         return Ok(record.cohort);
     }
 
+    let current_layout_exists = current_layout_exists?;
     let legacy_layout_exists = legacy_layout_exists?;
-    let cohort = if app_data_dir.join(CURRENT_LAYOUT_DATABASE).is_file() || legacy_layout_exists {
+    let cohort = if current_layout_exists || legacy_layout_exists {
         InstallationCohort::EstablishedBeforeLandingV1
     } else {
         InstallationCohort::FreshWithLandingV1
@@ -87,7 +101,11 @@ fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<Installatio
 
     match temporary.persist_noclobber(path) {
         Ok(_) => {
-            sync_parent_directory(path)?;
+            if let Err(error) = sync_parent_directory(path) {
+                log::warn!(
+                    "Installation cohort marker was published but directory sync failed: {error}"
+                );
+            }
             Ok(cohort)
         }
         Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -134,11 +152,11 @@ mod tests {
     #[test]
     fn classifies_and_persists_a_fresh_installation() {
         let root = tempdir().unwrap();
-        let first = initialize_installation_cohort(root.path(), Ok(false)).unwrap();
+        let first = initialize_installation_cohort(root.path(), Ok(false), Ok(false)).unwrap();
         assert_eq!(first, InstallationCohort::FreshWithLandingV1);
 
         fs::write(root.path().join(CURRENT_LAYOUT_DATABASE), b"later").unwrap();
-        let second = initialize_installation_cohort(root.path(), Ok(false)).unwrap();
+        let second = initialize_installation_cohort(root.path(), Ok(false), Ok(false)).unwrap();
         assert_eq!(second, InstallationCohort::FreshWithLandingV1);
     }
 
@@ -147,13 +165,13 @@ mod tests {
         let current = tempdir().unwrap();
         fs::write(current.path().join(CURRENT_LAYOUT_DATABASE), b"existing").unwrap();
         assert_eq!(
-            initialize_installation_cohort(current.path(), Ok(false)).unwrap(),
+            initialize_installation_cohort(current.path(), Ok(true), Ok(false)).unwrap(),
             InstallationCohort::EstablishedBeforeLandingV1
         );
 
         let legacy = tempdir().unwrap();
         assert_eq!(
-            initialize_installation_cohort(legacy.path(), Ok(true)).unwrap(),
+            initialize_installation_cohort(legacy.path(), Ok(false), Ok(true)).unwrap(),
             InstallationCohort::EstablishedBeforeLandingV1
         );
     }
@@ -170,7 +188,7 @@ mod tests {
             let barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
                 barrier.wait();
-                initialize_installation_cohort(&path, Ok(legacy_exists)).unwrap()
+                initialize_installation_cohort(&path, Ok(false), Ok(legacy_exists)).unwrap()
             })
         });
         barrier.wait();
@@ -179,7 +197,7 @@ mod tests {
         assert_eq!(cohorts[0], InstallationCohort::FreshWithLandingV1);
         assert_eq!(cohorts[1], cohorts[0]);
         assert_eq!(
-            initialize_installation_cohort(&path, Ok(false)).unwrap(),
+            initialize_installation_cohort(&path, Ok(false), Ok(false)).unwrap(),
             cohorts[0]
         );
     }
@@ -187,7 +205,12 @@ mod tests {
     #[test]
     fn detection_failure_does_not_publish_a_fresh_marker() {
         let root = tempdir().unwrap();
-        assert!(initialize_installation_cohort(root.path(), Err("unavailable".into())).is_err());
+        assert!(initialize_installation_cohort(
+            root.path(),
+            Err("metadata unavailable".into()),
+            Ok(false),
+        )
+        .is_err());
         assert!(!root.path().join(MARKER_FILE_NAME).exists());
     }
 
@@ -202,7 +225,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            initialize_installation_cohort(root.path(), Ok(false)).unwrap(),
+            initialize_installation_cohort(root.path(), Ok(false), Ok(false)).unwrap(),
             InstallationCohort::Unknown
         );
         assert!(String::from_utf8(fs::read(marker).unwrap())

--- a/src-tauri/src/services/installation_cohort.rs
+++ b/src-tauri/src/services/installation_cohort.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tokio::sync::watch;
 
 const MARKER_FILE_NAME: &str = "installation-cohort-v1.json";
@@ -65,32 +65,50 @@ pub fn initialize_installation_cohort(
     } else {
         InstallationCohort::FreshWithLandingV1
     };
-    persist_marker(&marker_path, cohort)?;
-    Ok(cohort)
+    persist_marker(&marker_path, cohort)
 }
 
-fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<(), String> {
+fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<InstallationCohort, String> {
     let record = InstallationCohortRecord {
         version: MARKER_VERSION,
         cohort,
     };
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Installation cohort marker has no parent directory".to_string())?;
     let bytes = serde_json::to_vec(&record)
         .map_err(|error| format!("Failed to serialize installation cohort marker: {error}"))?;
-    let part_path = part_path(path);
-    let result = (|| {
-        let mut file = fs::File::create(&part_path)
-            .map_err(|error| format!("Failed to create installation cohort marker: {error}"))?;
-        file.write_all(&bytes)
-            .and_then(|_| file.sync_all())
-            .map_err(|error| format!("Failed to write installation cohort marker: {error}"))?;
-        fs::rename(&part_path, path)
-            .map_err(|error| format!("Failed to publish installation cohort marker: {error}"))?;
-        sync_parent_directory(path)
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&part_path);
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|error| format!("Failed to create installation cohort marker: {error}"))?;
+    temporary
+        .write_all(&bytes)
+        .and_then(|_| temporary.as_file().sync_all())
+        .map_err(|error| format!("Failed to write installation cohort marker: {error}"))?;
+
+    match temporary.persist_noclobber(path) {
+        Ok(_) => {
+            sync_parent_directory(path)?;
+            Ok(cohort)
+        }
+        Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+            read_published_cohort(path)
+        }
+        Err(error) => Err(format!(
+            "Failed to publish installation cohort marker: {}",
+            error.error
+        )),
     }
-    result
+}
+
+fn read_published_cohort(path: &Path) -> Result<InstallationCohort, String> {
+    let bytes = fs::read(path)
+        .map_err(|error| format!("Failed to read published installation cohort marker: {error}"))?;
+    let record: InstallationCohortRecord = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("Invalid published installation cohort marker: {error}"))?;
+    if record.version != MARKER_VERSION || record.cohort == InstallationCohort::Unknown {
+        return Err("Published installation cohort marker is unsupported".to_string());
+    }
+    Ok(record.cohort)
 }
 
 #[cfg(unix)]
@@ -106,10 +124,6 @@ fn sync_parent_directory(path: &Path) -> Result<(), String> {
 #[cfg(not(unix))]
 fn sync_parent_directory(_path: &Path) -> Result<(), String> {
     Ok(())
-}
-
-fn part_path(path: &Path) -> PathBuf {
-    path.with_extension("json.part")
 }
 
 #[cfg(test)]
@@ -141,6 +155,32 @@ mod tests {
         assert_eq!(
             initialize_installation_cohort(legacy.path(), Ok(true)).unwrap(),
             InstallationCohort::EstablishedBeforeLandingV1
+        );
+    }
+
+    #[test]
+    fn concurrent_initializers_use_the_published_winner() {
+        use std::sync::{Arc, Barrier};
+
+        let root = tempdir().unwrap();
+        let path = Arc::new(root.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(3));
+        let handles = [false, false].map(|legacy_exists| {
+            let path = Arc::clone(&path);
+            let barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                barrier.wait();
+                initialize_installation_cohort(&path, Ok(legacy_exists)).unwrap()
+            })
+        });
+        barrier.wait();
+
+        let cohorts = handles.map(|handle| handle.join().unwrap());
+        assert_eq!(cohorts[0], InstallationCohort::FreshWithLandingV1);
+        assert_eq!(cohorts[1], cohorts[0]);
+        assert_eq!(
+            initialize_installation_cohort(&path, Ok(false)).unwrap(),
+            cohorts[0]
         );
     }
 

--- a/src-tauri/src/services/installation_cohort.rs
+++ b/src-tauri/src/services/installation_cohort.rs
@@ -1,0 +1,136 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const MARKER_FILE_NAME: &str = "installation-cohort-v1.json";
+const MARKER_VERSION: u32 = 1;
+const CURRENT_LAYOUT_DATABASE: &str = "berd.sqlite";
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InstallationCohort {
+    FreshWithLandingV1,
+    EstablishedBeforeLandingV1,
+}
+
+#[derive(Clone, Debug)]
+pub struct InstallationCohortState(pub InstallationCohort);
+
+#[derive(Deserialize, Serialize)]
+struct InstallationCohortRecord {
+    version: u32,
+    cohort: InstallationCohort,
+}
+
+pub fn initialize_installation_cohort(
+    app_data_dir: &Path,
+    legacy_layout_exists: bool,
+) -> Result<InstallationCohortState, String> {
+    fs::create_dir_all(app_data_dir)
+        .map_err(|error| format!("Failed to create app data directory: {error}"))?;
+    let marker_path = app_data_dir.join(MARKER_FILE_NAME);
+
+    if marker_path.exists() {
+        let bytes = fs::read(&marker_path)
+            .map_err(|error| format!("Failed to read installation cohort marker: {error}"))?;
+        let Ok(record) = serde_json::from_slice::<InstallationCohortRecord>(&bytes) else {
+            return Ok(InstallationCohortState(
+                InstallationCohort::EstablishedBeforeLandingV1,
+            ));
+        };
+        if record.version != MARKER_VERSION {
+            return Ok(InstallationCohortState(
+                InstallationCohort::EstablishedBeforeLandingV1,
+            ));
+        }
+        return Ok(InstallationCohortState(record.cohort));
+    }
+
+    let cohort = if app_data_dir.join(CURRENT_LAYOUT_DATABASE).is_file() || legacy_layout_exists {
+        InstallationCohort::EstablishedBeforeLandingV1
+    } else {
+        InstallationCohort::FreshWithLandingV1
+    };
+    persist_marker(&marker_path, cohort)?;
+    Ok(InstallationCohortState(cohort))
+}
+
+fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<(), String> {
+    let record = InstallationCohortRecord {
+        version: MARKER_VERSION,
+        cohort,
+    };
+    let bytes = serde_json::to_vec(&record)
+        .map_err(|error| format!("Failed to serialize installation cohort marker: {error}"))?;
+    let part_path = part_path(path);
+    let mut file = fs::File::create(&part_path)
+        .map_err(|error| format!("Failed to create installation cohort marker: {error}"))?;
+    file.write_all(&bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| format!("Failed to write installation cohort marker: {error}"))?;
+    fs::rename(&part_path, path)
+        .map_err(|error| format!("Failed to publish installation cohort marker: {error}"))
+}
+
+fn part_path(path: &Path) -> PathBuf {
+    path.with_extension("json.part")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn classifies_and_persists_a_fresh_installation() {
+        let root = tempdir().unwrap();
+        let first = initialize_installation_cohort(root.path(), false).unwrap();
+        assert_eq!(first.0, InstallationCohort::FreshWithLandingV1);
+
+        fs::write(root.path().join(CURRENT_LAYOUT_DATABASE), b"later").unwrap();
+        let second = initialize_installation_cohort(root.path(), false).unwrap();
+        assert_eq!(second.0, InstallationCohort::FreshWithLandingV1);
+    }
+
+    #[test]
+    fn classifies_current_or_legacy_layouts_as_established() {
+        let current = tempdir().unwrap();
+        fs::write(current.path().join(CURRENT_LAYOUT_DATABASE), b"existing").unwrap();
+        assert_eq!(
+            initialize_installation_cohort(current.path(), false)
+                .unwrap()
+                .0,
+            InstallationCohort::EstablishedBeforeLandingV1
+        );
+
+        let legacy = tempdir().unwrap();
+        assert_eq!(
+            initialize_installation_cohort(legacy.path(), true)
+                .unwrap()
+                .0,
+            InstallationCohort::EstablishedBeforeLandingV1
+        );
+    }
+
+    #[test]
+    fn treats_an_unsupported_marker_as_established_and_preserves_it() {
+        let root = tempdir().unwrap();
+        let marker = root.path().join(MARKER_FILE_NAME);
+        fs::write(
+            &marker,
+            br#"{"version":2,"cohort":"fresh-with-landing-v1"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            initialize_installation_cohort(root.path(), false)
+                .unwrap()
+                .0,
+            InstallationCohort::EstablishedBeforeLandingV1
+        );
+        assert!(String::from_utf8(fs::read(marker).unwrap())
+            .unwrap()
+            .contains("\"version\":2"));
+    }
+}

--- a/src-tauri/src/services/installation_cohort.rs
+++ b/src-tauri/src/services/installation_cohort.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use tokio::sync::watch;
 
 const MARKER_FILE_NAME: &str = "installation-cohort-v1.json";
 const MARKER_VERSION: u32 = 1;
@@ -12,10 +13,17 @@ const CURRENT_LAYOUT_DATABASE: &str = "berd.sqlite";
 pub enum InstallationCohort {
     FreshWithLandingV1,
     EstablishedBeforeLandingV1,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallationCohortReadiness {
+    Initializing,
+    Ready(InstallationCohort),
 }
 
 #[derive(Clone, Debug)]
-pub struct InstallationCohortState(pub InstallationCohort);
+pub struct InstallationCohortState(pub watch::Receiver<InstallationCohortReadiness>);
 
 #[derive(Deserialize, Serialize)]
 struct InstallationCohortRecord {
@@ -23,10 +31,18 @@ struct InstallationCohortRecord {
     cohort: InstallationCohort,
 }
 
+pub fn installation_cohort_channel() -> (
+    watch::Sender<InstallationCohortReadiness>,
+    InstallationCohortState,
+) {
+    let (sender, receiver) = watch::channel(InstallationCohortReadiness::Initializing);
+    (sender, InstallationCohortState(receiver))
+}
+
 pub fn initialize_installation_cohort(
     app_data_dir: &Path,
-    legacy_layout_exists: bool,
-) -> Result<InstallationCohortState, String> {
+    legacy_layout_exists: Result<bool, String>,
+) -> Result<InstallationCohort, String> {
     fs::create_dir_all(app_data_dir)
         .map_err(|error| format!("Failed to create app data directory: {error}"))?;
     let marker_path = app_data_dir.join(MARKER_FILE_NAME);
@@ -35,25 +51,22 @@ pub fn initialize_installation_cohort(
         let bytes = fs::read(&marker_path)
             .map_err(|error| format!("Failed to read installation cohort marker: {error}"))?;
         let Ok(record) = serde_json::from_slice::<InstallationCohortRecord>(&bytes) else {
-            return Ok(InstallationCohortState(
-                InstallationCohort::EstablishedBeforeLandingV1,
-            ));
+            return Ok(InstallationCohort::Unknown);
         };
-        if record.version != MARKER_VERSION {
-            return Ok(InstallationCohortState(
-                InstallationCohort::EstablishedBeforeLandingV1,
-            ));
+        if record.version != MARKER_VERSION || record.cohort == InstallationCohort::Unknown {
+            return Ok(InstallationCohort::Unknown);
         }
-        return Ok(InstallationCohortState(record.cohort));
+        return Ok(record.cohort);
     }
 
+    let legacy_layout_exists = legacy_layout_exists?;
     let cohort = if app_data_dir.join(CURRENT_LAYOUT_DATABASE).is_file() || legacy_layout_exists {
         InstallationCohort::EstablishedBeforeLandingV1
     } else {
         InstallationCohort::FreshWithLandingV1
     };
     persist_marker(&marker_path, cohort)?;
-    Ok(InstallationCohortState(cohort))
+    Ok(cohort)
 }
 
 fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<(), String> {
@@ -64,13 +77,35 @@ fn persist_marker(path: &Path, cohort: InstallationCohort) -> Result<(), String>
     let bytes = serde_json::to_vec(&record)
         .map_err(|error| format!("Failed to serialize installation cohort marker: {error}"))?;
     let part_path = part_path(path);
-    let mut file = fs::File::create(&part_path)
-        .map_err(|error| format!("Failed to create installation cohort marker: {error}"))?;
-    file.write_all(&bytes)
-        .and_then(|_| file.sync_all())
-        .map_err(|error| format!("Failed to write installation cohort marker: {error}"))?;
-    fs::rename(&part_path, path)
-        .map_err(|error| format!("Failed to publish installation cohort marker: {error}"))
+    let result = (|| {
+        let mut file = fs::File::create(&part_path)
+            .map_err(|error| format!("Failed to create installation cohort marker: {error}"))?;
+        file.write_all(&bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|error| format!("Failed to write installation cohort marker: {error}"))?;
+        fs::rename(&part_path, path)
+            .map_err(|error| format!("Failed to publish installation cohort marker: {error}"))?;
+        sync_parent_directory(path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&part_path);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Installation cohort marker has no parent directory".to_string())?;
+    fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| format!("Failed to sync installation cohort directory: {error}"))
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<(), String> {
+    Ok(())
 }
 
 fn part_path(path: &Path) -> PathBuf {
@@ -85,12 +120,12 @@ mod tests {
     #[test]
     fn classifies_and_persists_a_fresh_installation() {
         let root = tempdir().unwrap();
-        let first = initialize_installation_cohort(root.path(), false).unwrap();
-        assert_eq!(first.0, InstallationCohort::FreshWithLandingV1);
+        let first = initialize_installation_cohort(root.path(), Ok(false)).unwrap();
+        assert_eq!(first, InstallationCohort::FreshWithLandingV1);
 
         fs::write(root.path().join(CURRENT_LAYOUT_DATABASE), b"later").unwrap();
-        let second = initialize_installation_cohort(root.path(), false).unwrap();
-        assert_eq!(second.0, InstallationCohort::FreshWithLandingV1);
+        let second = initialize_installation_cohort(root.path(), Ok(false)).unwrap();
+        assert_eq!(second, InstallationCohort::FreshWithLandingV1);
     }
 
     #[test]
@@ -98,23 +133,26 @@ mod tests {
         let current = tempdir().unwrap();
         fs::write(current.path().join(CURRENT_LAYOUT_DATABASE), b"existing").unwrap();
         assert_eq!(
-            initialize_installation_cohort(current.path(), false)
-                .unwrap()
-                .0,
+            initialize_installation_cohort(current.path(), Ok(false)).unwrap(),
             InstallationCohort::EstablishedBeforeLandingV1
         );
 
         let legacy = tempdir().unwrap();
         assert_eq!(
-            initialize_installation_cohort(legacy.path(), true)
-                .unwrap()
-                .0,
+            initialize_installation_cohort(legacy.path(), Ok(true)).unwrap(),
             InstallationCohort::EstablishedBeforeLandingV1
         );
     }
 
     #[test]
-    fn treats_an_unsupported_marker_as_established_and_preserves_it() {
+    fn detection_failure_does_not_publish_a_fresh_marker() {
+        let root = tempdir().unwrap();
+        assert!(initialize_installation_cohort(root.path(), Err("unavailable".into())).is_err());
+        assert!(!root.path().join(MARKER_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn treats_an_unsupported_marker_as_unknown_and_preserves_it() {
         let root = tempdir().unwrap();
         let marker = root.path().join(MARKER_FILE_NAME);
         fs::write(
@@ -124,10 +162,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            initialize_installation_cohort(root.path(), false)
-                .unwrap()
-                .0,
-            InstallationCohort::EstablishedBeforeLandingV1
+            initialize_installation_cohort(root.path(), Ok(false)).unwrap(),
+            InstallationCohort::Unknown
         );
         assert!(String::from_utf8(fs::read(marker).unwrap())
             .unwrap()

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -12,6 +12,7 @@ pub mod distro_bundle;
 pub(crate) mod e2e_mode;
 pub(crate) mod env_key;
 pub(crate) mod goose_config;
+pub(crate) mod installation_cohort;
 #[cfg(target_os = "macos")]
 pub(crate) mod installer_media;
 #[cfg_attr(

--- a/src/app/AppShell.berdctl.test.tsx
+++ b/src/app/AppShell.berdctl.test.tsx
@@ -11,6 +11,7 @@ import { gooseServeSelectionFromExecutionTarget } from "@/features/chat/lib/goos
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
+import { dispatchOnboarding } from "@/features/onboarding/model";
 import { useShortcutsDialogStore } from "@/features/shortcuts/stores/shortcutsDialogStore";
 import { useRuntimeConfigStore } from "@/shared/runtime-config/runtimeConfigStore";
 import { useDefaultProviderReadinessStore } from "@/features/providers/stores/defaultProviderReadinessStore";
@@ -253,6 +254,7 @@ describe("AppShell berdctl integration", () => {
     vi.stubEnv("VITE_AUTOMATIONS", "1");
     window.history.replaceState(null, "", "/");
     window.localStorage.clear();
+    dispatchOnboarding({ type: "complete" });
     useShortcutsDialogStore.setState({ open: false });
     mockAcpCreateSession.mockReset();
     mockAcpCreateSession.mockResolvedValue({ sessionId: "created-session" });

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -29,6 +29,7 @@ import { OPEN_SETTINGS_EVENT } from "@/features/settings/lib/settingsEvents";
 import { SHORTCUT_PREFERENCES_STORAGE_KEY } from "@/features/shortcuts/lib/shortcutRegistry";
 import { useShortcutsDialogStore } from "@/features/shortcuts/stores/shortcutsDialogStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
+import { dispatchOnboarding } from "@/features/onboarding/model";
 import {
   resetHomeWidgetStoreForTests,
   useHomeWidgetStore,
@@ -893,6 +894,7 @@ describe("AppShell global navigation", () => {
   afterEach(cleanup);
 
   beforeEach(() => {
+    dispatchOnboarding({ type: "complete" });
     resetHomeWidgetStoreForTests();
     resetStarterWidgetPickerRequestForTests();
     mockRepairManagedGooseModelSelection.mockReset();

--- a/src/app/AppShell.startupDiagnostics.test.tsx
+++ b/src/app/AppShell.startupDiagnostics.test.tsx
@@ -6,6 +6,7 @@ import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
+import { dispatchOnboarding } from "@/features/onboarding/model";
 import { AppShell } from "./AppShell";
 
 const mocks = vi.hoisted(() => ({
@@ -117,6 +118,7 @@ describe("AppShell startup diagnostics", () => {
     vi.clearAllMocks();
     window.history.replaceState(null, "", "/");
     window.localStorage.clear();
+    dispatchOnboarding({ type: "complete" });
     mocks.startupState.ready = true;
     mocks.startupState.error = null;
     mocks.migrationState.status = "ready";

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -218,7 +218,6 @@ import {
   isSystemNotification,
 } from "@/shared/types/messages";
 import { isDesignSystemExplorerEnabled } from "@/features/design-system/lib/designSystemEnabled";
-import { FIRST_RUN_ONBOARDING_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import { useExperiment } from "@/features/experiments/experimentPreferences";
 import { OnboardingFlow } from "@/features/onboarding/ui/OnboardingFlow";
 import { useOnboardingState } from "@/features/onboarding/model";
@@ -770,9 +769,6 @@ export function AppShell({
   const [agentsPersonaId, setAgentsPersonaId] = useState<string | null>(null);
   const [globalComposerFocusRequest, setGlobalComposerFocusRequest] =
     useState(0);
-  const onboardingExperiment = useExperiment(
-    FIRST_RUN_ONBOARDING_EXPERIMENT_ID,
-  );
   const onboardingState = useOnboardingState();
   const omittedStarterTaskIds = useMemo<ReadonlySet<StarterTaskId>>(
     () =>
@@ -4924,10 +4920,7 @@ export function AppShell({
     );
   }
 
-  const shouldShowOnboarding =
-    onboardingExperiment?.enabled === true &&
-    onboardingState.lifecycle !== "completed";
-  if (shouldShowOnboarding) {
+  if (onboardingState.lifecycle !== "completed") {
     return <OnboardingFlow />;
   }
 

--- a/src/features/experiments/ExperimentsSettings.tsx
+++ b/src/features/experiments/ExperimentsSettings.tsx
@@ -5,7 +5,6 @@ import { toast } from "sonner";
 import {
   BERDY_ONBOARDING_EXPERIMENT_ID,
   EXPERIMENT_DEFINITIONS,
-  HIDDEN_EXPERIMENT_IDS,
   type ExperimentDefinition,
 } from "./experimentDefinitions";
 import { ExperimentConfigControls } from "./ExperimentConfigControls";
@@ -62,8 +61,7 @@ export function ExperimentsSettings({
     () =>
       getVisibleExperimentRegistry(registry).filter(
         (definition) =>
-          !HIDDEN_EXPERIMENT_IDS.has(definition.id) &&
-          (definition.settingsVisibility !== "dev" || import.meta.env.DEV),
+          definition.settingsVisibility !== "dev" || import.meta.env.DEV,
       ),
     [registry],
   );

--- a/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
+++ b/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
@@ -7,7 +7,6 @@ import {
   BERDY_ONBOARDING_EXPERIMENT_ID,
   BUILDERBOT_SURFACE_EXPERIMENT_ID,
   EXPERIMENT_DEFINITIONS,
-  FIRST_RUN_ONBOARDING_EXPERIMENT_ID,
   SKILL_DISCOVERY_EXPERIMENT_ID,
   STARTER_TASKS_EXPERIMENT_ID,
   TRANSCRIPT_VIRTUAL_RENDERER_EXPERIMENT_ID,
@@ -137,7 +136,6 @@ describe("ExperimentsSettings", () => {
       VOICE_CONVERSATION_EXPERIMENT_ID,
       AVATAR_COLLECTION_PAGE_EXPERIMENT_ID,
       BERDY_ONBOARDING_EXPERIMENT_ID,
-      FIRST_RUN_ONBOARDING_EXPERIMENT_ID,
     ]);
   });
 
@@ -193,11 +191,6 @@ describe("ExperimentsSettings", () => {
       ),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(
-        i18n.t("experiments.firstRunOnboarding.title", { ns: "settings" }),
-      ),
-    ).not.toBeInTheDocument();
-    expect(
       screen.queryByRole("region", {
         name: i18n.t("experiments.onboarding.title", { ns: "settings" }),
       }),
@@ -220,22 +213,6 @@ describe("ExperimentsSettings", () => {
         name: i18n.t("experiments.onboarding.confirm", { ns: "settings" }),
       }),
     );
-  });
-
-  it("keeps first-run onboarding registered but hidden from settings", () => {
-    vi.stubEnv("DEV", true);
-    window.localStorage.setItem(
-      EXPERIMENT_PREFERENCES_STORAGE_KEY,
-      JSON.stringify({
-        version: 2,
-        experiments: {
-          [FIRST_RUN_ONBOARDING_EXPERIMENT_ID]: { enabled: true },
-        },
-      }),
-    );
-    renderWithProviders(<ExperimentsSettings />);
-
-    expect(screen.queryByText("First-run onboarding")).not.toBeInTheDocument();
   });
 
   it("resets Berdy onboarding from its experiment card", async () => {

--- a/src/features/experiments/experimentDefinitions.ts
+++ b/src/features/experiments/experimentDefinitions.ts
@@ -63,12 +63,6 @@ export const BERDY_ONBOARDING_EXPERIMENT_ID = "berdy-onboarding";
 
 export const SKILL_DISCOVERY_EXPERIMENT_ID = "skill-discovery";
 
-export const FIRST_RUN_ONBOARDING_EXPERIMENT_ID = "first-run-onboarding";
-
-export const HIDDEN_EXPERIMENT_IDS = new Set<string>([
-  FIRST_RUN_ONBOARDING_EXPERIMENT_ID,
-]);
-
 export const EXPERIMENT_DEFINITIONS = [
   {
     id: BUILDERBOT_SURFACE_EXPERIMENT_ID,
@@ -115,14 +109,6 @@ export const EXPERIMENT_DEFINITIONS = [
     id: BERDY_ONBOARDING_EXPERIMENT_ID,
     titleKey: "experiments.berdyOnboarding.title",
     descriptionKey: "experiments.berdyOnboarding.description",
-    settingsVisibility: "dev",
-  },
-  {
-    id: FIRST_RUN_ONBOARDING_EXPERIMENT_ID,
-    titleKey: "experiments.firstRunOnboarding.title",
-    descriptionKey: "experiments.firstRunOnboarding.description",
-    defaultEnabled: false,
-    manualEnableOnly: true,
     settingsVisibility: "dev",
   },
 ] as const satisfies readonly ExperimentDefinition[];

--- a/src/features/feedback/FeedbackDialog.test.tsx
+++ b/src/features/feedback/FeedbackDialog.test.tsx
@@ -54,6 +54,7 @@ vi.mock("@/shared/api/feedback", async (importOriginal) => {
 describe("FeedbackDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
     mockGetVersion.mockResolvedValue("0.1.0-test");
     mockOpenDialog.mockResolvedValue(null);
     mockInspectAttachmentPaths.mockResolvedValue([]);

--- a/src/features/feedback/submitFeedbackReport.test.ts
+++ b/src/features/feedback/submitFeedbackReport.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/shared/telemetry/client", () => ({
 describe("submitFeedbackReport", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
     mockGetVersion.mockResolvedValue("1.2.3");
     vi.mocked(submitFeedbackIssue).mockResolvedValue({
       issueUrl: "https://linear.test/BOT-1",

--- a/src/features/feedback/submitFeedbackReport.ts
+++ b/src/features/feedback/submitFeedbackReport.ts
@@ -6,6 +6,7 @@ import {
 } from "@/shared/api/feedback";
 import { getPlatform } from "@/shared/lib/platform";
 import { trackFeedbackSubmitted } from "@/shared/telemetry/client";
+import { getTelemetryConsent } from "@/shared/telemetry/consentPreference";
 
 export interface SubmitFeedbackReportInput {
   title: string;
@@ -58,7 +59,9 @@ export async function submitFeedbackReport(
     doctorReport,
     labelIds: input.labelIds,
   });
-  trackFeedbackSubmitted();
+  if (getTelemetryConsent() === true) {
+    trackFeedbackSubmitted();
+  }
   return result;
 }
 

--- a/src/features/onboarding/api/installationCohort.test.ts
+++ b/src/features/onboarding/api/installationCohort.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  getInstallationCohort,
+  INSTALLATION_COHORT_TIMEOUT_MS,
+} from "./installationCohort";
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+describe("getInstallationCohort", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("rejects a stalled lookup after the deadline", async () => {
+    vi.useFakeTimers();
+    vi.mocked(invoke).mockReturnValue(new Promise(() => {}));
+    const result = expect(getInstallationCohort()).rejects.toThrow("timed out");
+
+    await vi.advanceTimersByTimeAsync(INSTALLATION_COHORT_TIMEOUT_MS);
+
+    await result;
+  });
+});

--- a/src/features/onboarding/api/installationCohort.ts
+++ b/src/features/onboarding/api/installationCohort.ts
@@ -1,0 +1,6 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { InstallationCohort } from "@/features/onboarding/model";
+
+export function getInstallationCohort(): Promise<InstallationCohort> {
+  return invoke<InstallationCohort>("get_installation_cohort");
+}

--- a/src/features/onboarding/api/installationCohort.ts
+++ b/src/features/onboarding/api/installationCohort.ts
@@ -1,6 +1,23 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { InstallationCohort } from "@/features/onboarding/model";
 
+export const INSTALLATION_COHORT_TIMEOUT_MS = 5_000;
+
 export function getInstallationCohort(): Promise<InstallationCohort> {
-  return invoke<InstallationCohort>("get_installation_cohort");
+  return new Promise((resolve, reject) => {
+    const timeout = window.setTimeout(
+      () => reject(new Error("Installation cohort lookup timed out")),
+      INSTALLATION_COHORT_TIMEOUT_MS,
+    );
+    void invoke<InstallationCohort>("get_installation_cohort").then(
+      (cohort) => {
+        window.clearTimeout(timeout);
+        resolve(cohort);
+      },
+      (error) => {
+        window.clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
 }

--- a/src/features/onboarding/model/onboardingStore.test.ts
+++ b/src/features/onboarding/model/onboardingStore.test.ts
@@ -9,11 +9,13 @@ import {
   replayOnboarding,
   resetOnboarding,
   resetOnboardingStoreForTests,
+  setOnboardingStorageForTests,
   subscribeToOnboarding,
 } from "./onboardingStore";
 
 describe("onboarding persistence", () => {
   beforeEach(() => {
+    setOnboardingStorageForTests(undefined);
     window.localStorage.clear();
     resetOnboardingStoreForTests();
   });
@@ -33,6 +35,29 @@ describe("onboarding persistence", () => {
       lifecycle: "completed",
       step: "complete",
     });
+  });
+
+  it("graduates established installations when storage is unavailable or fails", () => {
+    setOnboardingStorageForTests(null);
+    initializeOnboardingGraduation("established-before-landing-v1");
+    expect(getOnboardingSnapshot().lifecycle).toBe("completed");
+
+    setOnboardingStorageForTests({
+      getItem: () => {
+        throw new Error("unavailable");
+      },
+    } as unknown as Storage);
+    initializeOnboardingGraduation("established-before-landing-v1");
+    expect(getOnboardingSnapshot().lifecycle).toBe("completed");
+
+    setOnboardingStorageForTests({
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("full");
+      },
+    } as unknown as Storage);
+    initializeOnboardingGraduation("established-before-landing-v1");
+    expect(getOnboardingSnapshot().lifecycle).toBe("completed");
   });
 
   it("graduates malformed current state but preserves a newer record", () => {

--- a/src/features/onboarding/model/onboardingStore.test.ts
+++ b/src/features/onboarding/model/onboardingStore.test.ts
@@ -4,7 +4,6 @@ import {
   dispatchOnboarding,
   getOnboardingSnapshot,
   initializeOnboardingGraduation,
-  ONBOARDING_GRADUATION_STORAGE_KEY,
   ONBOARDING_STORAGE_KEY,
   ONBOARDING_STORAGE_VERSION,
   replayOnboarding,
@@ -20,19 +19,14 @@ describe("onboarding persistence", () => {
   });
 
   it("keeps onboarding pending for a fresh installation", () => {
-    initializeOnboardingGraduation();
+    initializeOnboardingGraduation("fresh-with-landing-v1");
     resetOnboardingStoreForTests();
 
     expect(getOnboardingSnapshot()).toEqual(INITIAL_ONBOARDING_STATE);
-    expect(window.localStorage.getItem(ONBOARDING_GRADUATION_STORAGE_KEY)).toBe(
-      "1",
-    );
   });
 
   it("marks an established installation complete during graduation", () => {
-    window.localStorage.setItem("goose-theme-mode", "dark");
-
-    initializeOnboardingGraduation();
+    initializeOnboardingGraduation("established-before-landing-v1");
     resetOnboardingStoreForTests();
 
     expect(getOnboardingSnapshot()).toMatchObject({
@@ -44,7 +38,7 @@ describe("onboarding persistence", () => {
   it("preserves existing onboarding progress during graduation", () => {
     dispatchOnboarding({ type: "start" });
 
-    initializeOnboardingGraduation();
+    initializeOnboardingGraduation("fresh-with-landing-v1");
     resetOnboardingStoreForTests();
 
     expect(getOnboardingSnapshot()).toMatchObject({

--- a/src/features/onboarding/model/onboardingStore.test.ts
+++ b/src/features/onboarding/model/onboardingStore.test.ts
@@ -3,6 +3,8 @@ import { INITIAL_ONBOARDING_STATE } from "./onboardingState";
 import {
   dispatchOnboarding,
   getOnboardingSnapshot,
+  initializeOnboardingGraduation,
+  ONBOARDING_GRADUATION_STORAGE_KEY,
   ONBOARDING_STORAGE_KEY,
   ONBOARDING_STORAGE_VERSION,
   replayOnboarding,
@@ -15,6 +17,40 @@ describe("onboarding persistence", () => {
   beforeEach(() => {
     window.localStorage.clear();
     resetOnboardingStoreForTests();
+  });
+
+  it("keeps onboarding pending for a fresh installation", () => {
+    initializeOnboardingGraduation();
+    resetOnboardingStoreForTests();
+
+    expect(getOnboardingSnapshot()).toEqual(INITIAL_ONBOARDING_STATE);
+    expect(window.localStorage.getItem(ONBOARDING_GRADUATION_STORAGE_KEY)).toBe(
+      "1",
+    );
+  });
+
+  it("marks an established installation complete during graduation", () => {
+    window.localStorage.setItem("goose-theme-mode", "dark");
+
+    initializeOnboardingGraduation();
+    resetOnboardingStoreForTests();
+
+    expect(getOnboardingSnapshot()).toMatchObject({
+      lifecycle: "completed",
+      step: "complete",
+    });
+  });
+
+  it("preserves existing onboarding progress during graduation", () => {
+    dispatchOnboarding({ type: "start" });
+
+    initializeOnboardingGraduation();
+    resetOnboardingStoreForTests();
+
+    expect(getOnboardingSnapshot()).toMatchObject({
+      lifecycle: "in-progress",
+      step: "welcome",
+    });
   });
 
   it("persists versioned state and hydrates it on a new lifecycle", () => {

--- a/src/features/onboarding/model/onboardingStore.test.ts
+++ b/src/features/onboarding/model/onboardingStore.test.ts
@@ -35,6 +35,29 @@ describe("onboarding persistence", () => {
     });
   });
 
+  it("graduates malformed current state but preserves a newer record", () => {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, "not json");
+    initializeOnboardingGraduation("established-before-landing-v1");
+    resetOnboardingStoreForTests();
+    expect(getOnboardingSnapshot().lifecycle).toBe("completed");
+
+    const newerRecord = JSON.stringify({
+      version: ONBOARDING_STORAGE_VERSION + 1,
+      state: { future: true },
+    });
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, newerRecord);
+    initializeOnboardingGraduation("established-before-landing-v1");
+    expect(window.localStorage.getItem(ONBOARDING_STORAGE_KEY)).toBe(
+      newerRecord,
+    );
+  });
+
+  it("does not graduate when the cohort is unknown", () => {
+    initializeOnboardingGraduation("unknown");
+    resetOnboardingStoreForTests();
+    expect(getOnboardingSnapshot()).toEqual(INITIAL_ONBOARDING_STATE);
+  });
+
   it("preserves existing onboarding progress during graduation", () => {
     dispatchOnboarding({ type: "start" });
 

--- a/src/features/onboarding/model/onboardingStore.ts
+++ b/src/features/onboarding/model/onboardingStore.ts
@@ -16,7 +16,10 @@ import {
 
 export const ONBOARDING_STORAGE_VERSION = 1;
 export const ONBOARDING_STORAGE_KEY = "berd:onboarding:v1";
-export const ONBOARDING_GRADUATION_STORAGE_KEY = "berd:onboarding:graduated-v1";
+
+export type InstallationCohort =
+  | "fresh-with-landing-v1"
+  | "established-before-landing-v1";
 
 interface PersistedOnboardingState {
   version: typeof ONBOARDING_STORAGE_VERSION;
@@ -43,21 +46,18 @@ function storage(): Storage | null {
   }
 }
 
-/**
- * Graduates first-run onboarding without sending established installations
- * through a newly enabled flow. A blank storage area represents a fresh app
- * profile; any pre-existing app state means Berd has run before.
- */
-export function initializeOnboardingGraduation(): void {
+/** Preserve authored onboarding state while graduating established installs. */
+export function initializeOnboardingGraduation(
+  cohort: InstallationCohort,
+): void {
   const target = storage();
-  if (!target || target.getItem(ONBOARDING_GRADUATION_STORAGE_KEY) !== null) {
-    return;
-  }
+  if (!target) return;
 
   try {
-    const hasOnboardingState = target.getItem(ONBOARDING_STORAGE_KEY) !== null;
-    const hasExistingAppState = target.length > 0;
-    if (!hasOnboardingState && hasExistingAppState) {
+    if (
+      target.getItem(ONBOARDING_STORAGE_KEY) === null &&
+      cohort === "established-before-landing-v1"
+    ) {
       const completedState: OnboardingState = {
         ...INITIAL_ONBOARDING_STATE,
         lifecycle: "completed",
@@ -71,7 +71,6 @@ export function initializeOnboardingGraduation(): void {
         } satisfies PersistedOnboardingState),
       );
     }
-    target.setItem(ONBOARDING_GRADUATION_STORAGE_KEY, "1");
   } catch {
     // Onboarding remains usable if localStorage is unavailable or full.
   }

--- a/src/features/onboarding/model/onboardingStore.ts
+++ b/src/features/onboarding/model/onboardingStore.ts
@@ -34,12 +34,14 @@ let storageListening = false;
 let snapshot: OnboardingState = { ...INITIAL_ONBOARDING_STATE };
 let hydrated = false;
 let hasUnsupportedNewerRecord = false;
+let storageOverrideForTests: Storage | null | undefined;
 
 const workTypeIds = new Set<string>(WORK_TYPE_IDS);
 const agentIds = new Set(RECOMMENDED_AGENTS.map((agent) => agent.id));
 const harnessIds = new Set<string>(CURATED_HARNESS_IDS);
 
 function storage(): Storage | null {
+  if (storageOverrideForTests !== undefined) return storageOverrideForTests;
   try {
     return typeof window === "undefined" ? null : window.localStorage;
   } catch {
@@ -51,8 +53,20 @@ function storage(): Storage | null {
 export function initializeOnboardingGraduation(
   cohort: InstallationCohort,
 ): void {
+  const completedState: OnboardingState = {
+    ...INITIAL_ONBOARDING_STATE,
+    lifecycle: "completed",
+    step: "complete",
+  };
   const target = storage();
-  if (!target) return;
+  if (!target) {
+    if (cohort === "established-before-landing-v1") {
+      snapshot = completedState;
+      hydrated = true;
+      emit();
+    }
+    return;
+  }
 
   try {
     const raw = target.getItem(ONBOARDING_STORAGE_KEY);
@@ -75,11 +89,9 @@ export function initializeOnboardingGraduation(
       }
     })();
     if (!preserveExisting && cohort === "established-before-landing-v1") {
-      const completedState: OnboardingState = {
-        ...INITIAL_ONBOARDING_STATE,
-        lifecycle: "completed",
-        step: "complete",
-      };
+      snapshot = completedState;
+      hydrated = true;
+      emit();
       target.setItem(
         ONBOARDING_STORAGE_KEY,
         JSON.stringify({
@@ -89,6 +101,11 @@ export function initializeOnboardingGraduation(
       );
     }
   } catch {
+    if (cohort === "established-before-landing-v1") {
+      snapshot = completedState;
+      hydrated = true;
+      emit();
+    }
     // Onboarding remains usable if localStorage is unavailable or full.
   }
 }
@@ -285,4 +302,12 @@ export function resetOnboardingStoreForTests(): void {
   snapshot = { ...INITIAL_ONBOARDING_STATE };
   hydrated = false;
   hasUnsupportedNewerRecord = false;
+}
+
+/** Test-only storage override for restricted WebView behavior. */
+export function setOnboardingStorageForTests(
+  target: Storage | null | undefined,
+): void {
+  storageOverrideForTests = target;
+  resetOnboardingStoreForTests();
 }

--- a/src/features/onboarding/model/onboardingStore.ts
+++ b/src/features/onboarding/model/onboardingStore.ts
@@ -16,6 +16,7 @@ import {
 
 export const ONBOARDING_STORAGE_VERSION = 1;
 export const ONBOARDING_STORAGE_KEY = "berd:onboarding:v1";
+export const ONBOARDING_GRADUATION_STORAGE_KEY = "berd:onboarding:graduated-v1";
 
 interface PersistedOnboardingState {
   version: typeof ONBOARDING_STORAGE_VERSION;
@@ -39,6 +40,40 @@ function storage(): Storage | null {
     return typeof window === "undefined" ? null : window.localStorage;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Graduates first-run onboarding without sending established installations
+ * through a newly enabled flow. A blank storage area represents a fresh app
+ * profile; any pre-existing app state means Berd has run before.
+ */
+export function initializeOnboardingGraduation(): void {
+  const target = storage();
+  if (!target || target.getItem(ONBOARDING_GRADUATION_STORAGE_KEY) !== null) {
+    return;
+  }
+
+  try {
+    const hasOnboardingState = target.getItem(ONBOARDING_STORAGE_KEY) !== null;
+    const hasExistingAppState = target.length > 0;
+    if (!hasOnboardingState && hasExistingAppState) {
+      const completedState: OnboardingState = {
+        ...INITIAL_ONBOARDING_STATE,
+        lifecycle: "completed",
+        step: "complete",
+      };
+      target.setItem(
+        ONBOARDING_STORAGE_KEY,
+        JSON.stringify({
+          version: ONBOARDING_STORAGE_VERSION,
+          state: completedState,
+        } satisfies PersistedOnboardingState),
+      );
+    }
+    target.setItem(ONBOARDING_GRADUATION_STORAGE_KEY, "1");
+  } catch {
+    // Onboarding remains usable if localStorage is unavailable or full.
   }
 }
 

--- a/src/features/onboarding/model/onboardingStore.ts
+++ b/src/features/onboarding/model/onboardingStore.ts
@@ -19,7 +19,8 @@ export const ONBOARDING_STORAGE_KEY = "berd:onboarding:v1";
 
 export type InstallationCohort =
   | "fresh-with-landing-v1"
-  | "established-before-landing-v1";
+  | "established-before-landing-v1"
+  | "unknown";
 
 interface PersistedOnboardingState {
   version: typeof ONBOARDING_STORAGE_VERSION;
@@ -54,10 +55,26 @@ export function initializeOnboardingGraduation(
   if (!target) return;
 
   try {
-    if (
-      target.getItem(ONBOARDING_STORAGE_KEY) === null &&
-      cohort === "established-before-landing-v1"
-    ) {
+    const raw = target.getItem(ONBOARDING_STORAGE_KEY);
+    const preserveExisting = (() => {
+      if (raw === null) return false;
+      try {
+        const value: unknown = JSON.parse(raw);
+        if (!value || typeof value !== "object") return false;
+        const record = value as Partial<PersistedOnboardingState>;
+        return (
+          (typeof record.version === "number" &&
+            record.version > ONBOARDING_STORAGE_VERSION) ||
+          (record.version === ONBOARDING_STORAGE_VERSION &&
+            isValidPersistedState(
+              record.state as Partial<OnboardingState> | undefined,
+            ))
+        );
+      } catch {
+        return false;
+      }
+    })();
+    if (!preserveExisting && cohort === "established-before-landing-v1") {
       const completedState: OnboardingState = {
         ...INITIAL_ONBOARDING_STATE,
         lifecycle: "completed",
@@ -92,14 +109,38 @@ function isLifecycle(value: unknown): value is OnboardingLifecycle {
   );
 }
 
+function isValidPersistedState(
+  state: Partial<OnboardingState> | undefined,
+): state is OnboardingState {
+  return Boolean(
+    state &&
+      isLifecycle(state.lifecycle) &&
+      isStep(state.step) &&
+      isStringArray(state.selectedWorkTypeIds) &&
+      state.selectedWorkTypeIds.every((id) => workTypeIds.has(id)) &&
+      (state.selectedAgentId === null ||
+        (typeof state.selectedAgentId === "string" &&
+          agentIds.has(state.selectedAgentId))) &&
+      (state.selectedHarnessId === null ||
+        (typeof state.selectedHarnessId === "string" &&
+          harnessIds.has(state.selectedHarnessId))) &&
+      (state.completedHarnessSetupIds === undefined ||
+        (isStringArray(state.completedHarnessSetupIds) &&
+          state.completedHarnessSetupIds.every((id) => harnessIds.has(id)))) &&
+      (state.step === "complete") === (state.lifecycle === "completed") &&
+      (state.step !== "harness-setup" || state.selectedHarnessId !== null),
+  );
+}
+
 function parsePersisted(raw: string | null): OnboardingState {
   hasUnsupportedNewerRecord = false;
   if (raw === null) return { ...INITIAL_ONBOARDING_STATE };
 
   try {
     const value: unknown = JSON.parse(raw);
-    if (!value || typeof value !== "object")
+    if (!value || typeof value !== "object") {
       return { ...INITIAL_ONBOARDING_STATE };
+    }
     const record = value as Partial<PersistedOnboardingState>;
     if (record.version !== ONBOARDING_STORAGE_VERSION) {
       hasUnsupportedNewerRecord =
@@ -108,29 +149,7 @@ function parsePersisted(raw: string | null): OnboardingState {
       return { ...INITIAL_ONBOARDING_STATE };
     }
     const state = record.state as Partial<OnboardingState> | undefined;
-    if (
-      !state ||
-      !isLifecycle(state.lifecycle) ||
-      !isStep(state.step) ||
-      !isStringArray(state.selectedWorkTypeIds) ||
-      !state.selectedWorkTypeIds.every((id) => workTypeIds.has(id)) ||
-      !(
-        state.selectedAgentId === null ||
-        (typeof state.selectedAgentId === "string" &&
-          agentIds.has(state.selectedAgentId))
-      ) ||
-      !(
-        state.selectedHarnessId === null ||
-        (typeof state.selectedHarnessId === "string" &&
-          harnessIds.has(state.selectedHarnessId))
-      ) ||
-      (state.completedHarnessSetupIds !== undefined &&
-        (!isStringArray(state.completedHarnessSetupIds) ||
-          !state.completedHarnessSetupIds.every((id) => harnessIds.has(id)))) ||
-      (state.step === "complete" && state.lifecycle !== "completed") ||
-      (state.step !== "complete" && state.lifecycle === "completed") ||
-      (state.step === "harness-setup" && state.selectedHarnessId === null)
-    ) {
+    if (!isValidPersistedState(state)) {
       return { ...INITIAL_ONBOARDING_STATE };
     }
     return {

--- a/src/features/onboarding/ui/OnboardingShell.tsx
+++ b/src/features/onboarding/ui/OnboardingShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, type ReactNode } from "react";
 import { IconChevronLeft } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/lib/cn";
 
 interface OnboardingShellProps {
   title?: ReactNode;
@@ -10,6 +11,7 @@ interface OnboardingShellProps {
   backDisabled?: boolean;
   children: ReactNode;
   actions?: ReactNode;
+  contentClassName?: string;
 }
 
 export function OnboardingShell({
@@ -19,6 +21,7 @@ export function OnboardingShell({
   backDisabled = false,
   children,
   actions,
+  contentClassName,
 }: OnboardingShellProps) {
   const { t } = useTranslation("onboarding");
   const headingRef = useRef<HTMLHeadingElement>(null);
@@ -61,7 +64,12 @@ export function OnboardingShell({
           ) : null}
         </header>
       ) : null}
-      <div className="relative z-10 flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
+      <div
+        className={cn(
+          "relative z-10 flex min-h-0 flex-1 items-center justify-center overflow-y-auto",
+          contentClassName,
+        )}
+      >
         {children}
       </div>
       {actions ? (

--- a/src/features/onboarding/ui/WelcomeStep.test.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.test.tsx
@@ -55,6 +55,9 @@ describe("WelcomeStep", () => {
     });
     expect(heading).toBeInTheDocument();
     expect(heading).toHaveFocus();
+    const scrollRegion = heading.closest("[class*='overflow-y-auto']");
+    expect(scrollRegion).toHaveClass("max-[760px]:overflow-y-auto");
+    expect(scrollRegion).toHaveClass("max-[760px]:overflow-x-hidden");
     expect(screen.getByTestId("project-cube")).toBeInTheDocument();
     expect(
       screen.getByRole("checkbox", { name: /share anonymous usage data/i }),

--- a/src/features/onboarding/ui/WelcomeStep.test.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.test.tsx
@@ -5,6 +5,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WelcomeStep } from "./WelcomeStep";
 
 const motionMocks = vi.hoisted(() => ({ reduced: false }));
+const telemetryMocks = vi.hoisted(() => ({ start: vi.fn() }));
+
+vi.mock("@/shared/telemetry/startup", () => ({
+  startTelemetryIfConsented: telemetryMocks.start,
+}));
 
 vi.mock("motion/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("motion/react")>();
@@ -45,6 +50,7 @@ function renderStep(onStart = vi.fn()) {
 describe("WelcomeStep", () => {
   afterEach(() => {
     motionMocks.reduced = false;
+    telemetryMocks.start.mockReset();
     localStorage.clear();
   });
 
@@ -76,6 +82,27 @@ describe("WelcomeStep", () => {
     await userEvent.click(screen.getByRole("button", { name: "Let’s go" }));
 
     expect(localStorage.getItem("berd:telemetry-consent:v1")).toBe("false");
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("advances even when telemetry startup throws", async () => {
+    telemetryMocks.start.mockImplementation(() => {
+      throw new Error("analytics unavailable");
+    });
+    // React re-throws handler errors to window.onerror; keep the expected
+    // failure from registering as an unhandled test error.
+    const swallowExpectedError = (event: ErrorEvent) => event.preventDefault();
+    window.addEventListener("error", swallowExpectedError);
+    const onStart = renderStep();
+
+    try {
+      await userEvent.click(screen.getByRole("button", { name: "Let’s go" }));
+    } finally {
+      window.removeEventListener("error", swallowExpectedError);
+    }
+
+    expect(telemetryMocks.start).toHaveBeenCalledOnce();
+    expect(localStorage.getItem("berd:telemetry-consent:v1")).toBe("true");
     expect(onStart).toHaveBeenCalledOnce();
   });
 

--- a/src/features/onboarding/ui/WelcomeStep.test.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.test.tsx
@@ -45,6 +45,7 @@ function renderStep(onStart = vi.fn()) {
 describe("WelcomeStep", () => {
   afterEach(() => {
     motionMocks.reduced = false;
+    localStorage.clear();
   });
 
   it("starts onboarding from the landing page", async () => {
@@ -64,6 +65,17 @@ describe("WelcomeStep", () => {
     ).toBeChecked();
 
     await userEvent.click(screen.getByRole("button", { name: "Let’s go" }));
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("persists opt out before advancing", async () => {
+    const onStart = renderStep();
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /share anonymous usage data/i }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Let’s go" }));
+
+    expect(localStorage.getItem("berd:telemetry-consent:v1")).toBe("false");
     expect(onStart).toHaveBeenCalledOnce();
   });
 

--- a/src/features/onboarding/ui/WelcomeStep.test.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WelcomeStep } from "./WelcomeStep";
+
+const motionMocks = vi.hoisted(() => ({ reduced: false }));
+
+vi.mock("motion/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("motion/react")>();
+  return {
+    ...actual,
+    useReducedMotion: () => motionMocks.reduced,
+  };
+});
+
+vi.mock("@/features/projects/artifact/ProjectArtifactPreview", () => ({
+  ProjectArtifactPreview: ({
+    gestureFreezeActive,
+    motionImpulse,
+  }: {
+    gestureFreezeActive?: boolean;
+    motionImpulse?: unknown;
+  }) => (
+    <div
+      data-testid="project-cube"
+      data-frozen={gestureFreezeActive ? "true" : "false"}
+      data-has-motion={motionImpulse ? "true" : "false"}
+    />
+  ),
+}));
+
+function renderStep(onStart = vi.fn()) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={client}>
+      <WelcomeStep onStart={onStart} />
+    </QueryClientProvider>,
+  );
+  return onStart;
+}
+
+describe("WelcomeStep", () => {
+  afterEach(() => {
+    motionMocks.reduced = false;
+  });
+
+  it("starts onboarding from the landing page", async () => {
+    const onStart = renderStep();
+
+    const heading = screen.getByRole("heading", {
+      name: "Welcome to Berd. Your place for doing.",
+    });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveFocus();
+    expect(screen.getByTestId("project-cube")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: /share anonymous usage data/i }),
+    ).toBeChecked();
+
+    await userEvent.click(screen.getByRole("button", { name: "Let’s go" }));
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
+  it("freezes decorative cube motion when reduced motion is requested", () => {
+    motionMocks.reduced = true;
+    renderStep();
+
+    expect(screen.getByTestId("project-cube")).toHaveAttribute(
+      "data-frozen",
+      "true",
+    );
+    expect(screen.getByTestId("project-cube")).toHaveAttribute(
+      "data-has-motion",
+      "false",
+    );
+  });
+
+  it("opens usage details in a dialog", async () => {
+    renderStep();
+
+    await userEvent.click(screen.getByRole("button", { name: "Learn more" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Sharing usage data" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("What we collect")).toBeInTheDocument();
+    expect(screen.getByText("What we don’t collect")).toBeInTheDocument();
+  });
+});

--- a/src/features/onboarding/ui/WelcomeStep.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.tsx
@@ -12,6 +12,11 @@ import {
 } from "@/shared/ui/dialog";
 import { ProjectArtifactPreview } from "@/features/projects/artifact/ProjectArtifactPreview";
 import type { ProjectArtifactMotionImpulse } from "@/features/projects/artifact/types";
+import {
+  getTelemetryConsent,
+  setTelemetryConsent,
+} from "@/shared/telemetry/consentPreference";
+import { startTelemetryIfConsented } from "@/shared/telemetry/startup";
 import { OnboardingShell } from "./OnboardingShell";
 
 interface WelcomeStepProps {
@@ -32,7 +37,9 @@ export function WelcomeStep({ onStart }: WelcomeStepProps) {
   const reduceMotion = useReducedMotion() === true;
   const checkboxId = useId();
   const headingRef = useRef<HTMLHeadingElement>(null);
-  const [shareUsageData, setShareUsageData] = useState(true);
+  const [shareUsageData, setShareUsageData] = useState(
+    () => getTelemetryConsent() ?? true,
+  );
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [cubeMotion, setCubeMotion] = useState<ProjectArtifactMotionImpulse>();
   const lastPointer = useRef<{ x: number; y: number; time: number } | null>(
@@ -158,7 +165,12 @@ export function WelcomeStep({ onStart }: WelcomeStepProps) {
             type="button"
             size="lg"
             className="mt-9 w-[calc(100%-80px)] max-[760px]:mx-auto"
-            onClick={onStart}
+            onClick={() => {
+              if (setTelemetryConsent(shareUsageData) && shareUsageData) {
+                startTelemetryIfConsented();
+              }
+              onStart();
+            }}
           >
             {t("welcome.getStarted")}
           </Button>

--- a/src/features/onboarding/ui/WelcomeStep.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.tsx
@@ -100,7 +100,7 @@ export function WelcomeStep({ onStart }: WelcomeStepProps) {
   };
 
   return (
-    <OnboardingShell contentClassName="max-[760px]:overflow-visible">
+    <OnboardingShell contentClassName="max-[760px]:overflow-x-hidden max-[760px]:overflow-y-auto">
       <motion.div
         className="relative grid h-full w-full grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] items-center gap-[clamp(3rem,8vw,10rem)] px-[clamp(0rem,4vw,5rem)] pt-[var(--spacing-app-top-bar)] max-[760px]:grid-cols-1 max-[760px]:gap-0 max-[760px]:px-8"
         initial="hidden"

--- a/src/features/onboarding/ui/WelcomeStep.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.tsx
@@ -166,10 +166,15 @@ export function WelcomeStep({ onStart }: WelcomeStepProps) {
             size="lg"
             className="mt-9 w-[calc(100%-80px)] max-[760px]:mx-auto"
             onClick={() => {
-              if (setTelemetryConsent(shareUsageData) && shareUsageData) {
-                startTelemetryIfConsented();
+              // Consent is persisted before telemetry starts, so onboarding has
+              // to advance regardless of how the telemetry seam behaves.
+              try {
+                if (setTelemetryConsent(shareUsageData) && shareUsageData) {
+                  startTelemetryIfConsented();
+                }
+              } finally {
+                onStart();
               }
-              onStart();
             }}
           >
             {t("welcome.getStarted")}

--- a/src/features/onboarding/ui/WelcomeStep.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.tsx
@@ -5,7 +5,6 @@ import { Button } from "@/shared/ui/button";
 import { Checkbox } from "@/shared/ui/checkbox";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
@@ -189,23 +188,10 @@ export function WelcomeStep({ onStart }: WelcomeStepProps) {
       <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
         <DialogContent
           size="xl"
+          closeLabel={t("actions.close", { ns: "common" })}
           className="gap-5 rounded-[28px] p-10 pr-12"
           overlayClassName="bg-background/45 [backdrop-filter:blur(14px)_saturate(80%)] [-webkit-backdrop-filter:blur(14px)_saturate(80%)]"
-          showCloseButton={false}
         >
-          <DialogClose className="absolute top-5 right-5 flex size-7 items-center justify-center rounded-full text-foreground/80 transition-opacity hover:opacity-60 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none">
-            <svg
-              aria-hidden="true"
-              className="size-4"
-              viewBox="0 0 16 16"
-              fill="currentColor"
-            >
-              <path d="M3.76 2.35a1 1 0 0 0-1.41 1.41L6.59 8l-4.24 4.24a1 1 0 1 0 1.41 1.41L8 9.41l4.24 4.24a1 1 0 0 0 1.41-1.41L9.41 8l4.24-4.24a1 1 0 0 0-1.41-1.41L8 6.59 3.76 2.35Z" />
-            </svg>
-            <span className="sr-only">
-              {t("actions.close", { ns: "common" })}
-            </span>
-          </DialogClose>
           <DialogHeader>
             <DialogTitle className="text-[20px] font-normal">
               {t("welcome.usageDialog.title")}

--- a/src/features/onboarding/ui/WelcomeStep.tsx
+++ b/src/features/onboarding/ui/WelcomeStep.tsx
@@ -1,9 +1,18 @@
+import { useEffect, useId, useRef, useState, type PointerEvent } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/shared/ui/button";
-import { BerdIcon } from "@/shared/ui/icons/BerdIcon";
-import { useArtifacts } from "@/shared/hooks/useArtifacts";
-import { selectCollectionImageUrl } from "@/shared/api/artifacts";
+import { Checkbox } from "@/shared/ui/checkbox";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { ProjectArtifactPreview } from "@/features/projects/artifact/ProjectArtifactPreview";
+import type { ProjectArtifactMotionImpulse } from "@/features/projects/artifact/types";
 import { OnboardingShell } from "./OnboardingShell";
 
 interface WelcomeStepProps {
@@ -15,79 +24,216 @@ const reveal = {
   visible: { opacity: 1, y: 0 },
 };
 
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
 export function WelcomeStep({ onStart }: WelcomeStepProps) {
-  const { t } = useTranslation("onboarding");
-  const reduceMotion = useReducedMotion();
-  const duration = reduceMotion ? 0 : 0.28;
-  const { data: artifacts } = useArtifacts();
-  const projectThumbnail = selectCollectionImageUrl(
-    artifacts,
-    "onboarding",
-    "project-cube",
-  );
-  const avatarThumbnail = selectCollectionImageUrl(
-    artifacts,
-    "onboarding",
-    "avatar-thumbnail",
+  const { t } = useTranslation(["onboarding", "common"]);
+  const reduceMotion = useReducedMotion() === true;
+  const checkboxId = useId();
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const [shareUsageData, setShareUsageData] = useState(true);
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [cubeMotion, setCubeMotion] = useState<ProjectArtifactMotionImpulse>();
+  const lastPointer = useRef<{ x: number; y: number; time: number } | null>(
+    null,
   );
 
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  const updateCubeMotion = (event: PointerEvent<HTMLDivElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    const current = {
+      x: event.clientX,
+      y: event.clientY,
+      time: event.timeStamp,
+    };
+    const previous = lastPointer.current;
+    lastPointer.current = current;
+    const hoverX = clamp(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -1,
+      1,
+    );
+    const hoverY = clamp(
+      -(((event.clientY - rect.top) / rect.height) * 2 - 1),
+      -1,
+      1,
+    );
+    const elapsed = Math.max(
+      current.time - (previous?.time ?? current.time),
+      8,
+    );
+    const deltaX = previous ? (current.x - previous.x) / rect.width : 0;
+    const deltaY = previous ? (current.y - previous.y) / rect.height : 0;
+    const velocityBoost = clamp(
+      1 + (Math.hypot(deltaX, deltaY) / (elapsed / 1000)) * 0.22,
+      0.9,
+      3.1,
+    );
+    setCubeMotion((motion) => ({
+      sequence: (motion?.sequence ?? 0) + 1,
+      deltaX: clamp(deltaX * velocityBoost, -0.3, 0.3),
+      deltaY: clamp(deltaY * velocityBoost, -0.3, 0.3),
+      hoverX: Math.abs(hoverX) < 0.08 ? 0.22 : hoverX,
+      hoverY: Math.abs(hoverY) < 0.08 ? 0.16 : hoverY,
+    }));
+  };
+
+  const resetCubeMotion = () => {
+    lastPointer.current = null;
+    setCubeMotion((motion) =>
+      motion
+        ? {
+            ...motion,
+            sequence: motion.sequence + 1,
+            deltaX: 0,
+            deltaY: 0,
+            hoverX: 0,
+            hoverY: 0,
+          }
+        : motion,
+    );
+  };
+
   return (
-    <OnboardingShell>
+    <OnboardingShell contentClassName="max-[760px]:overflow-visible">
       <motion.div
-        className="flex h-full items-center justify-center px-8 pb-4"
+        className="relative grid h-full w-full grid-cols-[minmax(0,1.05fr)_minmax(360px,0.95fr)] items-center gap-[clamp(3rem,8vw,10rem)] px-[clamp(0rem,4vw,5rem)] pt-[var(--spacing-app-top-bar)] max-[760px]:grid-cols-1 max-[760px]:gap-0 max-[760px]:px-8"
         initial="hidden"
         animate="visible"
-        transition={{ staggerChildren: reduceMotion ? 0 : 0.32 }}
+        transition={{ staggerChildren: reduceMotion ? 0 : 0.12 }}
       >
-        <div className="text-center">
-          <motion.h1
-            variants={reveal}
-            transition={{ duration }}
-            className="text-[48px] leading-tight font-normal text-foreground"
+        <motion.div
+          variants={reveal}
+          transition={{ duration: reduceMotion ? 0 : 0.35 }}
+          className="flex h-[min(92vh,980px)] w-[min(62vw,980px)] translate-x-16 items-center justify-self-end overflow-visible max-[760px]:absolute max-[760px]:bottom-[calc(-18vh-80px)] max-[760px]:left-1/2 max-[760px]:h-[62vh] max-[760px]:w-full max-[760px]:-translate-x-1/2 max-[760px]:justify-center"
+          aria-hidden="true"
+          onPointerEnter={reduceMotion ? undefined : updateCubeMotion}
+          onPointerMove={reduceMotion ? undefined : updateCubeMotion}
+          onPointerLeave={reduceMotion ? undefined : resetCubeMotion}
+        >
+          <div className="h-[120%] w-[120%] shrink-0 -translate-x-64 scale-[1.0875] max-[760px]:h-[145%] max-[760px]:w-[145%] max-[760px]:translate-x-0 max-[760px]:translate-y-12 max-[760px]:scale-[1.15]">
+            <ProjectArtifactPreview
+              input={{
+                projectId: "berd-welcome",
+                name: "Welcome to Berd",
+                color: "olive",
+                artifact: {
+                  seed: 18,
+                  color: "olive",
+                  mood: "serene",
+                  moodIntensity: 0.72,
+                  contentMode: "cube",
+                },
+              }}
+              variant="tile"
+              cameraDistanceScale={1.2}
+              motionImpulse={reduceMotion ? undefined : cubeMotion}
+              gestureFreezeActive={reduceMotion}
+              className="h-full w-full"
+            />
+          </div>
+        </motion.div>
+
+        <motion.section
+          variants={reveal}
+          transition={{ duration: reduceMotion ? 0 : 0.35 }}
+          className="w-full max-w-[390px] justify-self-start max-[760px]:absolute max-[760px]:top-[42%] max-[760px]:left-1/2 max-[760px]:-translate-x-1/2 max-[760px]:-translate-y-1/2 max-[760px]:text-center"
+        >
+          <h1
+            ref={headingRef}
+            tabIndex={-1}
+            className="text-[clamp(2.25rem,3.2vw,3.5rem)] leading-[0.98] font-normal tracking-[-0.045em] text-foreground outline-none"
           >
             {t("welcome.title")}
-          </motion.h1>
-          <div className="mt-3 text-[48px] leading-[1.28] text-muted-foreground">
-            <motion.div variants={reveal} transition={{ duration }}>
-              {t("welcome.projects")}{" "}
-              {projectThumbnail ? (
-                <img
-                  src={projectThumbnail}
-                  alt=""
-                  className="inline h-[64px] w-auto object-contain align-middle"
-                />
-              ) : null}
-              ,
-            </motion.div>
-            <motion.div variants={reveal} transition={{ duration }}>
-              {t("welcome.agents")}{" "}
-              {avatarThumbnail ? (
-                <img
-                  src={avatarThumbnail}
-                  alt=""
-                  className="inline h-[76px] w-auto object-contain align-middle"
-                />
-              ) : null}
-              , {t("welcome.and")}
-            </motion.div>
-            <motion.div variants={reveal} transition={{ duration }}>
-              {t("welcome.done")}{" "}
-              <span className="inline-flex size-12 rotate-[-10deg] items-center justify-center rounded-[8px] bg-foreground align-middle text-background">
-                <BerdIcon className="size-8" />
-              </span>
-            </motion.div>
-          </div>
-          <motion.div
-            variants={reveal}
-            transition={{ duration }}
-            className="mt-7"
+            <br />
+            {t("welcome.subtitle")}
+          </h1>
+
+          <Button
+            type="button"
+            size="lg"
+            className="mt-9 w-[calc(100%-80px)] max-[760px]:mx-auto"
+            onClick={onStart}
           >
-            <Button type="button" className="w-[230px]" onClick={onStart}>
-              {t("welcome.getStarted")}
-            </Button>
-          </motion.div>
-        </div>
+            {t("welcome.getStarted")}
+          </Button>
+
+          <div className="mt-6 flex w-[calc(100%-72px)] items-start gap-2.5 text-left text-xs leading-[1.15] text-muted-foreground max-[760px]:mx-auto">
+            <Checkbox
+              id={checkboxId}
+              checked={shareUsageData}
+              onCheckedChange={(checked) => setShareUsageData(checked === true)}
+              aria-describedby={`${checkboxId}-description`}
+            />
+            <p id={`${checkboxId}-description`}>
+              <label htmlFor={checkboxId}>{t("welcome.usageConsent")}</label>{" "}
+              <Button
+                type="button"
+                variant="link"
+                className="text-xs"
+                onClick={() => setDetailsOpen(true)}
+              >
+                {t("welcome.learnMore")}
+              </Button>
+            </p>
+          </div>
+        </motion.section>
       </motion.div>
+
+      <Dialog open={detailsOpen} onOpenChange={setDetailsOpen}>
+        <DialogContent
+          size="xl"
+          className="gap-5 rounded-[28px] p-10 pr-12"
+          overlayClassName="bg-background/45 [backdrop-filter:blur(14px)_saturate(80%)] [-webkit-backdrop-filter:blur(14px)_saturate(80%)]"
+          showCloseButton={false}
+        >
+          <DialogClose className="absolute top-5 right-5 flex size-7 items-center justify-center rounded-full text-foreground/80 transition-opacity hover:opacity-60 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none">
+            <svg
+              aria-hidden="true"
+              className="size-4"
+              viewBox="0 0 16 16"
+              fill="currentColor"
+            >
+              <path d="M3.76 2.35a1 1 0 0 0-1.41 1.41L6.59 8l-4.24 4.24a1 1 0 1 0 1.41 1.41L8 9.41l4.24 4.24a1 1 0 0 0 1.41-1.41L9.41 8l4.24-4.24a1 1 0 0 0-1.41-1.41L8 6.59 3.76 2.35Z" />
+            </svg>
+            <span className="sr-only">
+              {t("actions.close", { ns: "common" })}
+            </span>
+          </DialogClose>
+          <DialogHeader>
+            <DialogTitle className="text-[20px] font-normal">
+              {t("welcome.usageDialog.title")}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogDescription className="text-sm leading-[1.35]">
+            {t("welcome.usageDialog.intro")}
+          </DialogDescription>
+          <div className="space-y-5 text-sm leading-[1.35]">
+            <section>
+              <h2 className="font-normal text-foreground">
+                {t("welcome.usageDialog.collectTitle")}
+              </h2>
+              <p className="mt-1 text-muted-foreground">
+                {t("welcome.usageDialog.collectBody")}
+              </p>
+            </section>
+            <section>
+              <h2 className="font-normal text-foreground">
+                {t("welcome.usageDialog.notCollectTitle")}
+              </h2>
+              <p className="mt-1 text-muted-foreground">
+                {t("welcome.usageDialog.notCollectBody")}
+              </p>
+            </section>
+          </div>
+        </DialogContent>
+      </Dialog>
     </OnboardingShell>
   );
 }

--- a/src/features/projects/artifact/ProjectArtifactPreview.tsx
+++ b/src/features/projects/artifact/ProjectArtifactPreview.tsx
@@ -33,6 +33,7 @@ interface ProjectArtifactPreviewProps {
   gestureFreezeActive?: boolean;
   renderPaused?: boolean;
   onGlCanvasReady?: (canvas: HTMLCanvasElement) => void;
+  cameraDistanceScale?: number;
 }
 
 function canUseWebGlRenderer(): boolean {
@@ -148,6 +149,7 @@ export function ProjectArtifactPreview({
   gestureFreezeActive,
   renderPaused = false,
   onGlCanvasReady,
+  cameraDistanceScale,
   variant = "preview",
 }: ProjectArtifactPreviewProps) {
   const state = useMemo(() => deriveProjectArtifactState(input), [input]);
@@ -215,6 +217,7 @@ export function ProjectArtifactPreview({
             gestureFreezeActive={gestureFreezeActive}
             motionImpulse={motionImpulse}
             onGlCanvasReady={onGlCanvasReady}
+            cameraDistanceScale={cameraDistanceScale}
             state={state}
             variant={variant}
           />

--- a/src/features/projects/artifact/ProjectArtifactRenderer.tsx
+++ b/src/features/projects/artifact/ProjectArtifactRenderer.tsx
@@ -156,15 +156,16 @@ const CANVAS_CAMERA = {
 
 function getCanvasCamera(
   variant: NonNullable<ProjectArtifactRendererProps["variant"]>,
+  distanceScale = 1,
 ) {
   const config =
     variant === "tile" ? CANVAS_CAMERA.tile : CANVAS_CAMERA.preview;
   return {
-    position: [config.position[0], config.position[1], config.position[2]] as [
-      number,
-      number,
-      number,
-    ],
+    position: [
+      config.position[0] * distanceScale,
+      config.position[1] * distanceScale,
+      config.position[2] * distanceScale,
+    ] as [number, number, number],
     fov: config.fov,
     near: 1,
     far: 100,
@@ -1748,6 +1749,7 @@ export function ProjectArtifactRenderer({
   environmentUrl,
   imageUrls,
   className,
+  cameraDistanceScale = 1,
   gestureFreezeActive = false,
   motionImpulse,
   onGlCanvasReady,
@@ -1934,7 +1936,7 @@ export function ProjectArtifactRenderer({
       >
         <Canvas
           key={canvasKey}
-          camera={getCanvasCamera(variant)}
+          camera={getCanvasCamera(variant, cameraDistanceScale)}
           className={cn(
             "relative h-full w-full [transform:translateZ(0)]",
             variant === "tile" ? "overflow-visible" : "rounded-[28px]",

--- a/src/features/projects/artifact/types.ts
+++ b/src/features/projects/artifact/types.ts
@@ -58,6 +58,8 @@ export interface ProjectArtifactRendererProps {
   /** Pauses continuous rendering while a mounted preview is not visible. */
   renderPaused?: boolean;
   onGlCanvasReady?: (canvas: HTMLCanvasElement) => void;
+  /** Pulls the camera back to provide extra framing around oversized embeds. */
+  cameraDistanceScale?: number;
 }
 
 export type ProjectArtifactPinState = { projectId: string };

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -94,6 +94,20 @@ describe("main entrypoint telemetry startup", () => {
     });
   });
 
+  it("reports cohort lookup failures without blocking startup", async () => {
+    const error = new Error("state unavailable");
+    mockInvoke.mockRejectedValueOnce(error);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await loadMainAt("");
+
+    await screen.findByTestId("main-app");
+    expect(mockReportRendererError).toHaveBeenCalledWith(
+      "installation_cohort_failed",
+      error,
+    );
+  });
+
   it("does not start launch telemetry for session windows", async () => {
     await loadMainAt("?sessionKey=c2Vzc2lvbi0xMjM");
 

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -21,6 +21,10 @@ vi.mock("@/app/RendererTelemetry", () => ({
   RendererTelemetry: () => null,
 }));
 
+vi.mock("@/app/ui/StartupLoadingView", () => ({
+  StartupLoadingView: () => <div data-testid="startup-loading" />,
+}));
+
 vi.mock("@/app/SessionWindowApp", () => ({
   SessionWindowApp: ({ sessionId }: { sessionId: string }) => (
     <div data-testid="session-app">{sessionId}</div>

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockInstallRendererDiagnostics = vi.hoisted(() => vi.fn());
 const mockReportRendererError = vi.hoisted(() => vi.fn());
 const mockInvoke = vi.hoisted(() => vi.fn());
+const mockInitTelemetry = vi.hoisted(() => vi.fn());
+const mockTrackAppLaunched = vi.hoisted(() => vi.fn());
 
 vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
 vi.mock("@/shared/styles/globals.css", () => ({}));
@@ -56,6 +58,11 @@ vi.mock("@/shared/i18n", () => ({
   I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@/shared/telemetry/client", () => ({
+  initTelemetry: mockInitTelemetry,
+  trackAppLaunched: mockTrackAppLaunched,
+}));
+
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
 
 vi.mock("@/shared/theme/ThemeProvider", () => ({
@@ -76,12 +83,16 @@ describe("main entrypoint telemetry startup", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    localStorage.clear();
+    mockInitTelemetry.mockReset();
+    mockTrackAppLaunched.mockReset();
     mockInvoke.mockResolvedValue("fresh-with-landing-v1");
     globalThis.fetch = vi.fn() as typeof globalThis.fetch;
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
+    localStorage.clear();
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
@@ -108,6 +119,24 @@ describe("main entrypoint telemetry startup", () => {
     await screen.findByTestId("main-app");
     expect(mockReportRendererError).toHaveBeenCalledWith(
       "installation_cohort_failed",
+      error,
+    );
+  });
+
+  it("reports telemetry init failures without blocking startup", async () => {
+    const error = new Error("analytics unavailable");
+    mockInitTelemetry.mockImplementation(() => {
+      throw error;
+    });
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
+
+    await loadMainAt("");
+
+    await screen.findByTestId("main-app");
+    expect(mockInitTelemetry).toHaveBeenCalledOnce();
+    expect(mockTrackAppLaunched).not.toHaveBeenCalled();
+    expect(mockReportRendererError).toHaveBeenCalledWith(
+      "telemetry_init_failed",
       error,
     );
   });

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -72,6 +72,7 @@ describe("main entrypoint telemetry startup", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockInvoke.mockResolvedValue("fresh-with-landing-v1");
     globalThis.fetch = vi.fn() as typeof globalThis.fetch;
   });
 
@@ -81,12 +82,13 @@ describe("main entrypoint telemetry startup", () => {
     vi.restoreAllMocks();
   });
 
-  it("runs the production startup path without telemetry network or native-command work", async () => {
+  it("resolves the installation cohort before rendering the main app", async () => {
     await loadMainAt("");
 
     await screen.findByTestId("main-app");
     expect(globalThis.fetch).not.toHaveBeenCalled();
-    expect(mockInvoke).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledOnce();
+    expect(mockInvoke).toHaveBeenCalledWith("get_installation_cohort");
     expect(mockInstallRendererDiagnostics).toHaveBeenCalledWith({
       windowKind: "main",
     });
@@ -101,6 +103,7 @@ describe("main entrypoint telemetry startup", () => {
     expect(mockInstallRendererDiagnostics).toHaveBeenCalledWith({
       windowKind: "session",
     });
+    expect(mockInvoke).not.toHaveBeenCalled();
   });
 
   it("does not start launch telemetry for malformed session windows", async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,7 @@ import { getInstallationCohort } from "@/features/onboarding/api/installationCoh
 import { initializeOnboardingGraduation } from "@/features/onboarding/model";
 import { UpdaterProvider } from "@/features/updates/hooks/useUpdater";
 import { I18nProvider } from "@/shared/i18n";
-import { initTelemetry, trackAppLaunched } from "@/shared/telemetry/client";
+import { startTelemetryIfConsented } from "@/shared/telemetry/startup";
 import { ThemeProvider } from "@/shared/theme/ThemeProvider";
 import { TooltipProvider } from "@/shared/ui/tooltip";
 import { RendererErrorBoundary } from "@/app/ui/RendererErrorBoundary";
@@ -173,8 +173,7 @@ if (bootError) {
       initializeOnboardingGraduation("unknown");
     })
     .finally(() => {
-      initTelemetry();
-      trackAppLaunched();
+      startTelemetryIfConsented();
 
       reactRoot.render(
         <React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ import { App } from "@/app/App";
 import { GitStateEvents } from "@/app/GitStateEvents";
 import { LocalMediaCacheEvents } from "@/app/LocalMediaCacheEvents";
 import { RendererTelemetry } from "@/app/RendererTelemetry";
+import { StartupLoadingView } from "@/app/ui/StartupLoadingView";
 import { BackgroundQueuedMessageDrain } from "@/features/chat/ui/BackgroundQueuedMessageDrain";
 import { getInstallationCohort } from "@/features/onboarding/api/installationCohort";
 import { initializeOnboardingGraduation } from "@/features/onboarding/model";
@@ -163,6 +164,13 @@ if (bootError) {
       renderBootError("The session window bundle could not be loaded.");
     });
 } else {
+  reactRoot.render(
+    <React.StrictMode>
+      <I18nProvider>
+        <StartupLoadingView />
+      </I18nProvider>
+    </React.StrictMode>,
+  );
   getInstallationCohort()
     .then((cohort) => {
       initializeOnboardingGraduation(cohort);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -170,7 +170,7 @@ if (bootError) {
     .catch((error) => {
       console.error("Failed to resolve installation cohort:", error);
       reportRendererError("installation_cohort_failed", error);
-      initializeOnboardingGraduation("established-before-landing-v1");
+      initializeOnboardingGraduation("unknown");
     })
     .finally(() => {
       initTelemetry();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { GitStateEvents } from "@/app/GitStateEvents";
 import { LocalMediaCacheEvents } from "@/app/LocalMediaCacheEvents";
 import { RendererTelemetry } from "@/app/RendererTelemetry";
 import { BackgroundQueuedMessageDrain } from "@/features/chat/ui/BackgroundQueuedMessageDrain";
+import { getInstallationCohort } from "@/features/onboarding/api/installationCohort";
 import { initializeOnboardingGraduation } from "@/features/onboarding/model";
 import { UpdaterProvider } from "@/features/updates/hooks/useUpdater";
 import { I18nProvider } from "@/shared/i18n";
@@ -33,7 +34,6 @@ try {
 } catch {
   // localStorage may be unavailable in some environments; ignore.
 }
-initializeOnboardingGraduation();
 
 // React Query's default focus detection relies on `visibilitychange`, which
 // the Tauri webview does not fire when the app window merely loses or regains
@@ -163,30 +163,41 @@ if (bootError) {
       renderBootError("The session window bundle could not be loaded.");
     });
 } else {
-  initTelemetry();
-  trackAppLaunched();
+  getInstallationCohort()
+    .then((cohort) => {
+      initializeOnboardingGraduation(cohort);
+    })
+    .catch((error) => {
+      console.error("Failed to resolve installation cohort:", error);
+      reportRendererError("installation_cohort_failed", error);
+      initializeOnboardingGraduation("established-before-landing-v1");
+    })
+    .finally(() => {
+      initTelemetry();
+      trackAppLaunched();
 
-  reactRoot.render(
-    <React.StrictMode>
-      <TooltipProvider>
-        <RendererErrorBoundary>
-          <QueryClientProvider client={queryClient}>
-            <AcpToolsEvents />
-            <GitStateEvents />
-            <LocalMediaCacheEvents />
-            <BackgroundQueuedMessageDrain />
-            <OptionalBerdctlBridge />
-            <RendererTelemetry />
-            <I18nProvider>
-              <ThemeProvider>
-                <UpdaterProvider>
-                  <App />
-                </UpdaterProvider>
-              </ThemeProvider>
-            </I18nProvider>
-          </QueryClientProvider>
-        </RendererErrorBoundary>
-      </TooltipProvider>
-    </React.StrictMode>,
-  );
+      reactRoot.render(
+        <React.StrictMode>
+          <TooltipProvider>
+            <RendererErrorBoundary>
+              <QueryClientProvider client={queryClient}>
+                <AcpToolsEvents />
+                <GitStateEvents />
+                <LocalMediaCacheEvents />
+                <BackgroundQueuedMessageDrain />
+                <OptionalBerdctlBridge />
+                <RendererTelemetry />
+                <I18nProvider>
+                  <ThemeProvider>
+                    <UpdaterProvider>
+                      <App />
+                    </UpdaterProvider>
+                  </ThemeProvider>
+                </I18nProvider>
+              </QueryClientProvider>
+            </RendererErrorBoundary>
+          </TooltipProvider>
+        </React.StrictMode>,
+      );
+    });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { GitStateEvents } from "@/app/GitStateEvents";
 import { LocalMediaCacheEvents } from "@/app/LocalMediaCacheEvents";
 import { RendererTelemetry } from "@/app/RendererTelemetry";
 import { BackgroundQueuedMessageDrain } from "@/features/chat/ui/BackgroundQueuedMessageDrain";
+import { initializeOnboardingGraduation } from "@/features/onboarding/model";
 import { UpdaterProvider } from "@/features/updates/hooks/useUpdater";
 import { I18nProvider } from "@/shared/i18n";
 import { initTelemetry, trackAppLaunched } from "@/shared/telemetry/client";
@@ -32,6 +33,7 @@ try {
 } catch {
   // localStorage may be unavailable in some environments; ignore.
 }
+initializeOnboardingGraduation();
 
 // React Query's default focus detection relies on `visibilitychange`, which
 // the Tauri webview does not fire when the app window merely loses or regains

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -181,8 +181,6 @@ if (bootError) {
       initializeOnboardingGraduation("unknown");
     })
     .finally(() => {
-      startTelemetryIfConsented();
-
       reactRoot.render(
         <React.StrictMode>
           <TooltipProvider>
@@ -206,5 +204,8 @@ if (bootError) {
           </TooltipProvider>
         </React.StrictMode>,
       );
+
+      // After render, so telemetry startup can never gate booting the app.
+      startTelemetryIfConsented();
     });
 }

--- a/src/shared/i18n/locales/en/onboarding.json
+++ b/src/shared/i18n/locales/en/onboarding.json
@@ -3,12 +3,19 @@
     "goBack": "Go back"
   },
   "welcome": {
-    "title": "Welcome to Berd",
-    "projects": "A place to build projects",
-    "agents": "work with agents",
-    "and": "and",
-    "done": "get work done",
-    "getStarted": "Get started"
+    "title": "Welcome to Berd.",
+    "subtitle": "Your place for doing.",
+    "getStarted": "Let’s go",
+    "usageConsent": "Share anonymous usage data to help improve Berd.",
+    "learnMore": "Learn more",
+    "usageDialog": {
+      "title": "Sharing usage data",
+      "intro": "We use a random installation ID, not your identity, to see how Berd is used and fix what’s broken.",
+      "collectTitle": "What we collect",
+      "collectBody": "Usage events, such as features used, errors, and performance, tied to a random installation ID.",
+      "notCollectTitle": "What we don’t collect",
+      "notCollectBody": "Your name, email, or account. Berd has no login, so there’s nothing to tie data to."
+    }
   },
   "workTypes": {
     "title": "What type of work will you use Berd for?",

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -206,11 +206,6 @@
     "defaultLabel": "default",
     "description": "Opt into in-progress Berd features on this device. Experiments can change, break, or disappear.",
     "emptyDescription": "New experiments will appear here when they are ready for opt-in testing.",
-    "firstRunOnboarding": {
-      "description": "Preview the new first-install onboarding flow. Unfinished progress resumes when the experiment is enabled again.",
-      "replay": "Replay onboarding",
-      "title": "First-run onboarding"
-    },
     "onboarding": {
       "cancel": "Cancel",
       "confirm": "Reset canvas",

--- a/src/shared/i18n/locales/es/onboarding.json
+++ b/src/shared/i18n/locales/es/onboarding.json
@@ -3,12 +3,19 @@
     "goBack": "Volver"
   },
   "welcome": {
-    "title": "Te damos la bienvenida a Berd",
-    "projects": "Un lugar para crear proyectos",
-    "agents": "trabajar con agentes",
-    "and": "y",
-    "done": "completar tu trabajo",
-    "getStarted": "Comenzar"
+    "title": "Te damos la bienvenida a Berd.",
+    "subtitle": "Tu lugar para hacer.",
+    "getStarted": "Vamos",
+    "usageConsent": "Comparte datos de uso anónimos para ayudar a mejorar Berd.",
+    "learnMore": "Más información",
+    "usageDialog": {
+      "title": "Compartir datos de uso",
+      "intro": "Usamos un identificador de instalación aleatorio, no tu identidad, para saber cómo se usa Berd y corregir lo que no funciona.",
+      "collectTitle": "Qué recopilamos",
+      "collectBody": "Eventos de uso, como las funciones utilizadas, errores y rendimiento, vinculados a un identificador de instalación aleatorio.",
+      "notCollectTitle": "Qué no recopilamos",
+      "notCollectBody": "Tu nombre, correo electrónico o cuenta. Berd no requiere iniciar sesión, así que no hay nada que vincule los datos contigo."
+    }
   },
   "workTypes": {
     "title": "¿Para qué tipo de trabajo usarás Berd?",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -206,11 +206,6 @@
     "defaultLabel": "predeterminado",
     "description": "Activa funciones de Berd en desarrollo en este dispositivo. Los experimentos pueden cambiar, fallar o desaparecer.",
     "emptyDescription": "Los nuevos experimentos aparecerán aquí cuando estén listos para probarse.",
-    "firstRunOnboarding": {
-      "description": "Previsualiza el nuevo flujo de incorporación de la primera instalación. El progreso sin terminar se reanuda cuando se vuelve a activar el experimento.",
-      "replay": "Repetir incorporación",
-      "title": "Incorporación del primer inicio"
-    },
     "onboarding": {
       "cancel": "Cancelar",
       "confirm": "Restablecer lienzo",

--- a/src/shared/telemetry/consentPreference.test.ts
+++ b/src/shared/telemetry/consentPreference.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getTelemetryConsent, setTelemetryConsent } from "./consentPreference";
+
+describe("telemetry consent preference", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("is unset until an explicit choice is persisted", () => {
+    expect(getTelemetryConsent()).toBeNull();
+    expect(setTelemetryConsent(false)).toBe(true);
+    expect(getTelemetryConsent()).toBe(false);
+    expect(setTelemetryConsent(true)).toBe(true);
+    expect(getTelemetryConsent()).toBe(true);
+  });
+
+  it("fails closed for malformed values", () => {
+    localStorage.setItem("berd:telemetry-consent:v1", "yes");
+    expect(getTelemetryConsent()).toBeNull();
+  });
+});

--- a/src/shared/telemetry/consentPreference.ts
+++ b/src/shared/telemetry/consentPreference.ts
@@ -1,0 +1,21 @@
+const TELEMETRY_CONSENT_STORAGE_KEY = "berd:telemetry-consent:v1";
+
+export function getTelemetryConsent(): boolean | null {
+  try {
+    const value = localStorage.getItem(TELEMETRY_CONSENT_STORAGE_KEY);
+    if (value === "true") return true;
+    if (value === "false") return false;
+  } catch {
+    // Missing storage is treated as no consent.
+  }
+  return null;
+}
+
+export function setTelemetryConsent(enabled: boolean): boolean {
+  try {
+    localStorage.setItem(TELEMETRY_CONSENT_STORAGE_KEY, String(enabled));
+    return getTelemetryConsent() === enabled;
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/telemetry/startup.test.ts
+++ b/src/shared/telemetry/startup.test.ts
@@ -10,11 +10,17 @@ vi.mock("@/shared/telemetry/client", () => ({
   trackAppLaunched: telemetry.launch,
 }));
 
+const diagnostics = vi.hoisted(() => ({ report: vi.fn() }));
+vi.mock("@/app/lib/rendererDiagnostics", () => ({
+  reportRendererError: diagnostics.report,
+}));
+
 describe("telemetry startup", () => {
   beforeEach(() => {
     localStorage.clear();
-    telemetry.init.mockClear();
-    telemetry.launch.mockClear();
+    telemetry.init.mockReset();
+    telemetry.launch.mockReset();
+    diagnostics.report.mockClear();
     resetTelemetryStartupForTests();
   });
 
@@ -31,5 +37,38 @@ describe("telemetry startup", () => {
     localStorage.setItem("berd:telemetry-consent:v1", "false");
     expect(startTelemetryIfConsented()).toBe(false);
     expect(telemetry.init).not.toHaveBeenCalled();
+  });
+
+  it("reports a failed init without throwing or retrying", () => {
+    const error = new Error("analytics unavailable");
+    telemetry.init.mockImplementation(() => {
+      throw error;
+    });
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
+
+    expect(startTelemetryIfConsented()).toBe(false);
+    expect(telemetry.launch).not.toHaveBeenCalled();
+    expect(diagnostics.report).toHaveBeenCalledWith(
+      "telemetry_init_failed",
+      error,
+    );
+
+    expect(startTelemetryIfConsented()).toBe(false);
+    expect(telemetry.init).toHaveBeenCalledOnce();
+  });
+
+  it("keeps telemetry started when the launch event fails", () => {
+    const error = new Error("event queue full");
+    telemetry.launch.mockImplementation(() => {
+      throw error;
+    });
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
+
+    expect(startTelemetryIfConsented()).toBe(true);
+    expect(telemetry.init).toHaveBeenCalledOnce();
+    expect(diagnostics.report).toHaveBeenCalledWith(
+      "telemetry_launch_event_failed",
+      error,
+    );
   });
 });

--- a/src/shared/telemetry/startup.test.ts
+++ b/src/shared/telemetry/startup.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetTelemetryStartupForTests,
+  startTelemetryIfConsented,
+} from "./startup";
+
+const telemetry = vi.hoisted(() => ({ init: vi.fn(), launch: vi.fn() }));
+vi.mock("@/shared/telemetry/client", () => ({
+  initTelemetry: telemetry.init,
+  trackAppLaunched: telemetry.launch,
+}));
+
+describe("telemetry startup", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    telemetry.init.mockClear();
+    telemetry.launch.mockClear();
+    resetTelemetryStartupForTests();
+  });
+
+  it("starts once only after explicit consent", () => {
+    expect(startTelemetryIfConsented()).toBe(false);
+    localStorage.setItem("berd:telemetry-consent:v1", "true");
+    expect(startTelemetryIfConsented()).toBe(true);
+    expect(startTelemetryIfConsented()).toBe(false);
+    expect(telemetry.init).toHaveBeenCalledOnce();
+    expect(telemetry.launch).toHaveBeenCalledOnce();
+  });
+
+  it("does not start after opt out", () => {
+    localStorage.setItem("berd:telemetry-consent:v1", "false");
+    expect(startTelemetryIfConsented()).toBe(false);
+    expect(telemetry.init).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/telemetry/startup.ts
+++ b/src/shared/telemetry/startup.ts
@@ -1,13 +1,31 @@
+import { reportRendererError } from "@/app/lib/rendererDiagnostics";
 import { initTelemetry, trackAppLaunched } from "@/shared/telemetry/client";
 import { getTelemetryConsent } from "@/shared/telemetry/consentPreference";
 
 let started = false;
 
+/**
+ * Best-effort: telemetry never gates onboarding or rendering. One init attempt
+ * per renderer process — a failed init disables telemetry until relaunch rather
+ * than retrying into a failing SDK. Returns whether telemetry is now running.
+ */
 export function startTelemetryIfConsented(): boolean {
   if (started || getTelemetryConsent() !== true) return false;
   started = true;
-  initTelemetry();
-  trackAppLaunched();
+
+  try {
+    initTelemetry();
+  } catch (error) {
+    reportRendererError("telemetry_init_failed", error);
+    return false;
+  }
+
+  // Init succeeded, so losing one launch event is not worth disabling telemetry.
+  try {
+    trackAppLaunched();
+  } catch (error) {
+    reportRendererError("telemetry_launch_event_failed", error);
+  }
   return true;
 }
 

--- a/src/shared/telemetry/startup.ts
+++ b/src/shared/telemetry/startup.ts
@@ -1,0 +1,16 @@
+import { initTelemetry, trackAppLaunched } from "@/shared/telemetry/client";
+import { getTelemetryConsent } from "@/shared/telemetry/consentPreference";
+
+let started = false;
+
+export function startTelemetryIfConsented(): boolean {
+  if (started || getTelemetryConsent() !== true) return false;
+  started = true;
+  initTelemetry();
+  trackAppLaunched();
+  return true;
+}
+
+export function resetTelemetryStartupForTests(): void {
+  started = false;
+}

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -1,7 +1,18 @@
 import type * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { Slot } from "@radix-ui/react-slot";
-import { XIcon } from "lucide-react";
+function SolidXIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={className}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+    >
+      <path d="M3.76 2.35a1 1 0 0 0-1.41 1.41L6.59 8l-4.24 4.24a1 1 0 1 0 1.41 1.41L8 9.41l4.24 4.24a1 1 0 0 0 1.41-1.41L9.41 8l4.24-4.24a1 1 0 0 0-1.41-1.41L8 6.59 3.76 2.35Z" />
+    </svg>
+  );
+}
 
 import { cn } from "@/shared/lib/cn";
 
@@ -81,6 +92,7 @@ function DialogContent({
   overlayClassName,
   positionerClassName,
   showCloseButton = true,
+  closeLabel = "Close",
   size = "lg",
   surface = "glass",
   ...props
@@ -88,6 +100,7 @@ function DialogContent({
   overlayClassName?: string;
   positionerClassName?: string;
   showCloseButton?: boolean;
+  closeLabel?: string;
   size?: DialogSize;
   surface?: DialogSurface;
 }) {
@@ -123,8 +136,8 @@ function DialogContent({
               data-slot="dialog-close"
               className="focus-visible:ring-ring/50 data-[state=open]:bg-muted data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
             >
-              <XIcon />
-              <span className="sr-only">Close</span>
+              <SolidXIcon />
+              <span className="sr-only">{closeLabel}</span>
             </DialogPrimitive.Close>
           )}
         </DialogPrimitive.Content>


### PR DESCRIPTION
**Category:** new-feature
**User Impact:** New Berd installations now open with a responsive welcome experience before entering the main canvas.
**Problem:** Berd previously entered the product without a designed first-run introduction or clear usage-data disclosure. Existing installations also need to remain uninterrupted when the experience becomes the default.
**Solution:** Add an interactive, accessible landing page and graduate the old experiment into the normal first-run flow, backed by a durable installation-cohort marker that safely distinguishes new installs from upgrades.

> [!NOTE]
> The usage-data checkbox is intentionally awaiting the follow-up telemetry preference hookup and should not be treated as release-ready consent behavior yet.

<details>
<summary>File changes</summary>

**src-tauri/Cargo.toml**
Makes unique temporary-file support available to the installation cohort service.

**src-tauri/src/commands/installation.rs**
Exposes the resolved installation cohort to the renderer after startup initialization settles.

**src-tauri/src/commands/mod.rs**
Registers the installation command module.

**src-tauri/src/lib.rs**
Initializes cohort state before app-data migration and registers the command without blocking startup on classification failures.

**src-tauri/src/services/app_data_migration.rs**
Provides authoritative legacy-layout detection for upgrade classification.

**src-tauri/src/services/installation_cohort.rs**
Persists a versioned fresh-versus-established cohort marker with concurrent-launch and crash-safety handling.

**src-tauri/src/services/mod.rs**
Registers the installation cohort service.

**src/app/AppShell.tsx**
Makes incomplete onboarding the normal first-run route instead of an experimental route.

**src/features/experiments/ExperimentsSettings.tsx**
Removes obsolete hidden-experiment filtering after first-run onboarding graduation.

**src/features/experiments/__tests__/ExperimentsSettings.test.tsx**
Updates experiment settings coverage for the graduated flow.

**src/features/experiments/experimentDefinitions.ts**
Removes the retired first-run onboarding experiment definition.

**src/features/onboarding/api/installationCohort.ts**
Adds the typed renderer API for reading the native installation cohort.

**src/features/onboarding/model/onboardingStore.test.ts**
Covers fresh installs, upgrades, malformed records, unavailable storage, and persistence compatibility.

**src/features/onboarding/model/onboardingStore.ts**
Graduates established users without showing onboarding while preserving authored or newer-version state.

**src/features/onboarding/ui/OnboardingShell.tsx**
Allows the welcome layout to customize its content overflow without forking the shell.

**src/features/onboarding/ui/WelcomeStep.test.tsx**
Covers welcome actions, focus, reduced motion, project rendering, and disclosure behavior.

**src/features/onboarding/ui/WelcomeStep.tsx**
Implements the responsive landing page, interactive project cube, consent disclosure, and glass dialog.

**src/features/projects/artifact/ProjectArtifactPreview.tsx**
Passes optional camera framing through the artifact preview boundary.

**src/features/projects/artifact/ProjectArtifactRenderer.tsx**
Supports adjusted camera distance for oversized embedded project cubes.

**src/features/projects/artifact/types.ts**
Adds the typed camera-distance renderer contract.

**src/main.test.tsx**
Verifies cohort lookup and startup fallback behavior for main and session windows.

**src/main.tsx**
Resolves installation cohort before rendering the main app while preserving session-window startup.

**src/shared/i18n/locales/en/onboarding.json**
Adds English welcome and usage-data disclosure copy.

**src/shared/i18n/locales/en/settings.json**
Removes retired experiment copy.

**src/shared/i18n/locales/es/onboarding.json**
Adds Spanish welcome and usage-data disclosure copy.

**src/shared/i18n/locales/es/settings.json**
Removes retired experiment copy.

**src/shared/ui/dialog.tsx**
Uses a shared solid close icon and supports a localized accessible close label.

</details>
