### PR TITLE
feat(chat): default to gender-neutral pronouns via an always-on interaction norms preamble

### DIFF
--- a/distro/agents/agt-builder.md
+++ b/distro/agents/agt-builder.md
@@ -26,7 +26,7 @@ Build in the open. Draft and show the concrete proposed agent or diff first. Wai
 
 **Ask before you assume, especially on voice.** If they haven't said how the agent should sound, don't invent a personality and hope it's close. Ask directly, or offer two contrasting options and let them react. An agent's voice is the hardest thing to get right by guessing.
 
-**Don't give an agent a gender the creator didn't ask for.** Personality, yes. Pronouns, no. Write descriptions and instructions with they/them or no pronouns at all, and do the same for any people the instructions describe. If the creator wants the agent to be a "he" or a "she," they'll say so, and then it's theirs to have.
+**Don't give an agent a gender the creator didn't ask for.** Personality, yes. Pronouns, no. Write descriptions and instructions with it/its or they/them, whichever fits the framing — "it" for an agent described as a tool ("it reviews your drafts"), "they" for one described as a character — or sidestep pronouns entirely. People the instructions describe get they/them unless the creator said otherwise. If the creator wants the agent to be a "he" or a "she," they'll say so, and then it's theirs to have.
 
 **Show the actual result, not a description of it.** Once something's built or changed, say plainly what it can do now, and let them try it. "It's ready" is worse than "try asking it to X."
 

--- a/distro/agents/agt-builder.md
+++ b/distro/agents/agt-builder.md
@@ -26,6 +26,8 @@ Build in the open. Draft and show the concrete proposed agent or diff first. Wai
 
 **Ask before you assume, especially on voice.** If they haven't said how the agent should sound, don't invent a personality and hope it's close. Ask directly, or offer two contrasting options and let them react. An agent's voice is the hardest thing to get right by guessing.
 
+**Don't give an agent a gender the creator didn't ask for.** Personality, yes. Pronouns, no. Write descriptions and instructions with they/them or no pronouns at all, and do the same for any people the instructions describe. If the creator wants the agent to be a "he" or a "she," they'll say so, and then it's theirs to have.
+
 **Show the actual result, not a description of it.** Once something's built or changed, say plainly what it can do now, and let them try it. "It's ready" is worse than "try asking it to X."
 
 **When refining, ask what specifically felt off before changing anything.** "Make it better" isn't a note. "It agreed with a bad idea" or "it never explains why" is. Get the specific complaint, then make the specific fix. Don't rewrite the whole personality over one bad exchange.

--- a/distro/skills/agent-builder/SKILL.md
+++ b/distro/skills/agent-builder/SKILL.md
@@ -37,7 +37,7 @@ Agent instructions here.
 ```
 Required frontmatter keys are name and description. Preserve all other frontmatter keys when editing existing agents unless the user explicitly changes them. The Markdown body is the agent’s system prompt/persona instructions.
 
-When writing or generating a description or body, do not assign the agent a gender or gendered pronouns unless the user asked for one — use they/them or no pronouns, for the agent and for any people the instructions describe. Preserve pronouns the user chose, in either direction.
+When writing or generating a description or body, do not assign the agent a gender or gendered pronouns unless the user asked for one. Use it/its or they/them for the agent, matching how it is framed (tool vs. character), or avoid pronouns; people the instructions describe get they/them. Preserve pronouns the user chose, in either direction.
 
 ## Names and Slugs
 

--- a/distro/skills/agent-builder/SKILL.md
+++ b/distro/skills/agent-builder/SKILL.md
@@ -37,6 +37,8 @@ Agent instructions here.
 ```
 Required frontmatter keys are name and description. Preserve all other frontmatter keys when editing existing agents unless the user explicitly changes them. The Markdown body is the agent’s system prompt/persona instructions.
 
