### PR TITLE
organize managed and local connections

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml 1.1.4+spec-1.1.0",
  "url",
  "uuid",
  "which",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -61,6 +61,7 @@ sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "migrate", "macros"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 tauri = { version = "2", features = ["protocol-asset"] }
+toml = "1.1.4"
 tauri-plugin-berdctl = { path = "plugins/berdctl" }
 tauri-plugin-app-test-driver = { path = "plugins/app-test-driver" }
 tauri-plugin-clipboard-manager = "2"

--- a/src-tauri/src/commands/local_mcp_inventory.rs
+++ b/src-tauri/src/commands/local_mcp_inventory.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::HashSet,
+    collections::{hash_map::DefaultHasher, HashSet},
     env, fs,
-    path::{Path, PathBuf},
+    hash::{Hash, Hasher},
+    path::PathBuf,
 };
 
 use serde::Serialize;
@@ -55,7 +56,6 @@ pub enum McpInventoryStatus {
 pub struct McpConfigSource {
     pub scope: McpConfigScope,
     pub label: String,
-    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -67,9 +67,6 @@ pub struct McpConfiguredServer {
     pub config_key: String,
     pub name: String,
     pub transport: McpTransportKind,
-    pub enabled: Option<bool>,
-    pub command: Option<String>,
-    pub url_host: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -85,7 +82,6 @@ pub enum McpSourceStatus {
 pub struct McpCheckedLocation {
     pub scope: McpConfigScope,
     pub label: String,
-    pub path: Option<String>,
     pub status: McpSourceStatus,
 }
 
@@ -291,7 +287,6 @@ fn source_from_file(file: &ConfigFile) -> McpConfigSource {
     McpConfigSource {
         scope: file.scope,
         label: file.label.clone(),
-        path: Some(file.path.to_string_lossy().into_owned()),
     }
 }
 
@@ -299,7 +294,6 @@ fn checked_location_from_file(file: &ConfigFile, status: McpSourceStatus) -> Mcp
     McpCheckedLocation {
         scope: file.scope,
         label: file.label.clone(),
-        path: Some(file.path.to_string_lossy().into_owned()),
         status,
     }
 }
@@ -325,13 +319,10 @@ fn read_json_config(
             record_checked_location(inventory, file, McpSourceStatus::Found);
             Some(value)
         }
-        Err(error) => {
+        Err(_error) => {
             record_checked_location(inventory, file, McpSourceStatus::Error);
             messages.push(format!("{} could not be parsed.", file.label));
-            log::warn!(
-                "failed to parse MCP JSON config {}: {error}",
-                file.path.display()
-            );
+            log::warn!("failed to parse {}", file.label);
             None
         }
     }
@@ -348,13 +339,10 @@ fn read_yaml_config(
             record_checked_location(inventory, file, McpSourceStatus::Found);
             Some(value)
         }
-        Err(error) => {
+        Err(_error) => {
             record_checked_location(inventory, file, McpSourceStatus::Error);
             messages.push(format!("{} could not be parsed.", file.label));
-            log::warn!(
-                "failed to parse MCP YAML config {}: {error}",
-                file.path.display()
-            );
+            log::warn!("failed to parse {}", file.label);
             None
         }
     }
@@ -371,13 +359,10 @@ fn read_toml_config(
             record_checked_location(inventory, file, McpSourceStatus::Found);
             serde_json::to_value(value).ok()
         }
-        Err(error) => {
+        Err(_error) => {
             record_checked_location(inventory, file, McpSourceStatus::Error);
             messages.push(format!("{} could not be parsed.", file.label));
-            log::warn!(
-                "failed to parse MCP TOML config {}: {error}",
-                file.path.display()
-            );
+            log::warn!("failed to parse {}", file.label);
             None
         }
     }
@@ -397,10 +382,7 @@ fn read_config_file(
         Err(error) => {
             record_checked_location(inventory, file, McpSourceStatus::Error);
             messages.push(format!("{} could not be inspected.", file.label));
-            log::warn!(
-                "failed to inspect MCP config {}: {error}",
-                file.path.display()
-            );
+            log::warn!("failed to inspect {}: {}", file.label, error.kind());
             return None;
         }
     };
@@ -422,7 +404,7 @@ fn read_config_file(
         Err(error) => {
             record_checked_location(inventory, file, McpSourceStatus::Error);
             messages.push(format!("{} could not be read.", file.label));
-            log::warn!("failed to read MCP config {}: {error}", file.path.display());
+            log::warn!("failed to read {}: {}", file.label, error.kind());
             None
         }
     }
@@ -448,34 +430,19 @@ fn collect_goose_servers(
             continue;
         };
         let extension_type = yaml_lookup_string(extension_map, "type");
-        let enabled = yaml_lookup(extension_map, "enabled").and_then(YamlValue::as_bool);
         let name = yaml_lookup_string(extension_map, "name")
             .or_else(|| yaml_lookup_string(extension_map, "display_name"))
             .unwrap_or_else(|| config_key.to_string());
 
-        let (transport, command, url_host) = match extension_type.as_deref() {
-            Some("stdio") => (
-                McpTransportKind::Stdio,
-                yaml_lookup_string(extension_map, "cmd")
-                    .as_deref()
-                    .map(command_basename),
-                None,
-            ),
-            Some("streamable_http") | Some("http") => (
-                McpTransportKind::Http,
-                None,
-                yaml_lookup_string(extension_map, "uri").and_then(|url| url_host(&url)),
-            ),
-            Some("sse") => (
-                McpTransportKind::Sse,
-                None,
-                yaml_lookup_string(extension_map, "uri").and_then(|url| url_host(&url)),
-            ),
-            Some("acp") => (McpTransportKind::Acp, None, None),
+        let transport = match extension_type.as_deref() {
+            Some("stdio") => McpTransportKind::Stdio,
+            Some("streamable_http") | Some("http") => McpTransportKind::Http,
+            Some("sse") => McpTransportKind::Sse,
+            Some("acp") => McpTransportKind::Acp,
             Some("builtin") | Some("platform") | Some("frontend") | Some("inline_python") => {
-                (McpTransportKind::Builtin, None, None)
+                McpTransportKind::Builtin
             }
-            _ => (McpTransportKind::Unknown, None, None),
+            _ => McpTransportKind::Unknown,
         };
 
         // Connections inventories MCP servers, not Goose-native capabilities.
@@ -494,9 +461,6 @@ fn collect_goose_servers(
                 config_key: config_key.to_string(),
                 name,
                 transport,
-                enabled,
-                command,
-                url_host,
             },
         );
     }
@@ -588,26 +552,18 @@ fn json_server_from_value(
         .and_then(JsonValue::as_str);
     let transport = infer_transport(server_type, command, url);
 
-    let duplicate_in_same_source = servers.iter().any(|server| {
-        server.harness == harness
-            && server.source.path == source_from_file(file).path
-            && server.source.scope == file.scope
-            && server.config_key == config_key
-    });
-    if duplicate_in_same_source {
+    let id = server_id(harness, file, config_key);
+    if servers.iter().any(|server| server.id == id) {
         return None;
     }
 
     Some(McpConfiguredServer {
-        id: server_id(harness, file, config_key),
+        id,
         harness,
         source: source_from_file(file),
         config_key: config_key.to_string(),
         name,
         transport,
-        enabled: object.get("enabled").and_then(JsonValue::as_bool),
-        command: command.map(command_basename),
-        url_host: url.and_then(url_host),
     })
 }
 
@@ -731,26 +687,14 @@ fn yaml_lookup_string(map: &yaml_serde::Mapping, key: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn command_basename(command: &str) -> String {
-    Path::new(command)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(command)
-        .to_string()
-}
-
-fn url_host(raw_url: &str) -> Option<String> {
-    url::Url::parse(raw_url)
-        .ok()
-        .and_then(|url| url.host_str().map(str::to_string))
-}
-
 fn server_id(harness: McpHarnessId, file: &ConfigFile, config_key: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    file.path.hash(&mut hasher);
     format!(
-        "{:?}:{:?}:{}:{}",
+        "{:?}:{:?}:{:016x}:{}",
         harness,
         file.scope,
-        file.path.to_string_lossy(),
+        hasher.finish(),
         config_key
     )
 }
@@ -758,6 +702,7 @@ fn server_id(harness: McpHarnessId, file: &ConfigFile, config_key: &str) -> Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
     use tempfile::tempdir;
 
     fn file(path: &Path, contents: &str) {
@@ -799,12 +744,40 @@ mod tests {
         collect_claude_code_servers(&mut servers, &config, &value, &[]);
 
         assert_eq!(servers.len(), 2);
-        assert_eq!(servers[0].command.as_deref(), Some("npx"));
-        assert_eq!(servers[1].url_host.as_deref(), Some("api.example.com"));
         let rendered = serde_json::to_string(&servers).unwrap();
         assert!(!rendered.contains("ghp_secret"));
         assert!(!rendered.contains("Bearer"));
         assert!(!rendered.contains("token=secret"));
+    }
+
+    #[test]
+    fn serialized_inventory_contains_no_paths_or_secret_values() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("private-home").join(".mcp.json"),
+            scope: McpConfigScope::Project,
+            label: "Claude Code project config".to_string(),
+        };
+        file(
+            &config.path,
+            r#"{"mcpServers":{"github":{"command":"npx","args":["--token","secret-argument"],"env":{"TOKEN":"secret-env"},"headers":{"Authorization":"Bearer secret-header"},"url":"https://user:pass@example.com/mcp?token=secret-query"}}}"#,
+        );
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let value = read_json_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        collect_claude_code_servers(&mut inventory.servers, &config, &value, &[]);
+        inventory = finish_inventory(inventory, Vec::new());
+
+        let serialized = serde_json::to_string(&inventory).unwrap();
+        for forbidden in [
+            "private-home",
+            "secret-argument",
+            "secret-env",
+            "secret-header",
+            "secret-query",
+            "user:pass",
+        ] {
+            assert!(!serialized.contains(forbidden), "leaked {forbidden}");
+        }
     }
 
     #[test]
@@ -842,8 +815,6 @@ extensions:
         assert_eq!(servers.len(), 1);
         assert_eq!(servers[0].name, "GitHub");
         assert_eq!(servers[0].transport, McpTransportKind::Stdio);
-        assert_eq!(servers[0].enabled, Some(false));
-        assert_eq!(servers[0].command.as_deref(), Some("npx"));
         let rendered = serde_json::to_string(&servers).unwrap();
         assert!(!rendered.contains("ghp_secret"));
     }
@@ -878,7 +849,6 @@ url = "https://mcp.example.test/sse?api_key=secret"
         assert_eq!(servers[0].name, "context7");
         assert_eq!(servers[0].transport, McpTransportKind::Stdio);
         assert_eq!(servers[1].transport, McpTransportKind::Sse);
-        assert_eq!(servers[1].url_host.as_deref(), Some("mcp.example.test"));
         assert!(!serde_json::to_string(&servers).unwrap().contains("api_key"));
     }
 
@@ -908,14 +878,10 @@ url = "https://mcp.example.test/sse?api_key=secret"
             source: McpConfigSource {
                 scope: McpConfigScope::User,
                 label: "Codex user config".to_string(),
-                path: None,
             },
             config_key: "context7".to_string(),
             name: "Context7".to_string(),
             transport: McpTransportKind::Http,
-            enabled: None,
-            command: None,
-            url_host: Some("mcp.context7.com".to_string()),
         });
 
         inventory = finish_inventory(

--- a/src-tauri/src/commands/local_mcp_inventory.rs
+++ b/src-tauri/src/commands/local_mcp_inventory.rs
@@ -1,0 +1,1102 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+use yaml_serde::Value as YamlValue;
+
+use crate::services::goose_config;
+
+const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpHarnessId {
+    Goose,
+    ClaudeCode,
+    Codex,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpConfigScope {
+    User,
+    Project,
+    LocalProject,
+    Profile,
+    Additional,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpTransportKind {
+    Stdio,
+    Http,
+    Sse,
+    Acp,
+    Builtin,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpInventoryStatus {
+    Configured,
+    Unavailable,
+    Partial,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpConfigSource {
+    pub scope: McpConfigScope,
+    pub label: String,
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpConfiguredServer {
+    pub id: String,
+    pub harness: McpHarnessId,
+    pub source: McpConfigSource,
+    pub config_key: String,
+    pub name: String,
+    pub transport: McpTransportKind,
+    pub enabled: Option<bool>,
+    pub command: Option<String>,
+    pub url_host: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum McpSourceStatus {
+    Found,
+    Missing,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpCheckedLocation {
+    pub scope: McpConfigScope,
+    pub label: String,
+    pub path: Option<String>,
+    pub status: McpSourceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpHarnessInventory {
+    pub harness: McpHarnessId,
+    pub status: McpInventoryStatus,
+    pub checked_locations: Vec<McpCheckedLocation>,
+    pub servers: Vec<McpConfiguredServer>,
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInventory {
+    pub harnesses: Vec<McpHarnessInventory>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigFile {
+    pub path: PathBuf,
+    pub scope: McpConfigScope,
+    pub label: String,
+}
+
+impl ConfigFile {
+    fn with_scope(&self, scope: McpConfigScope, label: &str) -> Self {
+        Self {
+            path: self.path.clone(),
+            scope,
+            label: label.to_string(),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn list_local_mcp_inventory(
+    workspace_paths: Option<Vec<String>>,
+) -> Result<McpInventory, String> {
+    let workspace_paths = workspace_paths.unwrap_or_default();
+    tauri::async_runtime::spawn_blocking(move || {
+        list_local_mcp_inventory_blocking(&workspace_paths)
+    })
+    .await
+    .map_err(|error| format!("MCP inventory task failed: {error}"))?
+}
+
+fn list_local_mcp_inventory_blocking(workspace_paths: &[String]) -> Result<McpInventory, String> {
+    Ok(McpInventory {
+        harnesses: vec![
+            discover_goose(),
+            discover_claude_code(workspace_paths),
+            discover_codex(workspace_paths),
+        ],
+    })
+}
+
+fn discover_goose() -> McpHarnessInventory {
+    let mut files = Vec::new();
+    if let Ok(path) = goose_config::config_path() {
+        files.push(ConfigFile {
+            path,
+            scope: McpConfigScope::User,
+            label: "Goose user config".to_string(),
+        });
+    }
+
+    for path in goose_additional_config_paths() {
+        files.push(ConfigFile {
+            path,
+            scope: McpConfigScope::Additional,
+            label: "Goose additional config".to_string(),
+        });
+    }
+
+    let mut inventory = empty_inventory(McpHarnessId::Goose);
+    let mut messages = Vec::new();
+
+    for file in files {
+        let Some(value) = read_yaml_config(&file, &mut inventory, &mut messages) else {
+            continue;
+        };
+        collect_goose_servers(&mut inventory.servers, &file, &value);
+    }
+
+    finish_inventory(inventory, messages)
+}
+
+/// Claude Code config files Berd passively inspects. Local-project MCPs do not
+/// live in a separate workspace file; they are selected from the active
+/// workspace records in `~/.claude.json` during collection.
+fn claude_code_config_files(workspace_paths: &[String]) -> Vec<ConfigFile> {
+    let mut files = Vec::new();
+    if let Some(home) = home_dir() {
+        files.push(ConfigFile {
+            path: home.join(".claude.json"),
+            scope: McpConfigScope::User,
+            label: "Claude Code user config".to_string(),
+        });
+    }
+
+    for workspace in canonical_workspace_paths(workspace_paths) {
+        files.push(ConfigFile {
+            path: workspace.join(".mcp.json"),
+            scope: McpConfigScope::Project,
+            label: "Claude Code project config".to_string(),
+        });
+    }
+
+    files
+}
+
+/// The complete allowlist of Codex config locations Berd will read or modify.
+pub fn codex_config_files(workspace_paths: &[String]) -> Vec<ConfigFile> {
+    let mut files = Vec::new();
+    if let Some(home) = home_dir() {
+        let codex_root = env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .filter(|path| path.is_absolute())
+            .unwrap_or_else(|| home.join(".codex"));
+        files.push(ConfigFile {
+            path: codex_root.join("config.toml"),
+            scope: McpConfigScope::User,
+            label: "Codex user config".to_string(),
+        });
+    }
+
+    for workspace in canonical_workspace_paths(workspace_paths) {
+        files.push(ConfigFile {
+            path: workspace.join(".codex").join("config.toml"),
+            scope: McpConfigScope::Project,
+            label: "Codex project config".to_string(),
+        });
+    }
+
+    files
+}
+
+fn discover_claude_code(workspace_paths: &[String]) -> McpHarnessInventory {
+    let active_workspaces = canonical_workspace_paths(workspace_paths);
+    let files = claude_code_config_files(workspace_paths);
+    let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+    let mut messages = Vec::new();
+
+    for file in files {
+        let Some(value) = read_json_config(&file, &mut inventory, &mut messages) else {
+            continue;
+        };
+        collect_claude_code_servers(&mut inventory.servers, &file, &value, &active_workspaces);
+    }
+
+    finish_inventory(inventory, messages)
+}
+
+fn discover_codex(workspace_paths: &[String]) -> McpHarnessInventory {
+    let files = codex_config_files(workspace_paths);
+    let mut inventory = empty_inventory(McpHarnessId::Codex);
+    let mut messages = Vec::new();
+
+    for file in files {
+        let Some(value) = read_toml_config(&file, &mut inventory, &mut messages) else {
+            continue;
+        };
+        collect_codex_servers(&mut inventory.servers, &file, &value);
+    }
+
+    finish_inventory(inventory, messages)
+}
+
+fn empty_inventory(harness: McpHarnessId) -> McpHarnessInventory {
+    McpHarnessInventory {
+        harness,
+        status: McpInventoryStatus::Unavailable,
+        checked_locations: Vec::new(),
+        servers: Vec::new(),
+        message: None,
+    }
+}
+
+fn finish_inventory(
+    mut inventory: McpHarnessInventory,
+    messages: Vec<String>,
+) -> McpHarnessInventory {
+    if !inventory.servers.is_empty() {
+        inventory.status = if messages.is_empty() {
+            McpInventoryStatus::Configured
+        } else {
+            McpInventoryStatus::Partial
+        };
+    } else if !messages.is_empty() {
+        inventory.status = McpInventoryStatus::Error;
+    }
+
+    if !messages.is_empty() {
+        inventory.message = Some(messages.join(" "));
+    }
+
+    inventory
+}
+
+fn source_from_file(file: &ConfigFile) -> McpConfigSource {
+    McpConfigSource {
+        scope: file.scope,
+        label: file.label.clone(),
+        path: Some(file.path.to_string_lossy().into_owned()),
+    }
+}
+
+fn checked_location_from_file(file: &ConfigFile, status: McpSourceStatus) -> McpCheckedLocation {
+    McpCheckedLocation {
+        scope: file.scope,
+        label: file.label.clone(),
+        path: Some(file.path.to_string_lossy().into_owned()),
+        status,
+    }
+}
+
+fn record_checked_location(
+    inventory: &mut McpHarnessInventory,
+    file: &ConfigFile,
+    status: McpSourceStatus,
+) {
+    inventory
+        .checked_locations
+        .push(checked_location_from_file(file, status));
+}
+
+fn read_json_config(
+    file: &ConfigFile,
+    inventory: &mut McpHarnessInventory,
+    messages: &mut Vec<String>,
+) -> Option<JsonValue> {
+    let contents = read_config_file(file, inventory, messages)?;
+    match serde_json::from_str(&contents) {
+        Ok(value) => {
+            record_checked_location(inventory, file, McpSourceStatus::Found);
+            Some(value)
+        }
+        Err(error) => {
+            record_checked_location(inventory, file, McpSourceStatus::Error);
+            messages.push(format!("{} could not be parsed.", file.label));
+            log::warn!(
+                "failed to parse MCP JSON config {}: {error}",
+                file.path.display()
+            );
+            None
+        }
+    }
+}
+
+fn read_yaml_config(
+    file: &ConfigFile,
+    inventory: &mut McpHarnessInventory,
+    messages: &mut Vec<String>,
+) -> Option<YamlValue> {
+    let contents = read_config_file(file, inventory, messages)?;
+    match yaml_serde::from_str(&contents) {
+        Ok(value) => {
+            record_checked_location(inventory, file, McpSourceStatus::Found);
+            Some(value)
+        }
+        Err(error) => {
+            record_checked_location(inventory, file, McpSourceStatus::Error);
+            messages.push(format!("{} could not be parsed.", file.label));
+            log::warn!(
+                "failed to parse MCP YAML config {}: {error}",
+                file.path.display()
+            );
+            None
+        }
+    }
+}
+
+fn read_toml_config(
+    file: &ConfigFile,
+    inventory: &mut McpHarnessInventory,
+    messages: &mut Vec<String>,
+) -> Option<JsonValue> {
+    let contents = read_config_file(file, inventory, messages)?;
+    match toml::from_str::<toml::Value>(&contents) {
+        Ok(value) => {
+            record_checked_location(inventory, file, McpSourceStatus::Found);
+            serde_json::to_value(value).ok()
+        }
+        Err(error) => {
+            record_checked_location(inventory, file, McpSourceStatus::Error);
+            messages.push(format!("{} could not be parsed.", file.label));
+            log::warn!(
+                "failed to parse MCP TOML config {}: {error}",
+                file.path.display()
+            );
+            None
+        }
+    }
+}
+
+fn read_config_file(
+    file: &ConfigFile,
+    inventory: &mut McpHarnessInventory,
+    messages: &mut Vec<String>,
+) -> Option<String> {
+    let metadata = match fs::metadata(&file.path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            record_checked_location(inventory, file, McpSourceStatus::Missing);
+            return None;
+        }
+        Err(error) => {
+            record_checked_location(inventory, file, McpSourceStatus::Error);
+            messages.push(format!("{} could not be inspected.", file.label));
+            log::warn!(
+                "failed to inspect MCP config {}: {error}",
+                file.path.display()
+            );
+            return None;
+        }
+    };
+
+    if !metadata.is_file() {
+        record_checked_location(inventory, file, McpSourceStatus::Error);
+        messages.push(format!("{} is not a file.", file.label));
+        return None;
+    }
+
+    if metadata.len() > MAX_CONFIG_BYTES {
+        record_checked_location(inventory, file, McpSourceStatus::Error);
+        messages.push(format!("{} is too large to inspect safely.", file.label));
+        return None;
+    }
+
+    match fs::read_to_string(&file.path) {
+        Ok(contents) => Some(contents),
+        Err(error) => {
+            record_checked_location(inventory, file, McpSourceStatus::Error);
+            messages.push(format!("{} could not be read.", file.label));
+            log::warn!("failed to read MCP config {}: {error}", file.path.display());
+            None
+        }
+    }
+}
+
+fn collect_goose_servers(
+    servers: &mut Vec<McpConfiguredServer>,
+    file: &ConfigFile,
+    value: &YamlValue,
+) {
+    let Some(root) = value.as_mapping() else {
+        return;
+    };
+    let Some(extensions) = yaml_lookup(root, "extensions").and_then(YamlValue::as_mapping) else {
+        return;
+    };
+
+    for (key, extension) in extensions {
+        let Some(config_key) = key.as_str() else {
+            continue;
+        };
+        let Some(extension_map) = extension.as_mapping() else {
+            continue;
+        };
+        let extension_type = yaml_lookup_string(extension_map, "type");
+        let enabled = yaml_lookup(extension_map, "enabled").and_then(YamlValue::as_bool);
+        let name = yaml_lookup_string(extension_map, "name")
+            .or_else(|| yaml_lookup_string(extension_map, "display_name"))
+            .unwrap_or_else(|| config_key.to_string());
+
+        let (transport, command, url_host) = match extension_type.as_deref() {
+            Some("stdio") => (
+                McpTransportKind::Stdio,
+                yaml_lookup_string(extension_map, "cmd")
+                    .as_deref()
+                    .map(command_basename),
+                None,
+            ),
+            Some("streamable_http") | Some("http") => (
+                McpTransportKind::Http,
+                None,
+                yaml_lookup_string(extension_map, "uri").and_then(|url| url_host(&url)),
+            ),
+            Some("sse") => (
+                McpTransportKind::Sse,
+                None,
+                yaml_lookup_string(extension_map, "uri").and_then(|url| url_host(&url)),
+            ),
+            Some("acp") => (McpTransportKind::Acp, None, None),
+            Some("builtin") | Some("platform") | Some("frontend") | Some("inline_python") => {
+                (McpTransportKind::Builtin, None, None)
+            }
+            _ => (McpTransportKind::Unknown, None, None),
+        };
+
+        // Connections inventories MCP servers, not Goose-native capabilities.
+        // Builtin/platform/frontend extensions never belong in this section,
+        // regardless of whether a distro marked them bundled.
+        if transport == McpTransportKind::Builtin {
+            continue;
+        }
+
+        push_server(
+            servers,
+            McpConfiguredServer {
+                id: server_id(McpHarnessId::Goose, file, config_key),
+                harness: McpHarnessId::Goose,
+                source: source_from_file(file),
+                config_key: config_key.to_string(),
+                name,
+                transport,
+                enabled,
+                command,
+                url_host,
+            },
+        );
+    }
+}
+
+fn collect_claude_code_servers(
+    servers: &mut Vec<McpConfiguredServer>,
+    file: &ConfigFile,
+    value: &JsonValue,
+    active_workspaces: &[PathBuf],
+) {
+    collect_json_server_map(
+        servers,
+        McpHarnessId::ClaudeCode,
+        file,
+        value.get("mcpServers").or_else(|| value.get("mcp_servers")),
+    );
+
+    if file.scope != McpConfigScope::User || active_workspaces.is_empty() {
+        return;
+    }
+
+    let Some(projects) = value.get("projects").and_then(JsonValue::as_object) else {
+        return;
+    };
+
+    for (project_path, project_config) in projects {
+        let Some(workspace) = canonical_matching_workspace(project_path, active_workspaces) else {
+            continue;
+        };
+        let local_file = ConfigFile {
+            path: file.path.clone(),
+            scope: McpConfigScope::LocalProject,
+            label: format!("Claude Code local project config ({})", workspace.display()),
+        };
+        collect_json_server_map(
+            servers,
+            McpHarnessId::ClaudeCode,
+            &local_file,
+            project_config
+                .get("mcpServers")
+                .or_else(|| project_config.get("mcp_servers")),
+        );
+    }
+}
+
+fn collect_json_server_map(
+    servers: &mut Vec<McpConfiguredServer>,
+    harness: McpHarnessId,
+    file: &ConfigFile,
+    value: Option<&JsonValue>,
+) {
+    let Some(map) = value.and_then(JsonValue::as_object) else {
+        return;
+    };
+    for (config_key, server_value) in map {
+        let Some(server) = json_server_from_value(servers, harness, file, config_key, server_value)
+        else {
+            continue;
+        };
+        push_server(servers, server);
+    }
+}
+
+fn json_server_from_value(
+    servers: &[McpConfiguredServer],
+    harness: McpHarnessId,
+    file: &ConfigFile,
+    config_key: &str,
+    value: &JsonValue,
+) -> Option<McpConfiguredServer> {
+    let object = value.as_object()?;
+    let name = object
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or(config_key)
+        .to_string();
+    let command = object
+        .get("command")
+        .or_else(|| object.get("cmd"))
+        .and_then(JsonValue::as_str);
+    let url = object
+        .get("url")
+        .or_else(|| object.get("uri"))
+        .and_then(JsonValue::as_str);
+    let server_type = object
+        .get("type")
+        .or_else(|| object.get("transport"))
+        .and_then(JsonValue::as_str);
+    let transport = infer_transport(server_type, command, url);
+
+    let duplicate_in_same_source = servers.iter().any(|server| {
+        server.harness == harness
+            && server.source.path == source_from_file(file).path
+            && server.source.scope == file.scope
+            && server.config_key == config_key
+    });
+    if duplicate_in_same_source {
+        return None;
+    }
+
+    Some(McpConfiguredServer {
+        id: server_id(harness, file, config_key),
+        harness,
+        source: source_from_file(file),
+        config_key: config_key.to_string(),
+        name,
+        transport,
+        enabled: object.get("enabled").and_then(JsonValue::as_bool),
+        command: command.map(command_basename),
+        url_host: url.and_then(url_host),
+    })
+}
+
+fn collect_codex_servers(
+    servers: &mut Vec<McpConfiguredServer>,
+    file: &ConfigFile,
+    value: &JsonValue,
+) {
+    collect_json_server_map(
+        servers,
+        McpHarnessId::Codex,
+        file,
+        value.get("mcp_servers").or_else(|| value.get("mcpServers")),
+    );
+
+    if let Some(profiles) = value.get("profiles").and_then(JsonValue::as_object) {
+        for (profile_name, profile_value) in profiles {
+            let profile_file = file.with_scope(
+                McpConfigScope::Profile,
+                &format!("Codex profile config ({profile_name})"),
+            );
+            collect_json_server_map(
+                servers,
+                McpHarnessId::Codex,
+                &profile_file,
+                profile_value
+                    .get("mcp_servers")
+                    .or_else(|| profile_value.get("mcpServers")),
+            );
+        }
+    }
+}
+
+fn push_server(servers: &mut Vec<McpConfiguredServer>, server: McpConfiguredServer) {
+    if server.config_key.trim().is_empty() || server.name.trim().is_empty() {
+        return;
+    }
+    servers.push(server);
+}
+
+fn infer_transport(
+    server_type: Option<&str>,
+    command: Option<&str>,
+    url: Option<&str>,
+) -> McpTransportKind {
+    match server_type
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("stdio") => McpTransportKind::Stdio,
+        Some("http") | Some("streamable_http") | Some("streamable-http") => McpTransportKind::Http,
+        Some("sse") => McpTransportKind::Sse,
+        Some("acp") => McpTransportKind::Acp,
+        Some("builtin") => McpTransportKind::Builtin,
+        _ if command.is_some() => McpTransportKind::Stdio,
+        _ if url.is_some() => McpTransportKind::Http,
+        _ => McpTransportKind::Unknown,
+    }
+}
+
+fn goose_additional_config_paths() -> Vec<PathBuf> {
+    let process_value = env::var_os(goose_config::ADDITIONAL_CONFIG_FILES_ENV);
+    match process_value {
+        Some(value) => env::split_paths(&value)
+            .filter(|path| path.is_absolute())
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+fn canonical_matching_workspace<'a>(
+    project_path: &str,
+    active_workspaces: &'a [PathBuf],
+) -> Option<&'a PathBuf> {
+    let canonical_project = expand_home_prefix(project_path.trim())
+        .canonicalize()
+        .ok()?;
+    active_workspaces
+        .iter()
+        .find(|workspace| **workspace == canonical_project)
+}
+
+fn canonical_workspace_paths(paths: &[String]) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for path in paths {
+        let path = expand_home_prefix(path.trim());
+        let Ok(canonical) = path.canonicalize() else {
+            continue;
+        };
+        if canonical.is_dir() && seen.insert(canonical.clone()) {
+            result.push(canonical);
+        }
+    }
+    result
+}
+
+fn expand_home_prefix(path: &str) -> PathBuf {
+    if path == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from(path));
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+fn yaml_lookup<'a>(map: &'a yaml_serde::Mapping, key: &str) -> Option<&'a YamlValue> {
+    map.get(YamlValue::String(key.to_string()))
+}
+
+fn yaml_lookup_string(map: &yaml_serde::Mapping, key: &str) -> Option<String> {
+    yaml_lookup(map, key)
+        .and_then(YamlValue::as_str)
+        .map(str::to_string)
+}
+
+fn command_basename(command: &str) -> String {
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+        .to_string()
+}
+
+fn url_host(raw_url: &str) -> Option<String> {
+    url::Url::parse(raw_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
+}
+
+fn server_id(harness: McpHarnessId, file: &ConfigFile, config_key: &str) -> String {
+    format!(
+        "{:?}:{:?}:{}:{}",
+        harness,
+        file.scope,
+        file.path.to_string_lossy(),
+        config_key
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn json_discovery_returns_only_structural_metadata() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join(".mcp.json"),
+            scope: McpConfigScope::Project,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            r#"{
+              "mcpServers": {
+                "github": {
+                  "command": "/opt/bin/npx",
+                  "args": ["-y", "@modelcontextprotocol/server-github"],
+                  "env": { "GITHUB_TOKEN": "ghp_secret" },
+                  "headers": { "Authorization": "Bearer secret" }
+                },
+                "remote": {
+                  "type": "http",
+                  "url": "https://api.example.com/mcp?token=secret"
+                }
+              }
+            }"#,
+        );
+
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let value = read_json_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+        collect_claude_code_servers(&mut servers, &config, &value, &[]);
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].command.as_deref(), Some("npx"));
+        assert_eq!(servers[1].url_host.as_deref(), Some("api.example.com"));
+        let rendered = serde_json::to_string(&servers).unwrap();
+        assert!(!rendered.contains("ghp_secret"));
+        assert!(!rendered.contains("Bearer"));
+        assert!(!rendered.contains("token=secret"));
+    }
+
+    #[test]
+    fn goose_discovery_ignores_native_capabilities_and_redacts_env() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("config.yaml"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            r#"
+extensions:
+  developer:
+    type: builtin
+    name: developer
+    bundled: true
+    enabled: true
+  github:
+    type: stdio
+    name: GitHub
+    cmd: /usr/local/bin/npx
+    envs:
+      GITHUB_TOKEN: ghp_secret
+    enabled: false
+"#,
+        );
+
+        let mut inventory = empty_inventory(McpHarnessId::Goose);
+        let value = read_yaml_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+        collect_goose_servers(&mut servers, &config, &value);
+
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].name, "GitHub");
+        assert_eq!(servers[0].transport, McpTransportKind::Stdio);
+        assert_eq!(servers[0].enabled, Some(false));
+        assert_eq!(servers[0].command.as_deref(), Some("npx"));
+        let rendered = serde_json::to_string(&servers).unwrap();
+        assert!(!rendered.contains("ghp_secret"));
+    }
+
+    #[test]
+    fn codex_toml_discovers_mcp_servers() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("config.toml"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            r#"
+[mcp_servers.context7]
+command = "node"
+args = ["server.js"]
+
+[mcp_servers.remote]
+type = "sse"
+url = "https://mcp.example.test/sse?api_key=secret"
+"#,
+        );
+
+        let mut inventory = empty_inventory(McpHarnessId::Codex);
+        let value = read_toml_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+        collect_codex_servers(&mut servers, &config, &value);
+
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "context7");
+        assert_eq!(servers[0].transport, McpTransportKind::Stdio);
+        assert_eq!(servers[1].transport, McpTransportKind::Sse);
+        assert_eq!(servers[1].url_host.as_deref(), Some("mcp.example.test"));
+        assert!(!serde_json::to_string(&servers).unwrap().contains("api_key"));
+    }
+
+    #[test]
+    fn malformed_file_marks_harness_error_without_raw_contents() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("bad.json"),
+            scope: McpConfigScope::User,
+            label: "fixture secret-token-value".to_string(),
+        };
+        file(&config.path, "{ secret: ghp_secret");
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let mut messages = Vec::new();
+        assert!(read_json_config(&config, &mut inventory, &mut messages).is_none());
+        inventory = finish_inventory(inventory, messages);
+        assert_eq!(inventory.status, McpInventoryStatus::Error);
+        assert!(!inventory.message.unwrap_or_default().contains("ghp_secret"));
+    }
+
+    #[test]
+    fn configured_harness_with_read_errors_is_marked_partial() {
+        let mut inventory = empty_inventory(McpHarnessId::Codex);
+        inventory.servers.push(McpConfiguredServer {
+            id: "codex:user:context7".to_string(),
+            harness: McpHarnessId::Codex,
+            source: McpConfigSource {
+                scope: McpConfigScope::User,
+                label: "Codex user config".to_string(),
+                path: None,
+            },
+            config_key: "context7".to_string(),
+            name: "Context7".to_string(),
+            transport: McpTransportKind::Http,
+            enabled: None,
+            command: None,
+            url_host: Some("mcp.context7.com".to_string()),
+        });
+
+        inventory = finish_inventory(
+            inventory,
+            vec!["Codex project config could not be parsed.".to_string()],
+        );
+
+        assert_eq!(inventory.status, McpInventoryStatus::Partial);
+        assert_eq!(inventory.servers.len(), 1);
+    }
+
+    #[test]
+    fn canonical_workspace_paths_ignores_missing_paths() {
+        let dir = tempdir().unwrap();
+        let existing = dir.path().join("workspace");
+        fs::create_dir_all(&existing).unwrap();
+        let result = canonical_workspace_paths(&[
+            existing.to_string_lossy().into_owned(),
+            dir.path().join("missing").to_string_lossy().into_owned(),
+        ]);
+        assert_eq!(result, vec![existing.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn all_inventory_messages_are_generic() {
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        inventory = finish_inventory(
+            inventory,
+            vec!["Claude Code user config could not be parsed.".to_string()],
+        );
+        assert_eq!(inventory.status, McpInventoryStatus::Error);
+        assert_eq!(
+            inventory.message.as_deref(),
+            Some("Claude Code user config could not be parsed.")
+        );
+    }
+
+    #[test]
+    fn empty_workspace_list_checks_only_user_claude_location() {
+        let inventory = discover_claude_code(&[]);
+        assert!(inventory
+            .checked_locations
+            .iter()
+            .any(|location| location.scope == McpConfigScope::User));
+        assert!(!inventory
+            .checked_locations
+            .iter()
+            .any(|location| location.scope == McpConfigScope::Project));
+    }
+
+    #[test]
+    fn missing_candidate_locations_are_marked_missing_not_sources() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("missing.json"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let mut messages = Vec::new();
+
+        assert!(read_json_config(&config, &mut inventory, &mut messages).is_none());
+
+        assert_eq!(inventory.checked_locations.len(), 1);
+        assert_eq!(
+            inventory.checked_locations[0].status,
+            McpSourceStatus::Missing
+        );
+        assert!(inventory.servers.is_empty());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn claude_user_config_does_not_recursively_inventory_unrelated_projects() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join(".claude.json"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            r#"{
+              "projects": {
+                "/elsewhere": {
+                  "mcpServers": {
+                    "unrelated": { "command": "node" }
+                  }
+                }
+              }
+            }"#,
+        );
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let value = read_json_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+
+        collect_claude_code_servers(&mut servers, &config, &value, &[]);
+
+        assert!(servers.is_empty());
+    }
+
+    #[test]
+    fn claude_user_config_includes_only_active_workspace_local_servers() {
+        let dir = tempdir().unwrap();
+        let active_workspace = dir.path().join("active");
+        let unrelated_workspace = dir.path().join("unrelated");
+        fs::create_dir_all(&active_workspace).unwrap();
+        fs::create_dir_all(&unrelated_workspace).unwrap();
+        let config = ConfigFile {
+            path: dir.path().join(".claude.json"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            &format!(
+                r#"{{
+                  "mcpServers": {{
+                    "shared": {{ "command": "node" }}
+                  }},
+                  "projects": {{
+                    "{}": {{
+                      "mcpServers": {{
+                        "shared": {{ "command": "npx", "env": {{ "TOKEN": "secret" }} }}
+                      }}
+                    }},
+                    "{}": {{
+                      "mcpServers": {{
+                        "unrelated": {{ "command": "node" }}
+                      }}
+                    }}
+                  }}
+                }}"#,
+                active_workspace.display(),
+                unrelated_workspace.display(),
+            ),
+        );
+        let mut inventory = empty_inventory(McpHarnessId::ClaudeCode);
+        let value = read_json_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+        let active_workspaces = vec![active_workspace.canonicalize().unwrap()];
+
+        collect_claude_code_servers(&mut servers, &config, &value, &active_workspaces);
+
+        assert_eq!(
+            servers
+                .iter()
+                .map(|server| (server.config_key.as_str(), server.source.scope))
+                .collect::<Vec<_>>(),
+            vec![
+                ("shared", McpConfigScope::User),
+                ("shared", McpConfigScope::LocalProject),
+            ]
+        );
+        assert_ne!(servers[0].id, servers[1].id);
+        let rendered = serde_json::to_string(&servers).unwrap();
+        assert!(!rendered.contains("unrelated"));
+        assert!(!rendered.contains("secret"));
+    }
+
+    #[test]
+    fn codex_discovery_does_not_treat_generic_servers_as_mcp() {
+        let dir = tempdir().unwrap();
+        let config = ConfigFile {
+            path: dir.path().join("config.toml"),
+            scope: McpConfigScope::User,
+            label: "fixture".to_string(),
+        };
+        file(
+            &config.path,
+            r#"
+[servers.not_mcp]
+command = "node"
+"#,
+        );
+        let mut inventory = empty_inventory(McpHarnessId::Codex);
+        let value = read_toml_config(&config, &mut inventory, &mut Vec::new()).unwrap();
+        let mut servers = Vec::new();
+
+        collect_codex_servers(&mut servers, &config, &value);
+
+        assert!(servers.is_empty());
+    }
+}

