### PR TITLE
Bump bb CLI to 0.7.12

### DIFF
--- a/bb-cli/Cargo.lock
+++ b/bb-cli/Cargo.lock
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "sq-kgoose"
-version = "0.7.11"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "builderbot-auth",

--- a/bb-cli/Cargo.toml
+++ b/bb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sq-kgoose"
-version = "0.7.11"
+version = "0.7.12"
 edition = "2021"
 rust-version = "1.88.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

The Compose authentication change in #38 changed the `bb` binary, and the bb release contract requires a version update before Berd packages it. This bumps the shared bb-cli package and lockfile from 0.7.11 to 0.7.12 so the next installed Berd release carries an identifiable CLI version.

### Related issue

Follow-up to #38.

### Testing

- `cd bb-cli && source ./bin/activate-hermit && just check`
- `just build-bb-release`; `bb --version` reports 0.7.12
- `scripts/prepare-bb-cli-resource.sh`; the staged resource reports 0.7.12
- Repository pre-commit and pre-push gates