+When writing or generating a description or body, do not assign the agent a gender or gendered pronouns unless the user asked for one — use they/them or no pronouns, for the agent and for any people the instructions describe. Preserve pronouns the user chose, in either direction.
+
 ## Names and Slugs
 
 For create/rename, require a trimmed name that is non-empty, ≤80 characters, and contains no `/` or `\`.

--- a/src/shared/api/__tests__/acp.test.ts
+++ b/src/shared/api/__tests__/acp.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_STYLE_GUIDELINES_PROMPT,
   STYLE_GUIDELINES_STORAGE_KEY,
 } from "@/shared/preferences/styleGuidelinesPreference";
+import { INTERACTION_NORMS_PREAMBLE } from "@/shared/api/interactionNorms";
 
 const mockLoadSession = vi.fn();
 const mockNewSession = vi.fn();
@@ -285,16 +286,22 @@ describe("acpSendMessage", () => {
     expect(mockAppendSessionSystemPrompt).toHaveBeenNthCalledWith(
       3,
       sessionId,
-      "berd_app_context",
-      "",
+      "berd_interaction_norms",
+      INTERACTION_NORMS_PREAMBLE,
     );
     expect(mockAppendSessionSystemPrompt).toHaveBeenNthCalledWith(
       4,
       sessionId,
+      "berd_app_context",
+      "",
+    );
+    expect(mockAppendSessionSystemPrompt).toHaveBeenNthCalledWith(
+      5,
+      sessionId,
       "client_system_prompt",
       "You are Starfriend.",
     );
-    expect(mockAppendSessionSystemPrompt).toHaveBeenCalledTimes(4);
+    expect(mockAppendSessionSystemPrompt).toHaveBeenCalledTimes(5);
   });
 
   it("adds the default style guidelines when unset", async () => {
@@ -370,6 +377,31 @@ describe("acpSendMessage", () => {
       "acp-session-preamble",
       "berd_app_context",
       "[Berd]\nberdctl is on your PATH.",
+    );
+  });
+
+  it("hands the interaction norms off in-band for external agents, before the persona", async () => {
+    const sessionRegistry = await import("../acpSessionRegistry");
+    const { __resetAllPersonaHandoffs } = await import("../acpPersonaHandoff");
+    const { acpSendMessage } = await import("../acp");
+    __resetAllPersonaHandoffs();
+
+    sessionRegistry.registerPreparedSession(
+      "acp-session-norms-ext",
+      "claude-acp",
+      "/tmp/project",
+      "test-model",
+    );
+
+    await acpSendMessage("acp-session-norms-ext", "hello", {
+      systemPrompt: "You are Starfriend.",
+    });
+
+    const [, blocks] = mockPrompt.mock.calls[0];
+    expect(blocks[0].annotations).toEqual({ audience: ["assistant"] });
+    expect(blocks[0].text).toContain(INTERACTION_NORMS_PREAMBLE);
+    expect(blocks[0].text.indexOf(INTERACTION_NORMS_PREAMBLE)).toBeLessThan(
+      blocks[0].text.indexOf("You are Starfriend."),
     );
   });
 

--- a/src/shared/api/acp.ts
+++ b/src/shared/api/acp.ts
@@ -31,6 +31,7 @@ import { useRuntimeConfigStore } from "@/shared/runtime-config/runtimeConfigStor
 import { resolveManagedGooseProviderSelection } from "@/shared/runtime-config/modelProviderPolicy";
 import { getStyleGuidelinesPrompt } from "@/shared/preferences/styleGuidelinesPreference";
 import { getBerdctlPreamble } from "@/features/berdctl/appPreamble";
+import { INTERACTION_NORMS_PREAMBLE } from "@/shared/api/interactionNorms";
 import { perfLog } from "@/shared/lib/perfLog";
 import {
   applySessionConfigOptionsSnapshot,
@@ -114,6 +115,7 @@ function resolveProvidersCatalog(providers: AcpProvider[]): AcpProvider[] {
     .filter((provider): provider is AcpProvider => provider !== null);
 }
 
+const BERD_INTERACTION_NORMS_SYSTEM_PROMPT_KEY = "berd_interaction_norms";
 const BERD_APP_CONTEXT_SYSTEM_PROMPT_KEY = "berd_app_context";
 const BERD_STYLE_GUIDELINES_SYSTEM_PROMPT_KEY = "berd_style_guidelines";
 const LEGACY_STYLE_GUIDELINES_SYSTEM_PROMPT_KEY =
@@ -186,6 +188,14 @@ async function acpSendMessageNow(
       sessionId,
       getStyleGuidelinesPrompt(),
     );
+    // App-level defaults with no off switch. Sent before user-authored
+    // sections so the user's own content arrives after — and therefore
+    // reads as — the override. See interactionNorms.ts.
+    await directAcp.appendSessionSystemPrompt(
+      sessionId,
+      BERD_INTERACTION_NORMS_SYSTEM_PROMPT_KEY,
+      INTERACTION_NORMS_PREAMBLE,
+    );
     // Keyed and re-sent on every send (empty when berdctl is unreachable),
     // so availability changes self-correct on the next message.
     await directAcp.appendSessionSystemPrompt(
@@ -199,11 +209,14 @@ async function acpSendMessageNow(
       systemPrompt?.trim() ? systemPrompt : "",
     );
   } else {
+    const appPreamble = [INTERACTION_NORMS_PREAMBLE, berdctlPreamble]
+      .filter((part): part is string => Boolean(part?.trim()))
+      .join("\n\n");
     personaHandoffClaim = preparePersonaHandoff(
       sessionId,
       providerId,
       systemPrompt,
-      berdctlPreamble,
+      appPreamble,
     );
   }
 

--- a/src/shared/api/interactionNorms.ts
+++ b/src/shared/api/interactionNorms.ts
@@ -1,0 +1,19 @@
+/**
+ * App-level interaction norms injected unconditionally on every send, for
+ * every harness. Unlike the style guidelines (user-editable, goose-only) or
+ * the berdctl preamble (absent when the broker is down), this block has no
+ * off switch: it encodes Berd-the-app's defaults, not the user's
+ * preferences.
+ *
+ * Precedence is deliberate: these are defaults, so anything the user states
+ * — in the moment, in a persona, or in their own instruction files — wins.
+ * The wording says so explicitly, and both delivery paths place this block
+ * before user-authored content so that content reads as the override, not
+ * the other way around.
+ *
+ * Kept tiny (~50 tokens). Every norm added here taxes every send of every
+ * session, so entries must be cross-cutting behavioral defaults that can't
+ * live anywhere more targeted.
+ */
+export const INTERACTION_NORMS_PREAMBLE = `[Defaults]
+- Never assume anyone's gender — the user, people they mention, or agents. Use they/them (or equivalent gender-neutral phrasing in other languages) unless that person's pronouns are stated or clearly established. This is a default: pronouns given by the user always win.`;

--- a/src/shared/api/interactionNorms.ts
+++ b/src/shared/api/interactionNorms.ts
@@ -16,4 +16,4 @@
  * live anywhere more targeted.
  */
 export const INTERACTION_NORMS_PREAMBLE = `[Defaults]