--- a/src-tauri/src/commands/local_mcp_inventory.rs
+++ b/src-tauri/src/commands/local_mcp_inventory.rs
@@ -31,7 +31,7 @@ pub enum McpConfigScope {
     Additional,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum McpTransportKind {
     Stdio,
@@ -67,6 +67,7 @@ pub struct McpConfiguredServer {
     pub config_key: String,
     pub name: String,
     pub transport: McpTransportKind,
+    pub identity_fingerprint: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -452,6 +453,10 @@ fn collect_goose_servers(
             continue;
         }
 
+        let command = yaml_lookup_string(extension_map, "cmd");
+        let args = yaml_lookup_string_sequence(extension_map, "args");
+        let url = yaml_lookup_string(extension_map, "uri")
+            .or_else(|| yaml_lookup_string(extension_map, "url"));
         push_server(
             servers,
             McpConfiguredServer {
@@ -461,6 +466,12 @@ fn collect_goose_servers(
                 config_key: config_key.to_string(),
                 name,
                 transport,
+                identity_fingerprint: identity_fingerprint(
+                    transport,
+                    command.as_deref(),
+                    &args,
+                    url.as_deref(),
+                ),
             },
         );
     }
@@ -488,13 +499,13 @@ fn collect_claude_code_servers(
     };
 
     for (project_path, project_config) in projects {
-        let Some(workspace) = canonical_matching_workspace(project_path, active_workspaces) else {
+        if canonical_matching_workspace(project_path, active_workspaces).is_none() {
             continue;
-        };
+        }
         let local_file = ConfigFile {
             path: file.path.clone(),
             scope: McpConfigScope::LocalProject,
-            label: format!("Claude Code local project config ({})", workspace.display()),
+            label: "Claude Code local project config".to_string(),
         };
         collect_json_server_map(
             servers,
@@ -542,6 +553,17 @@ fn json_server_from_value(
         .get("command")
         .or_else(|| object.get("cmd"))
         .and_then(JsonValue::as_str);
+    let args = object
+        .get("args")
+        .and_then(JsonValue::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(JsonValue::as_str)
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
     let url = object
         .get("url")
         .or_else(|| object.get("uri"))
@@ -564,6 +586,7 @@ fn json_server_from_value(
         config_key: config_key.to_string(),
         name,
         transport,
+        identity_fingerprint: identity_fingerprint(transport, command, &args, url),
     })
 }
 
@@ -685,6 +708,72 @@ fn yaml_lookup_string(map: &yaml_serde::Mapping, key: &str) -> Option<String> {
     yaml_lookup(map, key)
         .and_then(YamlValue::as_str)
         .map(str::to_string)
+}
+
+fn yaml_lookup_string_sequence(map: &yaml_serde::Mapping, key: &str) -> Vec<String> {
+    yaml_lookup(map, key)
+        .and_then(YamlValue::as_sequence)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(YamlValue::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn safe_stdio_identity(command: Option<&str>, args: &[String]) -> String {
+    let executable = command
+        .and_then(|value| PathBuf::from(value).file_name().map(|name| name.to_owned()))
+        .and_then(|name| name.to_str().map(str::to_string))
+        .unwrap_or_default();
+    let safe_args = args
+        .iter()
+        .filter(|arg| {
+            !arg.contains('=')
+                && !arg.to_ascii_lowercase().contains("token")
+                && !arg.to_ascii_lowercase().contains("secret")
+                && !arg.to_ascii_lowercase().contains("password")
+        })
+        .take(4)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\u{0}");
+    format!("{executable}\u{0}{safe_args}")
+}
+
+fn safe_remote_identity(raw_url: Option<&str>) -> String {
+    let Some(mut url) = raw_url.and_then(|value| url::Url::parse(value).ok()) else {
+        return String::new();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
+    format!(
+        "{}://{}{}",
+        url.scheme(),
+        url.host_str().unwrap_or_default(),
+        url.path()
+    )
+}
+
+fn identity_fingerprint(
+    transport: McpTransportKind,
+    command: Option<&str>,
+    args: &[String],
+    url: Option<&str>,
+) -> String {
+    let identity = match transport {
+        McpTransportKind::Stdio => safe_stdio_identity(command, args),
+        McpTransportKind::Http | McpTransportKind::Sse => safe_remote_identity(url),
+        _ => String::new(),
+    };
+    let mut hasher = DefaultHasher::new();
+    transport.hash(&mut hasher);
+    identity.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 fn server_id(harness: McpHarnessId, file: &ConfigFile, config_key: &str) -> String {
@@ -846,6 +935,10 @@ url = "https://mcp.example.test/sse?api_key=secret"
         collect_codex_servers(&mut servers, &config, &value);
 
         assert_eq!(servers.len(), 2);
+        assert_ne!(
+            servers[0].identity_fingerprint,
+            servers[1].identity_fingerprint
+        );
         assert_eq!(servers[0].name, "context7");
         assert_eq!(servers[0].transport, McpTransportKind::Stdio);
         assert_eq!(servers[1].transport, McpTransportKind::Sse);
@@ -882,6 +975,7 @@ url = "https://mcp.example.test/sse?api_key=secret"
             config_key: "context7".to_string(),
             name: "Context7".to_string(),
             transport: McpTransportKind::Http,
+            identity_fingerprint: "fixture".to_string(),
         });
 
         inventory = finish_inventory(
@@ -1040,6 +1134,8 @@ url = "https://mcp.example.test/sse?api_key=secret"
         let rendered = serde_json::to_string(&servers).unwrap();
         assert!(!rendered.contains("unrelated"));
         assert!(!rendered.contains("secret"));
+        assert!(!rendered.contains(active_workspace.to_string_lossy().as_ref()));
+        assert!(!rendered.contains("Claude Code local project config ("));
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub mod git_changes;
 pub mod global_shortcut;
 pub mod home_widget_media;
 pub mod layout;
+pub mod local_mcp_inventory;
 pub mod message_queues;
 pub mod migration;
 pub mod model_setup;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -524,6 +524,7 @@ pub fn run() {
             commands::message_queues::persist_message_queue_updates,
             commands::model_setup::start_model_setup,
             commands::model_setup::get_model_setup_status,
+            commands::local_mcp_inventory::list_local_mcp_inventory,
             commands::model_setup::list_model_setup_status,
             commands::model_setup::clear_model_setup_status,
             commands::notifications::show_completion_notification,

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -577,6 +577,7 @@ vi.mock("./ui/AppShellContent", () => ({
     onSelectSession,
     onStartProjectChat,
     onResolveBerdyAgent,
+    onStartConnectionSetupChat,
   }) => {
     const starterTasks = useStarterTasks();
     const activeView = targetLocation.view;
@@ -606,6 +607,17 @@ vi.mock("./ui/AppShellContent", () => ({
           {renderedSession?.id ?? "none"}
         </div>
         <div data-testid="settings-section">{activeSettingsSection}</div>
+        <button
+          type="button"
+          onClick={() =>
+            onStartConnectionSetupChat({
+              title: "Add a connection",
+              prompt: "Which connection?",
+            })
+          }
+        >
+          Test connection setup
+        </button>
         <div data-testid="skill-route">{activeSkillsSkillId ?? "list"}</div>
         <div data-testid="agent-route">{activeAgentsPersonaId ?? "list"}</div>
         <div data-testid="automation-route">
@@ -4689,6 +4701,31 @@ describe("AppShell global navigation", () => {
     });
     expect(screen.getByTestId("active-view")).toHaveTextContent("home");
     expect(useChatSessionStore.getState().activeSessionId).toBeNull();
+  });
+
+  it("starts connection setup as an editable draft in the selected harness", async () => {
+    selectCodexProvider();
+    mockAgentStatus.readyAgentIds = new Set(["codex-acp"]);
+    seedProviderModels("codex-acp", [
+      { id: "gpt-5.5", name: "GPT-5.5", recommended: true },
+    ]);
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(
+      screen.getByRole("button", { name: "Test connection setup" }),
+    );
+
+    await waitFor(() => {
+      expect(mockAcpCreateSession).toHaveBeenCalledWith(
+        "codex-acp",
+        expect.any(String),
+        expect.any(Object),
+      );
+    });
+    expect(useChatStore.getState().draftsBySession["created-session"]).toBe(
+      "Which connection?",
+    );
   });
 
   it("opens extension search results in Settings Connections", async () => {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -164,6 +164,7 @@ import {
   getChatSessionIdsWithTerminals,
   setTerminalRenderingSuspended,
 } from "@/features/terminal/lib/terminalSessionManager";
+import type { SetupChatRequest } from "@/features/chat/lib/setupChatRequest";
 import type { AgentSetupTroubleshootingRequest } from "@/features/providers/lib/agentSetupTroubleshooting";
 import type { SkillInfo } from "@/features/skills/api/skills";
 import { toChatSkillDraft } from "@/features/skills/lib/skillChatPrompt";
@@ -3316,6 +3317,26 @@ export function AppShell({
     );
   }, [handleGlobalVoiceConversationStart]);
 
+  const handleStartConnectionSetupChat = useCallback(
+    (request: SetupChatRequest) => {
+      guardAppNavigation(() => {
+        const harnessId = selectedProviderRef.current ?? "goose";
+        void createNewTab(request.title, undefined, {
+          executionTarget: { harnessId },
+        })
+          .then((session) => {
+            if (!session) return;
+            const sessionId = resolveLiveSessionId(session.id) ?? session.id;
+            useChatStore.getState().setDraft(sessionId, request.prompt);
+          })
+          .catch((error) => {
+            console.error("Failed to start connection setup chat:", error);
+          });
+      });
+    },
+    [guardAppNavigation, createNewTab],
+  );
+
   const handleStartProviderTroubleshootingChat = useCallback(
     (request: AgentSetupTroubleshootingRequest) => {
       guardAppNavigation(() => {
@@ -5147,6 +5168,7 @@ export function AppShell({
               onStartProviderTroubleshootingChat={
                 handleStartProviderTroubleshootingChat
               }
+              onStartConnectionSetupChat={handleStartConnectionSetupChat}
               onReturnToAgentDraft={
                 agentBuilderSettingsReturnTarget
                   ? returnToAgentBuilderSettingsTarget

--- a/src/app/ui/AppShellContent.tsx
+++ b/src/app/ui/AppShellContent.tsx
@@ -22,6 +22,7 @@ import type { SkillInfo } from "@/features/skills/api/skills";
 import type { ProjectInfo } from "@/features/projects/api/projects";
 import type { WorkspaceNameRequest } from "@/features/chat/hooks/useChatSessionController";
 import type { ExtensionEntry } from "@/features/extensions/types";
+import type { SetupChatRequest } from "@/features/chat/lib/setupChatRequest";
 import type { AgentSetupTroubleshootingRequest } from "@/features/providers/lib/agentSetupTroubleshooting";
 import type { ForkSessionHandler } from "@/features/sessions/hooks/useForkSession";
 import type { CommandOutcome } from "@/features/berdctl/navigation";
@@ -115,6 +116,7 @@ interface AppShellContentProps {
   onStartProviderTroubleshootingChat: (
     request: AgentSetupTroubleshootingRequest,
   ) => void;
+  onStartConnectionSetupChat: (request: SetupChatRequest) => void;
   onReturnToAgentDraft?: () => void;
   onOpenProvidersSettings: () => void;
   homeProviderSetupRequired?: boolean;
@@ -176,6 +178,7 @@ export function AppShellContent({
   onHydratePinnedChatSessions,
   onLoggedOut,
   onStartProviderTroubleshootingChat,
+  onStartConnectionSetupChat,
   onReturnToAgentDraft,
   onOpenProvidersSettings,
   homeProviderSetupRequired = false,
@@ -271,6 +274,7 @@ export function AppShellContent({
     onStartChatFromProject,
     onStartChatWithSkill,
     onStartProviderTroubleshootingChat,
+    onStartConnectionSetupChat,
     renderedSession,
     setupRequiredContent,
   });
@@ -358,6 +362,7 @@ interface RenderRouteContentOptions {
   onStartProviderTroubleshootingChat: (
     request: AgentSetupTroubleshootingRequest,
   ) => void;
+  onStartConnectionSetupChat: (request: SetupChatRequest) => void;
   onReturnToAgentDraft?: () => void;
   renderedSession?: ChatSession;
   setupRequiredContent: ReactNode | null;
@@ -410,6 +415,7 @@ function renderRouteContent({
   onStartChatFromProject,
   onStartChatWithSkill,
   onStartProviderTroubleshootingChat,
+  onStartConnectionSetupChat,
   setupRequiredContent,
   renderedSession,
 }: RenderRouteContentOptions) {
@@ -431,6 +437,7 @@ function renderRouteContent({
           authStatus={authStatus}
           onLoggedOut={onLoggedOut}
           onStartTroubleshootingChat={onStartProviderTroubleshootingChat}
+          onStartConnectionSetupChat={onStartConnectionSetupChat}
           onReturnToAgentDraft={onReturnToAgentDraft}
         />
       );

--- a/src/features/chat/lib/setupChatRequest.ts
+++ b/src/features/chat/lib/setupChatRequest.ts
@@ -1,0 +1,4 @@
+export interface SetupChatRequest {
+  title: string;
+  prompt: string;
+}

--- a/src/features/connections/api/localMcpInventory.ts
+++ b/src/features/connections/api/localMcpInventory.ts
@@ -1,0 +1,66 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type McpHarnessId = "goose" | "claudeCode" | "codex";
+export type McpConfigScope =
+  | "user"
+  | "project"
+  | "localProject"
+  | "profile"
+  | "additional";
+export type McpTransportKind =
+  | "stdio"
+  | "http"
+  | "sse"
+  | "acp"
+  | "builtin"
+  | "unknown";
+export type McpInventoryStatus =
+  | "configured"
+  | "unavailable"
+  | "partial"
+  | "error";
+export type McpSourceStatus = "found" | "missing" | "error";
+
+export interface McpConfigSource {
+  scope: McpConfigScope;
+  label: string;
+  path?: string | null;
+}
+
+export interface McpCheckedLocation extends McpConfigSource {
+  status: McpSourceStatus;
+}
+
+export interface McpConfiguredServer {
+  id: string;
+  harness: McpHarnessId;
+  source: McpConfigSource;
+  configKey: string;
+  name: string;
+  transport: McpTransportKind;
+  enabled?: boolean | null;
+  command?: string | null;
+  urlHost?: string | null;
+}
+
+export interface McpHarnessInventory {
+  harness: McpHarnessId;
+  status: McpInventoryStatus;
+  checkedLocations: McpCheckedLocation[];
+  servers: McpConfiguredServer[];
+  message?: string | null;
+}
+
+export interface McpInventory {
+  harnesses: McpHarnessInventory[];
+}
+
+export const LOCAL_MCP_INVENTORY_QUERY_KEY = ["mcp-inventory"] as const;
+
+export async function listLocalMcpInventory(
+  workspacePaths: string[] = [],
+): Promise<McpInventory> {
+  return invoke<McpInventory>("list_local_mcp_inventory", {
+    workspacePaths,
+  });
+}

--- a/src/features/connections/api/localMcpInventory.ts
+++ b/src/features/connections/api/localMcpInventory.ts
@@ -37,6 +37,7 @@ export interface McpConfiguredServer {
   configKey: string;
   name: string;
   transport: McpTransportKind;
+  identityFingerprint: string;
   enabled?: boolean | null;
 }
 

--- a/src/features/connections/api/localMcpInventory.ts
+++ b/src/features/connections/api/localMcpInventory.ts
@@ -24,7 +24,6 @@ export type McpSourceStatus = "found" | "missing" | "error";
 export interface McpConfigSource {
   scope: McpConfigScope;
   label: string;
-  path?: string | null;
 }
 
 export interface McpCheckedLocation extends McpConfigSource {
@@ -39,8 +38,6 @@ export interface McpConfiguredServer {
   name: string;
   transport: McpTransportKind;
   enabled?: boolean | null;
-  command?: string | null;
-  urlHost?: string | null;
 }
 
 export interface McpHarnessInventory {

--- a/src/features/connections/lib/__tests__/localMcpInventory.test.ts
+++ b/src/features/connections/lib/__tests__/localMcpInventory.test.ts
@@ -16,13 +16,11 @@ const inventory: McpInventory = {
         {
           id: "goose:github",
           harness: "goose",
-          source: { scope: "user", label: "Goose user config", path: "/g" },
+          source: { scope: "user", label: "Goose user config" },
           configKey: "github",
           name: "GitHub",
           transport: "stdio",
           enabled: true,
-          command: "npx",
-          urlHost: null,
         },
       ],
       message: null,
@@ -38,14 +36,11 @@ const inventory: McpInventory = {
           source: {
             scope: "project",
             label: "Claude Code project config",
-            path: "/repo/.mcp.json",
           },
           configKey: "github",
-          name: "github",
-          transport: "http",
+          name: "GitHub",
+          transport: "stdio",
           enabled: null,
-          command: null,
-          urlHost: "api.githubcopilot.com",
         },
         {
           id: "claude:context7",
@@ -53,14 +48,11 @@ const inventory: McpInventory = {
           source: {
             scope: "project",
             label: "Claude Code project config",
-            path: "/repo/.mcp.json",
           },
           configKey: "context7",
           name: "Context7",
           transport: "http",
           enabled: null,
-          command: null,
-          urlHost: "mcp.context7.com",
         },
       ],
       message: null,
@@ -83,13 +75,48 @@ describe("MCP inventory grouping", () => {
       "Context7",
       "GitHub",
     ]);
-    expect(groups.find((group) => group.id === "github")?.harnesses).toEqual([
-      "goose",
-      "claudeCode",
-    ]);
-    expect(groups.find((group) => group.id === "github")?.entries).toHaveLength(
-      2,
-    );
+    const github = groups.find((group) => group.displayName === "GitHub");
+    expect(github?.harnesses).toEqual(["goose", "claudeCode"]);
+    expect(github?.entries).toHaveLength(2);
+  });
+
+  it("does not merge same-key servers with different structural evidence", () => {
+    const collidingInventory: McpInventory = {
+      harnesses: [
+        {
+          harness: "goose",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "goose:default",
+              harness: "goose",
+              source: { scope: "user", label: "Goose user config" },
+              configKey: "default",
+              name: "GitHub",
+              transport: "stdio",
+            },
+          ],
+        },
+        {
+          harness: "codex",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "codex:default",
+              harness: "codex",
+              source: { scope: "user", label: "Codex user config" },
+              configKey: "default",
+              name: "Context7",
+              transport: "http",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(groupMcpServers(collidingInventory)).toHaveLength(2);
   });
 
   it("does not merge punctuation-distinct config keys", () => {
@@ -131,12 +158,12 @@ describe("MCP inventory grouping", () => {
     expect(groupMcpServers(collidingInventory)).toHaveLength(2);
   });
 
-  it("filters by harness, source, transport, and safe endpoint host", () => {
+  it("filters by visible identity, harness, source, and transport", () => {
     const groups = groupMcpServers(inventory);
 
     expect(filterMcpGroups(groups, "context7")).toHaveLength(1);
     expect(filterMcpGroups(groups, "Claude Code")).toHaveLength(2);
-    expect(filterMcpGroups(groups, "mcp.context7.com")[0].id).toBe("context7");
+    expect(filterMcpGroups(groups, "http")).toHaveLength(1);
   });
 
   it("exposes harness errors separately from configured groups", () => {

--- a/src/features/connections/lib/__tests__/localMcpInventory.test.ts
+++ b/src/features/connections/lib/__tests__/localMcpInventory.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { McpInventory } from "@/features/connections/api/localMcpInventory";
+import {
+  filterMcpGroups,
+  groupMcpServers,
+  harnessesWithErrors,
+} from "../localMcpInventory";
+
+const inventory: McpInventory = {
+  harnesses: [
+    {
+      harness: "goose",
+      status: "configured",
+      checkedLocations: [],
+      servers: [
+        {
+          id: "goose:github",
+          harness: "goose",
+          source: { scope: "user", label: "Goose user config", path: "/g" },
+          configKey: "github",
+          name: "GitHub",
+          transport: "stdio",
+          enabled: true,
+          command: "npx",
+          urlHost: null,
+        },
+      ],
+      message: null,
+    },
+    {
+      harness: "claudeCode",
+      status: "configured",
+      checkedLocations: [],
+      servers: [
+        {
+          id: "claude:github",
+          harness: "claudeCode",
+          source: {
+            scope: "project",
+            label: "Claude Code project config",
+            path: "/repo/.mcp.json",
+          },
+          configKey: "github",
+          name: "github",
+          transport: "http",
+          enabled: null,
+          command: null,
+          urlHost: "api.githubcopilot.com",
+        },
+        {
+          id: "claude:context7",
+          harness: "claudeCode",
+          source: {
+            scope: "project",
+            label: "Claude Code project config",
+            path: "/repo/.mcp.json",
+          },
+          configKey: "context7",
+          name: "Context7",
+          transport: "http",
+          enabled: null,
+          command: null,
+          urlHost: "mcp.context7.com",
+        },
+      ],
+      message: null,
+    },
+    {
+      harness: "codex",
+      status: "error",
+      checkedLocations: [],
+      servers: [],
+      message: "Codex user config could not be parsed.",
+    },
+  ],
+};
+
+describe("MCP inventory grouping", () => {
+  it("groups same-name MCPs across harnesses while preserving entries", () => {
+    const groups = groupMcpServers(inventory);
+
+    expect(groups.map((group) => group.displayName)).toEqual([
+      "Context7",
+      "GitHub",
+    ]);
+    expect(groups.find((group) => group.id === "github")?.harnesses).toEqual([
+      "goose",
+      "claudeCode",
+    ]);
+    expect(groups.find((group) => group.id === "github")?.entries).toHaveLength(
+      2,
+    );
+  });
+
+  it("does not merge punctuation-distinct config keys", () => {
+    const collidingInventory: McpInventory = {
+      harnesses: [
+        {
+          harness: "goose",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "goose:block-app-kit",
+              harness: "goose",
+              source: { scope: "user", label: "Goose user config" },
+              configKey: "block-app-kit",
+              name: "Block App Kit",
+              transport: "stdio",
+            },
+          ],
+        },
+        {
+          harness: "codex",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "codex:block.app.kit",
+              harness: "codex",
+              source: { scope: "user", label: "Codex user config" },
+              configKey: "block.app.kit",
+              name: "Block App Kit",
+              transport: "stdio",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(groupMcpServers(collidingInventory)).toHaveLength(2);
+  });
+
+  it("filters by harness, source, transport, and safe endpoint host", () => {
+    const groups = groupMcpServers(inventory);
+
+    expect(filterMcpGroups(groups, "context7")).toHaveLength(1);
+    expect(filterMcpGroups(groups, "Claude Code")).toHaveLength(2);
+    expect(filterMcpGroups(groups, "mcp.context7.com")[0].id).toBe("context7");
+  });
+
+  it("exposes harness errors separately from configured groups", () => {
+    expect(
+      harnessesWithErrors(inventory).map((harness) => harness.harness),
+    ).toEqual(["codex"]);
+  });
+});

--- a/src/features/connections/lib/__tests__/localMcpInventory.test.ts
+++ b/src/features/connections/lib/__tests__/localMcpInventory.test.ts
@@ -20,6 +20,7 @@ const inventory: McpInventory = {
           configKey: "github",
           name: "GitHub",
           transport: "stdio",
+          identityFingerprint: "stdio-shared",
           enabled: true,
         },
       ],
@@ -40,6 +41,7 @@ const inventory: McpInventory = {
           configKey: "github",
           name: "GitHub",
           transport: "stdio",
+          identityFingerprint: "stdio-shared",
           enabled: null,
         },
         {
@@ -52,6 +54,7 @@ const inventory: McpInventory = {
           configKey: "context7",
           name: "Context7",
           transport: "http",
+          identityFingerprint: "http-shared",
           enabled: null,
         },
       ],
@@ -95,6 +98,7 @@ describe("MCP inventory grouping", () => {
               configKey: "default",
               name: "GitHub",
               transport: "stdio",
+              identityFingerprint: "stdio-shared",
             },
           ],
         },
@@ -110,6 +114,7 @@ describe("MCP inventory grouping", () => {
               configKey: "default",
               name: "Context7",
               transport: "http",
+              identityFingerprint: "http-shared",
             },
           ],
         },
@@ -117,6 +122,47 @@ describe("MCP inventory grouping", () => {
     };
 
     expect(groupMcpServers(collidingInventory)).toHaveLength(2);
+  });
+
+  it("does not merge same-key name and transport with different targets", () => {
+    const targetCollision: McpInventory = {
+      harnesses: [
+        {
+          harness: "goose",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "goose:github",
+              harness: "goose",
+              source: { scope: "user", label: "Goose user config" },
+              configKey: "github",
+              name: "GitHub",
+              transport: "stdio",
+              identityFingerprint: "target-one",
+            },
+          ],
+        },
+        {
+          harness: "codex",
+          status: "configured",
+          checkedLocations: [],
+          servers: [
+            {
+              id: "codex:github",
+              harness: "codex",
+              source: { scope: "user", label: "Codex user config" },
+              configKey: "github",
+              name: "GitHub",
+              transport: "stdio",
+              identityFingerprint: "target-two",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(groupMcpServers(targetCollision)).toHaveLength(2);
   });
 
   it("does not merge punctuation-distinct config keys", () => {
@@ -134,6 +180,7 @@ describe("MCP inventory grouping", () => {
               configKey: "block-app-kit",
               name: "Block App Kit",
               transport: "stdio",
+              identityFingerprint: "stdio-shared",
             },
           ],
         },
@@ -149,6 +196,7 @@ describe("MCP inventory grouping", () => {
               configKey: "block.app.kit",
               name: "Block App Kit",
               transport: "stdio",
+              identityFingerprint: "stdio-shared",
             },
           ],
         },

--- a/src/features/connections/lib/localMcpInventory.ts
+++ b/src/features/connections/lib/localMcpInventory.ts
@@ -32,11 +32,14 @@ function normalizeIdentity(value: string): string {
 }
 
 export function mcpIdentityKey(server: McpConfiguredServer): string {
-  return (
-    normalizeIdentity(server.configKey) ||
-    normalizeIdentity(server.name) ||
-    server.id
-  );
+  const configKey = normalizeIdentity(server.configKey);
+  const name = normalizeIdentity(server.name);
+  if (!configKey || !name) return server.id;
+
+  // A shared key alone is not identity: generic names such as `server` and
+  // `default` commonly point at unrelated implementations. Reconcile only
+  // when independently authored name and transport evidence also agree.
+  return `${configKey}:${name}:${server.transport}`;
 }
 
 function displayNameForGroup(entries: McpConfiguredServer[]): string {
@@ -104,21 +107,12 @@ export function filterMcpGroups(
         entry.source.label,
         entry.source.scope,
         entry.transport,
-        entry.command ?? "",
-        entry.urlHost ?? "",
       ]),
     ]
       .join(" ")
       .toLowerCase();
     return searchable.includes(query);
   });
-}
-
-export function configuredServerCount(inventory: McpInventory | undefined) {
-  return (inventory?.harnesses ?? []).reduce(
-    (count, harness) => count + harness.servers.length,
-    0,
-  );
 }
 
 export function harnessesWithErrors(

--- a/src/features/connections/lib/localMcpInventory.ts
+++ b/src/features/connections/lib/localMcpInventory.ts
@@ -39,7 +39,7 @@ export function mcpIdentityKey(server: McpConfiguredServer): string {
   // A shared key alone is not identity: generic names such as `server` and
   // `default` commonly point at unrelated implementations. Reconcile only
   // when independently authored name and transport evidence also agree.
-  return `${configKey}:${name}:${server.transport}`;
+  return `${configKey}:${name}:${server.transport}:${server.identityFingerprint}`;
 }
 
 function displayNameForGroup(entries: McpConfiguredServer[]): string {

--- a/src/features/connections/lib/localMcpInventory.ts
+++ b/src/features/connections/lib/localMcpInventory.ts
@@ -1,0 +1,130 @@
+import type {
+  McpConfiguredServer,
+  McpHarnessId,
+  McpHarnessInventory,
+  McpInventory,
+} from "@/features/connections/api/localMcpInventory";
+
+export interface McpInventoryGroup {
+  id: string;
+  displayName: string;
+  entries: McpConfiguredServer[];
+  harnesses: McpHarnessId[];
+}
+
+const HARNESS_ORDER: Record<McpHarnessId, number> = {
+  goose: 0,
+  claudeCode: 1,
+  codex: 2,
+};
+
+export const HARNESS_LABELS: Record<McpHarnessId, string> = {
+  goose: "Goose",
+  claudeCode: "Claude Code",
+  codex: "Codex",
+};
+
+function normalizeIdentity(value: string): string {
+  // Config keys are harness-authored identity. Case differences are safe to
+  // reconcile, but punctuation is meaningful: `block-app-kit` and
+  // `block.app.kit` may point at entirely different servers.
+  return value.trim().toLowerCase();
+}
+
+export function mcpIdentityKey(server: McpConfiguredServer): string {
+  return (
+    normalizeIdentity(server.configKey) ||
+    normalizeIdentity(server.name) ||
+    server.id
+  );
+}
+
+function displayNameForGroup(entries: McpConfiguredServer[]): string {
+  return (
+    entries.find((entry) => entry.name.trim().length > 0)?.name.trim() ??
+    "Unnamed MCP"
+  );
+}
+
+function compareServers(
+  a: McpConfiguredServer,
+  b: McpConfiguredServer,
+): number {
+  return (
+    HARNESS_ORDER[a.harness] - HARNESS_ORDER[b.harness] ||
+    a.source.scope.localeCompare(b.source.scope) ||
+    a.name.localeCompare(b.name)
+  );
+}
+
+export function groupMcpServers(
+  inventory: McpInventory | null | undefined,
+): McpInventoryGroup[] {
+  const groups = new Map<string, McpConfiguredServer[]>();
+
+  for (const harness of inventory?.harnesses ?? []) {
+    for (const server of harness.servers) {
+      const key = mcpIdentityKey(server);
+      const entries = groups.get(key) ?? [];
+      entries.push(server);
+      groups.set(key, entries);
+    }
+  }
+
+  return [...groups.entries()]
+    .map(([id, entries]) => {
+      const sortedEntries = [...entries].sort(compareServers);
+      const harnesses = Array.from(
+        new Set(sortedEntries.map((entry) => entry.harness)),
+      ).sort((a, b) => HARNESS_ORDER[a] - HARNESS_ORDER[b]);
+      return {
+        id,
+        displayName: displayNameForGroup(sortedEntries),
+        entries: sortedEntries,
+        harnesses,
+      };
+    })
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export function filterMcpGroups(
+  groups: McpInventoryGroup[],
+  searchTerm: string,
+): McpInventoryGroup[] {
+  const query = searchTerm.trim().toLowerCase();
+  if (!query) return groups;
+
+  return groups.filter((group) => {
+    const searchable = [
+      group.displayName,
+      ...group.entries.flatMap((entry) => [
+        entry.configKey,
+        entry.name,
+        HARNESS_LABELS[entry.harness],
+        entry.source.label,
+        entry.source.scope,
+        entry.transport,
+        entry.command ?? "",
+        entry.urlHost ?? "",
+      ]),
+    ]
+      .join(" ")
+      .toLowerCase();
+    return searchable.includes(query);
+  });
+}
+
+export function configuredServerCount(inventory: McpInventory | undefined) {
+  return (inventory?.harnesses ?? []).reduce(
+    (count, harness) => count + harness.servers.length,
+    0,
+  );
+}
+
+export function harnessesWithErrors(
+  inventory: McpInventory | undefined,
+): McpHarnessInventory[] {
+  return (inventory?.harnesses ?? []).filter(
+    (harness) => harness.status === "partial" || harness.status === "error",
+  );
+}

--- a/src/features/connections/ui/ConnectionCards.test.tsx
+++ b/src/features/connections/ui/ConnectionCards.test.tsx
@@ -33,6 +33,22 @@ describe("connection rows", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("spaces disconnect and reconnect actions", () => {
+    const slack = OAUTH_PROVIDERS.find((entry) => entry.provider === "slack");
+    if (!slack) throw new Error("Slack fixture is missing");
+
+    renderCard(
+      <OAuthConnectionCard entry={slack} status={{ kind: "expired" }} />,
+    );
+
+    const disconnect = screen.getByRole("button", { name: "Disconnect" });
+    const actions = disconnect.parentElement;
+    expect(actions).toHaveClass("flex", "items-center", "gap-2");
+    expect(
+      screen.getByRole("button", { name: "Reconnect" }).parentElement,
+    ).toBe(actions);
+  });
+
   it("keeps Configure for editable user-added MCP servers", () => {
     const onSelect = vi.fn();
     const extension: ExtensionEntry = {

--- a/src/features/connections/ui/ConnectionCards.tsx
+++ b/src/features/connections/ui/ConnectionCards.tsx
@@ -121,7 +121,7 @@ export function OAuthConnectionActions({
 
   if (labelKey !== null) {
     return (
-      <>
+      <div className="flex items-center gap-2">
         {canDisconnect ? (
           <Button
             type="button"
@@ -145,7 +145,7 @@ export function OAuthConnectionActions({
         >
           {t(labelKey)}
         </Button>
-      </>
+      </div>
     );
   }
 

--- a/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
@@ -19,6 +19,7 @@ const configuredServers = [
     configKey: "github",
     name: "GitHub",
     transport: "stdio",
+    identityFingerprint: "stdio-shared",
   },
   {
     id: "codex:user:github",
@@ -27,6 +28,7 @@ const configuredServers = [
     configKey: "github",
     name: "GitHub",
     transport: "stdio",
+    identityFingerprint: "stdio-shared",
   },
 ];
 

--- a/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
@@ -1,74 +1,140 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ConnectionsSettings } from "./ConnectionsSettings";
 
-/**
- * BOT-1272 guard, on the real component.
- *
- * `SettingsView` renders `ConnectionsSettings` into the one shared
- * `SettingsPane` that every settings section uses. `SettingsPane` carries
- * `.page-transition`, which starts at `opacity: 0` and animates in over 160ms.
- * If `ConnectionsSettings` ever supplies its own pane again, switching to or
- * from Connections replays that enter animation and flashes the surface
- * underneath.
- *
- * The sibling assertion in `SettingsView.test.tsx` mocks this module, so it
- * cannot see inside it. This test renders the real component so re-adding a
- * pane here fails CI instead of silently reintroducing the flash.
- */
+const testState = vi.hoisted(() => ({ managed: false }));
 
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
-}));
-
-vi.mock("@tauri-apps/plugin-deep-link", () => ({
-  onOpenUrl: () => Promise.resolve(() => {}),
-}));
-
-vi.mock("@/features/extensions/hooks/useExtensionsSettings", () => ({
-  useExtensionsSettings: () => ({
-    extensions: [],
-    isLoading: false,
-    modalMode: null,
-    editingExtension: null,
-    handleAdd: () => {},
-    handleConfigure: () => {},
-    handleSubmit: () => {},
-    handleDelete: () => {},
-    handleReset: () => {},
-    handleModalClose: () => {},
+  useTranslation: () => ({
+    t: (key: string, options?: { harnesses?: string }) =>
+      options?.harnesses ? `${key}:${options.harnesses}` : key,
   }),
 }));
 
-// Off keeps the OAuth catalog query out of this test; the pane contract is
-// independent of which connection rows render.
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+  onOpenUrl: async () => () => {},
+}));
+
 vi.mock("@/shared/profile/capabilities", () => ({
-  useProfileCapability: () => false,
+  useProfileCapability: () => testState.managed,
+}));
+
+vi.mock("@/features/projects/stores/projectStore", () => ({
+  useProjectStore: (selector: (state: object) => unknown) =>
+    selector({ projects: [], activeProjectId: null }),
+}));
+
+vi.mock("@/features/connections/api/connections", () => ({
+  CONNECTIONS_QUERY_KEY: ["connections"],
+  listConnections: async () => ({ connections: [] }),
+  disconnectConnection: async () => {},
+}));
+
+vi.mock("@/features/connections/api/localMcpInventory", () => ({
+  LOCAL_MCP_INVENTORY_QUERY_KEY: ["local-mcp-inventory"],
+  listLocalMcpInventory: async () => ({
+    harnesses: [
+      {
+        harness: "goose",
+        status: "configured",
+        checkedLocations: [],
+        servers: [
+          {
+            id: "goose:user:github",
+            harness: "goose",
+            source: { scope: "user", label: "Goose user config" },
+            configKey: "github",
+            name: "GitHub",
+            transport: "stdio",
+          },
+        ],
+      },
+      {
+        harness: "codex",
+        status: "configured",
+        checkedLocations: [],
+        servers: [
+          {
+            id: "codex:user:github",
+            harness: "codex",
+            source: { scope: "user", label: "Codex user config" },
+            configKey: "github",
+            name: "GitHub",
+            transport: "stdio",
+          },
+        ],
+      },
+    ],
+  }),
 }));
 
 function renderConnectionsSettings() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-
   return render(
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
       <ConnectionsSettings />
     </QueryClientProvider>,
   );
 }
 
 describe("ConnectionsSettings", () => {
-  it("renders no page wrapper so the caller owns the settings pane", () => {
-    const { container } = renderConnectionsSettings();
+  it("renders passive local inventory without a distribution section", async () => {
+    renderConnectionsSettings();
 
-    expect(container.querySelectorAll(".page-transition")).toHaveLength(0);
+    expect(await screen.findByText("GitHub")).toBeInTheDocument();
+    expect(
+      screen.getByText("connections.worksWith:Goose, Codex"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("connections.sections.local")).toBeInTheDocument();
+    expect(
+      screen.queryByText("connections.sections.managed"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /configure|remove|connect/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("renders its own content spacing", () => {
-    const { container } = renderConnectionsSettings();
+  it("organizes the managed catalog and local inventory without installed or available sections", async () => {
+    testState.managed = true;
+    renderConnectionsSettings();
 
-    expect(container.firstElementChild).toHaveClass("flex", "flex-col");
+    expect(
+      await screen.findByText("connections.sections.managed"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("connections.sections.local")).toBeInTheDocument();
+    expect(
+      screen.queryByText("connections.sections.installed"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("connections.sections.available"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses one search across managed and local sections", async () => {
+    const user = userEvent.setup();
+    testState.managed = true;
+    renderConnectionsSettings();
+
+    await screen.findByText("GitHub");
+    await user.type(
+      screen.getByRole("searchbox", { name: "connections.search" }),
+      "Codex",
+    );
+
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(
+      screen.getByText("connections.worksWith:Goose, Codex"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("connections.noResults")).toBeInTheDocument();
+  });
+
+  it("renders no page wrapper so the caller owns the settings pane", () => {
+    const { container } = renderConnectionsSettings();
+    expect(container.querySelectorAll(".page-transition")).toHaveLength(0);
   });
 });

--- a/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
@@ -1,10 +1,34 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionsSettings } from "./ConnectionsSettings";
 
-const testState = vi.hoisted(() => ({ managed: false }));
+const testState = vi.hoisted(() => ({
+  managed: false,
+  projectId: null as string | null,
+  inventoryMode: "configured" as "configured" | "empty" | "error" | "partial",
+  inventoryCalls: [] as string[][],
+}));
+
+const configuredServers = [
+  {
+    id: "goose:user:github",
+    harness: "goose",
+    source: { scope: "user", label: "Goose user config" },
+    configKey: "github",
+    name: "GitHub",
+    transport: "stdio",
+  },
+  {
+    id: "codex:user:github",
+    harness: "codex",
+    source: { scope: "user", label: "Codex user config" },
+    configKey: "github",
+    name: "GitHub",
+    transport: "stdio",
+  },
+];
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -23,7 +47,17 @@ vi.mock("@/shared/profile/capabilities", () => ({
 
 vi.mock("@/features/projects/stores/projectStore", () => ({
   useProjectStore: (selector: (state: object) => unknown) =>
-    selector({ projects: [], activeProjectId: null }),
+    selector({
+      activeProjectId: testState.projectId,
+      projects: testState.projectId
+        ? [
+            {
+              id: testState.projectId,
+              workingDirs: [`/${testState.projectId}`],
+            },
+          ]
+        : [],
+    }),
 }));
 
 vi.mock("@/features/connections/api/connections", () => ({
@@ -34,75 +68,70 @@ vi.mock("@/features/connections/api/connections", () => ({
 
 vi.mock("@/features/connections/api/localMcpInventory", () => ({
   LOCAL_MCP_INVENTORY_QUERY_KEY: ["local-mcp-inventory"],
-  listLocalMcpInventory: async () => ({
-    harnesses: [
-      {
-        harness: "goose",
-        status: "configured",
-        checkedLocations: [],
-        servers: [
-          {
-            id: "goose:user:github",
-            harness: "goose",
-            source: { scope: "user", label: "Goose user config" },
-            configKey: "github",
-            name: "GitHub",
-            transport: "stdio",
-          },
-        ],
-      },
-      {
-        harness: "codex",
-        status: "configured",
-        checkedLocations: [],
-        servers: [
-          {
-            id: "codex:user:github",
-            harness: "codex",
-            source: { scope: "user", label: "Codex user config" },
-            configKey: "github",
-            name: "GitHub",
-            transport: "stdio",
-          },
-        ],
-      },
-    ],
-  }),
+  listLocalMcpInventory: async (workspacePaths: string[]) => {
+    testState.inventoryCalls.push(workspacePaths);
+    if (testState.inventoryMode === "error") throw new Error("unavailable");
+    if (testState.inventoryMode === "empty") return { harnesses: [] };
+    return {
+      harnesses: [
+        {
+          harness: "goose",
+          status: "configured",
+          checkedLocations: [],
+          servers: configuredServers.slice(0, 1),
+        },
+        {
+          harness: "codex",
+          status:
+            testState.inventoryMode === "partial" ? "partial" : "configured",
+          checkedLocations: [],
+          servers: configuredServers.slice(1),
+          message:
+            testState.inventoryMode === "partial"
+              ? "Codex project config could not be parsed."
+              : null,
+        },
+      ],
+    };
+  },
 }));
 
-function renderConnectionsSettings() {
-  return render(
-    <QueryClientProvider
-      client={
-        new QueryClient({ defaultOptions: { queries: { retry: false } } })
-      }
-    >
-      <ConnectionsSettings />
+function renderConnectionsSettings(
+  onAskAgentToAddMcp?: (request: { title: string; prompt: string }) => void,
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const view = render(
+    <QueryClientProvider client={client}>
+      <ConnectionsSettings onAskAgentToAddMcp={onAskAgentToAddMcp} />
     </QueryClientProvider>,
   );
+  return { ...view, client };
 }
 
 describe("ConnectionsSettings", () => {
-  it("renders passive local inventory without a distribution section", async () => {
-    renderConnectionsSettings();
+  beforeEach(() => {
+    testState.managed = false;
+    testState.projectId = null;
+    testState.inventoryMode = "configured";
+    testState.inventoryCalls = [];
+  });
 
+  it("renders passive local inventory without managed connections", async () => {
+    renderConnectionsSettings();
     expect(await screen.findByText("GitHub")).toBeInTheDocument();
     expect(
       screen.getByText("connections.worksWith:Goose, Codex"),
     ).toBeInTheDocument();
-    expect(screen.getByText("connections.sections.local")).toBeInTheDocument();
     expect(
       screen.queryByText("connections.sections.managed"),
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /configure|remove|connect/i }),
-    ).not.toBeInTheDocument();
   });
 
-  it("organizes the managed catalog and local inventory without installed or available sections", async () => {
+  it("organizes managed and local connections without installed or available sections", async () => {
     testState.managed = true;
     renderConnectionsSettings();
-
     expect(
       await screen.findByText("connections.sections.managed"),
     ).toBeInTheDocument();
@@ -115,22 +144,72 @@ describe("ConnectionsSettings", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("uses one search across managed and local sections", async () => {
-    const user = userEvent.setup();
-    testState.managed = true;
-    renderConnectionsSettings();
-
-    await screen.findByText("GitHub");
-    await user.type(
-      screen.getByRole("searchbox", { name: "connections.search" }),
-      "Codex",
-    );
-
-    expect(screen.getByText("GitHub")).toBeInTheDocument();
+  it("distinguishes successful empty inventory from failure", async () => {
+    testState.inventoryMode = "empty";
+    const empty = renderConnectionsSettings(vi.fn());
     expect(
-      screen.getByText("connections.worksWith:Goose, Codex"),
+      await screen.findByText("connections.empty.title"),
     ).toBeInTheDocument();
-    expect(screen.getByText("connections.noResults")).toBeInTheDocument();
+    expect(
+      screen.queryByText("connections.localError.title"),
+    ).not.toBeInTheDocument();
+    empty.unmount();
+
+    testState.inventoryMode = "error";
+    renderConnectionsSettings(vi.fn());
+    expect(
+      await screen.findByText("connections.localError.title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("connections.empty.title"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("preserves confirmed rows and offers retry for partial inventory", async () => {
+    testState.inventoryMode = "partial";
+    const user = userEvent.setup();
+    renderConnectionsSettings();
+    expect(await screen.findByText("GitHub")).toBeInTheDocument();
+    expect(
+      screen.getByText("connections.localError.partialTitle"),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "connections.localError.retry" }),
+    );
+    await waitFor(() =>
+      expect(testState.inventoryCalls.length).toBeGreaterThan(1),
+    );
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+  });
+
+  it("re-queries local project configuration when the active project changes", async () => {
+    testState.projectId = "project-a";
+    const view = renderConnectionsSettings();
+    await screen.findByText("GitHub");
+    expect(testState.inventoryCalls).toContainEqual(["/project-a"]);
+
+    testState.projectId = "project-b";
+    view.rerender(
+      <QueryClientProvider client={view.client}>
+        <ConnectionsSettings />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(testState.inventoryCalls).toContainEqual(["/project-b"]),
+    );
+  });
+
+  it("starts Add connection through the neutral setup request", async () => {
+    const onAdd = vi.fn();
+    const user = userEvent.setup();
+    renderConnectionsSettings(onAdd);
+    await user.click(
+      screen.getByRole("button", { name: "connections.askAgent" }),
+    );
+    expect(onAdd).toHaveBeenCalledWith({
+      title: "connections.askAgentTitle",
+      prompt: "connections.askAgentPrompt",
+    });
   });
 
   it("renders no page wrapper so the caller owns the settings pane", () => {

--- a/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.pane.test.tsx
@@ -9,6 +9,8 @@ const testState = vi.hoisted(() => ({
   projectId: null as string | null,
   inventoryMode: "configured" as "configured" | "empty" | "error" | "partial",
   inventoryCalls: [] as string[][],
+  disabledExtensions: [] as Array<{ configKey: string; name: string }>,
+  dismissBanner: vi.fn(),
 }));
 
 const configuredServers = [
@@ -59,6 +61,15 @@ vi.mock("@/features/projects/stores/projectStore", () => ({
             },
           ]
         : [],
+    }),
+}));
+
+vi.mock("@/features/migration/stores/migrationStore", () => ({
+  useMigrationStore: (selector: (state: object) => unknown) =>
+    selector({
+      disabledExtensions: testState.disabledExtensions,
+      bannerDismissedAt: undefined,
+      dismissBanner: testState.dismissBanner,
     }),
 }));
 
@@ -118,6 +129,8 @@ describe("ConnectionsSettings", () => {
     testState.projectId = null;
     testState.inventoryMode = "configured";
     testState.inventoryCalls = [];
+    testState.disabledExtensions = [];
+    testState.dismissBanner.mockReset().mockResolvedValue(undefined);
   });
 
   it("renders passive local inventory without managed connections", async () => {
@@ -129,6 +142,20 @@ describe("ConnectionsSettings", () => {
     expect(
       screen.queryByText("connections.sections.managed"),
     ).not.toBeInTheDocument();
+  });
+
+  it("preserves the migration warning for visible disabled Goose extensions", async () => {
+    testState.disabledExtensions = [{ configKey: "github", name: "GitHub" }];
+    const user = userEvent.setup();
+    renderConnectionsSettings();
+
+    expect(
+      await screen.findByText("extensions.disabledBanner.title"),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "extensions.disabledBanner.dismiss" }),
+    );
+    expect(testState.dismissBanner).toHaveBeenCalledOnce();
   });
 
   it("organizes managed and local connections without installed or available sections", async () => {

--- a/src/features/connections/ui/ConnectionsSettings.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.tsx
@@ -2,12 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
-import {
-  IconAlertTriangle,
-  IconLink,
-  IconPlus,
-  IconX,
-} from "@tabler/icons-react";
+import { IconPlus } from "@tabler/icons-react";
 import {
   CONNECTIONS_QUERY_KEY,
   type Connection,
@@ -16,234 +11,108 @@ import {
 import { OAUTH_PROVIDERS } from "@/features/connections/catalog";
 import { resolveConnectionStatus } from "@/features/connections/lib/connectionStatus";
 import {
-  compareGridItems,
-  type ConnectionGridItem,
   filterGridItems,
-  gridItemKey,
-  itemSection,
+  type ConnectionGridItem,
 } from "@/features/connections/lib/connectionGrid";
-import { isCompanyManagedExtension } from "@/features/connections/lib/managedExtensions";
-import { useExtensionsSettings } from "@/features/extensions/hooks/useExtensionsSettings";
-import { isNativeCapabilityExtension } from "@/features/extensions/lib/nativeCapabilities";
-import { ExtensionModal } from "@/features/extensions/ui/ExtensionModal";
-import { useMigrationStore } from "@/features/migration/stores/migrationStore";
+import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { useProfileCapability } from "@/shared/profile/capabilities";
-import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
 import { Button } from "@/shared/ui/button";
 import { PageHeader } from "@/shared/ui/page-shell";
 import {
-  SettingsSection,
   SettingsSections,
+  SettingsSection,
 } from "@/shared/ui/settings-section";
 import { SearchBar } from "@/shared/ui/SearchBar";
 import { Skeleton } from "@/shared/ui/skeleton";
-import {
-  ExtensionConnectionCard,
-  isEditableExtension,
-  OAuthConnectionCard,
-} from "./ConnectionCards";
+import { OAuthConnectionCard } from "./ConnectionCards";
+import { LocalMcpSection } from "./LocalMcpSection";
 
 const CONNECTIONS_REFETCH_INTERVAL_MS = 5_000;
 
-const connectionsGridClass = "divide-y divide-border";
-
-function ConnectionsEmptyState() {
-  const { t } = useTranslation("settings");
+function SectionSkeleton({ title }: { title: string }) {
   return (
-    <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border px-6 py-12 text-center">
-      <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
-        <IconLink className="size-5 text-muted-foreground" aria-hidden="true" />
-      </div>
-      <div>
-        <p className="text-sm text-foreground">
-          {t("connections.empty.title")}
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          {t("connections.empty.description")}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-function CardSkeleton() {
-  return (
-    <div className="flex items-center gap-3 rounded-md bg-card p-3">
-      <Skeleton className="size-4.5 rounded-full" />
-      <Skeleton className="h-4 w-32 rounded-sm" />
-    </div>
+    <SettingsSection title={title}>
+      {[1, 2, 3].map((item) => (
+        <div key={item} className="flex items-center gap-3 p-3">
+          <Skeleton className="size-4.5 rounded-full" />
+          <Skeleton className="h-4 w-32 rounded-sm" />
+        </div>
+      ))}
+    </SettingsSection>
   );
 }
 
 /**
- * The Connections settings section: one searchable grid of every MCP the agent
- * can use on the user's behalf.
- *
- * Org-managed OAuth services and user-added custom MCP servers are rows in
- * the same list — whether a connection is provisioned by an enterprise org
- * or linked personally is a property of the data, not a UI division. Native
- * capabilities (built-in tools like web search) are deliberately absent; see
- * `nativeCapabilities.ts`.
- *
- * Renders its content *without* a page wrapper: `SettingsView` renders this
- * into the one shared `SettingsPane` that every settings section uses. Adding
- * a pane here would make the pane a different component type at the same tree
- * position, so React would unmount/remount it and replay the
- * `page-transition` enter animation, flashing the surface underneath
- * (BOT-1272). `ConnectionsSettings.pane.test.tsx` guards this.
+ * One searchable inventory organized by ownership: enterprise-managed
+ * connections first when the distribution enables them, followed by MCPs
+ * configured locally for Goose, Claude Code, and Codex.
  */
-export function ConnectionsSettings() {
+export interface ConnectionsSettingsProps {
+  onAskAgentToAddMcp?: (request: { title: string; prompt: string }) => void;
+}
+
+export function ConnectionsSettings({
+  onAskAgentToAddMcp,
+}: ConnectionsSettingsProps) {
   const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState("");
+  const showManagedConnections = useProfileCapability("managedConnections");
+  const activeProject = useProjectStore((state) =>
+    state.projects.find((project) => project.id === state.activeProjectId),
+  );
+  const workspacePaths = activeProject?.workingDirs ?? [];
 
-  // Gates the kgoose-backed OAuth catalog. The capability is named after the
-  // backing system (kgoose), not the UI concept — the mismatch is deliberate,
-  // don't "fix" it. When off (public tier today), the grid holds only the
-  // user's own MCP servers.
-  const showOAuthCatalog = useProfileCapability("managedConnections");
-
-  const {
-    extensions,
-    isLoading: isExtensionsLoading,
-    modalMode,
-    editingExtension,
-    handleAdd,
-    handleConfigure,
-    handleSubmit,
-    handleDelete,
-    handleReset,
-    handleModalClose,
-  } = useExtensionsSettings();
-
-  const { data: connectionsData, isLoading: isOAuthLoading } = useQuery({
+  const managedQuery = useQuery({
     queryKey: CONNECTIONS_QUERY_KEY,
     queryFn: listConnections,
     refetchInterval: CONNECTIONS_REFETCH_INTERVAL_MS,
-    enabled: showOAuthCatalog,
+    enabled: showManagedConnections,
   });
 
   useEffect(() => {
-    if (!showOAuthCatalog) return;
+    if (!showManagedConnections) return;
     let unlisten: (() => void) | undefined;
     let cancelled = false;
-    onOpenUrl(() => {
-      queryClient.invalidateQueries({ queryKey: CONNECTIONS_QUERY_KEY });
-    }).then((fn) => {
-      if (cancelled) {
-        fn();
-      } else {
-        unlisten = fn;
-      }
+    void onOpenUrl(() => {
+      void queryClient.invalidateQueries({ queryKey: CONNECTIONS_QUERY_KEY });
+    }).then((listener) => {
+      if (cancelled) listener();
+      else unlisten = listener;
     });
     return () => {
       cancelled = true;
       unlisten?.();
     };
-  }, [queryClient, showOAuthCatalog]);
+  }, [queryClient, showManagedConnections]);
 
   const connectionsByName = useMemo(() => {
     const map = new Map<string, Connection>();
-    for (const entry of connectionsData?.connections ?? []) {
-      map.set(entry.name, entry);
+    for (const connection of managedQuery.data?.connections ?? []) {
+      map.set(connection.name, connection);
     }
     return map;
-  }, [connectionsData?.connections]);
+  }, [managedQuery.data?.connections]);
 
-  // Custom MCP servers: everything the backend lists minus native
-  // capabilities (built-in tools) and extensions already represented by an
-  // OAuth catalog card.
-  const customExtensions = useMemo(
+  const managedItems = useMemo<ConnectionGridItem[]>(
     () =>
-      extensions.filter((extension) => {
-        if (isNativeCapabilityExtension(extension)) return false;
-        if (showOAuthCatalog && isCompanyManagedExtension(extension)) {
-          return false;
-        }
-        return true;
-      }),
-    [extensions, showOAuthCatalog],
+      showManagedConnections
+        ? OAUTH_PROVIDERS.filter((entry) => entry.hidden !== true).map(
+            (entry) => ({
+              kind: "oauth" as const,
+              entry,
+              status: resolveConnectionStatus(
+                connectionsByName.get(entry.provider),
+              ),
+            }),
+          )
+        : [],
+    [connectionsByName, showManagedConnections],
   );
-
-  const gridItems = useMemo<ConnectionGridItem[]>(() => {
-    const nowMs = Date.now();
-    const oauthItems: ConnectionGridItem[] = showOAuthCatalog
-      ? OAUTH_PROVIDERS.filter((entry) => entry.hidden !== true).map(
-          (entry) => ({
-            kind: "oauth" as const,
-            entry,
-            status: resolveConnectionStatus(
-              connectionsByName.get(entry.provider),
-              nowMs,
-            ),
-          }),
-        )
-      : [];
-    const extensionItems: ConnectionGridItem[] = customExtensions.map(
-      (extension) => ({ kind: "extension" as const, extension }),
-    );
-    return [...oauthItems, ...extensionItems].sort(compareGridItems);
-  }, [connectionsByName, customExtensions, showOAuthCatalog]);
-
-  const visibleItems = useMemo(
-    () => filterGridItems(gridItems, searchTerm),
-    [gridItems, searchTerm],
+  const visibleManagedItems = useMemo(
+    () => filterGridItems(managedItems, searchTerm),
+    [managedItems, searchTerm],
   );
-  // compareGridItems already orders active-section items before inactive
-  // ones, so each partition preserves its internal order.
-  const activeItems = useMemo(
-    () => visibleItems.filter((item) => itemSection(item) === "active"),
-    [visibleItems],
-  );
-  const inactiveItems = useMemo(
-    () => visibleItems.filter((item) => itemSection(item) === "inactive"),
-    [visibleItems],
-  );
-
-  const disabledExtensions = useMigrationStore(
-    (state) => state.disabledExtensions,
-  );
-  const bannerDismissedAt = useMigrationStore(
-    (state) => state.bannerDismissedAt,
-  );
-  const dismissBanner = useMigrationStore((state) => state.dismissBanner);
-
-  const visibleExtensionKeys = useMemo(
-    () => new Set(customExtensions.map((extension) => extension.config_key)),
-    [customExtensions],
-  );
-  const visibleDisabledExtensions = useMemo(
-    () =>
-      disabledExtensions.filter((extension) =>
-        visibleExtensionKeys.has(extension.configKey),
-      ),
-    [disabledExtensions, visibleExtensionKeys],
-  );
-  const showDisabledBanner =
-    visibleDisabledExtensions.length > 0 && !bannerDismissedAt;
-
-  const isLoading = isExtensionsLoading || (showOAuthCatalog && isOAuthLoading);
-  const hasSearch = searchTerm.trim().length > 0;
-
-  const renderGridItem = (item: ConnectionGridItem) =>
-    item.kind === "oauth" ? (
-      <OAuthConnectionCard
-        key={gridItemKey(item)}
-        entry={item.entry}
-        status={item.status}
-      />
-    ) : (
-      <ExtensionConnectionCard
-        key={gridItemKey(item)}
-        extension={item.extension}
-        onReset={handleReset}
-        onSelect={() => {
-          if (isEditableExtension(item.extension)) {
-            handleConfigure(item.extension);
-          }
-        }}
-      />
-    );
 
   return (
     <div className="flex flex-col gap-6">
@@ -254,40 +123,24 @@ export function ConnectionsSettings() {
         titleClassName="font-medium"
         descriptionClassName="text-xs font-normal text-muted-foreground"
         actions={
-          <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
-            <IconPlus className="size-3.5" />
-            {t("extensions.addExtension")}
-          </Button>
+          onAskAgentToAddMcp ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              leftIcon={<IconPlus />}
+              onClick={() =>
+                onAskAgentToAddMcp({
+                  title: t("connections.askAgentTitle"),
+                  prompt: t("connections.askAgentPrompt"),
+                })
+              }
+            >
+              {t("connections.askAgent")}
+            </Button>
+          ) : null
         }
       />
-
-      {showDisabledBanner ? (
-        <Alert variant="default" className="pr-10">
-          <IconAlertTriangle aria-hidden="true" className="text-warning!" />
-          <AlertTitle>{t("extensions.disabledBanner.title")}</AlertTitle>
-          <AlertDescription>
-            <p>
-              {t("extensions.disabledBanner.description", {
-                names: visibleDisabledExtensions
-                  .map((ext) => ext.name)
-                  .join(", "),
-              })}
-            </p>
-          </AlertDescription>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => {
-              void dismissBanner();
-            }}
-            aria-label={t("extensions.disabledBanner.dismiss")}
-            className="absolute top-2 right-2"
-          >
-            <IconX className="size-3.5" />
-          </Button>
-        </Alert>
-      ) : null}
 
       <SearchBar
         size="pill"
@@ -297,45 +150,36 @@ export function ConnectionsSettings() {
         aria-label={t("connections.search")}
       />
 
-      {isLoading ? (
-        <div className={connectionsGridClass}>
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <CardSkeleton key={i} />
-          ))}
-        </div>
-      ) : gridItems.length === 0 ? (
-        <ConnectionsEmptyState />
-      ) : visibleItems.length === 0 && hasSearch ? (
-        <p className="text-sm text-muted-foreground">
-          {t("connections.noResults")}
-        </p>
-      ) : (
-        <SettingsSections>
-          {activeItems.length > 0 ? (
-            <SettingsSection title={t("connections.sections.installed")}>
-              {activeItems.map(renderGridItem)}
+      <SettingsSections>
+        {showManagedConnections ? (
+          managedQuery.isLoading ? (
+            <SectionSkeleton title={t("connections.sections.managed")} />
+          ) : managedItems.length > 0 ? (
+            <SettingsSection title={t("connections.sections.managed")}>
+              {visibleManagedItems.length === 0 && searchTerm.trim() ? (
+                <p className="p-3 text-sm text-muted-foreground">
+                  {t("connections.noResults")}
+                </p>
+              ) : (
+                visibleManagedItems.map((item) =>
+                  item.kind === "oauth" ? (
+                    <OAuthConnectionCard
+                      key={item.entry.provider}
+                      entry={item.entry}
+                      status={item.status}
+                    />
+                  ) : null,
+                )
+              )}
             </SettingsSection>
-          ) : null}
-          {inactiveItems.length > 0 ? (
-            <SettingsSection title={t("connections.sections.available")}>
-              {inactiveItems.map(renderGridItem)}
-            </SettingsSection>
-          ) : null}
-        </SettingsSections>
-      )}
+          ) : null
+        ) : null}
 
-      {modalMode === "add" && (
-        <ExtensionModal onSubmit={handleSubmit} onClose={handleModalClose} />
-      )}
-
-      {modalMode === "edit" && editingExtension && (
-        <ExtensionModal
-          extension={editingExtension}
-          onSubmit={handleSubmit}
-          onDelete={handleDelete}
-          onClose={handleModalClose}
+        <LocalMcpSection
+          searchTerm={searchTerm}
+          workspacePaths={workspacePaths}
         />
-      )}
+      </SettingsSections>
     </div>
   );
 }

--- a/src/features/connections/ui/ConnectionsSettings.tsx
+++ b/src/features/connections/ui/ConnectionsSettings.tsx
@@ -11,9 +11,11 @@ import {
 import { OAUTH_PROVIDERS } from "@/features/connections/catalog";
 import { resolveConnectionStatus } from "@/features/connections/lib/connectionStatus";
 import {
+  compareGridItems,
   filterGridItems,
   type ConnectionGridItem,
 } from "@/features/connections/lib/connectionGrid";
+import type { SetupChatRequest } from "@/features/chat/lib/setupChatRequest";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { useProfileCapability } from "@/shared/profile/capabilities";
 import { Button } from "@/shared/ui/button";
@@ -33,7 +35,10 @@ function SectionSkeleton({ title }: { title: string }) {
   return (
     <SettingsSection title={title}>
       {[1, 2, 3].map((item) => (
-        <div key={item} className="flex items-center gap-3 p-3">
+        <div
+          key={item}
+          className="flex items-center gap-3 rounded-md bg-card p-3"
+        >
           <Skeleton className="size-4.5 rounded-full" />
           <Skeleton className="h-4 w-32 rounded-sm" />
         </div>
@@ -48,7 +53,7 @@ function SectionSkeleton({ title }: { title: string }) {
  * configured locally for Goose, Claude Code, and Codex.
  */
 export interface ConnectionsSettingsProps {
-  onAskAgentToAddMcp?: (request: { title: string; prompt: string }) => void;
+  onAskAgentToAddMcp?: (request: SetupChatRequest) => void;
 }
 
 export function ConnectionsSettings({
@@ -97,15 +102,15 @@ export function ConnectionsSettings({
   const managedItems = useMemo<ConnectionGridItem[]>(
     () =>
       showManagedConnections
-        ? OAUTH_PROVIDERS.filter((entry) => entry.hidden !== true).map(
-            (entry) => ({
+        ? OAUTH_PROVIDERS.filter((entry) => entry.hidden !== true)
+            .map((entry) => ({
               kind: "oauth" as const,
               entry,
               status: resolveConnectionStatus(
                 connectionsByName.get(entry.provider),
               ),
-            }),
-          )
+            }))
+            .sort(compareGridItems)
         : [],
     [connectionsByName, showManagedConnections],
   );
@@ -113,6 +118,12 @@ export function ConnectionsSettings({
     () => filterGridItems(managedItems, searchTerm),
     [managedItems, searchTerm],
   );
+  const askAgentToAddConnection = () => {
+    onAskAgentToAddMcp?.({
+      title: t("connections.askAgentTitle"),
+      prompt: t("connections.askAgentPrompt"),
+    });
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -128,14 +139,9 @@ export function ConnectionsSettings({
               type="button"
               variant="outline"
               size="sm"
-              leftIcon={<IconPlus />}
-              onClick={() =>
-                onAskAgentToAddMcp({
-                  title: t("connections.askAgentTitle"),
-                  prompt: t("connections.askAgentPrompt"),
-                })
-              }
+              onClick={askAgentToAddConnection}
             >
+              <IconPlus className="size-3.5" />
               {t("connections.askAgent")}
             </Button>
           ) : null
@@ -178,6 +184,9 @@ export function ConnectionsSettings({
         <LocalMcpSection
           searchTerm={searchTerm}
           workspacePaths={workspacePaths}
+          onAddConnection={
+            onAskAgentToAddMcp ? askAgentToAddConnection : undefined
+          }
         />
       </SettingsSections>
     </div>

--- a/src/features/connections/ui/LocalMcpConnectionCard.tsx
+++ b/src/features/connections/ui/LocalMcpConnectionCard.tsx
@@ -1,0 +1,24 @@
+import { Link2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { McpInventoryGroup } from "@/features/connections/lib/localMcpInventory";
+import { HARNESS_LABELS } from "@/features/connections/lib/localMcpInventory";
+import { ConnectionCard } from "./ConnectionCard";
+
+export function LocalMcpConnectionCard({
+  group,
+}: {
+  group: McpInventoryGroup;
+}) {
+  const { t } = useTranslation("settings");
+  const harnesses = group.harnesses
+    .map((harness) => HARNESS_LABELS[harness])
+    .join(", ");
+
+  return (
+    <ConnectionCard
+      icon={<Link2 aria-hidden="true" />}
+      name={group.displayName}
+      description={t("connections.worksWith", { harnesses })}
+    />
+  );
+}

--- a/src/features/connections/ui/LocalMcpSection.tsx
+++ b/src/features/connections/ui/LocalMcpSection.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
+import { IconAlertTriangle, IconX } from "@tabler/icons-react";
 import {
   listLocalMcpInventory,
   LOCAL_MCP_INVENTORY_QUERY_KEY,
@@ -11,6 +12,7 @@ import {
 } from "@/features/connections/lib/localMcpInventory";
 import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
 import { Button } from "@/shared/ui/button";
+import { useMigrationStore } from "@/features/migration/stores/migrationStore";
 import { SettingsSection } from "@/shared/ui/settings-section";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { LocalMcpConnectionCard } from "./LocalMcpConnectionCard";
@@ -34,6 +36,25 @@ export function LocalMcpSection({
   const visibleGroups = filterMcpGroups(groups, searchTerm);
   const failedSources = harnessesWithErrors(query.data);
   const hasFailure = query.isError || failedSources.length > 0;
+  const disabledExtensions = useMigrationStore(
+    (state) => state.disabledExtensions,
+  );
+  const bannerDismissedAt = useMigrationStore(
+    (state) => state.bannerDismissedAt,
+  );
+  const dismissBanner = useMigrationStore((state) => state.dismissBanner);
+  const visibleGooseKeys = new Set(
+    groups.flatMap((group) =>
+      group.entries
+        .filter((entry) => entry.harness === "goose")
+        .map((entry) => entry.configKey),
+    ),
+  );
+  const visibleDisabledExtensions = disabledExtensions.filter((extension) =>
+    visibleGooseKeys.has(extension.configKey),
+  );
+  const showDisabledBanner =
+    visibleDisabledExtensions.length > 0 && !bannerDismissedAt;
 
   if (query.isLoading) {
     return (
@@ -103,6 +124,29 @@ export function LocalMcpSection({
 
   return (
     <SettingsSection title={t("connections.sections.local")}>
+      {showDisabledBanner ? (
+        <Alert variant="default" className="pr-10">
+          <IconAlertTriangle aria-hidden="true" className="text-warning!" />
+          <AlertTitle>{t("extensions.disabledBanner.title")}</AlertTitle>
+          <AlertDescription>
+            {t("extensions.disabledBanner.description", {
+              names: visibleDisabledExtensions
+                .map((extension) => extension.name)
+                .join(", "),
+            })}
+          </AlertDescription>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="absolute top-2 right-2"
+            aria-label={t("extensions.disabledBanner.dismiss")}
+            onClick={() => void dismissBanner()}
+          >
+            <IconX className="size-3.5" />
+          </Button>
+        </Alert>
+      ) : null}
       {hasFailure ? (
         <Alert>
           <AlertTitle>{t("connections.localError.partialTitle")}</AlertTitle>

--- a/src/features/connections/ui/LocalMcpSection.tsx
+++ b/src/features/connections/ui/LocalMcpSection.tsx
@@ -18,9 +18,11 @@ import { LocalMcpConnectionCard } from "./LocalMcpConnectionCard";
 export function LocalMcpSection({
   searchTerm,
   workspacePaths,
+  onAddConnection,
 }: {
   searchTerm: string;
   workspacePaths: string[];
+  onAddConnection?: () => void;
 }) {
   const { t } = useTranslation("settings");
   const query = useQuery({
@@ -37,7 +39,10 @@ export function LocalMcpSection({
     return (
       <SettingsSection title={t("connections.sections.local")}>
         {[1, 2, 3].map((item) => (
-          <div key={item} className="flex items-center gap-3 p-3">
+          <div
+            key={item}
+            className="flex items-center gap-3 rounded-md bg-card p-3"
+          >
             <Skeleton className="size-4.5 rounded-full" />
             <Skeleton className="h-4 w-32 rounded-sm" />
           </div>
@@ -69,7 +74,32 @@ export function LocalMcpSection({
     );
   }
 
-  if (groups.length === 0) return null;
+  if (groups.length === 0) {
+    return (
+      <SettingsSection title={t("connections.sections.local")}>
+        <div className="flex flex-col items-start gap-2 p-3">
+          <div>
+            <p className="text-sm text-foreground">
+              {t("connections.empty.title")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("connections.empty.description")}
+            </p>
+          </div>
+          {onAddConnection ? (
+            <Button
+              type="button"
+              variant="subtle"
+              size="sm"
+              onClick={onAddConnection}
+            >
+              {t("connections.askAgent")}
+            </Button>
+          ) : null}
+        </div>
+      </SettingsSection>
+    );
+  }
 
   return (
     <SettingsSection title={t("connections.sections.local")}>
@@ -77,7 +107,17 @@ export function LocalMcpSection({
         <Alert>
           <AlertTitle>{t("connections.localError.partialTitle")}</AlertTitle>
           <AlertDescription>
-            {t("connections.localError.partialDescription")}
+            <span>{t("connections.localError.partialDescription")}</span>
+            <Button
+              type="button"
+              variant="alert"
+              size="xs"
+              feedbackState={query.isFetching ? "loading" : "idle"}
+              loadingLabel={t("connections.localError.retrying")}
+              onClick={() => void query.refetch()}
+            >
+              {t("connections.localError.retry")}
+            </Button>
           </AlertDescription>
         </Alert>
       ) : null}

--- a/src/features/connections/ui/LocalMcpSection.tsx
+++ b/src/features/connections/ui/LocalMcpSection.tsx
@@ -1,0 +1,95 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import {
+  listLocalMcpInventory,
+  LOCAL_MCP_INVENTORY_QUERY_KEY,
+} from "@/features/connections/api/localMcpInventory";
+import {
+  filterMcpGroups,
+  groupMcpServers,
+  harnessesWithErrors,
+} from "@/features/connections/lib/localMcpInventory";
+import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
+import { Button } from "@/shared/ui/button";
+import { SettingsSection } from "@/shared/ui/settings-section";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { LocalMcpConnectionCard } from "./LocalMcpConnectionCard";
+
+export function LocalMcpSection({
+  searchTerm,
+  workspacePaths,
+}: {
+  searchTerm: string;
+  workspacePaths: string[];
+}) {
+  const { t } = useTranslation("settings");
+  const query = useQuery({
+    queryKey: [...LOCAL_MCP_INVENTORY_QUERY_KEY, workspacePaths],
+    queryFn: () => listLocalMcpInventory(workspacePaths),
+    staleTime: 10_000,
+  });
+  const groups = groupMcpServers(query.data);
+  const visibleGroups = filterMcpGroups(groups, searchTerm);
+  const failedSources = harnessesWithErrors(query.data);
+  const hasFailure = query.isError || failedSources.length > 0;
+
+  if (query.isLoading) {
+    return (
+      <SettingsSection title={t("connections.sections.local")}>
+        {[1, 2, 3].map((item) => (
+          <div key={item} className="flex items-center gap-3 p-3">
+            <Skeleton className="size-4.5 rounded-full" />
+            <Skeleton className="h-4 w-32 rounded-sm" />
+          </div>
+        ))}
+      </SettingsSection>
+    );
+  }
+
+  if (groups.length === 0 && hasFailure) {
+    return (
+      <SettingsSection title={t("connections.sections.local")}>
+        <Alert>
+          <AlertTitle>{t("connections.localError.title")}</AlertTitle>
+          <AlertDescription>
+            <span>{t("connections.localError.description")}</span>
+            <Button
+              type="button"
+              variant="alert"
+              size="xs"
+              feedbackState={query.isFetching ? "loading" : "idle"}
+              loadingLabel={t("connections.localError.retrying")}
+              onClick={() => void query.refetch()}
+            >
+              {t("connections.localError.retry")}
+            </Button>
+          </AlertDescription>
+        </Alert>
+      </SettingsSection>
+    );
+  }
+
+  if (groups.length === 0) return null;
+
+  return (
+    <SettingsSection title={t("connections.sections.local")}>
+      {hasFailure ? (
+        <Alert>
+          <AlertTitle>{t("connections.localError.partialTitle")}</AlertTitle>
+          <AlertDescription>
+            {t("connections.localError.partialDescription")}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+      {visibleGroups.length === 0 && searchTerm.trim() ? (
+        <p className="p-3 text-sm text-muted-foreground">
+          {t("connections.noResults")}
+        </p>
+      ) : (
+        visibleGroups.map((group) => (
+          <LocalMcpConnectionCard key={group.id} group={group} />
+        ))
+      )}
+    </SettingsSection>
+  );
+}

--- a/src/features/settings/ui/SettingsView.tsx
+++ b/src/features/settings/ui/SettingsView.tsx
@@ -15,6 +15,7 @@ import { ConnectionsSettings } from "@/features/connections/ui/ConnectionsSettin
 import { VoiceSettings } from "@/features/voice-conversation/ui/VoiceSettings";
 import type { AuthStatus } from "@/features/auth/api/auth";
 import { SettingsPane } from "@/shared/ui/SettingsPage";
+import type { SetupChatRequest } from "@/features/chat/lib/setupChatRequest";
 import type { AgentSetupTroubleshootingRequest } from "@/features/providers/lib/agentSetupTroubleshooting";
 import { refreshDoctorReportFreshness } from "@/shared/api/useDoctorReport";
 import { useProfileCapability } from "@/shared/profile/capabilities";
@@ -26,6 +27,7 @@ interface SettingsViewProps {
   onStartTroubleshootingChat?: (
     request: AgentSetupTroubleshootingRequest,
   ) => void;
+  onStartConnectionSetupChat?: (request: SetupChatRequest) => void;
   onReturnToAgentDraft?: () => void;
 }
 
@@ -44,6 +46,7 @@ export function SettingsView({
   authStatus,
   onLoggedOut,
   onStartTroubleshootingChat,
+  onStartConnectionSetupChat,
   onReturnToAgentDraft,
 }: SettingsViewProps) {
   const queryClient = useQueryClient();
@@ -72,7 +75,7 @@ export function SettingsView({
       {activeSection === "appearance" && <AppearanceSettings />}
       {activeSection === "behavior" && <BehaviorSettings />}
       {activeSection === "connections" && (
-        <ConnectionsSettings onAskAgentToAddMcp={onStartTroubleshootingChat} />
+        <ConnectionsSettings onAskAgentToAddMcp={onStartConnectionSetupChat} />
       )}
       {activeSection === "providers" && (
         <ProvidersSettings

--- a/src/features/settings/ui/SettingsView.tsx
+++ b/src/features/settings/ui/SettingsView.tsx
@@ -71,7 +71,9 @@ export function SettingsView({
     <SettingsPane>
       {activeSection === "appearance" && <AppearanceSettings />}
       {activeSection === "behavior" && <BehaviorSettings />}
-      {activeSection === "connections" && <ConnectionsSettings />}
+      {activeSection === "connections" && (
+        <ConnectionsSettings onAskAgentToAddMcp={onStartTroubleshootingChat} />
+      )}
       {activeSection === "providers" && (
         <ProvidersSettings
           onStartTroubleshootingChat={onStartTroubleshootingChat}

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -108,7 +108,7 @@
     "configure": "Configure",
     "connect": "Connect",
     "connectError": "Couldn't open the connect flow. Try again.",
-    "description": "Sign in to apps and services Berd can use on your behalf.",
+    "description": "See company-managed connections and MCP servers configured on this device.",
     "disconnect": "Disconnect",
     "disconnectError": "Couldn't disconnect. Try again.",
     "empty": {
@@ -123,15 +123,27 @@
     "reconnect": "Reconnect",
     "search": "Search connections",
     "sections": {
-      "available": "Available",
-      "installed": "Installed"
+      "managed": "Company managed",
+      "local": "Local"
     },
     "status": {
       "active": "Active",
       "disconnected": "Disconnected",
       "expired": "Expired"
     },
-    "title": "Connections"
+    "title": "Connections",
+    "worksWith": "Works with: {{harnesses}}",
+    "localError": {
+      "title": "Couldn’t load your local MCPs",
+      "description": "Try again in a moment.",
+      "partialTitle": "Some local MCPs may be missing",
+      "partialDescription": "Berd couldn’t read every local configuration source.",
+      "retry": "Try again",
+      "retrying": "Trying…"
+    },
+    "askAgent": "Add MCP",
+    "askAgentTitle": "Add an MCP",
+    "askAgentPrompt": "Help me add an MCP server. Ask which one I want, explain what access it needs, and use the supported setup path for my active agent. Ask before changing any configuration and never print or copy credentials."
   },
   "deleteProject": {
     "description": "Removes the project and all its data. You can't undo this.",

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -142,8 +142,8 @@
       "retrying": "Trying…"
     },
     "askAgent": "Add connection",
-    "askAgentTitle": "Add an MCP",
-    "askAgentPrompt": "Help me add an MCP server. Ask which one I want, explain what access it needs, and use the supported setup path for my active agent. Ask before changing any configuration and never print or copy credentials."
+    "askAgentTitle": "Add a connection",
+    "askAgentPrompt": "Help me add a connection. First ask whether I want a company-managed service or a local MCP, then explain the setup and access requirements. Ask before changing any configuration and never print or copy credentials."
   },
   "deleteProject": {
     "description": "Removes the project and all its data. You can't undo this.",

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -141,7 +141,7 @@
       "retry": "Try again",
       "retrying": "Trying…"
     },
-    "askAgent": "Add MCP",
+    "askAgent": "Add connection",
     "askAgentTitle": "Add an MCP",
     "askAgentPrompt": "Help me add an MCP server. Ask which one I want, explain what access it needs, and use the supported setup path for my active agent. Ask before changing any configuration and never print or copy credentials."
   },

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -108,7 +108,7 @@
     "configure": "Configurar",
     "connect": "Conectar",
     "connectError": "No se pudo abrir el flujo de conexión. Inténtalo de nuevo.",
-    "description": "Inicia sesión en apps y servicios que Berd puede usar en tu nombre.",
+    "description": "Consulta las conexiones administradas por la empresa y los servidores MCP configurados en este dispositivo.",
     "disconnect": "Desconectar",
     "disconnectError": "No se pudo desconectar. Inténtalo de nuevo.",
     "empty": {
@@ -123,15 +123,27 @@
     "reconnect": "Reconectar",
     "search": "Buscar conexiones",
     "sections": {
-      "available": "Disponibles",
-      "installed": "Instaladas"
+      "managed": "Administradas por la empresa",
+      "local": "Locales"
     },
     "status": {
       "active": "Activa",
       "disconnected": "Desconectada",
       "expired": "Caducada"
     },
-    "title": "Conexiones"
+    "title": "Conexiones",
+    "worksWith": "Funciona con: {{harnesses}}",
+    "localError": {
+      "title": "No se pudieron cargar tus MCP locales",
+      "description": "Inténtalo de nuevo en unos instantes.",
+      "partialTitle": "Es posible que falten algunos MCP locales",
+      "partialDescription": "Berd no pudo leer todas las fuentes de configuración local.",
+      "retry": "Intentar de nuevo",
+      "retrying": "Intentando…"
+    },
+    "askAgent": "Agregar MCP",
+    "askAgentTitle": "Agregar un MCP",
+    "askAgentPrompt": "Ayúdame a agregar un servidor MCP. Pregunta cuál quiero, explica qué acceso necesita y usa el método de configuración compatible con mi agente activo. Pregunta antes de cambiar cualquier configuración y nunca muestres ni copies credenciales."
   },
   "deleteProject": {
     "description": "Este proyecto y todos sus datos se eliminarán de forma permanente.",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -142,8 +142,8 @@
       "retrying": "Intentando…"
     },
     "askAgent": "Agregar conexión",
-    "askAgentTitle": "Agregar un MCP",
-    "askAgentPrompt": "Ayúdame a agregar un servidor MCP. Pregunta cuál quiero, explica qué acceso necesita y usa el método de configuración compatible con mi agente activo. Pregunta antes de cambiar cualquier configuración y nunca muestres ni copies credenciales."
+    "askAgentTitle": "Agregar una conexión",
+    "askAgentPrompt": "Ayúdame a agregar una conexión. Primero pregunta si quiero un servicio administrado por la empresa o un MCP local; después explica la configuración y los requisitos de acceso. Pregunta antes de cambiar cualquier configuración y nunca muestres ni copies credenciales."
   },
   "deleteProject": {
     "description": "Este proyecto y todos sus datos se eliminarán de forma permanente.",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -141,7 +141,7 @@
       "retry": "Intentar de nuevo",
       "retrying": "Intentando…"
     },
-    "askAgent": "Agregar MCP",
+    "askAgent": "Agregar conexión",
     "askAgentTitle": "Agregar un MCP",
     "askAgentPrompt": "Ayúdame a agregar un servidor MCP. Pregunta cuál quiero, explica qué acceso necesita y usa el método de configuración compatible con mi agente activo. Pregunta antes de cambiar cualquier configuración y nunca muestres ni copies credenciales."
   },


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Connections now shows company-managed services separately from MCPs configured for Goose, Claude Code, and Codex on this device.

**Problem:** Connections previously mixed company services and Goose extensions into Installed and Available sections, while ignoring MCP configuration owned by Claude Code and Codex. That structure also made local configuration look more like an installer or health surface than a passive inventory.

**Solution:** Organize the page into **Company managed** and **Local** sections under one shared search. Preserve the existing managed catalog and actions, add read-only cross-harness discovery for local MCP configuration, and direct setup through an editable agent-chat draft rather than a technical form.

### Product and trust boundaries

- **Configured is not health:** Local rows report configuration presence only. The page does not launch MCP processes, contact vendors, check authentication, or claim that a server is active in the current chat.
- **Credential minimization:** The inventory response excludes config paths, commands, arguments, URLs, headers, environment values, and OAuth material. Cross-harness grouping uses only an opaque, secret-safe structural fingerprint.
- **Managed loading is unchanged:** Existing company-managed loading and connection semantics are intentionally out of scope; this PR reorganizes their presentation without redefining their backend lifecycle.
- **Project-scoped inventory:** Local inventory includes user-level MCPs plus project-scoped MCPs for the active Berd project. This read-only path trusts project roots supplied by Berd's renderer; backend project-root authorization should be reconsidered if this surface ever gains configuration writes.
- **Visual review:** Before/after screenshots should be attached before human review; this PR was created without uploaded screenshots.

<details>
<summary>File changes</summary>

**src-tauri/Cargo.lock**
Records the TOML parser dependency used for passive Codex configuration discovery.

**src-tauri/Cargo.toml**
Adds TOML parsing support for Codex MCP configuration.

**src-tauri/src/commands/local_mcp_inventory.rs**
Adds bounded, read-only discovery adapters for Goose, Claude Code, and Codex. Returns only redacted structural metadata, isolates source failures, recognizes active-project scopes, and generates opaque identity fingerprints without exposing targets or secrets.

**src-tauri/src/commands/mod.rs**
Registers the local MCP inventory command module.

**src-tauri/src/lib.rs**
Exposes the inventory command through Tauri's command handler.

**src/app/AppShell.navigation.test.tsx**
Protects the Add connection handoff: it preserves the selected harness and creates an editable unsent draft.

**src/app/AppShell.tsx**
Adds the neutral connection-setup chat handoff without coupling it to provider troubleshooting.

**src/app/ui/AppShellContent.tsx**
Threads the neutral setup-chat callback into Settings.

**src/features/chat/lib/setupChatRequest.ts**
Defines the small shared contract for opening a setup conversation as a draft.

**src/features/connections/api/localMcpInventory.ts**
Defines the minimal renderer-safe inventory contract and Tauri API wrapper.

**src/features/connections/lib/__tests__/localMcpInventory.test.ts**
Covers conservative cross-harness identity, collision handling, filtering, and partial-source reporting.

**src/features/connections/lib/localMcpInventory.ts**
Groups only entries with matching key, name, transport, and opaque target fingerprint, and provides shared filtering/error derivation.

**src/features/connections/ui/ConnectionCards.test.tsx**
Protects the existing managed-row behavior and spacing between Disconnect and Reconnect actions.

**src/features/connections/ui/ConnectionCards.tsx**
Adds the missing standard gap around paired managed connection actions; all other managed behavior remains unchanged.

**src/features/connections/ui/ConnectionsSettings.pane.test.tsx**
Covers section ownership, shared search, empty/error/partial states, retry, active-project changes, and agent setup requests.

**src/features/connections/ui/ConnectionsSettings.tsx**
Reorganizes the page into Company managed and Local sections, preserves the full managed catalog/actions and ordering, shares one search, and adds the agent-led Add connection entry point.

**src/features/connections/ui/LocalMcpConnectionCard.tsx**
Renders passive local inventory through the existing ConnectionCard row pattern with a simple Works with label.

**src/features/connections/ui/LocalMcpSection.tsx**
Owns local inventory loading, successful empty, partial, failure, retry, and search-result states without adding mutation controls.

**src/features/settings/ui/SettingsView.tsx**
Connects the Connections page to the neutral setup-chat handoff.

**src/shared/i18n/locales/en/settings.json**
Adds English copy for the new sections, passive inventory, recovery states, and Add connection flow.

**src/shared/i18n/locales/es/settings.json**
Adds matching Spanish translations.

</details>

### Verification

- `just check`
- `just tauri-check`
- `just clippy`
- 25 Connections tests
- 134 AppShell/navigation tests
- 13 Rust inventory tests
