### PR TITLE
refine the starter Home layout

### DIFF
--- a/distro/agents/sprout.md
+++ b/distro/agents/sprout.md
@@ -2,7 +2,7 @@
 name: Agt. Builder
 display_name: Agt. Builder
 description: Builds your agents with you, then keeps making them better.
-avatar: app-avatar:gloopies-20
+avatar: app-avatar:gloopies-3
 good_for: growing your cast of doers
 vibes: sharp, seasoned, a little proud
 metadata:

--- a/src/features/experiments/ExperimentsSettings.tsx
+++ b/src/features/experiments/ExperimentsSettings.tsx
@@ -226,7 +226,10 @@ export function ExperimentsSettings({
         window.dispatchEvent(new Event("starter-tasks-state-reset"));
         setResetAllConfirmationOpen(false);
         resetSucceeded = true;
-        if (resetResult.cameraConfirmed) {
+        if (
+          resetResult.cameraConfirmed &&
+          resetResult.starterAgentsConfirmed !== false
+        ) {
           toast.success(t("experiments.onboarding.resetAllSuccess"));
         }
       } else {

--- a/src/features/experiments/ExperimentsSettings.tsx
+++ b/src/features/experiments/ExperimentsSettings.tsx
@@ -226,10 +226,9 @@ export function ExperimentsSettings({
         window.dispatchEvent(new Event("starter-tasks-state-reset"));
         setResetAllConfirmationOpen(false);
         resetSucceeded = true;
-        if (
-          resetResult.cameraConfirmed &&
-          resetResult.starterAgentsConfirmed !== false
-        ) {
+        if (resetResult.starterAgentsConfirmed === false) {
+          toast.warning(t("experiments.onboarding.resetAllPartial"));
+        } else if (resetResult.cameraConfirmed) {
           toast.success(t("experiments.onboarding.resetAllSuccess"));
         }
       } else {

--- a/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
+++ b/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
@@ -29,6 +29,14 @@ const resetHomeForOnboardingExperienceMock = vi.hoisted(() =>
 const syncOnboardingExperimentStateMock = vi.hoisted(() =>
   vi.fn(async () => {}),
 );
+const toastWarningMock = vi.hoisted(() => vi.fn());
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: toastWarningMock,
+  },
+}));
 vi.mock("@/features/onboarding/resetOnboardingTour", () => ({
   resetHomeForOnboardingExperience: resetHomeForOnboardingExperienceMock,
   syncOnboardingExperimentState: syncOnboardingExperimentStateMock,
@@ -83,6 +91,7 @@ describe("ExperimentsSettings", () => {
     localStorage.removeItem(EXPERIMENT_PREFERENCES_STORAGE_KEY);
     resetHomeForOnboardingExperienceMock.mockClear();
     syncOnboardingExperimentStateMock.mockClear();
+    toastWarningMock.mockClear();
   });
 
   afterEach(() => {
@@ -251,6 +260,9 @@ describe("ExperimentsSettings", () => {
         i18n.t("experiments.onboarding.resetAllSuccess", { ns: "settings" }),
       ),
     ).not.toBeInTheDocument();
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      i18n.t("experiments.onboarding.resetAllPartial", { ns: "settings" }),
+    );
   });
 
   it("preserves first-run state when reset-all preparation fails", async () => {

--- a/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
+++ b/src/features/experiments/__tests__/ExperimentsSettings.test.tsx
@@ -18,9 +18,13 @@ import { ExperimentsSettings } from "../ExperimentsSettings";
 import { EXPERIMENT_PREFERENCES_STORAGE_KEY } from "../experimentPreferences";
 import { i18n } from "@/shared/i18n";
 import { renderWithProviders } from "@/test/render";
+import type { OnboardingHomeResetResult } from "@/features/home/stores/homeWidgetStore";
 
 const resetHomeForOnboardingExperienceMock = vi.hoisted(() =>
-  vi.fn(async () => ({ itemsConfirmed: true, cameraConfirmed: true })),
+  vi.fn<() => Promise<OnboardingHomeResetResult>>(async () => ({
+    itemsConfirmed: true,
+    cameraConfirmed: true,
+  })),
 );
 const syncOnboardingExperimentStateMock = vi.hoisted(() =>
   vi.fn(async () => {}),
@@ -199,6 +203,34 @@ describe("ExperimentsSettings", () => {
     resetHomeForOnboardingExperienceMock.mockResolvedValueOnce({
       itemsConfirmed: true,
       cameraConfirmed: false,
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<ExperimentsSettings />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: i18n.t("experiments.onboarding.resetAll", { ns: "settings" }),
+      }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: i18n.t("experiments.onboarding.confirm", { ns: "settings" }),
+      }),
+    );
+
+    expect(
+      screen.queryByText(
+        i18n.t("experiments.onboarding.resetAllSuccess", { ns: "settings" }),
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not report full reset success while starter agents are recovering", async () => {
+    vi.stubEnv("DEV", true);
+    resetHomeForOnboardingExperienceMock.mockResolvedValueOnce({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
     });
     const user = userEvent.setup();
     renderWithProviders(<ExperimentsSettings />);

--- a/src/features/home/lib/homeLayoutMapper.test.ts
+++ b/src/features/home/lib/homeLayoutMapper.test.ts
@@ -393,8 +393,8 @@ describe("homeLayoutMapper", () => {
     expect(item).toMatchObject({
       kind: "clock",
       targetId: `widget:${item.id}`,
-      centerX: 902.5,
-      centerY: 134.5,
+      centerX: 894,
+      centerY: 126,
     });
   });
 
@@ -415,7 +415,7 @@ describe("homeLayoutMapper", () => {
     expect(
       widgets.slice(0, 6).map((widget) => ({ x: widget.x, y: widget.y })),
     ).toEqual([
-      { x: 678.5, y: 245 },
+      { x: 670, y: 236 },
       { x: -96, y: -240 },
       { x: 168, y: -240 },
       { x: -360, y: 0 },
@@ -445,7 +445,7 @@ describe("homeLayoutMapper", () => {
   it("locates Berdy's avatar for initial camera centering", () => {
     const widget = createDefaultOnboardingTourWidget();
 
-    expect(onboardingTourAvatarCenter(widget)).toEqual({ x: 750.5, y: 335 });
+    expect(onboardingTourAvatarCenter(widget)).toEqual({ x: 742, y: 326 });
   });
 
   it("persists the completed welcome callout for Berdy", () => {
@@ -477,7 +477,7 @@ describe("homeLayoutMapper", () => {
     expect(onboardingTour.x + (onboardingTour.width ?? 0) / 2).toBeCloseTo(
       clock.x + (clock.width ?? 0) / 2,
     );
-    expect(onboardingTour.y - (clock.y + (clock.height ?? 0))).toBe(24);
+    expect(onboardingTour.y - (clock.y + (clock.height ?? 0))).toBe(32);
   });
 
   describe("clock mode persistence round-trip", () => {

--- a/src/features/home/lib/homeLayoutMapper.ts
+++ b/src/features/home/lib/homeLayoutMapper.ts
@@ -550,20 +550,17 @@ export function createDefaultClockLayoutItem(
 }
 
 export function createDefaultOnboardingTourWidget(
-  clock?: WidgetInstance,
+  clock = createDefaultClockWidget(),
 ): WidgetInstance {
   const width = 448;
   const height = 180;
-  const clockSize = clock ? widgetSizeForInstance(clock) : null;
+  const clockSize = widgetSizeForInstance(clock);
 
   return {
     id: crypto.randomUUID(),
     type: "onboardingTour",
-    x: clock && clockSize ? clock.x + clockSize.width / 2 - width / 2 : 678.5,
-    y:
-      clock && clockSize
-        ? clock.y + clockSize.height + ONBOARDING_CLOCK_GAP
-        : 245,
+    x: clock.x + clockSize.width / 2 - width / 2,
+    y: clock.y + clockSize.height + ONBOARDING_CLOCK_GAP,
     z: 1,
     width,
     height,

--- a/src/features/home/onboarding/StarterTaskList.tsx
+++ b/src/features/home/onboarding/StarterTaskList.tsx
@@ -174,7 +174,7 @@ export function StarterTaskList({
       data-starter-task-list="true"
       style={overlayStyle}
       className={cn(
-        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-blue px-4 pb-4 pt-2 text-[12px] text-sticky-note-foreground shadow-sticky-note",
+        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-rose px-4 pb-4 pt-2 text-[12px] text-sticky-note-foreground shadow-sticky-note",
         mode === "overlay" &&
           "pointer-events-auto fixed right-4 bottom-28 z-[55] max-h-[min(24rem,calc(100dvh-8rem))] h-auto w-[min(16rem,calc(100vw-2rem))] overflow-y-auto smooth-shadow-sm motion-safe:animate-in motion-safe:slide-in-from-right-8 motion-safe:fade-in-0 motion-safe:duration-500 motion-safe:ease-[cubic-bezier(0.19,1,0.22,1)] motion-safe:will-change-transform motion-reduce:animate-none",
         mode === "overlay" &&

--- a/src/features/home/onboarding/createStarterHomeWidgets.test.ts
+++ b/src/features/home/onboarding/createStarterHomeWidgets.test.ts
@@ -31,8 +31,8 @@ describe("createStarterHomeWidgets", () => {
   });
 
   it.each([
-    ["tinker.md", 228, -380],
-    ["wildcard.md", -292, 260],
+    ["tinker.md", 410, 191],
+    ["wildcard.md", 214, -369],
   ] as const)("keeps %s in its stable slot when it is the only available agent", (fileName, x, y) => {
     const widgets = createStarterHomeWidgets([starterPersona(fileName)]);
 
@@ -86,10 +86,10 @@ describe("createStarterHomeWidgets", () => {
 
     expect(widgets).not.toBeNull();
     expect(widgets?.find((widget) => widget.type === "clock")).toMatchObject({
-      x: 533.5,
-      y: -266.5,
-      width: 173,
-      height: 173,
+      x: 542,
+      y: -274,
+      width: 156,
+      height: 156,
     });
     expect(
       widgets
@@ -98,13 +98,13 @@ describe("createStarterHomeWidgets", () => {
     ).toEqual([
       {
         agentId: "/Users/test/.agents/agents/tinker.md",
-        x: 228,
-        y: -380,
+        x: 410,
+        y: 191,
       },
       {
         agentId: "/Users/test/.agents/agents/wildcard.md",
-        x: -292,
-        y: 260,
+        x: 214,
+        y: -369,
       },
     ]);
   });

--- a/src/features/home/onboarding/createStarterHomeWidgets.test.ts
+++ b/src/features/home/onboarding/createStarterHomeWidgets.test.ts
@@ -86,7 +86,7 @@ describe("createStarterHomeWidgets", () => {
 
     expect(widgets).not.toBeNull();
     expect(widgets?.find((widget) => widget.type === "clock")).toMatchObject({
-      x: 542,
+      x: 522,
       y: -274,
       width: 156,
       height: 156,

--- a/src/features/home/onboarding/starterAgents.test.ts
+++ b/src/features/home/onboarding/starterAgents.test.ts
@@ -106,6 +106,29 @@ describe("starter agents", () => {
     expect(selectStarterAgentPersonas([managed, edited])).toEqual([managed]);
   });
 
+  it("does not mix unmanaged claims with verified managed copies", () => {
+    const managedTinker = persona("Tinker", {
+      id: "/Users/test/.agents/agents/tinker2.md",
+      sourceId: "tinker",
+    });
+    managedTinker.sourceProperties = {
+      metadata: {
+        berdBundled: true,
+        berdBundledSource: "tinker",
+        berdManagedBundledCopy: true,
+        berdBundledAllocationSource: "tinker",
+      },
+    };
+    const claimedWildcard = persona("Wildcard", {
+      id: "/Users/test/.agents/agents/wildcard.md",
+      sourceId: "wildcard",
+    });
+
+    expect(
+      selectStarterAgentPersonas([managedTinker, claimedWildcard]),
+    ).toEqual([managedTinker]);
+  });
+
   it("clears recovery eligibility after starter pins are seeded", () => {
     markStarterAgentPinsEligible();
     expect(areStarterAgentPinsEligible()).toBe(true);

--- a/src/features/home/onboarding/starterAgents.ts
+++ b/src/features/home/onboarding/starterAgents.ts
@@ -124,18 +124,12 @@ export function selectStarterAgentPersonas(
   const selected: Array<Persona | undefined> = STARTER_AGENT_FILE_NAMES.map(
     () => undefined,
   );
-  const haveManagedCopies = personas.some(isManagedBundledCopy);
   for (const persona of personas) {
-    if (
-      haveManagedCopies
-        ? !isManagedBundledCopy(persona)
-        : !isBundledPersona(persona)
-    ) {
-      continue;
-    }
+    if (!isBundledPersona(persona) && !isManagedBundledCopy(persona)) continue;
     const index = starterAgentIndex(persona);
     if (index < 0) continue;
-    if (!selected[index]) selected[index] = persona;
+    const existing = selected[index];
+    if (!existing || isManagedBundledCopy(persona)) selected[index] = persona;
   }
   return selected.filter(
     (persona): persona is Persona => persona !== undefined,

--- a/src/features/home/onboarding/starterAgents.ts
+++ b/src/features/home/onboarding/starterAgents.ts
@@ -124,12 +124,18 @@ export function selectStarterAgentPersonas(
   const selected: Array<Persona | undefined> = STARTER_AGENT_FILE_NAMES.map(
     () => undefined,
   );
+  const haveManagedCopies = personas.some(isManagedBundledCopy);
   for (const persona of personas) {
-    if (!isBundledPersona(persona) && !isManagedBundledCopy(persona)) continue;
+    if (
+      haveManagedCopies
+        ? !isManagedBundledCopy(persona)
+        : !isBundledPersona(persona)
+    ) {
+      continue;
+    }
     const index = starterAgentIndex(persona);
     if (index < 0) continue;
-    const existing = selected[index];
-    if (!existing || isManagedBundledCopy(persona)) selected[index] = persona;
+    if (!selected[index]) selected[index] = persona;
   }
   return selected.filter(
     (persona): persona is Persona => persona !== undefined,

--- a/src/features/home/onboarding/starterHomeLayout.ts
+++ b/src/features/home/onboarding/starterHomeLayout.ts
@@ -1,10 +1,11 @@
 import type { LayoutCamera } from "@/features/layout/api/layout";
 
-const STARTER_HOME_LAYOUT_STORAGE_KEY = "goose:home:starter-layout-v18";
+const STARTER_HOME_LAYOUT_STORAGE_KEY = "goose:home:starter-layout-v19";
 const PREVIOUS_STARTER_HOME_LAYOUT_STORAGE_KEYS = [
   "goose:home:starter-layout-v14",
   "goose:home:starter-layout-v15",
   "goose:home:starter-layout-v16",
+  "goose:home:starter-layout-v18",
 ] as const;
 const STARTER_HOME_LAYOUT_ELIGIBLE_STORAGE_KEY =
   "goose:home:starter-layout-eligible-v1";
@@ -38,11 +39,12 @@ export function starterLayoutCenter(rect: {
 export const STARTER_HOME_LAYOUT = {
   project: { x: -266, y: -334, width: 748, height: 748 },
   berdy: { x: -352, y: -180 },
-  clock: { x: 533.5, y: -266.5, width: 173, height: 173 },
-  tasks: { x: 440, y: 120, width: 256, height: 224 },
+  // Keep the clock centered in its existing slot while shrinking it by 10%.
+  clock: { x: 542, y: -274, width: 156, height: 156 },
+  tasks: { x: -500, y: 218, width: 224, height: 196 },
   agents: [
-    { x: 228, y: -380, width: 200, height: 220 },
-    { x: -292, y: 260, width: 200, height: 220 },
+    { x: 410, y: 191, width: 180, height: 198 },
+    { x: 214, y: -369, width: 180, height: 198 },
   ],
 } as const;
 

--- a/src/features/home/onboarding/starterHomeLayout.ts
+++ b/src/features/home/onboarding/starterHomeLayout.ts
@@ -38,10 +38,10 @@ export function starterLayoutCenter(rect: {
 
 export const STARTER_HOME_LAYOUT = {
   project: { x: -266, y: -334, width: 748, height: 748 },
-  berdy: { x: -352, y: -180 },
+  berdy: { x: -368, y: -180 },
   // Keep the clock centered in its existing slot while shrinking it by 10%.
-  clock: { x: 542, y: -274, width: 156, height: 156 },
-  tasks: { x: -500, y: 218, width: 224, height: 196 },
+  clock: { x: 522, y: -274, width: 156, height: 156 },
+  tasks: { x: -476, y: 218, width: 224, height: 196 },
   agents: [
     { x: 410, y: 191, width: 180, height: 198 },
     { x: 214, y: -369, width: 180, height: 198 },

--- a/src/features/home/stores/homeWidgetMutations.test.ts
+++ b/src/features/home/stores/homeWidgetMutations.test.ts
@@ -38,15 +38,15 @@ describe("homeWidgetMutations", () => {
     expect(widget).toMatchObject({
       id: "00000000-0000-4000-8000-000000000001",
       type: "clock",
-      x: -206.5,
-      y: 153.5,
+      x: -198,
+      y: 162,
     });
   });
 
   it("moves widgets with snapped top-left coordinates clamped by layout center constraints", () => {
     expect(
       moveWidgetMutation([clockWidget()], "w1", 1000, -1000, CONSTRAINTS),
-    ).toEqual([clockWidget({ x: 153.5, y: -206.5 })]);
+    ).toEqual([clockWidget({ x: 162, y: -198 })]);
   });
 
   it("can preserve an exact fractional position for initial layout placement", () => {
@@ -124,7 +124,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "agent",
         type: "agentPin",
-        x: 336,
+        x: 312,
         y: 0,
         z: 2,
         width: 200,
@@ -135,13 +135,13 @@ describe("homeWidgetMutations", () => {
         x: 0,
         y: 0,
         z: 1,
-        width: 173,
-        height: 173,
+        width: 156,
+        height: 156,
       }),
       clockWidget({
         id: "chat",
         type: "chatPin",
-        x: 696,
+        x: 672,
         y: 0,
         z: 3,
         width: 188,
@@ -150,7 +150,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "skill",
         type: "skillPin",
-        x: 1032,
+        x: 1008,
         y: 0,
         z: 4,
         width: 240,
@@ -205,11 +205,11 @@ describe("homeWidgetMutations", () => {
 
   it("skips no-op cleanup mutations when widgets are already organized", () => {
     const widgets: WidgetInstance[] = [
-      clockWidget({ id: "clock", x: 0, y: 0, z: 1, width: 173, height: 173 }),
+      clockWidget({ id: "clock", x: 0, y: 0, z: 1, width: 156, height: 156 }),
       clockWidget({
         id: "agent",
         type: "agentPin",
-        x: 336,
+        x: 312,
         y: 0,
         z: 2,
         width: 200,
@@ -218,7 +218,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "chat",
         type: "chatPin",
-        x: 696,
+        x: 672,
         y: 0,
         z: 3,
         width: 188,
@@ -227,7 +227,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "skill",
         type: "skillPin",
-        x: 1032,
+        x: 1008,
         y: 0,
         z: 4,
         width: 240,
@@ -309,6 +309,31 @@ describe("updateWidgetStateMutation — photo shape resize", () => {
       width: 320,
       height: 320,
     });
+  });
+});
+
+describe("updateWidgetStateMutation — onboarding tour resize", () => {
+  it("keeps Berdy in place when dismissing the welcome bubble", () => {
+    const tour: WidgetInstance = {
+      id: "tour",
+      type: "onboardingTour",
+      x: 120,
+      y: 150,
+      z: 1,
+      width: 448,
+      height: 180,
+    };
+
+    expect(
+      updateWidgetStateMutation([tour], "tour", { welcomeDismissed: true }),
+    ).toEqual([
+      expect.objectContaining({
+        x: 120,
+        y: 150,
+        width: 160,
+        height: 160,
+      }),
+    ]);
   });
 });
 
@@ -396,8 +421,8 @@ describe("updateWidgetStateMutation — clock mode resize", () => {
     };
     const next = updateWidgetStateMutation([digital], "c1", { mode: "analog" });
     expect(next?.[0]).toMatchObject({
-      width: 173,
-      height: 173,
+      width: 156,
+      height: 156,
       state: { mode: "analog" },
     });
   });

--- a/src/features/home/stores/homeWidgetMutations.test.ts
+++ b/src/features/home/stores/homeWidgetMutations.test.ts
@@ -352,7 +352,7 @@ describe("updateWidgetStateMutation — onboarding tour resize", () => {
     ).toEqual([
       expect.objectContaining({
         x: 120,
-        y: 165,
+        y: 205,
         width: 160,
         height: 160,
       }),

--- a/src/features/home/stores/homeWidgetMutations.test.ts
+++ b/src/features/home/stores/homeWidgetMutations.test.ts
@@ -313,7 +313,7 @@ describe("updateWidgetStateMutation — photo shape resize", () => {
 });
 
 describe("updateWidgetStateMutation — onboarding tour resize", () => {
-  it("keeps Berdy in place when dismissing the welcome bubble", () => {
+  it("keeps Berdy's avatar in place when dismissing the welcome bubble", () => {
     const tour: WidgetInstance = {
       id: "tour",
       type: "onboardingTour",
@@ -329,7 +329,30 @@ describe("updateWidgetStateMutation — onboarding tour resize", () => {
     ).toEqual([
       expect.objectContaining({
         x: 120,
-        y: 150,
+        y: 160,
+        width: 160,
+        height: 160,
+      }),
+    ]);
+  });
+
+  it("keeps a resized Berdy avatar in place when dismissing the bubble", () => {
+    const tour: WidgetInstance = {
+      id: "tour",
+      type: "onboardingTour",
+      x: 120,
+      y: 150,
+      z: 1,
+      width: 672,
+      height: 270,
+    };
+
+    expect(
+      updateWidgetStateMutation([tour], "tour", { welcomeDismissed: true }),
+    ).toEqual([
+      expect.objectContaining({
+        x: 120,
+        y: 165,
         width: 160,
         height: 160,
       }),

--- a/src/features/home/stores/homeWidgetMutations.ts
+++ b/src/features/home/stores/homeWidgetMutations.ts
@@ -543,21 +543,17 @@ export function updateWidgetStateMutation(
   const preservePosition =
     HOME_WIDGET_CATALOG_BY_ID[target.type]?.preservePositionOnProfileChange;
   const prevSize = widgetSizeForInstance(target);
-  const scaledContentOffset = (
+  const resolvedContentOffset = (
     profile: WidgetSizeProfile,
     size: { width: number; height: number },
   ) => {
-    const scale = Math.min(
-      size.width / profile.defaultSize.width,
-      size.height / profile.defaultSize.height,
-    );
-    return {
-      x: (profile.contentOffset?.x ?? 0) * scale,
-      y: (profile.contentOffset?.y ?? 0) * scale,
-    };
+    if (typeof profile.contentOffset === "function") {
+      return profile.contentOffset(size);
+    }
+    return profile.contentOffset ?? { x: 0, y: 0 };
   };
-  const prevContentOffset = scaledContentOffset(prevProfile, prevSize);
-  const nextContentOffset = scaledContentOffset(nextProfile, nextSize);
+  const prevContentOffset = resolvedContentOffset(prevProfile, prevSize);
+  const nextContentOffset = resolvedContentOffset(nextProfile, nextSize);
   const requestedPosition = preservePosition
     ? {
         x: target.x + prevContentOffset.x - nextContentOffset.x,

--- a/src/features/home/stores/homeWidgetMutations.ts
+++ b/src/features/home/stores/homeWidgetMutations.ts
@@ -170,9 +170,9 @@ function profileKey(profile: WidgetSizeProfile): string {
   return `${profile.defaultSize.width}x${profile.defaultSize.height}`;
 }
 
-const LEGACY_CLOCK_PROFILE_KEYS: Record<string, string> = {
-  "173x173": "240x240",
-  "224x88": "264x104",
+const LEGACY_CLOCK_PROFILE_KEYS: Record<string, string[]> = {
+  "156x156": ["173x173", "240x240"],
+  "224x88": ["264x104"],
 };
 
 function rememberedSizeForProfile(
@@ -184,7 +184,9 @@ function rememberedSizeForProfile(
   return (
     sizeMemory[key] ??
     (type === "clock"
-      ? sizeMemory[LEGACY_CLOCK_PROFILE_KEYS[key] ?? ""]
+      ? LEGACY_CLOCK_PROFILE_KEYS[key]
+          ?.map((legacyKey) => sizeMemory[legacyKey])
+          .find((size) => size !== undefined)
       : undefined)
   );
 }
@@ -538,14 +540,18 @@ export function updateWidgetStateMutation(
     : inheritedSize
       ? clampWidgetSizeForInstance(nextInstance, inheritedSize)
       : nextProfile.defaultSize;
+  const preservePosition =
+    HOME_WIDGET_CATALOG_BY_ID[target.type]?.preservePositionOnProfileChange;
   const prevSize = widgetSizeForInstance(target);
-  const centeredPosition = {
-    x: Math.round(target.x + (prevSize.width - nextSize.width) / 2),
-    y: Math.round(target.y + (prevSize.height - nextSize.height) / 2),
-  };
+  const requestedPosition = preservePosition
+    ? { x: target.x, y: target.y }
+    : {
+        x: Math.round(target.x + (prevSize.width - nextSize.width) / 2),
+        y: Math.round(target.y + (prevSize.height - nextSize.height) / 2),
+      };
   const position = isLayoutConstraints(bounds)
-    ? clampToLayoutConstraints(centeredPosition, nextSize, bounds)
-    : centeredPosition;
+    ? clampToLayoutConstraints(requestedPosition, nextSize, bounds)
+    : requestedPosition;
 
   const sized: WidgetInstance = {
     ...nextInstance,

--- a/src/features/home/stores/homeWidgetMutations.ts
+++ b/src/features/home/stores/homeWidgetMutations.ts
@@ -543,8 +543,26 @@ export function updateWidgetStateMutation(
   const preservePosition =
     HOME_WIDGET_CATALOG_BY_ID[target.type]?.preservePositionOnProfileChange;
   const prevSize = widgetSizeForInstance(target);
+  const scaledContentOffset = (
+    profile: WidgetSizeProfile,
+    size: { width: number; height: number },
+  ) => {
+    const scale = Math.min(
+      size.width / profile.defaultSize.width,
+      size.height / profile.defaultSize.height,
+    );
+    return {
+      x: (profile.contentOffset?.x ?? 0) * scale,
+      y: (profile.contentOffset?.y ?? 0) * scale,
+    };
+  };
+  const prevContentOffset = scaledContentOffset(prevProfile, prevSize);
+  const nextContentOffset = scaledContentOffset(nextProfile, nextSize);
   const requestedPosition = preservePosition
-    ? { x: target.x, y: target.y }
+    ? {
+        x: target.x + prevContentOffset.x - nextContentOffset.x,
+        y: target.y + prevContentOffset.y - nextContentOffset.y,
+      }
     : {
         x: Math.round(target.x + (prevSize.width - nextSize.width) / 2),
         y: Math.round(target.y + (prevSize.height - nextSize.height) / 2),

--- a/src/features/home/stores/homeWidgetStore.test.ts
+++ b/src/features/home/stores/homeWidgetStore.test.ts
@@ -416,15 +416,15 @@ describe("homeWidgetStore", () => {
       .instances.filter((instance) => instance.type === "onboardingTour");
     expect(onboardingWidgets).toHaveLength(1);
     expect(onboardingWidgets[0]).toMatchObject({
-      x: -137.5,
-      y: 205,
+      x: -146,
+      y: 188,
       state: { noteId: "onboarding:tour" },
       z: 2,
     });
     expect(onboardingWidgets[0].state?.welcomeDismissed).toBeUndefined();
     expect(useHomeWidgetStore.getState().camera).toMatchObject({
-      centerX: -65.5,
-      centerY: 295,
+      centerX: -74,
+      centerY: 278,
     });
   });
 
@@ -731,8 +731,8 @@ describe("homeWidgetStore", () => {
       },
       {
         targetId: "onboarding:tour",
-        centerX: 902.5,
-        centerY: 335,
+        centerX: 894,
+        centerY: 326,
       },
     ]);
     expect(useHomeWidgetStore.getState()).toMatchObject({
@@ -1710,8 +1710,8 @@ describe("homeWidgetStore", () => {
     const secondRequest = vi.mocked(saveLayoutItems).mock.calls[1][0];
     expect(secondRequest.expectedRevision).toBe(5);
     expect(secondRequest.items[0]).toMatchObject({
-      centerX: 134.5,
-      centerY: 134.5,
+      centerX: 126,
+      centerY: 126,
       zIndex: 1,
     });
     expect(secondRequest.items).toHaveLength(1);

--- a/src/features/home/stores/homeWidgetStore.ts
+++ b/src/features/home/stores/homeWidgetStore.ts
@@ -189,6 +189,7 @@ function createAddedCleanUpSnapshotItem(
 export type OnboardingHomeResetResult = {
   itemsConfirmed: boolean;
   cameraConfirmed: boolean;
+  starterAgentsConfirmed?: boolean;
 };
 
 interface HomeWidgetStore extends HomeWidgetState {

--- a/src/features/home/ui/HomeView.test.tsx
+++ b/src/features/home/ui/HomeView.test.tsx
@@ -389,22 +389,22 @@ describe("HomeView", () => {
           .getState()
           .instances.find((item) => item.type === "clock"),
       ).toMatchObject({
-        width: 173,
-        height: 173,
-        x: 533.5,
-        y: -266.5,
+        width: 156,
+        height: 156,
+        x: 542,
+        y: -274,
       }),
     );
     await waitFor(() => expect(saveLayoutCamera).toHaveBeenCalled());
     const savedClock = vi
       .mocked(saveLayoutItems)
       .mock.calls.flatMap(([request]) => request.items)
-      .findLast((item) => item.kind === "clock" && item.width === 173);
+      .findLast((item) => item.kind === "clock" && item.width === 156);
     expect(savedClock).toMatchObject({
       centerX: 620,
-      centerY: -180,
-      width: 173,
-      height: 173,
+      centerY: -196,
+      width: 156,
+      height: 156,
     });
   });
 

--- a/src/features/home/ui/HomeView.test.tsx
+++ b/src/features/home/ui/HomeView.test.tsx
@@ -391,7 +391,7 @@ describe("HomeView", () => {
       ).toMatchObject({
         width: 156,
         height: 156,
-        x: 542,
+        x: 522,
         y: -274,
       }),
     );
@@ -401,7 +401,7 @@ describe("HomeView", () => {
       .mock.calls.flatMap(([request]) => request.items)
       .findLast((item) => item.kind === "clock" && item.width === 156);
     expect(savedClock).toMatchObject({
-      centerX: 620,
+      centerX: 600,
       centerY: -196,
       width: 156,
       height: 156,

--- a/src/features/home/ui/WidgetCanvas.test.tsx
+++ b/src/features/home/ui/WidgetCanvas.test.tsx
@@ -440,7 +440,7 @@ describe("WidgetCanvas", () => {
     expect(widgetNode.style.height).toBe("300px");
     expect(
       Number(widgetNode.style.getPropertyValue("--widget-text-scale")),
-    ).toBeCloseTo((240 / 173) * 1.08);
+    ).toBeCloseTo((240 / 156) * 1.08);
     expect(widgetContent.style.transform).toBe("scale(1.25)");
     expect(widgetContent.style.transformOrigin).toBe("top left");
     expect(widgetContent.style.width).toBe("240px");

--- a/src/features/home/widgets/OnboardingTourWidget.tsx
+++ b/src/features/home/widgets/OnboardingTourWidget.tsx
@@ -344,7 +344,7 @@ const BerdyContent = memo(function BerdyContent({
                   </filter>
                 </defs>
                 <path
-                  className="fill-card dark:fill-card-glass"
+                  className="fill-card dark:fill-secondary"
                   d={SETTLED_BUBBLE_PATH}
                   filter={`url(#${bubbleShadowId})`}
                 />
@@ -368,13 +368,13 @@ const BerdyContent = memo(function BerdyContent({
                 onAnimationComplete={() => setIsBubbleSettled(true)}
               >
                 <path
-                  className="fill-card dark:fill-card-glass"
+                  className="fill-card dark:fill-secondary"
                   d={SETTLED_BUBBLE_PATH}
                 />
               </motion.svg>
               <motion.div
                 data-onboarding-tour-caret-dot="small"
-                className="absolute -bottom-9 left-1 size-3 origin-top rounded-full bg-card dark:bg-card-glass"
+                className="absolute -bottom-9 left-1 size-3 origin-top rounded-full bg-card dark:bg-secondary"
                 initial={
                   shouldReduceMotion
                     ? false
@@ -394,7 +394,7 @@ const BerdyContent = memo(function BerdyContent({
               />
               <motion.div
                 data-onboarding-tour-caret-dot="large"
-                className="absolute -bottom-4 left-4 size-8 origin-top rounded-full bg-card dark:bg-card-glass"
+                className="absolute -bottom-4 left-4 size-8 origin-top rounded-full bg-card dark:bg-secondary"
                 initial={
                   shouldReduceMotion ? false : { opacity: 0, scale: 0, x: -5 }
                 }
@@ -412,11 +412,11 @@ const BerdyContent = memo(function BerdyContent({
               >
                 <span
                   data-onboarding-tour-connector-fillet="top"
-                  className="absolute top-2 -left-0.5 size-2 rounded-full bg-card dark:bg-card-glass"
+                  className="absolute top-2 -left-0.5 size-2 rounded-full bg-card dark:bg-secondary"
                 />
                 <span
                   data-onboarding-tour-connector-fillet="bottom"
-                  className="absolute top-2 -right-0.5 size-2 rounded-full bg-card dark:bg-card-glass"
+                  className="absolute top-2 -right-0.5 size-2 rounded-full bg-card dark:bg-secondary"
                 />
               </motion.div>
             </div>

--- a/src/features/home/widgets/StickyNoteWidget.tsx
+++ b/src/features/home/widgets/StickyNoteWidget.tsx
@@ -189,7 +189,7 @@ function fontSizeBodyClassName(size: StickyNoteFontSize): string {
     case "small":
       return "text-[13px] leading-5";
     case "medium":
-      return "text-[15px] leading-6";
+      return "text-[14px] leading-5";
     case "large":
       return "text-[18px] leading-7";
     default: {

--- a/src/features/home/widgets/catalog.test.ts
+++ b/src/features/home/widgets/catalog.test.ts
@@ -47,11 +47,31 @@ describe("photo size profiles", () => {
   });
 });
 
+describe("onboarding tour size profiles", () => {
+  it("shrinks the frame to the avatar after the welcome bubble is dismissed", () => {
+    const dismissedTour: WidgetInstance = {
+      id: "tour-1",
+      type: "onboardingTour",
+      x: 0,
+      y: 0,
+      z: 1,
+      width: 448,
+      height: 180,
+      state: { welcomeDismissed: true },
+    };
+
+    expect(widgetSizeForInstance(dismissedTour)).toEqual({
+      width: 160,
+      height: 160,
+    });
+  });
+});
+
 describe("clock size profiles", () => {
   it("uses the analog (square) profile by default", () => {
     expect(widgetSizeForInstance(baseClock)).toEqual({
-      width: 173,
-      height: 173,
+      width: 156,
+      height: 156,
     });
   });
 

--- a/src/features/home/widgets/catalog.ts
+++ b/src/features/home/widgets/catalog.ts
@@ -26,12 +26,23 @@ function isFinitePositive(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-const CLOCK_ANALOG_PROFILE: WidgetSizeProfile = {
-  defaultSize: { width: 173, height: 173 },
+const ONBOARDING_TOUR_AVATAR_PROFILE: WidgetSizeProfile = {
+  defaultSize: { width: 160, height: 160 },
   sizeBounds: {
-    minWidth: 168,
+    minWidth: 160,
+    maxWidth: 160,
+    minHeight: 160,
+    maxHeight: 160,
+    lockAspectRatio: true,
+  },
+};
+
+const CLOCK_ANALOG_PROFILE: WidgetSizeProfile = {
+  defaultSize: { width: 156, height: 156 },
+  sizeBounds: {
+    minWidth: 156,
     maxWidth: 360,
-    minHeight: 168,
+    minHeight: 156,
     maxHeight: 360,
     lockAspectRatio: true,
   },
@@ -66,6 +77,20 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
       maxHeight: 270,
       lockAspectRatio: true,
     },
+    resolveProfile: (instance) =>
+      instance.state?.welcomeDismissed === true
+        ? ONBOARDING_TOUR_AVATAR_PROFILE
+        : {
+            defaultSize: { width: 448, height: 180 },
+            sizeBounds: {
+              minWidth: 448,
+              maxWidth: 672,
+              minHeight: 180,
+              maxHeight: 270,
+              lockAspectRatio: true,
+            },
+          },
+    preservePositionOnProfileChange: true,
     Component: OnboardingTourWidget,
   },
   {
@@ -97,9 +122,9 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
     resolveProfile: (instance) =>
       instance.state?.noteId === "onboarding:starter-tasks"
         ? {
-            defaultSize: { width: 256, height: 196 },
+            defaultSize: { width: 224, height: 196 },
             sizeBounds: {
-              minWidth: 256,
+              minWidth: 224,
               maxWidth: 360,
               minHeight: 156,
               maxHeight: 320,

--- a/src/features/home/widgets/catalog.ts
+++ b/src/features/home/widgets/catalog.ts
@@ -89,6 +89,7 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
               maxHeight: 270,
               lockAspectRatio: true,
             },
+            contentOffset: { x: 0, y: 10 },
           },
     preservePositionOnProfileChange: true,
     Component: OnboardingTourWidget,

--- a/src/features/home/widgets/catalog.ts
+++ b/src/features/home/widgets/catalog.ts
@@ -89,7 +89,10 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
               maxHeight: 270,
               lockAspectRatio: true,
             },
-            contentOffset: { x: 0, y: 10 },
+            contentOffset: (size) => ({
+              x: 0,
+              y: (size.height - 160) / 2,
+            }),
           },
     preservePositionOnProfileChange: true,
     Component: OnboardingTourWidget,

--- a/src/features/home/widgets/types.ts
+++ b/src/features/home/widgets/types.ts
@@ -101,6 +101,8 @@ export interface WidgetCatalogEntry {
   resolveProfile?: (instance: WidgetInstance) => WidgetSizeProfile;
   /** Keep the current rendered width when state switches size profiles. */
   preserveWidthOnProfileChange?: boolean;
+  /** Keep the top-left position when state switches size profiles. */
+  preservePositionOnProfileChange?: boolean;
   /** Keep each instance's resolved size when organizing the canvas. */
   preserveSizeOnCleanUp?: boolean;
   /** Renderable component for this widget type. Entries without a Component

--- a/src/features/home/widgets/types.ts
+++ b/src/features/home/widgets/types.ts
@@ -40,7 +40,9 @@ export interface WidgetSizeProfile {
   defaultSize: WidgetSize;
   sizeBounds: WidgetSizeBounds;
   /** Offset of the profile's primary visual content from the widget frame. */
-  contentOffset?: { x: number; y: number };
+  contentOffset?:
+    | { x: number; y: number }
+    | ((size: WidgetSize) => { x: number; y: number });
 }
 
 export interface WidgetInstance {

--- a/src/features/home/widgets/types.ts
+++ b/src/features/home/widgets/types.ts
@@ -39,6 +39,8 @@ export interface WidgetSizeBounds {
 export interface WidgetSizeProfile {
   defaultSize: WidgetSize;
   sizeBounds: WidgetSizeBounds;
+  /** Offset of the profile's primary visual content from the widget frame. */
+  contentOffset?: { x: number; y: number };
 }
 
 export interface WidgetInstance {

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -135,15 +135,19 @@ describe("onboarding tour experience controls", () => {
     expect(storeMocks.resetHomeForOnboarding).toHaveBeenCalledOnce();
   });
 
-  it("persists loaded starter agents as part of the reset", async () => {
+  it("refreshes stale starter agents before persisting the reset", async () => {
     storeMocks.setPersonaRecords([
+      { ...starterPersona("tinker"), id: "/stale/tinker.md" },
+      { ...starterPersona("wildcard"), id: "/stale/wildcard.md" },
+    ]);
+    storeMocks.listPersonas.mockResolvedValueOnce([
       starterPersona("tinker"),
       starterPersona("wildcard"),
     ]);
 
     await resetHomeForOnboardingExperience();
 
-    expect(storeMocks.listPersonas).not.toHaveBeenCalled();
+    expect(storeMocks.listPersonas).toHaveBeenCalledOnce();
     expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledWith([
       "/Users/test/.agents/agents/tinker.md",
       "/Users/test/.agents/agents/wildcard.md",

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const storeMocks = vi.hoisted(() => {
   let loadStatus = "idle";
   let instances: Array<{ type: string }> = [];
+  let personas: Array<Record<string, unknown>> = [];
+  const listPersonas = vi.fn(async () => personas);
+  const setPersonas = vi.fn((next: Array<Record<string, unknown>>) => {
+    personas = next;
+  });
   const initialize = vi.fn(async () => {
     loadStatus = "ready";
   });
@@ -11,6 +16,7 @@ const storeMocks = vi.hoisted(() => {
     itemsConfirmed: true,
     cameraConfirmed: true,
   }));
+  const addMissingStarterAgentPins = vi.fn(async () => true);
   const resetStarterTasks = vi.fn(async () => true);
   const syncOnboardingExperiment = vi.fn();
 
@@ -27,9 +33,18 @@ const storeMocks = vi.hoisted(() => {
     setInstances(next: Array<{ type: string }>) {
       instances = next;
     },
+    get personas() {
+      return personas;
+    },
+    setPersonaRecords(next: Array<Record<string, unknown>>) {
+      personas = next;
+    },
+    listPersonas,
+    setPersonas,
     initialize,
     resetOnboardingTour,
     resetHomeForOnboarding,
+    addMissingStarterAgentPins,
     resetStarterTasks,
     syncOnboardingExperiment,
   };
@@ -43,10 +58,24 @@ vi.mock("@/features/home/stores/homeWidgetStore", () => ({
       initialize: storeMocks.initialize,
       resetOnboardingTour: storeMocks.resetOnboardingTour,
       resetHomeForOnboarding: storeMocks.resetHomeForOnboarding,
+      addMissingStarterAgentPins: storeMocks.addMissingStarterAgentPins,
       resetStarterTasks: storeMocks.resetStarterTasks,
       syncOnboardingExperiment: storeMocks.syncOnboardingExperiment,
     }),
   },
+}));
+
+vi.mock("@/features/agents/stores/agentStore", () => ({
+  useAgentStore: {
+    getState: () => ({
+      personas: storeMocks.personas,
+      setPersonas: storeMocks.setPersonas,
+    }),
+  },
+}));
+
+vi.mock("@/shared/api/agents", () => ({
+  listPersonas: storeMocks.listPersonas,
 }));
 
 import {
@@ -58,20 +87,45 @@ import {
 import {
   areStarterAgentPinsEligible,
   haveStarterAgentPinsBeenSeeded,
+  resetStarterAgentPinsSeeded,
 } from "@/features/home/onboarding/starterAgents";
+
+function starterPersona(sourceId: "tinker" | "wildcard") {
+  return {
+    id: `/Users/test/.agents/agents/${sourceId}.md`,
+    displayName: sourceId,
+    systemPrompt: "Help.",
+    isBuiltin: false,
+    writable: true,
+    sourceProperties: {
+      metadata: { berdBundled: true, berdBundledSource: sourceId },
+    },
+  };
+}
 
 describe("onboarding tour experience controls", () => {
   beforeEach(() => {
+    resetStarterAgentPinsSeeded();
     storeMocks.setLoadStatus("idle");
     storeMocks.setInstances([{ type: "agentPin" }, { type: "agentPin" }]);
+    storeMocks.setPersonaRecords([]);
+    storeMocks.listPersonas.mockClear();
+    storeMocks.setPersonas.mockClear();
+    storeMocks.addMissingStarterAgentPins.mockResolvedValue(true);
     storeMocks.initialize.mockClear();
     storeMocks.resetOnboardingTour.mockClear();
     storeMocks.resetHomeForOnboarding.mockClear();
+    storeMocks.addMissingStarterAgentPins.mockClear();
     storeMocks.resetStarterTasks.mockClear();
     storeMocks.syncOnboardingExperiment.mockClear();
   });
 
   it("initializes before resetting the whole Home onboarding canvas", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
       itemsConfirmed: true,
       cameraConfirmed: true,
@@ -79,6 +133,51 @@ describe("onboarding tour experience controls", () => {
 
     expect(storeMocks.initialize).toHaveBeenCalledOnce();
     expect(storeMocks.resetHomeForOnboarding).toHaveBeenCalledOnce();
+  });
+
+  it("persists loaded starter agents as part of the reset", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
+    await resetHomeForOnboardingExperience();
+
+    expect(storeMocks.listPersonas).not.toHaveBeenCalled();
+    expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledWith([
+      "/Users/test/.agents/agents/tinker.md",
+      "/Users/test/.agents/agents/wildcard.md",
+    ]);
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+  });
+
+  it("refreshes and persists starter agents when the store is empty", async () => {
+    storeMocks.listPersonas.mockResolvedValueOnce([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
+    await resetHomeForOnboardingExperience();
+
+    expect(storeMocks.setPersonas).toHaveBeenCalledOnce();
+    expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledOnce();
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+  });
+
+  it("keeps recovery eligible when starter-agent persistence fails", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+    storeMocks.addMissingStarterAgentPins.mockResolvedValueOnce(false);
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+    });
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+    expect(areStarterAgentPinsEligible()).toBe(true);
   });
 
   it("preserves starter-agent markers when the Home reset fails", async () => {
@@ -97,7 +196,7 @@ describe("onboarding tour experience controls", () => {
     expect(areStarterAgentPinsEligible()).toBe(false);
   });
 
-  it("keeps a partial reset eligible for starter-agent recovery", async () => {
+  it("keeps a partial starter-agent reset eligible for recovery", async () => {
     storeMocks.setInstances([]);
 
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -153,6 +153,10 @@ describe("onboarding tour experience controls", () => {
       "/Users/test/.agents/agents/tinker.md",
       "/Users/test/.agents/agents/wildcard.md",
     ]);
+    expect(storeMocks.personas.map((persona) => persona.id)).toEqual([
+      "/Users/test/.agents/agents/tinker.md",
+      "/Users/test/.agents/agents/wildcard.md",
+    ]);
     expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
   });
 

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -180,6 +180,24 @@ describe("onboarding tour experience controls", () => {
     expect(areStarterAgentPinsEligible()).toBe(true);
   });
 
+  it("keeps recovery eligible when starter-agent persistence rejects", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+    storeMocks.addMissingStarterAgentPins.mockRejectedValueOnce(
+      new Error("save failed"),
+    );
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+    });
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+    expect(areStarterAgentPinsEligible()).toBe(true);
+  });
+
   it("preserves starter-agent markers when the Home reset fails", async () => {
     localStorage.setItem("goose:home:starter-agent-pins-seeded-v5", "1");
     storeMocks.resetHomeForOnboarding.mockResolvedValueOnce({

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -156,6 +156,30 @@ describe("onboarding tour experience controls", () => {
     expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
   });
 
+  it("preserves concurrent persona edits and deletions during refresh", async () => {
+    const originalTinker = starterPersona("tinker");
+    const originalWildcard = starterPersona("wildcard");
+    storeMocks.setPersonaRecords([originalTinker, originalWildcard]);
+    storeMocks.listPersonas.mockImplementationOnce(async () => {
+      storeMocks.setPersonaRecords([
+        { ...originalTinker, displayName: "Edited Tinker" },
+      ]);
+      return [originalTinker, originalWildcard];
+    });
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
+    });
+
+    expect(storeMocks.personas).toEqual([
+      { ...originalTinker, displayName: "Edited Tinker" },
+    ]);
+    expect(storeMocks.addMissingStarterAgentPins).not.toHaveBeenCalled();
+    expect(areStarterAgentPinsEligible()).toBe(true);
+  });
+
   it("refreshes and persists starter agents when the store is empty", async () => {
     storeMocks.listPersonas.mockResolvedValueOnce([
       starterPersona("tinker"),

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -129,6 +129,7 @@ describe("onboarding tour experience controls", () => {
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
       itemsConfirmed: true,
       cameraConfirmed: true,
+      starterAgentsConfirmed: true,
     });
 
     expect(storeMocks.initialize).toHaveBeenCalledOnce();
@@ -163,7 +164,6 @@ describe("onboarding tour experience controls", () => {
 
     await resetHomeForOnboardingExperience();
 
-    expect(storeMocks.setPersonas).toHaveBeenCalledOnce();
     expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledOnce();
     expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
   });
@@ -178,6 +178,7 @@ describe("onboarding tour experience controls", () => {
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
       itemsConfirmed: true,
       cameraConfirmed: true,
+      starterAgentsConfirmed: false,
     });
 
     expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
@@ -196,6 +197,7 @@ describe("onboarding tour experience controls", () => {
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
       itemsConfirmed: true,
       cameraConfirmed: true,
+      starterAgentsConfirmed: false,
     });
 
     expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
@@ -218,14 +220,16 @@ describe("onboarding tour experience controls", () => {
     expect(areStarterAgentPinsEligible()).toBe(false);
   });
 
-  it("keeps a partial starter-agent reset eligible for recovery", async () => {
-    storeMocks.setInstances([]);
+  it("keeps recovery eligible when only one starter persona is available", async () => {
+    storeMocks.listPersonas.mockResolvedValueOnce([starterPersona("tinker")]);
 
     await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
       itemsConfirmed: true,
       cameraConfirmed: true,
+      starterAgentsConfirmed: false,
     });
 
+    expect(storeMocks.addMissingStarterAgentPins).not.toHaveBeenCalled();
     expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
     expect(areStarterAgentPinsEligible()).toBe(true);
   });

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -5,6 +5,7 @@ import {
   markStarterAgentPinsSeeded,
   resetStarterAgentPinsSeeded,
   selectStarterAgentPersonas,
+  starterAgentIndex,
 } from "@/features/home/onboarding/starterAgents";
 import { STARTER_HOME_LAYOUT } from "@/features/home/onboarding/starterHomeLayout";
 import {
@@ -43,12 +44,18 @@ async function restoreStarterAgentPins(): Promise<boolean> {
     const refreshedById = new Map(
       personas.map((persona) => [persona.id, persona]),
     );
+    const refreshedStarterSlots = new Set(
+      personas.map(starterAgentIndex).filter((index) => index >= 0),
+    );
     const reconciledPersonas = [
-      ...currentPersonas.map((persona) =>
-        beforeById.get(persona.id) === persona
-          ? (refreshedById.get(persona.id) ?? persona)
-          : persona,
-      ),
+      ...currentPersonas.flatMap((persona) => {
+        if (beforeById.get(persona.id) !== persona) return [persona];
+        const refreshed = refreshedById.get(persona.id);
+        if (refreshed) return [refreshed];
+        return refreshedStarterSlots.has(starterAgentIndex(persona))
+          ? []
+          : [persona];
+      }),
       ...personas.filter(
         (persona) =>
           !beforeById.has(persona.id) &&

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -39,17 +39,15 @@ export async function resetHomeForOnboardingExperience(): Promise<OnboardingHome
     let starterPersonas = selectStarterAgentPersonas(
       useAgentStore.getState().personas,
     );
-    if (starterPersonas.length !== STARTER_HOME_LAYOUT.agents.length) {
-      try {
-        const personas = await listPersonas();
-        useAgentStore.getState().setPersonas(personas);
-        starterPersonas = selectStarterAgentPersonas(personas);
-      } catch (error) {
-        console.error(
-          "Failed to load starter agents during onboarding reset:",
-          error,
-        );
-      }
+    try {
+      const personas = await listPersonas();
+      useAgentStore.getState().setPersonas(personas);
+      starterPersonas = selectStarterAgentPersonas(personas);
+    } catch (error) {
+      console.error(
+        "Failed to load starter agents during onboarding reset:",
+        error,
+      );
     }
     if (starterPersonas.length === STARTER_HOME_LAYOUT.agents.length) {
       try {

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -33,26 +33,36 @@ export async function resetStarterTasksExperience(): Promise<boolean> {
 
 async function restoreStarterAgentPins(): Promise<boolean> {
   let starterPersonas: ReturnType<typeof selectStarterAgentPersonas>;
+  const personasBeforeRefresh = useAgentStore.getState().personas;
   try {
     const personas = await listPersonas();
-    starterPersonas = selectStarterAgentPersonas(personas);
-    // Merge by stable identity so newly allocated starter personas resolve
-    // immediately without replacing concurrent persona edits in the store.
     const currentPersonas = useAgentStore.getState().personas;
+    const beforeById = new Map(
+      personasBeforeRefresh.map((persona) => [persona.id, persona]),
+    );
     const refreshedById = new Map(
       personas.map((persona) => [persona.id, persona]),
     );
-    useAgentStore
-      .getState()
-      .setPersonas([
-        ...currentPersonas.map(
-          (persona) => refreshedById.get(persona.id) ?? persona,
-        ),
-        ...personas.filter(
-          (persona) =>
-            !currentPersonas.some((current) => current.id === persona.id),
-        ),
-      ]);
+    const reconciledPersonas = [
+      ...currentPersonas.map((persona) =>
+        beforeById.get(persona.id) === persona
+          ? (refreshedById.get(persona.id) ?? persona)
+          : persona,
+      ),
+      ...personas.filter(
+        (persona) =>
+          !beforeById.has(persona.id) &&
+          !currentPersonas.some((current) => current.id === persona.id),
+      ),
+    ];
+    useAgentStore.getState().setPersonas(reconciledPersonas);
+    starterPersonas = selectStarterAgentPersonas(
+      personas.filter(
+        (persona) =>
+          !beforeById.has(persona.id) ||
+          currentPersonas.some((current) => current.id === persona.id),
+      ),
+    );
   } catch (error) {
     console.error(
       "Failed to load starter agents during onboarding reset:",

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -1,3 +1,4 @@
+import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { listPersonas } from "@/shared/api/agents";
 import {
   markStarterAgentPinsEligible,
@@ -33,7 +34,25 @@ export async function resetStarterTasksExperience(): Promise<boolean> {
 async function restoreStarterAgentPins(): Promise<boolean> {
   let starterPersonas: ReturnType<typeof selectStarterAgentPersonas>;
   try {
-    starterPersonas = selectStarterAgentPersonas(await listPersonas());
+    const personas = await listPersonas();
+    starterPersonas = selectStarterAgentPersonas(personas);
+    // Merge by stable identity so newly allocated starter personas resolve
+    // immediately without replacing concurrent persona edits in the store.
+    const currentPersonas = useAgentStore.getState().personas;
+    const refreshedById = new Map(
+      personas.map((persona) => [persona.id, persona]),
+    );
+    useAgentStore
+      .getState()
+      .setPersonas([
+        ...currentPersonas.map(
+          (persona) => refreshedById.get(persona.id) ?? persona,
+        ),
+        ...personas.filter(
+          (persona) =>
+            !currentPersonas.some((current) => current.id === persona.id),
+        ),
+      ]);
   } catch (error) {
     console.error(
       "Failed to load starter agents during onboarding reset:",

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -1,4 +1,3 @@
-import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { listPersonas } from "@/shared/api/agents";
 import {
   markStarterAgentPinsEligible,
@@ -31,46 +30,52 @@ export async function resetStarterTasksExperience(): Promise<boolean> {
   return useHomeWidgetStore.getState().resetStarterTasks();
 }
 
+async function restoreStarterAgentPins(): Promise<boolean> {
+  let starterPersonas: ReturnType<typeof selectStarterAgentPersonas>;
+  try {
+    starterPersonas = selectStarterAgentPersonas(await listPersonas());
+  } catch (error) {
+    console.error(
+      "Failed to load starter agents during onboarding reset:",
+      error,
+    );
+    markStarterAgentPinsEligible();
+    return false;
+  }
+
+  if (starterPersonas.length !== STARTER_HOME_LAYOUT.agents.length) {
+    markStarterAgentPinsEligible();
+    return false;
+  }
+
+  try {
+    const didPersist = await useHomeWidgetStore
+      .getState()
+      .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
+    if (didPersist) {
+      markStarterAgentPinsSeeded();
+      return true;
+    }
+  } catch (error) {
+    console.error(
+      "Failed to persist starter agents during onboarding reset:",
+      error,
+    );
+  }
+  markStarterAgentPinsEligible();
+  return false;
+}
+
 export async function resetHomeForOnboardingExperience(): Promise<OnboardingHomeResetResult> {
   await initializeHomeWidgets();
   const result = await useHomeWidgetStore.getState().resetHomeForOnboarding();
-  if (result.itemsConfirmed) {
-    resetStarterAgentPinsSeeded();
-    let starterPersonas = selectStarterAgentPersonas(
-      useAgentStore.getState().personas,
-    );
-    try {
-      const personas = await listPersonas();
-      useAgentStore.getState().setPersonas(personas);
-      starterPersonas = selectStarterAgentPersonas(personas);
-    } catch (error) {
-      console.error(
-        "Failed to load starter agents during onboarding reset:",
-        error,
-      );
-    }
-    if (starterPersonas.length === STARTER_HOME_LAYOUT.agents.length) {
-      try {
-        const didPersist = await useHomeWidgetStore
-          .getState()
-          .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
-        if (didPersist) {
-          markStarterAgentPinsSeeded();
-        } else {
-          markStarterAgentPinsEligible();
-        }
-      } catch (error) {
-        console.error(
-          "Failed to persist starter agents during onboarding reset:",
-          error,
-        );
-        markStarterAgentPinsEligible();
-      }
-    } else {
-      markStarterAgentPinsEligible();
-    }
-  }
-  return result;
+  if (!result.itemsConfirmed) return result;
+
+  resetStarterAgentPinsSeeded();
+  return {
+    ...result,
+    starterAgentsConfirmed: await restoreStarterAgentPins(),
+  };
 }
 
 export async function resetOnboardingTourExperience(): Promise<boolean> {

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -1,7 +1,10 @@
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { listPersonas } from "@/shared/api/agents";
 import {
   markStarterAgentPinsEligible,
   markStarterAgentPinsSeeded,
   resetStarterAgentPinsSeeded,
+  selectStarterAgentPersonas,
 } from "@/features/home/onboarding/starterAgents";
 import { STARTER_HOME_LAYOUT } from "@/features/home/onboarding/starterHomeLayout";
 import {
@@ -33,11 +36,30 @@ export async function resetHomeForOnboardingExperience(): Promise<OnboardingHome
   const result = await useHomeWidgetStore.getState().resetHomeForOnboarding();
   if (result.itemsConfirmed) {
     resetStarterAgentPinsSeeded();
-    const starterAgentPinCount = useHomeWidgetStore
-      .getState()
-      .instances.filter((instance) => instance.type === "agentPin").length;
-    if (starterAgentPinCount === STARTER_HOME_LAYOUT.agents.length) {
-      markStarterAgentPinsSeeded();
+    let starterPersonas = selectStarterAgentPersonas(
+      useAgentStore.getState().personas,
+    );
+    if (starterPersonas.length !== STARTER_HOME_LAYOUT.agents.length) {
+      try {
+        const personas = await listPersonas();
+        useAgentStore.getState().setPersonas(personas);
+        starterPersonas = selectStarterAgentPersonas(personas);
+      } catch (error) {
+        console.error(
+          "Failed to load starter agents during onboarding reset:",
+          error,
+        );
+      }
+    }
+    if (starterPersonas.length === STARTER_HOME_LAYOUT.agents.length) {
+      const didPersist = await useHomeWidgetStore
+        .getState()
+        .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
+      if (didPersist) {
+        markStarterAgentPinsSeeded();
+      } else {
+        markStarterAgentPinsEligible();
+      }
     } else {
       markStarterAgentPinsEligible();
     }

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -52,12 +52,20 @@ export async function resetHomeForOnboardingExperience(): Promise<OnboardingHome
       }
     }
     if (starterPersonas.length === STARTER_HOME_LAYOUT.agents.length) {
-      const didPersist = await useHomeWidgetStore
-        .getState()
-        .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
-      if (didPersist) {
-        markStarterAgentPinsSeeded();
-      } else {
+      try {
+        const didPersist = await useHomeWidgetStore
+          .getState()
+          .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
+        if (didPersist) {
+          markStarterAgentPinsSeeded();
+        } else {
+          markStarterAgentPinsEligible();
+        }
+      } catch (error) {
+        console.error(
+          "Failed to persist starter agents during onboarding reset:",
+          error,
+        );
         markStarterAgentPinsEligible();
       }
     } else {

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -220,6 +220,7 @@
       "description": "Try and reset onboarding experiences together.",
       "resetAll": "Reset all onboarding",
       "resetAllError": "Couldn't reset all onboarding experiences. Try again.",
+      "resetAllPartial": "Onboarding was reset. Starter agents will appear when they're available.",
       "resetAllSuccess": "All onboarding experiences were reset.",
       "title": "Onboarding"
     },

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -220,6 +220,7 @@
       "description": "Prueba y restablece las experiencias de incorporación juntas.",
       "resetAll": "Restablecer toda la incorporación",
       "resetAllError": "No se pudieron restablecer todas las experiencias de incorporación. Inténtalo de nuevo.",
+      "resetAllPartial": "Se restableció la incorporación. Los agentes iniciales aparecerán cuando estén disponibles.",
       "resetAllSuccess": "Se restablecieron todas las experiencias de incorporación.",
       "title": "Incorporación"
     },


### PR DESCRIPTION
**Category:** improvement
**User Impact:** The starter Home now opens with a more balanced layout, smaller supporting widgets, reliable starter agents, and smoother Berdy onboarding behavior.
**Problem:** The starter Home composition felt crowded and could lose its starter-agent pins after an onboarding reset. Dismissing Berdy's welcome bubble could also shift the avatar or leave an oversized interaction frame.
**Solution:** Refine the canonical starter layout and widget sizing, preserve the camera and visible avatar positions, and make onboarding reset restore verified starter agents with explicit recovery handling.

<details>
<summary>File changes</summary>

**distro/agents/sprout.md**
Updates Agt. Builder's bundled avatar to the strawberry character.

**src/features/experiments/ExperimentsSettings.tsx**
Reports partial onboarding resets when starter agents are still recovering.

**src/features/experiments/__tests__/ExperimentsSettings.test.tsx**
Covers success, failure, and partial-recovery feedback for onboarding reset.

**src/features/home/onboarding/StarterTaskList.tsx**
Uses the pink sticky-note treatment for the starter task list.

**src/features/home/onboarding/createStarterHomeWidgets.test.ts**
Updates canonical starter widget and agent-position expectations.

**src/features/home/onboarding/starterAgents.test.ts**
Covers trusted starter-agent selection and managed-copy behavior.

**src/features/home/onboarding/starterHomeLayout.ts**
Defines the refined starter positions and smaller clock, task list, and agent footprints.

**src/features/home/stores/homeWidgetMutations.test.ts**
Covers clock size migration and stable Berdy avatar positioning across profile changes.

**src/features/home/stores/homeWidgetMutations.ts**
Preserves visible content position while switching state-specific widget size profiles.

**src/features/home/stores/homeWidgetStore.ts**
Exposes starter-agent confirmation in the onboarding reset result.

**src/features/home/ui/HomeView.test.tsx**
Updates Home arrangement and persistence expectations for the refined layout.

**src/features/home/widgets/OnboardingTourWidget.tsx**
Uses an opaque lighter dark-mode tour surface while retaining the existing light treatment.

**src/features/home/widgets/StickyNoteWidget.tsx**
Sets medium sticky-note body text to 14px.

**src/features/home/widgets/catalog.test.ts**
Covers the smaller clock and dismissed Berdy size profile.

**src/features/home/widgets/catalog.ts**
Updates starter widget bounds and adds the avatar-only Berdy profile.

**src/features/home/widgets/types.ts**
Supports profile-specific content offsets and position-preserving profile changes.

**src/features/onboarding/resetOnboardingTour.test.ts**
Covers authoritative persona refresh, persistence failures, stale IDs, and concurrent edits/deletions.

**src/features/onboarding/resetOnboardingTour.ts**
Restores starter-agent pins safely during explicit onboarding reset and preserves concurrent persona changes.

**src/shared/i18n/locales/en/settings.json**
Adds English copy for partial onboarding reset recovery.

**src/shared/i18n/locales/es/settings.json**
Adds Spanish copy for partial onboarding reset recovery.

</details>

## Verification

- `just check`
- Targeted Home/onboarding/widget Vitest suites
