### PR TITLE
fix(sidebar): align settings nav top spacing with primary nav

### DIFF
--- a/src/app/views/__tests__/NavigationPanesView.test.tsx
+++ b/src/app/views/__tests__/NavigationPanesView.test.tsx
@@ -2077,10 +2077,9 @@ describe("NavigationPanesView", () => {
       name: /settings navigation/i,
     });
     expect(settingsNavigation).toHaveClass("px-1.5", "py-1");
-    expect(screen.getByRole("button", { name: /^back$/i })).toHaveClass(
-      "h-7",
-      "px-3",
-    );
+    const backButton = screen.getByRole("button", { name: /^back$/i });
+    expect(backButton.parentElement).toHaveClass("mt-1");
+    expect(backButton).toHaveClass("h-7", "px-3");
     expect(
       within(settingsNavigation).getByRole("button", { name: /providers/i }),
     ).toHaveClass("h-7", "px-3");

--- a/src/features/navigation/ui/PrimaryNavigationSurface.tsx
+++ b/src/features/navigation/ui/PrimaryNavigationSurface.tsx
@@ -236,7 +236,7 @@ export const PrimaryNavigationSurface = forwardRef<
           inert={!isSecondarySurface ? true : undefined}
           aria-hidden={!isSecondarySurface}
         >
-          <div className="flex h-7 flex-shrink-0 items-center px-1.5">
+          <div className="mt-1 flex h-7 flex-shrink-0 items-center px-1.5">
             <SidebarNavItem
               icon={IconArrowLeft}
               label={t("actions.backToMainNavigation")}


### PR DESCRIPTION
**Category:** fix
**User Impact:** The Settings sidebar navigation now starts at the same height as the main sidebar navigation, so switching into Settings no longer shifts the nav upward.

**Problem:** Opening Settings slides the sidebar to a secondary surface whose first row (the Back button) sat 4px higher than the Home row on the main surface, making the transition feel misaligned.

**Solution:** Give the settings back-button row the same top spacing the primary nav gets from its own padding, so both surfaces share one vertical rhythm. A class assertion pins the alignment against regressions.

<details>
<summary>File changes</summary>

**src/features/navigation/ui/PrimaryNavigationSurface.tsx**
Added `mt-1` to the settings surface's back-button row so its first row aligns with the primary nav's first row under the shared panel top inset.

**src/app/views/__tests__/NavigationPanesView.test.tsx**
Extended the settings-navigation test to assert the back row carries the new top spacing, so the alignment fails loudly if removed.

</details>