### PR TITLE
fix agent profile avatar affordance copy and route it to the gallery

### DIFF
--- a/src/features/agents/ui/AgentDetailPage.tsx
+++ b/src/features/agents/ui/AgentDetailPage.tsx
@@ -48,6 +48,9 @@ import { AgentProfileLayout } from "@/features/agents/ui/AgentProfileLayout";
 import { AgentIdentityRail } from "@/features/agents/ui/AgentIdentityRail";
 import { useAvatarLibrary } from "@/features/agents/hooks/useAvatarLibrary";
 import { AgentAvatarSection } from "@/features/agents/ui/AgentAvatarSection";
+import { AvatarCollectionOverlay } from "@/features/agents/ui/AvatarCollectionOverlay";
+import { useExperiment } from "@/features/experiments/experimentPreferences";
+import { AVATAR_COLLECTION_PAGE_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import {
   AVATAR_CUSTOMIZE_LABEL_CLASS,
   AVATAR_CUSTOMIZE_SURFACE_CLASS,
@@ -121,6 +124,12 @@ export function AgentDetailPage({
   const [avatarPreviewFailed, setAvatarPreviewFailed] = useState(false);
   const [avatarSavePending, setAvatarSavePending] = useState(false);
   const [showAvatarSection, setShowAvatarSection] = useState(false);
+  const [showAvatarOverlay, setShowAvatarOverlay] = useState(false);
+  // Same gate as the agent builder: when on, avatar picking happens in the
+  // full-surface collection gallery instead of the inline customize section.
+  const avatarCollectionOverlayEnabled = Boolean(
+    useExperiment(AVATAR_COLLECTION_PAGE_EXPERIMENT_ID)?.enabled,
+  );
   const [previousPersonaAvatarValue, setPreviousPersonaAvatarValue] =
     useState(personaAvatarValue);
   const [previousPersonaId, setPreviousPersonaId] = useState(persona.id);
@@ -182,11 +191,19 @@ export function AgentDetailPage({
   if (previousPersonaId !== persona.id) {
     setPreviousPersonaId(persona.id);
     setShowAvatarSection(false);
+    setShowAvatarOverlay(false);
   }
 
   const handleOpenAvatarSection = useCallback(() => {
+    // With the collection canvas experiment on, avatar picking opens the
+    // full-surface gallery takeover (same surface as the agent builder)
+    // instead of swapping the profile body for the inline customize section.
+    if (avatarCollectionOverlayEnabled) {
+      setShowAvatarOverlay(true);
+      return;
+    }
     runAgentViewTransition(() => setShowAvatarSection(true));
-  }, []);
+  }, [avatarCollectionOverlayEnabled]);
 
   const handleCloseAvatarSection = useCallback(() => {
     runAgentViewTransition(() => setShowAvatarSection(false));
@@ -249,10 +266,25 @@ export function AgentDetailPage({
     [commitAvatar],
   );
 
+  const handleSelectOverlayAvatar = useCallback(
+    (avatarId: string) => {
+      setShowAvatarOverlay(false);
+      handleSelectAvatar(avatarId);
+    },
+    [handleSelectAvatar],
+  );
+
+  const handleCloseAvatarOverlay = useCallback(() => {
+    setShowAvatarOverlay(false);
+  }, []);
+
   const avatarPreview = (
     <div className={AVATAR_CUSTOMIZE_SURFACE_CLASS}>
       <div
         className="h-full w-full"
+        // The gallery takeover's funnel exit collapses toward this preview,
+        // so selecting an avatar visibly lands it here.
+        data-avatar-funnel-target=""
         style={{ viewTransitionName: avatarTransitionName }}
       >
         {avatarMedia ? (
@@ -287,7 +319,7 @@ export function AgentDetailPage({
             className={AVATAR_CUSTOMIZE_LABEL_CLASS}
             aria-hidden="true"
           >
-            {t("builderRail.changeAvatar")}
+            {t("editor.changeAvatar")}
           </Badge>
         </>
       ) : null}
@@ -429,67 +461,78 @@ export function AgentDetailPage({
     </Button>
   );
 
+  const avatarCollectionOverlayNode = showAvatarOverlay ? (
+    <AvatarCollectionOverlay
+      library={avatarLibrary}
+      onSelectAvatar={handleSelectOverlayAvatar}
+      onClose={handleCloseAvatarOverlay}
+    />
+  ) : null;
+
   return (
-    <AgentProfileLayout
-      animateSections={false}
-      fieldsTransitionName={AGENT_PROFILE_FIELDS_TRANSITION_NAME}
-      header={profileHeader}
-      identityRail={
-        <AgentIdentityRail
-          avatar={avatarPreview}
-          leadingControl={null}
-          metadata={showAvatarSection ? [] : metadata}
-          modeControl={showAvatarSection ? backToProfileControl : null}
-        />
-      }
-    >
-      {showAvatarSection ? (
-        <AgentAvatarSection
-          avatarPreviewFailed={avatarPreviewFailed}
-          avatarPickerDisabled={avatarSavePending}
-          avatarUrlError={avatarUrlError}
-          avatarUrlInputId="agent-detail-avatar-url"
-          canSaveCustomAvatar={canSaveCustomAvatar}
-          clearDisabled={avatarSavePending}
-          customAvatarUrlValue={customAvatarUrlValue}
-          fieldGroupClassName="space-y-2"
-          fieldInputClassName={AVATAR_FIELD_INPUT_CLASS}
-          fieldLabelClassName={AVATAR_FIELD_LABEL_CLASS}
-          library={avatarLibrary}
-          onAvatarUrlChange={handleAvatarUrlChange}
-          onClearAvatar={handleClearAvatar}
-          onPreviewError={() => setAvatarPreviewFailed(true)}
-          onSaveCustomAvatar={handleSaveCustomAvatar}
-          onSelectAvatar={handleSelectAvatar}
-          selectedAvatarRef={selectedBundledAvatarRef}
-          showClearAvatar={trimmedAvatarValue.length > 0}
-          title={t("editor.customizeAvatar")}
-        />
-      ) : (
-        <div className="space-y-6">
-          <section
-            className="agents-unpaired-enter space-y-3 pt-6"
-            style={{ animationDelay: "80ms" }}
-            aria-labelledby="agent-instructions"
-          >
-            <h2 id="agent-instructions" className={CONTEXT_LABEL_CLASS}>
-              {t("view.instructions")}
-            </h2>
-            <div className={INSTRUCTIONS_PANEL_CLASS}>
-              <section
-                className={INSTRUCTIONS_SCROLL_CLASS}
-                // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to focus this nested scroll region.
-                tabIndex={0}
-                aria-labelledby="agent-instructions"
-              >
-                <MessageResponse className="min-w-0 pb-4 text-sm leading-relaxed">
-                  {persona.systemPrompt || " "}
-                </MessageResponse>
-              </section>
-            </div>
-          </section>
-        </div>
-      )}
-    </AgentProfileLayout>
+    <>
+      <AgentProfileLayout
+        animateSections={false}
+        fieldsTransitionName={AGENT_PROFILE_FIELDS_TRANSITION_NAME}
+        header={profileHeader}
+        identityRail={
+          <AgentIdentityRail
+            avatar={avatarPreview}
+            leadingControl={null}
+            metadata={showAvatarSection ? [] : metadata}
+            modeControl={showAvatarSection ? backToProfileControl : null}
+          />
+        }
+      >
+        {showAvatarSection ? (
+          <AgentAvatarSection
+            avatarPreviewFailed={avatarPreviewFailed}
+            avatarPickerDisabled={avatarSavePending}
+            avatarUrlError={avatarUrlError}
+            avatarUrlInputId="agent-detail-avatar-url"
+            canSaveCustomAvatar={canSaveCustomAvatar}
+            clearDisabled={avatarSavePending}
+            customAvatarUrlValue={customAvatarUrlValue}
+            fieldGroupClassName="space-y-2"
+            fieldInputClassName={AVATAR_FIELD_INPUT_CLASS}
+            fieldLabelClassName={AVATAR_FIELD_LABEL_CLASS}
+            library={avatarLibrary}
+            onAvatarUrlChange={handleAvatarUrlChange}
+            onClearAvatar={handleClearAvatar}
+            onPreviewError={() => setAvatarPreviewFailed(true)}
+            onSaveCustomAvatar={handleSaveCustomAvatar}
+            onSelectAvatar={handleSelectAvatar}
+            selectedAvatarRef={selectedBundledAvatarRef}
+            showClearAvatar={trimmedAvatarValue.length > 0}
+            title={t("editor.customizeAvatar")}
+          />
+        ) : (
+          <div className="space-y-6">
+            <section
+              className="agents-unpaired-enter space-y-3 pt-6"
+              style={{ animationDelay: "80ms" }}
+              aria-labelledby="agent-instructions"
+            >
+              <h2 id="agent-instructions" className={CONTEXT_LABEL_CLASS}>
+                {t("view.instructions")}
+              </h2>
+              <div className={INSTRUCTIONS_PANEL_CLASS}>
+                <section
+                  className={INSTRUCTIONS_SCROLL_CLASS}
+                  // biome-ignore lint/a11y/noNoninteractiveTabindex: Keyboard users need to focus this nested scroll region.
+                  tabIndex={0}
+                  aria-labelledby="agent-instructions"
+                >
+                  <MessageResponse className="min-w-0 pb-4 text-sm leading-relaxed">
+                    {persona.systemPrompt || " "}
+                  </MessageResponse>
+                </section>
+              </div>
+            </section>
+          </div>
+        )}
+      </AgentProfileLayout>
+      {avatarCollectionOverlayNode}
+    </>
   );
 }

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +14,8 @@ import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { toast } from "sonner";
 import { importPersonas } from "@/shared/api/agents";
+import { useAvatarLibrary } from "@/features/agents/hooks/useAvatarLibrary";
+import type { AvatarLibraryState } from "@/features/agents/hooks/useAvatarLibrary";
 import type { CreatePersonaRequest } from "@/shared/types/agents";
 import {
   EXPERIMENT_PREFERENCES_STORAGE_KEY,
@@ -125,19 +128,67 @@ vi.mock("@/features/agents/ui/PersonaFields/ProviderModelFields", () => ({
 }));
 
 vi.mock("@/features/agents/hooks/useAvatarLibrary", () => ({
-  useAvatarLibrary: () => ({
-    catalog: null,
-    cachedAvatarMediaById: {},
-    loading: false,
-    cacheChecking: false,
-    error: false,
-    errorCode: null,
-    mediaError: false,
-    mediaErrorCode: null,
-    retryCatalog: () => {},
-    retryMedia: () => {},
-  }),
+  useAvatarLibrary: vi.fn(),
 }));
+
+const EMPTY_AVATAR_LIBRARY: AvatarLibraryState = {
+  catalog: null,
+  cachedAvatarMediaById: {},
+  loading: false,
+  cacheChecking: false,
+  error: false,
+  errorCode: null,
+  mediaError: false,
+  mediaErrorCode: null,
+  retryCatalog: () => {},
+  retryMedia: () => {},
+};
+
+/**
+ * A one-avatar library, cached and ready, so the collection gallery renders a
+ * real selectable tile instead of an empty canvas.
+ */
+function singleAvatarLibrary(avatarId: string): AvatarLibraryState {
+  const variant = (extension: string, mimeType: string) => ({
+    path: `${avatarId}.${extension}`,
+    mimeType,
+    byteSize: 1,
+    sha256: avatarId,
+  });
+
+  return {
+    ...EMPTY_AVATAR_LIBRARY,
+    catalog: {
+      schemaVersion: 1,
+      catalogVersion: "v1",
+      collections: [
+        {
+          id: "gloopies",
+          label: "Gloopies",
+          coverAvatarId: avatarId,
+          avatarIds: [avatarId],
+        },
+      ],
+      assets: [
+        {
+          id: avatarId,
+          label: avatarId,
+          collectionId: "gloopies",
+          variants: {
+            webm: variant("webm", "video/webm"),
+            hevc: variant("mov", "video/quicktime"),
+          },
+        },
+      ],
+    },
+    cachedAvatarMediaById: {
+      [avatarId]: {
+        catalogVersion: "v1",
+        media: { src: `cached-${avatarId}`, mediaType: "image" },
+      },
+    },
+  };
+}
 
 const persona = {
   id: "/Users/x/.agents/agents/code-reviewer.md",
@@ -184,6 +235,7 @@ describe("AgentsView entry points", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAvatarLibrary).mockReturnValue(EMPTY_AVATAR_LIBRARY);
     // These tests exercise the inline customize section, so the collection
     // gallery experiment (auto-enabled in dev/test) is pinned off.
     // Gallery-specific tests re-enable it explicitly.
@@ -496,6 +548,64 @@ describe("AgentsView entry points", () => {
     // section (with its duplicate custom-URL form) never appears.
     expect(screen.getByTestId("avatar-collection-overlay")).toBeInTheDocument();
     expect(screen.queryByText("editor.avatarUrl")).not.toBeInTheDocument();
+  });
+
+  it("persists the avatar picked in the collection gallery and closes the takeover", async () => {
+    vi.mocked(useAvatarLibrary).mockReturnValue(
+      singleAvatarLibrary("gloopies-1"),
+    );
+    // jsdom reports zero rects; give the gallery canvas a real size so the
+    // scatter layout has a tile to lay avatars into.
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 1200,
+      bottom: 800,
+      width: 1200,
+      height: 800,
+      toJSON: () => ({}),
+    } as DOMRect);
+    localStorage.setItem(
+      EXPERIMENT_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        version: EXPERIMENT_PREFERENCES_STORAGE_VERSION,
+        experiments: {
+          [AVATAR_COLLECTION_PAGE_EXPERIMENT_ID]: { enabled: true },
+        },
+      }),
+    );
+    useAgentStore.setState({ personas: [persona] });
+    const user = userEvent.setup();
+
+    render(<AgentsView activePersonaId={persona.id} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "editor.customizeAvatar" }),
+    );
+
+    // Picking is two-step in the gallery: click highlights, Select commits.
+    const overlay = within(screen.getByTestId("avatar-collection-overlay"));
+    await user.click(overlay.getAllByRole("button", { name: "gloopies-1" })[0]);
+    await user.click(
+      overlay.getAllByRole("button", { name: "collectionPage.select" })[0],
+    );
+
+    // The selection is persisted as an app-avatar ref, not a raw id.
+    await waitFor(() =>
+      expect(mockUpdatePersona).toHaveBeenCalledWith(
+        expect.objectContaining({ id: persona.id }),
+        { avatar: "app-avatar:gloopies-1" },
+      ),
+    );
+
+    // The takeover hands control back to the profile after committing.
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("avatar-collection-overlay"),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it("clicking detail Start chat calls onStartChatWithAgent with the persona id", () => {

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -14,6 +14,11 @@ import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import { toast } from "sonner";
 import { importPersonas } from "@/shared/api/agents";
 import type { CreatePersonaRequest } from "@/shared/types/agents";
+import {
+  EXPERIMENT_PREFERENCES_STORAGE_KEY,
+  EXPERIMENT_PREFERENCES_STORAGE_VERSION,
+} from "@/features/experiments/experimentPreferences";
+import { AVATAR_COLLECTION_PAGE_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import { AgentsView } from "../AgentsView";
 
 const mockCreatePersona = vi.hoisted(() => vi.fn());
@@ -173,11 +178,24 @@ describe("AgentsView entry points", () => {
     });
     delete document.documentElement.dataset.agentTransition;
     Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+    localStorage.removeItem(EXPERIMENT_PREFERENCES_STORAGE_KEY);
     vi.restoreAllMocks();
   });
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // These tests exercise the inline customize section, so the collection
+    // gallery experiment (auto-enabled in dev/test) is pinned off.
+    // Gallery-specific tests re-enable it explicitly.
+    localStorage.setItem(
+      EXPERIMENT_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        version: EXPERIMENT_PREFERENCES_STORAGE_VERSION,
+        experiments: {
+          [AVATAR_COLLECTION_PAGE_EXPERIMENT_ID]: { enabled: false },
+        },
+      }),
+    );
     // Mirrors the real API: the created persona carries the persisted
     // identity the telemetry call sites are expected to report.
     mockCreatePersona.mockImplementation(
@@ -447,12 +465,37 @@ describe("AgentsView entry points", () => {
     const customizeAvatar = screen.getByRole("button", {
       name: "editor.customizeAvatar",
     });
-    expect(screen.getByText("builderRail.changeAvatar")).toBeInTheDocument();
+    expect(screen.getByText("editor.changeAvatar")).toBeInTheDocument();
     customizeAvatar.focus();
     expect(customizeAvatar).toHaveFocus();
     await user.keyboard("{Enter}");
 
     expect(screen.getByText("editor.avatarUrl")).toBeInTheDocument();
+  });
+
+  it("opens the avatar collection gallery instead of the inline section when the experiment is on", async () => {
+    localStorage.setItem(
+      EXPERIMENT_PREFERENCES_STORAGE_KEY,
+      JSON.stringify({
+        version: EXPERIMENT_PREFERENCES_STORAGE_VERSION,
+        experiments: {
+          [AVATAR_COLLECTION_PAGE_EXPERIMENT_ID]: { enabled: true },
+        },
+      }),
+    );
+    useAgentStore.setState({ personas: [persona] });
+    const user = userEvent.setup();
+
+    render(<AgentsView activePersonaId={persona.id} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "editor.customizeAvatar" }),
+    );
+
+    // The full-surface gallery takeover renders; the inline customize
+    // section (with its duplicate custom-URL form) never appears.
+    expect(screen.getByTestId("avatar-collection-overlay")).toBeInTheDocument();
+    expect(screen.queryByText("editor.avatarUrl")).not.toBeInTheDocument();
   });
 
   it("clicking detail Start chat calls onStartChatWithAgent with the persona id", () => {

--- a/src/shared/i18n/__tests__/agentAvatarAffordanceLocaleParity.test.ts
+++ b/src/shared/i18n/__tests__/agentAvatarAffordanceLocaleParity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import enAgents from "../locales/en/agents.json";
+import esAgents from "../locales/es/agents.json";
+
+/**
+ * Focused parity check for the agent-profile avatar affordance strings.
+ *
+ * These keys shipped once as raw `editor.changeAvatar` text in the UI because
+ * the `t()` call had no locale entry behind it. Component tests cannot catch
+ * that class of bug: they mock `react-i18next` so `t()` echoes the key back,
+ * which means a missing translation and a present one look identical.
+ *
+ * A blanket en↔es gate would be the better long-term tool, but the locales
+ * have pre-existing gaps that predate this feature. Until that backlog is
+ * cleared, this pins the contract for the keys the avatar affordance owns.
+ */
+
+const AVATAR_AFFORDANCE_KEYS = [
+  "changeAvatar",
+  "customizeAvatar",
+  "avatarBackToProfile",
+] as const;
+
+describe("agent avatar affordance locale parity", () => {
+  it.each(
+    AVATAR_AFFORDANCE_KEYS,
+  )("resolves editor.%s to real copy in both locales", (key) => {
+    const en = enAgents.editor[key];
+    const es = esAgents.editor[key];
+
+    expect(en).toBeTruthy();
+    expect(es).toBeTruthy();
+    // Guards the original bug: a value equal to the lookup key means the UI
+    // would render "editor.changeAvatar" instead of "Change avatar".
+    expect(en).not.toBe(`editor.${key}`);
+    expect(es).not.toBe(`editor.${key}`);
+    // Spanish must be translated, not an untouched English copy.
+    expect(es).not.toBe(en);
+  });
+});

--- a/src/shared/i18n/locales/en/agents.json
+++ b/src/shared/i18n/locales/en/agents.json
@@ -95,6 +95,7 @@
     "avatarLoading": "Loading",
     "avatarRetry": "Retry",
     "avatarBackToProfile": "Back to profile",
+    "changeAvatar": "Change avatar",
     "avatarUrl": "Custom avatar URL",
     "avatarUrlInvalid": "Enter a valid http or https URL without credentials.",
     "avatarUrlPlaceholder": "https://example.com/avatar.png",

--- a/src/shared/i18n/locales/es/agents.json
+++ b/src/shared/i18n/locales/es/agents.json
@@ -95,6 +95,7 @@
     "avatarLoading": "Cargando",
     "avatarRetry": "Reintentar",
     "avatarBackToProfile": "Volver al perfil",
+    "changeAvatar": "Cambiar avatar",
     "avatarUrl": "URL de avatar personalizada",
     "avatarUrlInvalid": "Ingresa una URL http o https válida sin credenciales.",
     "avatarUrlPlaceholder": "https://example.com/avatar.png",


### PR DESCRIPTION
## Overview

**Category:** `fix`
**User Impact:** Hovering an agent's avatar now reads "Change avatar" instead of raw developer text, and clicking it opens the avatar collections gallery instead of a duplicate picker.

**Problem:** The avatar affordance on the agent profile page showed the raw i18n key `editor.changeAvatar` on hover, because the `t()` call had no locale entry behind it. Clicking it also dropped the user into an inline "Customize" panel — a second, older avatar-picking surface with its own custom-URL form — even though the agent builder already opens the full-surface collections gallery for the same job.

**Solution:** Add the missing `editor.changeAvatar` string to both locales, and gate the click on the same `avatar-collection-page` experiment the builder rail already uses so both entry points lead to the same gallery. The inline section stays as the fallback when the experiment is off, so nothing regresses for users who don't have it. Reused the existing `AvatarCollectionOverlay` rather than forking a second gallery, including its funnel-exit animation so a picked avatar visibly lands on the profile preview.

<details>
<summary>File changes</summary>

**src/features/agents/ui/AgentDetailPage.tsx**
Point the hover badge at the now-existing `editor.changeAvatar` key. Route the avatar click to the full-surface `AvatarCollectionOverlay` when the collection-gallery experiment is on, falling back to the inline customize section otherwise. Clears the takeover when switching agents so it can't linger, and marks the avatar preview as the overlay's funnel-exit target.

**src/shared/i18n/locales/en/agents.json**
Add the missing `editor.changeAvatar` string that caused the raw key to render.

**src/shared/i18n/locales/es/agents.json**
Add the Spanish translation for the same key.

**src/shared/i18n/__tests__/agentAvatarAffordanceLocaleParity.test.ts**
New focused parity test. Component tests mock `react-i18next` so `t()` echoes the key back, meaning a missing translation and a real one look identical — this class of bug was invisible to them. Follows the existing parity-test pattern in this directory and fails if an avatar affordance key goes missing or untranslated.

**src/features/agents/ui/__tests__/AgentsView.entry.test.tsx**
Pin the gallery experiment off for the tests that exercise the inline section, since it auto-enables in dev/test. Adds two tests: one that the gallery opens instead of the inline form when the experiment is on, and one that clicks through the gallery's real two-step pick (highlight, then Select) and asserts the avatar persists as an app-avatar ref and the takeover closes.

</details>

## Reproduction Steps

1. Run the app in dev (`just dev`), where the `avatar-collection-page` experiment auto-enables.
2. Go to **Agents** and open any editable agent.
3. Hover the large avatar on the left. The label reads **"Change avatar"** — previously it read `editor.changeAvatar`.
4. Click the avatar. The avatar collections gallery takes over the window, instead of the old inline "Customize" panel with its own custom-URL field.
5. Click an avatar to highlight it, then click **Select**. The gallery collapses toward the profile avatar and the new avatar is saved.
6. To verify the fallback, turn the "avatar collection page" experiment off in Settings → Experiments and click the avatar again: the inline Customize section still works as before.