-- Never assume anyone's gender — the user, people they mention, or agents. Use they/them (or equivalent gender-neutral phrasing in other languages) unless that person's pronouns are stated or clearly established. This is a default: pronouns given by the user always win.`;
+- Never assume anyone's gender — the user, people they mention, or agents. Use they/them (or equivalent gender-neutral phrasing in other languages) unless that person's pronouns are stated or clearly established. For agents and other software, it/its is also fine — whichever reads more naturally. This is a default: pronouns given by the user always win.`;


### PR DESCRIPTION
## Why
Agents and chats were assigning he/him or she/her pronouns to people and agents without any prior instruction. The default for anyone — the user, people they mention, or agents — should be they/them unless pronouns are stated or clearly established.

## What
- Add a tiny always-on `[Defaults]` interaction-norms preamble (~50 tokens) in `interactionNorms.ts`
- Inject it on every send for goose-managed sessions under a new keyed section (`berd_interaction_norms`)
- Fold it into the in-band persona handoff for external harnesses (Claude Code, Codex, …), ahead of the persona
- Place it before user-authored content on both paths, and state explicitly that user-given pronouns always win
- Add an authoring rule to the builder persona (`agt-builder.md`) and the `agent-builder` skill: generated agents get no gender or gendered pronouns unless the creator asks — needed because personas override the runtime preamble

## Risk Assessment
Low — adds one short system-prompt block per send and two authoring-guidance lines; no behavior change beyond the stated default, and users override it by simply stating pronouns.

Generated with Goose