### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.6.2](https://github.com/block/berd/releases/tag/v0.6.2) - 2026-08-18
+
+Berd 0.6.1 expands the starter agent collection, improves agent sharing, and makes connections and agent activity easier to navigate.
+
+- **More starter agents:** Explore seven bundled agents, including Agt Builder, Choosey, Copycat, Pushback, Tinker, and Wildcard. New Home canvases feature Tinker and Wildcard, while existing layouts remain unchanged.
+- **Slack-friendly agent sharing:** Download agent cards as ZIP files so their instructions and settings remain intact when shared through Slack. PNG and Markdown exports remain available from the same download menu.
+- **Organized connections:** Connections are now grouped into company-managed services and local MCPs configured for Goose, Claude Code, or Codex. A shared search and agent-guided setup flow make connections easier to find and add.
+- **More stable Agent Work details:** Expanding previous steps no longer causes the conversation to jump unexpectedly. Long tool details now stay compact in a scrollable, keyboard-accessible area.
+
+**Full Changelog**: https://github.com/block/berd/compare/v0.6.1...fc0cced1
+
 ## [v0.6.1](https://github.com/block/berd/releases/tag/v0.6.1) - 2026-08-17
 
 Berd 0.6.0 improves queued messaging, long-chat reliability, agent cards, and the Home experience, alongside smoother installation and updates.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "berd",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Berd"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "audioadapter-buffers",
@@ -581,7 +581,7 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "berdctl"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Berd"
-version = "0.6.1"
+version = "0.6.2"
 description = "Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.6.1"
+version = "0.6.2"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Berd",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "xyz.block.berd",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
synchronize app, cli, plugin, lockfile, and changelog versions.
