### PR TITLE
import agents from zip files

### DIFF
--- a/src/features/agents/lib/agentZipImport.test.ts
+++ b/src/features/agents/lib/agentZipImport.test.ts
@@ -36,6 +36,35 @@ describe("agent ZIP import", () => {
     expect(extractAgentFileFromZip(archive).name).toBe("reviewer.agent.png");
   });
 
+  it("rejects duplicate supported paths before extraction collapses them", () => {
+    const archive = zipSync({
+      "one.md": new Uint8Array([1]),
+      "two.md": new Uint8Array([2]),
+    });
+    const duplicatePathArchive = new Uint8Array(archive);
+    const originalName = new TextEncoder().encode("two.md");
+    const duplicateName = new TextEncoder().encode("one.md");
+    for (
+      let offset = 0;
+      offset <= duplicatePathArchive.length - originalName.length;
+      offset += 1
+    ) {
+      if (
+        originalName.every(
+          (byte, index) => duplicatePathArchive[offset + index] === byte,
+        )
+      ) {
+        duplicatePathArchive.set(duplicateName, offset);
+      }
+    }
+
+    expect(() => extractAgentFileFromZip(duplicatePathArchive)).toThrow(
+      expect.objectContaining<Partial<AgentZipImportError>>({
+        code: "multipleAgents",
+      }),
+    );
+  });
+
   it("rejects ambiguous archives with a typed error", () => {
     const archive = zipSync({
       "one.persona.md": new Uint8Array([1]),

--- a/src/features/agents/lib/agentZipImport.test.ts
+++ b/src/features/agents/lib/agentZipImport.test.ts
@@ -1,0 +1,76 @@
+import { zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+import { MAX_PERSONA_IMPORT_BYTES } from "./personaImport";
+import {
+  type AgentZipImportError,
+  extractAgentFileFromZip,
+  isAgentZipFileName,
+} from "./agentZipImport";
+
+describe("agent ZIP import", () => {
+  it("extracts a portable agent image", () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const archive = zipSync({ "reviewer.agent.png": bytes });
+
+    expect(extractAgentFileFromZip(archive)).toEqual({
+      name: "reviewer.agent.png",
+      bytes,
+    });
+  });
+
+  it("extracts persona markdown", () => {
+    const bytes = new TextEncoder().encode("---\nname: reviewer\n---\nReview.");
+    const archive = zipSync({ "reviewer.persona.md": bytes });
+
+    const extracted = extractAgentFileFromZip(archive);
+    expect(extracted.name).toBe("reviewer.persona.md");
+    expect(Array.from(extracted.bytes)).toEqual(Array.from(bytes));
+  });
+
+  it("ignores macOS metadata", () => {
+    const archive = zipSync({
+      "__MACOSX/._reviewer.agent.png": new Uint8Array([9]),
+      "folder/reviewer.agent.png": new Uint8Array([1]),
+    });
+
+    expect(extractAgentFileFromZip(archive).name).toBe("reviewer.agent.png");
+  });
+
+  it("rejects ambiguous archives with a typed error", () => {
+    const archive = zipSync({
+      "one.persona.md": new Uint8Array([1]),
+      "two.json": new Uint8Array([2]),
+    });
+
+    expect(() => extractAgentFileFromZip(archive)).toThrow(
+      expect.objectContaining<Partial<AgentZipImportError>>({
+        code: "multipleAgents",
+      }),
+    );
+  });
+
+  it("enforces the direct-import limit on nested text agents", () => {
+    const archive = zipSync({
+      "large.persona.md": new Uint8Array(MAX_PERSONA_IMPORT_BYTES + 1),
+    });
+
+    expect(() => extractAgentFileFromZip(archive)).toThrow(
+      expect.objectContaining<Partial<AgentZipImportError>>({
+        code: "tooLarge",
+        maxBytes: MAX_PERSONA_IMPORT_BYTES,
+      }),
+    );
+  });
+
+  it("reports malformed archives with a typed error", () => {
+    expect(() => extractAgentFileFromZip(new Uint8Array([1, 2, 3]))).toThrow(
+      expect.objectContaining<Partial<AgentZipImportError>>({
+        code: "invalid",
+      }),
+    );
+  });
+
+  it("recognizes ZIP filenames case-insensitively", () => {
+    expect(isAgentZipFileName("Reviewer.Agent.ZIP")).toBe(true);
+  });
+});

--- a/src/features/agents/lib/agentZipImport.ts
+++ b/src/features/agents/lib/agentZipImport.ts
@@ -60,6 +60,7 @@ export function extractAgentFileFromZip(
   archiveBytes: Uint8Array,
 ): ExtractedAgentFile {
   let entryCount = 0;
+  let supportedEntryCount = 0;
   let totalUncompressedBytes = 0;
   let archive: Record<string, Uint8Array>;
   try {
@@ -74,14 +75,19 @@ export function extractAgentFileFromZip(
           throw new AgentZipImportError("tooLarge", MAX_SNAPSHOT_PNG_BYTES);
         }
         const name = entry.name.split("/").at(-1) ?? "";
-        if (
+        const isSupportedEntry =
           !entry.name.endsWith("/") &&
           !entry.name.split("/").includes("__MACOSX") &&
           !name.startsWith(".") &&
-          isSupportedAgentFileName(name) &&
-          entry.originalSize > maxAgentFileBytes(name)
-        ) {
-          throw new AgentZipImportError("tooLarge", maxAgentFileBytes(name));
+          isSupportedAgentFileName(name);
+        if (isSupportedEntry) {
+          supportedEntryCount += 1;
+          if (supportedEntryCount > 1) {
+            throw new AgentZipImportError("multipleAgents");
+          }
+          if (entry.originalSize > maxAgentFileBytes(name)) {
+            throw new AgentZipImportError("tooLarge", maxAgentFileBytes(name));
+          }
         }
         return !entry.name.endsWith("/");
       },

--- a/src/features/agents/lib/agentZipImport.ts
+++ b/src/features/agents/lib/agentZipImport.ts
@@ -1,0 +1,115 @@
+import { unzipSync } from "fflate";
+import { MAX_SNAPSHOT_PNG_BYTES } from "@/features/agents/agent-snapshot";
+import { MAX_PERSONA_IMPORT_BYTES } from "@/features/agents/lib/personaImport";
+
+const MAX_ARCHIVE_ENTRIES = 32;
+
+export type AgentZipImportErrorCode =
+  | "invalid"
+  | "tooManyFiles"
+  | "tooLarge"
+  | "missingAgent"
+  | "multipleAgents";
+
+export class AgentZipImportError extends Error {
+  constructor(
+    public readonly code: AgentZipImportErrorCode,
+    public readonly maxBytes?: number,
+  ) {
+    super(code);
+    this.name = "AgentZipImportError";
+  }
+}
+
+export interface ExtractedAgentFile {
+  bytes: Uint8Array;
+  name: string;
+}
+
+export function isAgentZipFileName(fileName: string): boolean {
+  return fileName.trim().toLowerCase().endsWith(".zip");
+}
+
+function isAgentImageFileName(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".png");
+}
+
+function isSupportedAgentFileName(fileName: string): boolean {
+  const lowerName = fileName.toLowerCase();
+  return (
+    isAgentImageFileName(lowerName) ||
+    lowerName.endsWith(".md") ||
+    lowerName.endsWith(".json")
+  );
+}
+
+function maxAgentFileBytes(fileName: string): number {
+  return isAgentImageFileName(fileName)
+    ? MAX_SNAPSHOT_PNG_BYTES
+    : MAX_PERSONA_IMPORT_BYTES;
+}
+
+function validateExtractedSize(fileName: string, size: number): void {
+  const maxBytes = maxAgentFileBytes(fileName);
+  if (size > maxBytes) {
+    throw new AgentZipImportError("tooLarge", maxBytes);
+  }
+}
+
+export function extractAgentFileFromZip(
+  archiveBytes: Uint8Array,
+): ExtractedAgentFile {
+  let entryCount = 0;
+  let totalUncompressedBytes = 0;
+  let archive: Record<string, Uint8Array>;
+  try {
+    archive = unzipSync(archiveBytes, {
+      filter(entry) {
+        entryCount += 1;
+        if (entryCount > MAX_ARCHIVE_ENTRIES) {
+          throw new AgentZipImportError("tooManyFiles");
+        }
+        totalUncompressedBytes += entry.originalSize;
+        if (totalUncompressedBytes > MAX_SNAPSHOT_PNG_BYTES) {
+          throw new AgentZipImportError("tooLarge", MAX_SNAPSHOT_PNG_BYTES);
+        }
+        const name = entry.name.split("/").at(-1) ?? "";
+        if (
+          !entry.name.endsWith("/") &&
+          !entry.name.split("/").includes("__MACOSX") &&
+          !name.startsWith(".") &&
+          isSupportedAgentFileName(name) &&
+          entry.originalSize > maxAgentFileBytes(name)
+        ) {
+          throw new AgentZipImportError("tooLarge", maxAgentFileBytes(name));
+        }
+        return !entry.name.endsWith("/");
+      },
+    });
+  } catch (error) {
+    if (error instanceof AgentZipImportError) throw error;
+    throw new AgentZipImportError("invalid");
+  }
+
+  const candidates = Object.entries(archive).filter(([path]) => {
+    const parts = path.split("/");
+    const name = parts.at(-1) ?? "";
+    return (
+      !parts.includes("__MACOSX") &&
+      !name.startsWith(".") &&
+      isSupportedAgentFileName(name)
+    );
+  });
+
+  if (candidates.length === 0) {
+    throw new AgentZipImportError("missingAgent");
+  }
+  if (candidates.length > 1) {
+    throw new AgentZipImportError("multipleAgents");
+  }
+
+  const [path, bytes] = candidates[0];
+  const name = path.split("/").at(-1) ?? path;
+  validateExtractedSize(name, bytes.length);
+  return { bytes, name };
+}

--- a/src/features/agents/lib/agentZipImport.ts
+++ b/src/features/agents/lib/agentZipImport.ts
@@ -56,6 +56,61 @@ function validateExtractedSize(fileName: string, size: number): void {
   }
 }
 
+export const AGENT_ZIP_IMPORT_TIMEOUT_MS = 15_000;
+
+export function extractAgentFileFromZipInWorker(
+  archiveBytes: Uint8Array,
+  signal?: AbortSignal,
+  timeoutMs = AGENT_ZIP_IMPORT_TIMEOUT_MS,
+): Promise<ExtractedAgentFile> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("./agentZipImport.worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    let settled = false;
+    const finish = (operation: () => void) => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      signal?.removeEventListener("abort", handleAbort);
+      worker.terminate();
+      operation();
+    };
+    const handleAbort = () =>
+      finish(() => reject(new DOMException("Aborted", "AbortError")));
+    const timeout = window.setTimeout(
+      () => finish(() => reject(new AgentZipImportError("invalid"))),
+      timeoutMs,
+    );
+    worker.onmessage = (
+      event: MessageEvent<
+        | ExtractedAgentFile
+        | {
+            error: { code: AgentZipImportErrorCode; maxBytes?: number };
+          }
+      >,
+    ) => {
+      if ("error" in event.data) {
+        const { code, maxBytes } = event.data.error;
+        finish(() => reject(new AgentZipImportError(code, maxBytes)));
+      } else {
+        const extracted = event.data;
+        finish(() => resolve(extracted));
+      }
+    };
+    worker.onerror = () =>
+      finish(() => reject(new AgentZipImportError("invalid")));
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+    signal?.addEventListener("abort", handleAbort, { once: true });
+    const workerBytes = new Uint8Array(archiveBytes);
+    worker.postMessage({ archiveBytes: workerBytes }, [workerBytes.buffer]);
+  });
+}
+
 export function extractAgentFileFromZip(
   archiveBytes: Uint8Array,
 ): ExtractedAgentFile {

--- a/src/features/agents/lib/agentZipImport.worker.ts
+++ b/src/features/agents/lib/agentZipImport.worker.ts
@@ -1,0 +1,15 @@
+import { AgentZipImportError, extractAgentFileFromZip } from "./agentZipImport";
+
+self.onmessage = ({ data }: MessageEvent<{ archiveBytes: Uint8Array }>) => {
+  try {
+    const extracted = extractAgentFileFromZip(data.archiveBytes);
+    self.postMessage(extracted, { transfer: [extracted.bytes.buffer] });
+  } catch (error) {
+    self.postMessage({
+      error:
+        error instanceof AgentZipImportError
+          ? { code: error.code, maxBytes: error.maxBytes }
+          : { code: "invalid" },
+    });
+  }
+};

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -77,6 +77,7 @@ export function AgentImportDialog({
     null,
   );
   const preparationRef = useRef<AbortController | null>(null);
+  const [preparing, setPreparing] = useState(false);
   const [prepared, setPrepared] = useState<{
     bytes: Uint8Array;
     name: string;
@@ -144,6 +145,7 @@ export function AgentImportDialog({
     onImportFile: async (bytes, name) => {
       const controller = new AbortController();
       preparationRef.current = controller;
+      setPreparing(true);
       try {
         const result = await prepareImport(bytes, name, controller.signal);
         if (controller.signal.aborted) return;
@@ -159,6 +161,7 @@ export function AgentImportDialog({
       } finally {
         if (preparationRef.current === controller) {
           preparationRef.current = null;
+          setPreparing(false);
         }
       }
     },
@@ -232,6 +235,8 @@ export function AgentImportDialog({
           ) : (
             <div
               {...dropHandlers}
+              role="status"
+              aria-busy={preparing}
               className={cn(
                 "flex min-h-56 flex-col items-center justify-center gap-4 rounded-md border border-dashed border-border bg-muted/40 px-6 text-center",
                 isDragOver && "border-ring bg-muted/70",
@@ -241,11 +246,16 @@ export function AgentImportDialog({
                 className="size-10 text-muted-foreground"
                 aria-hidden="true"
               />
-              <p className="text-sm">{t("importDialog.dropTitle")}</p>
+              <p className="text-sm">
+                {preparing
+                  ? t("importDialog.preparing")
+                  : t("importDialog.dropTitle")}
+              </p>
               <Button
                 type="button"
                 variant="outline"
                 leftIcon={<IconUpload />}
+                feedbackState={preparing ? "loading" : "idle"}
                 onClick={openFilePicker}
               >
                 {t("importDialog.openFinder")}

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -222,7 +222,7 @@ export function AgentImportDialog({
           <input
             ref={fileInputRef}
             type="file"
-            accept=".agent.png,.png,.persona.md,.md,.json,image/png,text/markdown,text/plain,application/json"
+            accept=".agent.zip,.zip,.agent.png,.png,.persona.md,.md,.json,application/zip,application/x-zip-compressed,image/png,text/markdown,text/plain,application/json"
             className="hidden"
             onChange={handleFileChange}
           />

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { IconPhotoPlus, IconUpload } from "@tabler/icons-react";
 
 import { useTranslation } from "react-i18next";
@@ -37,6 +37,12 @@ export interface AgentImportPreview extends PersonaImportPreview {
 interface AgentImportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /**
+   * A file already validated and read by another import surface (the gallery
+   * drop zone). The dialog prepares it through the same flow as picker files
+   * so every entry point shares one preview/confirmation owner.
+   */
+  initialFile?: { bytes: Uint8Array; name: string } | null;
   onImportFile: (
     fileBytes: Uint8Array,
     fileName: string,
@@ -64,6 +70,7 @@ interface AgentImportDialogProps {
 export function AgentImportDialog({
   open,
   onOpenChange,
+  initialFile,
   onImportFile,
   prepareImport,
   validateImportFile,
@@ -135,14 +142,9 @@ export function AgentImportDialog({
     [prepared?.preview.cardImageUrl],
   );
 
-  const {
-    fileInputRef,
-    isDragOver,
-    dropHandlers,
-    handleFileChange,
-    openFilePicker,
-  } = useFileImportZone({
-    onImportFile: async (bytes, name) => {
+  const startPreparation = useCallback(
+    async (bytes: Uint8Array, name: string) => {
+      preparationRef.current?.abort();
       const controller = new AbortController();
       preparationRef.current = controller;
       setPreparing(true);
@@ -165,6 +167,29 @@ export function AgentImportDialog({
         }
       }
     },
+    [onImportError, prepareImport],
+  );
+
+  const consumedInitialFileRef = useRef<typeof initialFile>(null);
+  useEffect(() => {
+    if (!open) {
+      consumedInitialFileRef.current = null;
+      return;
+    }
+    if (initialFile && consumedInitialFileRef.current !== initialFile) {
+      consumedInitialFileRef.current = initialFile;
+      void startPreparation(initialFile.bytes, initialFile.name);
+    }
+  }, [open, initialFile, startPreparation]);
+
+  const {
+    fileInputRef,
+    isDragOver,
+    dropHandlers,
+    handleFileChange,
+    openFilePicker,
+  } = useFileImportZone({
+    onImportFile: startPreparation,
     validateFile: (file) => {
       preparationRef.current?.abort();
       setPrepared(null);
@@ -256,6 +281,7 @@ export function AgentImportDialog({
                 variant="outline"
                 leftIcon={<IconUpload />}
                 feedbackState={preparing ? "loading" : "idle"}
+                loadingLabel={t("importDialog.preparing")}
                 onClick={openFilePicker}
               >
                 {t("importDialog.openFinder")}

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -143,36 +143,41 @@ export function AgentImportDialog({
   );
 
   const startPreparation = useCallback(
-    async (bytes: Uint8Array, name: string) => {
+    (bytes: Uint8Array, name: string): AbortController => {
       preparationRef.current?.abort();
       const controller = new AbortController();
       preparationRef.current = controller;
       setPreparing(true);
-      try {
-        const result = await prepareImport(bytes, name, controller.signal);
-        if (controller.signal.aborted) {
-          // A discarded result never reaches prepared state, so the cleanup
-          // effect will not revoke its preview URL; dispose of it here.
-          const staleUrl = ("preview" in result ? result.preview : result)
-            .cardImageUrl;
-          if (staleUrl) URL.revokeObjectURL(staleUrl);
-          return;
+      void (async () => {
+        try {
+          const result = await prepareImport(bytes, name, controller.signal);
+          if (controller.signal.aborted) {
+            // A discarded result never reaches prepared state, so the cleanup
+            // effect will not revoke its preview URL; dispose of it here.
+            const staleUrl = ("preview" in result ? result.preview : result)
+              .cardImageUrl;
+            if (staleUrl) URL.revokeObjectURL(staleUrl);
+            return;
+          }
+          // The cleanup effect keyed by cardImageUrl revokes the previous URL
+          // exactly once when this prepared preview replaces it.
+          setPrepared(
+            "preview" in result ? result : { bytes, name, preview: result },
+          );
+        } catch (error) {
+          if (!controller.signal.aborted) {
+            onImportError(
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        } finally {
+          if (preparationRef.current === controller) {
+            preparationRef.current = null;
+            setPreparing(false);
+          }
         }
-        // The cleanup effect keyed by cardImageUrl revokes the previous URL
-        // exactly once when this prepared preview replaces it.
-        setPrepared(
-          "preview" in result ? result : { bytes, name, preview: result },
-        );
-      } catch (error) {
-        if (!controller.signal.aborted) {
-          onImportError(error instanceof Error ? error.message : String(error));
-        }
-      } finally {
-        if (preparationRef.current === controller) {
-          preparationRef.current = null;
-          setPreparing(false);
-        }
-      }
+      })();
+      return controller;
     },
     [onImportError, prepareImport],
   );
@@ -183,10 +188,23 @@ export function AgentImportDialog({
       consumedInitialFileRef.current = null;
       return;
     }
-    if (initialFile && consumedInitialFileRef.current !== initialFile) {
-      consumedInitialFileRef.current = initialFile;
-      void startPreparation(initialFile.bytes, initialFile.name);
+    if (!initialFile || consumedInitialFileRef.current === initialFile) {
+      return;
     }
+    consumedInitialFileRef.current = initialFile;
+    const controller = startPreparation(initialFile.bytes, initialFile.name);
+    return () => {
+      // Lifecycle cleanup (StrictMode replay, unmount) aborts this attempt.
+      // If it is still the active preparation, un-consume the file so a
+      // replayed effect can restart it; a picker selection that replaced
+      // this attempt keeps ownership and the marker stays consumed.
+      if (preparationRef.current === controller) {
+        controller.abort();
+        preparationRef.current = null;
+        setPreparing(false);
+        consumedInitialFileRef.current = null;
+      }
+    };
   }, [open, initialFile, startPreparation]);
 
   const {

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -150,7 +150,14 @@ export function AgentImportDialog({
       setPreparing(true);
       try {
         const result = await prepareImport(bytes, name, controller.signal);
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted) {
+          // A discarded result never reaches prepared state, so the cleanup
+          // effect will not revoke its preview URL; dispose of it here.
+          const staleUrl = ("preview" in result ? result.preview : result)
+            .cardImageUrl;
+          if (staleUrl) URL.revokeObjectURL(staleUrl);
+          return;
+        }
         // The cleanup effect keyed by cardImageUrl revokes the previous URL
         // exactly once when this prepared preview replaces it.
         setPrepared(

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -133,7 +133,10 @@ export function AgentImportDialog({
         onImportError(error instanceof Error ? error.message : String(error));
       }
     },
-    validateFile: validateImportFile,
+    validateFile: (file) => {
+      setPrepared(null);
+      return validateImportFile(file);
+    },
     onImportError,
     maxBytes: maxImportBytes,
     fileTooLargeMessage: importTooLargeMessage,

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IconPhotoPlus, IconUpload } from "@tabler/icons-react";
 
 import { useTranslation } from "react-i18next";
@@ -45,7 +45,14 @@ interface AgentImportDialogProps {
   prepareImport: (
     fileBytes: Uint8Array,
     fileName: string,
-  ) => AgentImportPreview;
+    signal: AbortSignal,
+  ) =>
+    | AgentImportPreview
+    | Promise<{
+        bytes: Uint8Array;
+        name: string;
+        preview: AgentImportPreview;
+      }>;
   validateImportFile: (
     file: Pick<File, "name" | "type" | "size">,
   ) => string | null;
@@ -69,6 +76,7 @@ export function AgentImportDialog({
   const [importAccentColor, setImportAccentColor] = useState<string | null>(
     null,
   );
+  const preparationRef = useRef<AbortController | null>(null);
   const [prepared, setPrepared] = useState<{
     bytes: Uint8Array;
     name: string;
@@ -76,8 +84,18 @@ export function AgentImportDialog({
   } | null>(null);
 
   useEffect(() => {
-    if (!open) setPrepared(null);
+    if (!open) {
+      preparationRef.current?.abort();
+      setPrepared(null);
+    }
   }, [open]);
+
+  useEffect(
+    () => () => {
+      preparationRef.current?.abort();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!prepared?.preview.cardImageUrl) {
@@ -123,17 +141,29 @@ export function AgentImportDialog({
     handleFileChange,
     openFilePicker,
   } = useFileImportZone({
-    onImportFile: (bytes, name) => {
+    onImportFile: async (bytes, name) => {
+      const controller = new AbortController();
+      preparationRef.current = controller;
       try {
-        const preview = prepareImport(bytes, name);
+        const result = await prepareImport(bytes, name, controller.signal);
+        if (controller.signal.aborted) return;
         // The cleanup effect keyed by cardImageUrl revokes the previous URL
         // exactly once when this prepared preview replaces it.
-        setPrepared({ bytes, name, preview });
+        setPrepared(
+          "preview" in result ? result : { bytes, name, preview: result },
+        );
       } catch (error) {
-        onImportError(error instanceof Error ? error.message : String(error));
+        if (!controller.signal.aborted) {
+          onImportError(error instanceof Error ? error.message : String(error));
+        }
+      } finally {
+        if (preparationRef.current === controller) {
+          preparationRef.current = null;
+        }
       }
     },
     validateFile: (file) => {
+      preparationRef.current?.abort();
       setPrepared(null);
       return validateImportFile(file);
     },

--- a/src/features/agents/ui/AgentsView.tsx
+++ b/src/features/agents/ui/AgentsView.tsx
@@ -59,7 +59,6 @@ import { isSafePngAvatarDataUrl } from "@/shared/lib/avatarUrl";
 import {
   AgentZipImportError,
   type ExtractedAgentFile,
-  extractAgentFileFromZip,
   extractAgentFileFromZipInWorker,
   isAgentZipFileName,
 } from "@/features/agents/lib/agentZipImport";
@@ -483,8 +482,10 @@ export function AgentsView({
       preview?: { snapshot?: ReturnType<typeof decodeAgentImage> },
     ) => {
       try {
+        // A .zip name only reaches this handler from the gallery drop zone;
+        // the import dialog always passes the extracted inner file.
         const extracted = isAgentZipFileName(fileName)
-          ? extractAgentFileFromZip(fileBytes)
+          ? await extractAgentFileFromZipInWorker(fileBytes)
           : { bytes: fileBytes, name: fileName };
         if (isAgentImageFileName(extracted.name)) {
           setImageImport({

--- a/src/features/agents/ui/AgentsView.tsx
+++ b/src/features/agents/ui/AgentsView.tsx
@@ -42,6 +42,7 @@ import type { Persona } from "@/shared/types/agents";
 import {
   formatAgentError,
   formatImportSuccessMessage,
+  formatPersonaImportFileSize,
   validatePersonaImportFile,
 } from "@/features/agents/lib/personaImport";
 import { isEmptyAgentsGallerySimulated } from "@/features/agents/lib/emptyGallerySimulation";
@@ -55,6 +56,12 @@ import { runAgentViewTransition } from "@/features/agents/lib/agentViewTransitio
 import { deleteDraftAgentSession } from "@/features/agents/lib/agentBuilderSession";
 import type { AppNavigationUpdateOptions } from "@/app/types/appNavigation";
 import { isSafePngAvatarDataUrl } from "@/shared/lib/avatarUrl";
+import {
+  AgentZipImportError,
+  type ExtractedAgentFile,
+  extractAgentFileFromZip,
+  isAgentZipFileName,
+} from "@/features/agents/lib/agentZipImport";
 
 function decodeImportFileBytes(fileBytes: Uint8Array): string {
   try {
@@ -75,6 +82,18 @@ function sourcePathToSlug(pathOrId: string): string {
 
 function isAgentImageFileName(fileName: string): boolean {
   return fileName.toLowerCase().endsWith(".png");
+}
+
+function formatAgentZipImportError(
+  error: AgentZipImportError,
+  t: (key: string, options?: Record<string, unknown>) => string,
+): string {
+  if (error.code === "tooLarge" && error.maxBytes) {
+    return t("view.importTooLarge", {
+      maxSize: formatPersonaImportFileSize(error.maxBytes),
+    });
+  }
+  return t(`zipImport.${error.code}`);
 }
 
 function exportFilenameFromPath(
@@ -413,6 +432,19 @@ export function AgentsView({
 
   const validateImportFile = useCallback(
     (file: Pick<File, "name" | "type" | "size">) => {
+      if (isAgentZipFileName(file.name)) {
+        if (file.size > MAX_SNAPSHOT_PNG_BYTES) {
+          return t("view.importTooLarge", { maxSize: "10 MB" });
+        }
+        if (
+          file.type &&
+          file.type !== "application/zip" &&
+          file.type !== "application/x-zip-compressed"
+        ) {
+          return t("view.importInvalidMimeType");
+        }
+        return null;
+      }
       if (isAgentImageFileName(file.name)) {
         if (file.size > MAX_SNAPSHOT_PNG_BYTES) {
           return t("imageImport.tooLarge");
@@ -457,16 +489,26 @@ export function AgentsView({
       preview?: { snapshot?: ReturnType<typeof decodeAgentImage> },
     ) => {
       try {
-        if (isAgentImageFileName(fileName)) {
+        const extracted = isAgentZipFileName(fileName)
+          ? extractAgentFileFromZip(fileBytes)
+          : { bytes: fileBytes, name: fileName };
+        if (isAgentImageFileName(extracted.name)) {
           setImageImport({
-            snapshot: preview?.snapshot ?? decodeAgentImage(fileBytes),
-            bytes: fileBytes,
+            snapshot: preview?.snapshot ?? decodeAgentImage(extracted.bytes),
+            bytes: extracted.bytes,
           });
           return;
         }
-        await handleImportContents(decodeImportFileBytes(fileBytes), fileName);
+        await handleImportContents(
+          decodeImportFileBytes(extracted.bytes),
+          extracted.name,
+        );
       } catch (err) {
-        toast.error(formatAgentError(err, t("view.importFailed")));
+        toast.error(
+          err instanceof AgentZipImportError
+            ? formatAgentZipImportError(err, t)
+            : formatAgentError(err, t("view.importFailed")),
+        );
       }
     },
     [handleImportContents, t],
@@ -480,16 +522,27 @@ export function AgentsView({
           onOpenChange={setImportDialogOpen}
           onImportFile={handleImportFileBytes}
           prepareImport={(bytes, name) => {
-            if (isAgentImageFileName(name)) {
-              const snapshot = decodeAgentImage(bytes);
-              const { width, height } = getPngDimensions(bytes);
+            let extracted: ExtractedAgentFile;
+            try {
+              extracted = isAgentZipFileName(name)
+                ? extractAgentFileFromZip(bytes)
+                : { bytes, name };
+            } catch (error) {
+              if (error instanceof AgentZipImportError) {
+                throw new Error(formatAgentZipImportError(error, t));
+              }
+              throw error;
+            }
+            if (isAgentImageFileName(extracted.name)) {
+              const snapshot = decodeAgentImage(extracted.bytes);
+              const { width, height } = getPngDimensions(extracted.bytes);
               return {
                 displayName:
                   snapshot.profile?.displayName ??
                   snapshot.definition.name ??
                   "Imported agent",
                 systemPrompt: snapshot.definition.systemPrompt ?? "",
-                identity: name,
+                identity: extracted.name,
                 avatar:
                   typeof snapshot.profile?.avatarDataUrl === "string" &&
                   isSafePngAvatarDataUrl(snapshot.profile.avatarDataUrl)
@@ -498,13 +551,16 @@ export function AgentsView({
                 snapshot,
                 cardAspectRatio: width / height,
                 cardImageUrl: URL.createObjectURL(
-                  new Blob([new Uint8Array(bytes).buffer], {
+                  new Blob([new Uint8Array(extracted.bytes).buffer], {
                     type: "image/png",
                   }),
                 ),
               };
             }
-            return previewPersonaImport(decodeImportFileBytes(bytes), name);
+            return previewPersonaImport(
+              decodeImportFileBytes(extracted.bytes),
+              extracted.name,
+            );
           }}
           validateImportFile={validateImportFile}
           onImportError={handleImportError}

--- a/src/features/agents/ui/AgentsView.tsx
+++ b/src/features/agents/ui/AgentsView.tsx
@@ -60,6 +60,7 @@ import {
   AgentZipImportError,
   type ExtractedAgentFile,
   extractAgentFileFromZip,
+  extractAgentFileFromZipInWorker,
   isAgentZipFileName,
 } from "@/features/agents/lib/agentZipImport";
 
@@ -436,13 +437,6 @@ export function AgentsView({
         if (file.size > MAX_SNAPSHOT_PNG_BYTES) {
           return t("view.importTooLarge", { maxSize: "10 MB" });
         }
-        if (
-          file.type &&
-          file.type !== "application/zip" &&
-          file.type !== "application/x-zip-compressed"
-        ) {
-          return t("view.importInvalidMimeType");
-        }
         return null;
       }
       if (isAgentImageFileName(file.name)) {
@@ -521,11 +515,11 @@ export function AgentsView({
           open
           onOpenChange={setImportDialogOpen}
           onImportFile={handleImportFileBytes}
-          prepareImport={(bytes, name) => {
+          prepareImport={async (bytes, name, signal) => {
             let extracted: ExtractedAgentFile;
             try {
               extracted = isAgentZipFileName(name)
-                ? extractAgentFileFromZip(bytes)
+                ? await extractAgentFileFromZipInWorker(bytes, signal)
                 : { bytes, name };
             } catch (error) {
               if (error instanceof AgentZipImportError) {
@@ -536,7 +530,7 @@ export function AgentsView({
             if (isAgentImageFileName(extracted.name)) {
               const snapshot = decodeAgentImage(extracted.bytes);
               const { width, height } = getPngDimensions(extracted.bytes);
-              return {
+              const preview = {
                 displayName:
                   snapshot.profile?.displayName ??
                   snapshot.definition.name ??
@@ -556,11 +550,13 @@ export function AgentsView({
                   }),
                 ),
               };
+              return { ...extracted, preview };
             }
-            return previewPersonaImport(
+            const preview = previewPersonaImport(
               decodeImportFileBytes(extracted.bytes),
               extracted.name,
             );
+            return { ...extracted, preview };
           }}
           validateImportFile={validateImportFile}
           onImportError={handleImportError}

--- a/src/features/agents/ui/AgentsView.tsx
+++ b/src/features/agents/ui/AgentsView.tsx
@@ -133,6 +133,10 @@ export function AgentsView({
   const [deletingPersona, setDeletingPersona] = useState<Persona | null>(null);
   const [sharingPersonaId, setSharingPersonaId] = useState<string | null>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [galleryImportFile, setGalleryImportFile] = useState<{
+    bytes: Uint8Array;
+    name: string;
+  } | null>(null);
   const [imageImport, setImageImport] = useState<{
     snapshot: SnapshotV1;
     bytes: Uint8Array;
@@ -482,31 +486,31 @@ export function AgentsView({
       preview?: { snapshot?: ReturnType<typeof decodeAgentImage> },
     ) => {
       try {
-        // A .zip name only reaches this handler from the gallery drop zone;
-        // the import dialog always passes the extracted inner file.
-        const extracted = isAgentZipFileName(fileName)
-          ? await extractAgentFileFromZipInWorker(fileBytes)
-          : { bytes: fileBytes, name: fileName };
-        if (isAgentImageFileName(extracted.name)) {
+        // The import dialog extracts ZIPs before this handler runs, so these
+        // bytes are always a directly importable agent file.
+        if (isAgentImageFileName(fileName)) {
           setImageImport({
-            snapshot: preview?.snapshot ?? decodeAgentImage(extracted.bytes),
-            bytes: extracted.bytes,
+            snapshot: preview?.snapshot ?? decodeAgentImage(fileBytes),
+            bytes: fileBytes,
           });
           return;
         }
-        await handleImportContents(
-          decodeImportFileBytes(extracted.bytes),
-          extracted.name,
-        );
+        await handleImportContents(decodeImportFileBytes(fileBytes), fileName);
       } catch (err) {
-        toast.error(
-          err instanceof AgentZipImportError
-            ? formatAgentZipImportError(err, t)
-            : formatAgentError(err, t("view.importFailed")),
-        );
+        toast.error(formatAgentError(err, t("view.importFailed")));
       }
     },
     [handleImportContents, t],
+  );
+
+  const handleGalleryImportFile = useCallback(
+    (fileBytes: Uint8Array, fileName: string) => {
+      // Gallery drops share the dialog's preparation flow (worker extraction,
+      // cancellation, preview, confirmation) instead of importing directly.
+      setGalleryImportFile({ bytes: fileBytes, name: fileName });
+      setImportDialogOpen(true);
+    },
+    [],
   );
 
   const dialogs = (
@@ -514,7 +518,11 @@ export function AgentsView({
       {importDialogOpen ? (
         <AgentImportDialog
           open
-          onOpenChange={setImportDialogOpen}
+          onOpenChange={(nextOpen) => {
+            setImportDialogOpen(nextOpen);
+            if (!nextOpen) setGalleryImportFile(null);
+          }}
+          initialFile={galleryImportFile}
           onImportFile={handleImportFileBytes}
           prepareImport={async (bytes, name, signal) => {
             let extracted: ExtractedAgentFile;
@@ -666,7 +674,7 @@ export function AgentsView({
           onImportAgentImage={() => setImportDialogOpen(true)}
           onContinueDraft={handleContinueDraft}
           onDeleteDraft={handleDeleteDraft}
-          onImportFile={handleImportFileBytes}
+          onImportFile={handleGalleryImportFile}
           validateImportFile={validateImportFile}
           onImportError={handleImportError}
           maxImportBytes={MAX_SNAPSHOT_PNG_BYTES}

--- a/src/features/agents/ui/AgentsView.tsx
+++ b/src/features/agents/ui/AgentsView.tsx
@@ -513,6 +513,55 @@ export function AgentsView({
     [],
   );
 
+  // Stable identity: the dialog's initial-file effect aborts and restarts
+  // preparation when this callback changes, so it must not change per render.
+  const prepareImportFile = useCallback(
+    async (bytes: Uint8Array, name: string, signal: AbortSignal) => {
+      let extracted: ExtractedAgentFile;
+      try {
+        extracted = isAgentZipFileName(name)
+          ? await extractAgentFileFromZipInWorker(bytes, signal)
+          : { bytes, name };
+      } catch (error) {
+        if (error instanceof AgentZipImportError) {
+          throw new Error(formatAgentZipImportError(error, t));
+        }
+        throw error;
+      }
+      if (isAgentImageFileName(extracted.name)) {
+        const snapshot = decodeAgentImage(extracted.bytes);
+        const { width, height } = getPngDimensions(extracted.bytes);
+        const preview = {
+          displayName:
+            snapshot.profile?.displayName ??
+            snapshot.definition.name ??
+            "Imported agent",
+          systemPrompt: snapshot.definition.systemPrompt ?? "",
+          identity: extracted.name,
+          avatar:
+            typeof snapshot.profile?.avatarDataUrl === "string" &&
+            isSafePngAvatarDataUrl(snapshot.profile.avatarDataUrl)
+              ? snapshot.profile.avatarDataUrl
+              : undefined,
+          snapshot,
+          cardAspectRatio: width / height,
+          cardImageUrl: URL.createObjectURL(
+            new Blob([new Uint8Array(extracted.bytes).buffer], {
+              type: "image/png",
+            }),
+          ),
+        };
+        return { ...extracted, preview };
+      }
+      const preview = previewPersonaImport(
+        decodeImportFileBytes(extracted.bytes),
+        extracted.name,
+      );
+      return { ...extracted, preview };
+    },
+    [t],
+  );
+
   const dialogs = (
     <>
       {importDialogOpen ? (
@@ -524,49 +573,7 @@ export function AgentsView({
           }}
           initialFile={galleryImportFile}
           onImportFile={handleImportFileBytes}
-          prepareImport={async (bytes, name, signal) => {
-            let extracted: ExtractedAgentFile;
-            try {
-              extracted = isAgentZipFileName(name)
-                ? await extractAgentFileFromZipInWorker(bytes, signal)
-                : { bytes, name };
-            } catch (error) {
-              if (error instanceof AgentZipImportError) {
-                throw new Error(formatAgentZipImportError(error, t));
-              }
-              throw error;
-            }
-            if (isAgentImageFileName(extracted.name)) {
-              const snapshot = decodeAgentImage(extracted.bytes);
-              const { width, height } = getPngDimensions(extracted.bytes);
-              const preview = {
-                displayName:
-                  snapshot.profile?.displayName ??
-                  snapshot.definition.name ??
-                  "Imported agent",
-                systemPrompt: snapshot.definition.systemPrompt ?? "",
-                identity: extracted.name,
-                avatar:
-                  typeof snapshot.profile?.avatarDataUrl === "string" &&
-                  isSafePngAvatarDataUrl(snapshot.profile.avatarDataUrl)
-                    ? snapshot.profile.avatarDataUrl
-                    : undefined,
-                snapshot,
-                cardAspectRatio: width / height,
-                cardImageUrl: URL.createObjectURL(
-                  new Blob([new Uint8Array(extracted.bytes).buffer], {
-                    type: "image/png",
-                  }),
-                ),
-              };
-              return { ...extracted, preview };
-            }
-            const preview = previewPersonaImport(
-              decodeImportFileBytes(extracted.bytes),
-              extracted.name,
-            );
-            return { ...extracted, preview };
-          }}
+          prepareImport={prepareImportFile}
           validateImportFile={validateImportFile}
           onImportError={handleImportError}
           maxImportBytes={MAX_SNAPSHOT_PNG_BYTES}

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -94,6 +94,61 @@ describe("AgentImportDialog", () => {
     expect(screen.queryByText("Reviewer")).not.toBeInTheDocument();
   });
 
+  it("revokes the preview URL of an aborted preparation result", async () => {
+    const revokeSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const preparation = deferred<{
+      bytes: Uint8Array;
+      name: string;
+      preview: AgentImportPreview;
+    }>();
+    const bytes = Uint8Array.from([1]);
+    const file = new File([bytes], "agent.zip", { type: "application/zip" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(bytes.buffer),
+    });
+    let preparationSignal: AbortSignal | undefined;
+    const props = importDialogProps({
+      prepareImport: (
+        _bytes: Uint8Array,
+        _name: string,
+        signal: AbortSignal,
+      ) => {
+        preparationSignal = signal;
+        return preparation.promise;
+      },
+    });
+    const { rerender } = render(<AgentImportDialog {...props} />);
+    const input =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+    await waitFor(() => expect(preparationSignal).toBeDefined());
+
+    // Close aborts the preparation before its result lands.
+    rerender(<AgentImportDialog {...props} open={false} />);
+    expect(preparationSignal?.aborted).toBe(true);
+
+    // The aborted result carries a blob URL that no state will ever own.
+    await act(async () => {
+      preparation.resolve({
+        bytes,
+        name: "stale.agent.png",
+        preview: {
+          displayName: "Stale",
+          systemPrompt: "Stale",
+          identity: "stale.agent.png",
+          cardImageUrl: "blob:stale-card",
+        },
+      });
+    });
+
+    expect(revokeSpy).toHaveBeenCalledWith("blob:stale-card");
+    expect(screen.queryByText("Stale")).not.toBeInTheDocument();
+    revokeSpy.mockRestore();
+  });
+
   it("cancels in-flight preparation when the dialog closes", async () => {
     const preparation = deferred<{
       bytes: Uint8Array;

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -6,7 +6,18 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { AgentImportDialog } from "../AgentImportDialog";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+import {
+  AgentImportDialog,
+  type AgentImportPreview,
+} from "../AgentImportDialog";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -80,6 +91,51 @@ describe("AgentImportDialog", () => {
       screen.queryByRole("button", { name: "importDialog.import" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Reviewer")).not.toBeInTheDocument();
+  });
+
+  it("cancels in-flight preparation when the dialog closes", async () => {
+    const preparation = deferred<{
+      bytes: Uint8Array;
+      name: string;
+      preview: AgentImportPreview;
+    }>();
+    const bytes = Uint8Array.from([1]);
+    const file = new File([bytes], "agent.zip", { type: "application/zip" });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(bytes.buffer),
+    });
+    let preparationSignal: AbortSignal | undefined;
+    const props = importDialogProps({
+      prepareImport: (
+        _bytes: Uint8Array,
+        _name: string,
+        signal: AbortSignal,
+      ) => {
+        preparationSignal = signal;
+        return preparation.promise;
+      },
+    });
+    const { rerender } = render(<AgentImportDialog {...props} />);
+    const input =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+    await waitFor(() => expect(preparationSignal).toBeDefined());
+
+    rerender(<AgentImportDialog {...props} open={false} />);
+    expect(preparationSignal?.aborted).toBe(true);
+
+    preparation.resolve({
+      bytes,
+      name: "stale.md",
+      preview: {
+        displayName: "Stale",
+        systemPrompt: "Stale",
+        identity: "stale.md",
+      },
+    });
+    await Promise.resolve();
+    expect(screen.queryByText("Stale")).not.toBeInTheDocument();
   });
 
   it("tilts the rendered import card toward the pointer and resets", async () => {

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   createEvent,
   fireEvent,
   render,
@@ -122,19 +123,24 @@ describe("AgentImportDialog", () => {
     fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
     await waitFor(() => expect(preparationSignal).toBeDefined());
 
+    // Pending preparation announces busy status and localized progress copy.
+    expect(screen.getByText("importDialog.preparing")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
+
     rerender(<AgentImportDialog {...props} open={false} />);
     expect(preparationSignal?.aborted).toBe(true);
 
-    preparation.resolve({
-      bytes,
-      name: "stale.md",
-      preview: {
-        displayName: "Stale",
-        systemPrompt: "Stale",
-        identity: "stale.md",
-      },
+    await act(async () => {
+      preparation.resolve({
+        bytes,
+        name: "stale.md",
+        preview: {
+          displayName: "Stale",
+          systemPrompt: "Stale",
+          identity: "stale.md",
+        },
+      });
     });
-    await Promise.resolve();
     expect(screen.queryByText("Stale")).not.toBeInTheDocument();
   });
 

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -20,7 +20,68 @@ vi.mock("motion/react", async (importOriginal) => {
   return { ...actual, useReducedMotion: () => false };
 });
 
+function importDialogProps(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    onImportFile: vi.fn(),
+    prepareImport: () => ({
+      displayName: "Reviewer",
+      systemPrompt: "Review carefully.",
+      identity: "agent.agent.png",
+    }),
+    validateImportFile: () => null,
+    onImportError: vi.fn(),
+    maxImportBytes: 1024,
+    importTooLargeMessage: "Too large",
+    ...overrides,
+  };
+}
+
 describe("AgentImportDialog", () => {
+  it("clears a prepared import when a replacement file is rejected", async () => {
+    const firstBytes = Uint8Array.from([1, 2, 3]);
+    const firstFile = new File([firstBytes], "agent.agent.png", {
+      type: "image/png",
+    });
+    Object.defineProperty(firstFile, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(firstBytes.buffer),
+    });
+    const rejectedFile = new File([new Uint8Array([9])], "broken.zip", {
+      type: "application/zip",
+    });
+    const onImportError = vi.fn();
+    render(
+      <AgentImportDialog
+        {...importDialogProps({
+          validateImportFile: (file: File) =>
+            file.name === "broken.zip" ? "Invalid ZIP" : null,
+          onImportError,
+        })}
+      />,
+    );
+    const input =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+
+    fireEvent.change(input as HTMLInputElement, {
+      target: { files: [firstFile] },
+    });
+    expect(
+      await screen.findByRole("button", { name: "importDialog.import" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(input as HTMLInputElement, {
+      target: { files: [rejectedFile] },
+    });
+
+    expect(onImportError).toHaveBeenCalledWith("Invalid ZIP");
+    expect(
+      screen.queryByRole("button", { name: "importDialog.import" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Reviewer")).not.toBeInTheDocument();
+  });
+
   it("tilts the rendered import card toward the pointer and resets", async () => {
     vi.spyOn(window, "matchMedia").mockReturnValue({
       matches: false,

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -123,8 +123,11 @@ describe("AgentImportDialog", () => {
     fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
     await waitFor(() => expect(preparationSignal).toBeDefined());
 
-    // Pending preparation announces busy status and localized progress copy.
-    expect(screen.getByText("importDialog.preparing")).toBeInTheDocument();
+    // Pending preparation announces busy status and localized progress copy
+    // in both the drop-zone status text and the loading button label.
+    expect(
+      screen.getAllByText("importDialog.preparing").length,
+    ).toBeGreaterThanOrEqual(2);
     expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true");
 
     rerender(<AgentImportDialog {...props} open={false} />);

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -45,6 +45,18 @@ const mockDraftSource = vi.hoisted(() => ({
   },
 }));
 
+vi.mock("@/features/agents/lib/agentZipImport", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/features/agents/lib/agentZipImport")
+    >();
+  return {
+    ...actual,
+    extractAgentFileFromZipInWorker: async (bytes: Uint8Array) =>
+      actual.extractAgentFileFromZip(bytes),
+  };
+});
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, options?: Record<string, unknown>) =>

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -45,15 +45,19 @@ const mockDraftSource = vi.hoisted(() => ({
   },
 }));
 
+const mockExtractInWorker = vi.hoisted(() => vi.fn());
+
 vi.mock("@/features/agents/lib/agentZipImport", async (importOriginal) => {
   const actual =
     await importOriginal<
       typeof import("@/features/agents/lib/agentZipImport")
     >();
+  mockExtractInWorker.mockImplementation(async (bytes: Uint8Array) =>
+    actual.extractAgentFileFromZip(bytes),
+  );
   return {
     ...actual,
-    extractAgentFileFromZipInWorker: async (bytes: Uint8Array) =>
-      actual.extractAgentFileFromZip(bytes),
+    extractAgentFileFromZipInWorker: mockExtractInWorker,
   };
 });
 
@@ -418,6 +422,32 @@ describe("AgentsView entry points", () => {
       await screen.findByRole("heading", { name: "imageImport.description" }),
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue("Test Agent Display")).toBeInTheDocument();
+  });
+
+  it("routes gallery ZIP drops through worker-backed extraction", async () => {
+    vi.mocked(importPersonas).mockResolvedValue([]);
+    const archive = zipSync({
+      "reviewer.persona.md": new TextEncoder().encode("---\n---\nReview."),
+    });
+    const file = new File([archive], "reviewer.zip", {
+      type: "application/zip",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(archive.buffer),
+    });
+    const { container } = render(<AgentsView />);
+    const dropZone = container.querySelector(".\\@container") as HTMLElement;
+
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    await waitFor(() => expect(mockExtractInWorker).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(importPersonas).toHaveBeenCalledWith(
+        expect.stringContaining("Review."),
+        "reviewer.persona.md",
+      ),
+    );
   });
 
   it("shows a localized error for an ambiguous agent ZIP", async () => {

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { zipSync } from "fflate";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { toast } from "sonner";
@@ -367,6 +368,72 @@ describe("AgentsView entry points", () => {
     ).toBeInTheDocument();
     expect(screen.getByDisplayValue("Test Agent Display")).toBeInTheDocument();
     expect(screen.getByText("You are a test agent.")).toBeInTheDocument();
+  });
+
+  it("previews a portable agent image imported from a ZIP", async () => {
+    const fixtureBytes = readFileSync(
+      resolve(
+        process.cwd(),
+        "src/features/agents/agent-snapshot/fixtures/buzz-v1-config-only.agent.png",
+      ),
+    );
+    const archive = zipSync({ "shared.agent.png": fixtureBytes });
+    const file = new File([archive], "shared.agent.zip", {
+      type: "application/zip",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(archive.buffer),
+    });
+    render(<AgentsView />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "gallery.importViaImage" }),
+    );
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="file"][accept*="application/zip"]',
+    );
+    expect(input).not.toBeNull();
+
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+
+    expect(
+      await screen.findByRole("img", { name: "importDialog.previewAlt" }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "importDialog.import" }),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "imageImport.description" }),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Test Agent Display")).toBeInTheDocument();
+  });
+
+  it("shows a localized error for an ambiguous agent ZIP", async () => {
+    const archive = zipSync({
+      "one.persona.md": new TextEncoder().encode("one"),
+      "two.json": new TextEncoder().encode("{}"),
+    });
+    const file = new File([archive], "agents.zip", {
+      type: "application/zip",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(archive.buffer),
+    });
+    render(<AgentsView />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "gallery.importViaImage" }),
+    );
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="file"][accept*="application/zip"]',
+    );
+    expect(input).not.toBeNull();
+
+    fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("zipImport.multipleAgents"),
+    );
   });
 
   it("reports malformed PNG imports instead of rejecting silently", async () => {

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -95,7 +95,12 @@ vi.mock("@/shared/api/artifacts", () => ({
     artifacts.assets.find((asset) => asset.path.endsWith(`/${id}.png`))?.path,
 }));
 
-vi.mock("@/shared/api/agents", () => ({
+vi.mock("@/shared/api/agents", async (importOriginal) => ({
+  // The preview builder is pure; the real one keeps gallery-drop tests
+  // exercising the actual parse-and-preview path.
+  previewPersonaImport: (
+    await importOriginal<typeof import("@/shared/api/agents")>()
+  ).previewPersonaImport,
   exportPersona: vi.fn(),
   importPersonas: vi.fn(),
   readImportPersonaFile: vi.fn(),
@@ -250,7 +255,7 @@ describe("AgentsView entry points", () => {
     vi.restoreAllMocks();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(useAvatarLibrary).mockReturnValue(EMPTY_AVATAR_LIBRARY);
     // These tests exercise the inline customize section, so the collection
@@ -264,6 +269,13 @@ describe("AgentsView entry points", () => {
           [AVATAR_COLLECTION_PAGE_EXPERIMENT_ID]: { enabled: false },
         },
       }),
+    );
+    // Restore the default passthrough after tests that defer extraction.
+    const actualZipImport = await vi.importActual<
+      typeof import("@/features/agents/lib/agentZipImport")
+    >("@/features/agents/lib/agentZipImport");
+    mockExtractInWorker.mockImplementation(async (bytes: Uint8Array) =>
+      actualZipImport.extractAgentFileFromZip(bytes),
     );
     // Mirrors the real API: the created persona carries the persisted
     // identity the telemetry call sites are expected to report.
@@ -379,6 +391,10 @@ describe("AgentsView entry points", () => {
 
     fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
 
+    // Gallery selections route through the shared import dialog preview.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "importDialog.import" }),
+    );
     expect(
       await screen.findByRole("heading", { name: "imageImport.description" }),
     ).toBeInTheDocument();
@@ -424,8 +440,132 @@ describe("AgentsView entry points", () => {
     expect(screen.getByDisplayValue("Test Agent Display")).toBeInTheDocument();
   });
 
-  it("routes gallery ZIP drops through worker-backed extraction", async () => {
+  it("routes gallery ZIP drops into the import dialog for confirmation", async () => {
     vi.mocked(importPersonas).mockResolvedValue([]);
+    const archive = zipSync({
+      "reviewer.persona.md": new TextEncoder().encode(
+        "---\nname: reviewer\n---\nReview.",
+      ),
+    });
+    const file = new File([archive], "reviewer.zip", {
+      type: "application/zip",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(archive.buffer),
+    });
+    const { container } = render(<AgentsView />);
+    const dropZone = container.querySelector(".\\@container") as HTMLElement;
+
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    // The drop opens the shared dialog and prepares through the worker; no
+    // personas are created before the user confirms.
+    await waitFor(() => expect(mockExtractInWorker).toHaveBeenCalled());
+    expect(
+      await screen.findByRole("button", { name: "importDialog.import" }),
+    ).toBeInTheDocument();
+    expect(importPersonas).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "importDialog.import" }),
+    );
+    await waitFor(() =>
+      expect(importPersonas).toHaveBeenCalledWith(
+        expect.stringContaining("Review."),
+        "reviewer.persona.md",
+      ),
+    );
+  });
+
+  it("only the latest gallery drop can win an extraction race", async () => {
+    vi.mocked(importPersonas).mockResolvedValue([]);
+    const resolvers: Array<{
+      name: string;
+      resolve: (value: { bytes: Uint8Array; name: string }) => void;
+      reject: (reason: unknown) => void;
+      signal?: AbortSignal;
+    }> = [];
+    mockExtractInWorker.mockImplementation(
+      (_bytes: Uint8Array, signal?: AbortSignal) =>
+        new Promise((resolve, reject) => {
+          resolvers.push({
+            name: `drop-${resolvers.length}`,
+            resolve,
+            reject,
+            signal,
+          });
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
+    const makeZipFile = (name: string) => {
+      const archive = zipSync({
+        [`${name}.persona.md`]: new TextEncoder().encode(
+          `---\nname: ${name}\n---\n${name}`,
+        ),
+      });
+      const file = new File([archive], `${name}.zip`, {
+        type: "application/zip",
+      });
+      Object.defineProperty(file, "arrayBuffer", {
+        configurable: true,
+        value: vi.fn().mockResolvedValue(archive.buffer),
+      });
+      return file;
+    };
+    const { container } = render(<AgentsView />);
+    const dropZone = container.querySelector(".\\@container") as HTMLElement;
+
+    fireEvent.drop(dropZone, { dataTransfer: { files: [makeZipFile("a")] } });
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+
+    // Dropping B onto the dialog's drop zone replaces A and aborts its work.
+    const dialogDropZone = screen.getByRole("status");
+    const fileB = makeZipFile("b");
+    fireEvent.drop(dialogDropZone, { dataTransfer: { files: [fileB] } });
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+    expect(resolvers[0].signal?.aborted).toBe(true);
+
+    // A resolving late must not surface or import.
+    resolvers[0].resolve({
+      bytes: new TextEncoder().encode("---\nname: a\n---\na"),
+      name: "a.persona.md",
+    });
+    resolvers[1].resolve({
+      bytes: new TextEncoder().encode("---\nname: b\n---\nb"),
+      name: "b.persona.md",
+    });
+    expect(
+      await screen.findByRole("button", { name: "importDialog.import" }),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "importDialog.import" }),
+    );
+    await waitFor(() =>
+      expect(importPersonas).toHaveBeenCalledWith(
+        expect.stringContaining("b"),
+        "b.persona.md",
+      ),
+    );
+    expect(importPersonas).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "a.persona.md",
+    );
+  });
+
+  it("closing the dialog cancels a pending gallery ZIP preparation", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockExtractInWorker.mockImplementation(
+      (_bytes: Uint8Array, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          capturedSignal = signal;
+          signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    );
     const archive = zipSync({
       "reviewer.persona.md": new TextEncoder().encode("---\n---\nReview."),
     });
@@ -440,14 +580,12 @@ describe("AgentsView entry points", () => {
     const dropZone = container.querySelector(".\\@container") as HTMLElement;
 
     fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+    await waitFor(() => expect(capturedSignal).toBeDefined());
 
-    await waitFor(() => expect(mockExtractInWorker).toHaveBeenCalled());
-    await waitFor(() =>
-      expect(importPersonas).toHaveBeenCalledWith(
-        expect.stringContaining("Review."),
-        "reviewer.persona.md",
-      ),
-    );
+    await userEvent.keyboard("{Escape}");
+
+    await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+    expect(importPersonas).not.toHaveBeenCalled();
   });
 
   it("shows a localized error for an ambiguous agent ZIP", async () => {
@@ -843,7 +981,14 @@ describe("AgentsView entry points", () => {
     }
 
     function importTextFile(name: string, type: string): File {
-      const bytes = new TextEncoder().encode("{}");
+      const contents = name.endsWith(".json")
+        ? JSON.stringify({
+            version: 1,
+            displayName: "Imported",
+            systemPrompt: "Imported prompt.",
+          })
+        : "---\nname: Imported\n---\nImported prompt.";
+      const bytes = new TextEncoder().encode(contents);
       const file = new File([bytes], name, { type });
       Object.defineProperty(file, "arrayBuffer", {
         configurable: true,
@@ -922,6 +1067,9 @@ describe("AgentsView entry points", () => {
           files: [importTextFile("team.agent.json", "application/json")],
         },
       });
+      await userEvent.click(
+        await screen.findByRole("button", { name: "importDialog.import" }),
+      );
 
       await waitFor(() =>
         expect(mockTrackAgentCreateCompleted).toHaveBeenCalledTimes(2),
@@ -947,6 +1095,9 @@ describe("AgentsView entry points", () => {
           files: [importTextFile("reviewer.persona.md", "text/markdown")],
         },
       });
+      await userEvent.click(
+        await screen.findByRole("button", { name: "importDialog.import" }),
+      );
 
       await waitFor(() => expect(toast.error).toHaveBeenCalled());
       expect(mockTrackAgentCreateCompleted).not.toHaveBeenCalled();
@@ -961,6 +1112,9 @@ describe("AgentsView entry points", () => {
       fireEvent.change(input as HTMLInputElement, {
         target: { files: [agentImageFixtureFile()] },
       });
+      await userEvent.click(
+        await screen.findByRole("button", { name: "importDialog.import" }),
+      );
       await screen.findByRole("heading", { name: "imageImport.description" });
       expect(mockTrackAgentCreateCompleted).not.toHaveBeenCalled();
 
@@ -986,6 +1140,9 @@ describe("AgentsView entry points", () => {
       fireEvent.change(input as HTMLInputElement, {
         target: { files: [agentImageFixtureFile()] },
       });
+      await userEvent.click(
+        await screen.findByRole("button", { name: "importDialog.import" }),
+      );
       await screen.findByRole("heading", { name: "imageImport.description" });
 
       const user = userEvent.setup();

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
@@ -553,6 +554,55 @@ describe("AgentsView entry points", () => {
       expect.anything(),
       "a.persona.md",
     );
+  });
+
+  it("gallery drops still preview under StrictMode effect replay", async () => {
+    const revokeSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const seenSignals: AbortSignal[] = [];
+    const actualZipImport = await vi.importActual<
+      typeof import("@/features/agents/lib/agentZipImport")
+    >("@/features/agents/lib/agentZipImport");
+    mockExtractInWorker.mockImplementation(
+      async (bytes: Uint8Array, signal?: AbortSignal) => {
+        if (signal) seenSignals.push(signal);
+        return actualZipImport.extractAgentFileFromZip(bytes);
+      },
+    );
+    const archive = zipSync({
+      "reviewer.persona.md": new TextEncoder().encode(
+        "---\nname: reviewer\n---\nReview.",
+      ),
+    });
+    const file = new File([archive], "reviewer.zip", {
+      type: "application/zip",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(archive.buffer),
+    });
+    const { container } = render(
+      <StrictMode>
+        <AgentsView />
+      </StrictMode>,
+    );
+    const dropZone = container.querySelector(".\\@container") as HTMLElement;
+
+    fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+    // StrictMode replays the initial-file effect: the first attempt is
+    // aborted by cleanup and the replayed effect restarts preparation.
+    expect(
+      await screen.findByRole("button", { name: "importDialog.import" }),
+    ).toBeInTheDocument();
+    expect(seenSignals.length).toBeGreaterThanOrEqual(2);
+    expect(seenSignals[0].aborted).toBe(true);
+    expect(seenSignals.at(-1)?.aborted).toBe(false);
+    // Exactly one preview is live; any aborted attempt revoked its URL.
+    const liveUrls = revokeSpy.mock.calls.length;
+    expect(liveUrls).toBeLessThanOrEqual(seenSignals.length - 1);
+    revokeSpy.mockRestore();
   });
 
   it("closing the dialog cancels a pending gallery ZIP preparation", async () => {

--- a/src/shared/i18n/locales/en/agents.json
+++ b/src/shared/i18n/locales/en/agents.json
@@ -225,8 +225,8 @@
     "deleted": "\"{{name}}\" deleted.",
     "exportFailed": "Failed to export agent.",
     "exportedTo": "Exported to {{filename}}",
-    "importInvalidExtension": "Unsupported file type. Choose a .persona.md or .json file.",
-    "importInvalidMimeType": "Unsupported file type. Choose a persona markdown or JSON file.",
+    "importInvalidExtension": "Unsupported file type. Choose an agent ZIP, PNG, .persona.md, or JSON file.",
+    "importInvalidMimeType": "Unsupported file type. Choose an agent ZIP, PNG, persona markdown, or JSON file.",
     "importTooLarge": "Import file must be {{maxSize}} or smaller.",
     "importFailed": "Failed to import agent.",
     "imported_one": "Imported {{count}} agent.",
@@ -263,9 +263,15 @@
     "tooLarge": "Agent image must be 10 MB or smaller.",
     "pngOnly": "Agent image must be a PNG file."
   },
+  "zipImport": {
+    "invalid": "The agent ZIP is invalid or damaged.",
+    "tooManyFiles": "The agent ZIP contains too many files.",
+    "missingAgent": "The ZIP doesn’t contain a supported agent file.",
+    "multipleAgents": "The ZIP must contain exactly one agent file."
+  },
   "importDialog": {
     "title": "Import an agent",
-    "description": "Import an agent with an image, .md, or JSON file.",
+    "description": "Import an agent with a ZIP, image, .md, or JSON file.",
     "dropTitle": "Drag and drop an agent file here",
     "openFinder": "Open Finder",
     "previewAlt": "Preview of {{name}}",

--- a/src/shared/i18n/locales/en/agents.json
+++ b/src/shared/i18n/locales/en/agents.json
@@ -273,6 +273,7 @@
     "title": "Import an agent",
     "description": "Import an agent with a ZIP, image, .md, or JSON file.",
     "dropTitle": "Drag and drop an agent file here",
+    "preparing": "Opening agent file…",
     "openFinder": "Open Finder",
     "previewAlt": "Preview of {{name}}",
     "import": "Import agent"

--- a/src/shared/i18n/locales/es/agents.json
+++ b/src/shared/i18n/locales/es/agents.json
@@ -273,6 +273,7 @@
     "title": "Importar un agente",
     "description": "Importa un agente con un archivo ZIP, una imagen o un archivo .md o JSON.",
     "dropTitle": "Arrastra y suelta aquí un archivo de agente",
+    "preparing": "Abriendo el archivo del agente…",
     "openFinder": "Abrir Finder",
     "previewAlt": "Vista previa de {{name}}",
     "import": "Importar agente"

--- a/src/shared/i18n/locales/es/agents.json
+++ b/src/shared/i18n/locales/es/agents.json
@@ -225,8 +225,8 @@
     "deleted": "Se eliminó \"{{name}}\".",
     "exportFailed": "No se pudo exportar el agente.",
     "exportedTo": "Exportado a {{filename}}",
-    "importInvalidExtension": "Tipo de archivo no compatible. Elige un archivo .persona.md o .json.",
-    "importInvalidMimeType": "Tipo de archivo no compatible. Elige un archivo de persona markdown o JSON.",
+    "importInvalidExtension": "Tipo de archivo no compatible. Elige un archivo ZIP, PNG, .persona.md o JSON de agente.",
+    "importInvalidMimeType": "Tipo de archivo no compatible. Elige un archivo ZIP, PNG, markdown de persona o JSON de agente.",
     "importTooLarge": "El archivo importado debe ser de {{maxSize}} o menos.",
     "importFailed": "No se pudo importar el agente.",
     "imported_one": "Se importó {{count}} agente.",
@@ -263,9 +263,15 @@
     "tooLarge": "La imagen del agente debe ser de 10 MB o menos.",
     "pngOnly": "La imagen del agente debe ser un archivo PNG."
   },
+  "zipImport": {
+    "invalid": "El archivo ZIP del agente no es válido o está dañado.",
+    "tooManyFiles": "El archivo ZIP del agente contiene demasiados archivos.",
+    "missingAgent": "El archivo ZIP no contiene un archivo de agente compatible.",
+    "multipleAgents": "El archivo ZIP debe contener exactamente un archivo de agente."
+  },
   "importDialog": {
     "title": "Importar un agente",
-    "description": "Importa un agente con una imagen o un archivo .md o JSON.",
+    "description": "Importa un agente con un archivo ZIP, una imagen o un archivo .md o JSON.",
     "dropTitle": "Arrastra y suelta aquí un archivo de agente",
     "openFinder": "Abrir Finder",
     "previewAlt": "Vista previa de {{name}}",


### PR DESCRIPTION
**Category:** new-feature
**User Impact:** Users can now import an agent directly from a ZIP file created by Berd’s agent export flow.

**Problem:** Exported agent ZIPs could be shared conveniently, but importing them required manually extracting the archive first. **Solution:** Accept ZIPs in the existing reviewed import flow, safely locate one supported agent payload, enforce archive and payload limits, and present localized validation errors.

<details>
<summary>File changes</summary>

**src/features/agents/lib/agentZipImport.ts**
Adds bounded ZIP extraction for one supported PNG, Markdown, or JSON agent payload, with typed validation failures for the UI.

**src/features/agents/lib/agentZipImport.test.ts**
Covers supported payloads, macOS metadata, malformed and ambiguous archives, filename handling, and nested size limits.

**src/features/agents/ui/AgentImportDialog.tsx**
Allows ZIP files through the existing file picker and drag-and-drop import surface.

**src/features/agents/ui/AgentsView.tsx**
Routes ZIP payloads through the same preview and confirmation flows as direct agent files and localizes ZIP-specific errors.

**src/features/agents/ui/__tests__/AgentsView.entry.test.tsx**
Verifies portable agent image ZIPs preview and continue into configuration, and ambiguous archives fail visibly.

**src/shared/i18n/locales/en/agents.json**
Updates supported-format guidance and adds English ZIP validation messages.

**src/shared/i18n/locales/es/agents.json**
Updates supported-format guidance and adds Spanish ZIP validation messages.

</details>
