### PR TITLE
refine the starter Home layout

### DIFF
--- a/distro/agents/agt-builder.md
+++ b/distro/agents/agt-builder.md
@@ -2,7 +2,7 @@
 name: Agt. Builder
 display_name: Agt. Builder
 description: Builds your agents with you, then keeps making them better.
-avatar: app-avatar:gloopies-20
+avatar: app-avatar:gloopies-3
 good_for: growing your cast of doers
 vibes: sharp, seasoned, a little proud
 metadata:

--- a/distro/agents/tinker.md
+++ b/distro/agents/tinker.md
@@ -7,6 +7,7 @@ good_for: making what you need, in Berd or out
 vibes: hands-on, resourceful
 metadata:
   berdBundled: true
+  berdBundledSource: tinker
 ---
 
 You are Tinker. Someone has a thing they wish existed — a tracker, a small tool, an interactive app, maybe a new agent or skill — and your job is to actually build it, or to help them figure out what shape it should take before you do. Berdy will offer the obvious version of this in passing, mid-conversation, when it notices a repeated task. You're the real session: when the mapping isn't obvious, when it's more than one piece, or when someone wants to sit down and build something on purpose.

--- a/distro/agents/wildcard.md
+++ b/distro/agents/wildcard.md
@@ -7,6 +7,7 @@ good_for: shaking something loose
 vibes: unfiltered, a little feral
 metadata:
   berdBundled: true
+  berdBundledSource: wildcard
 ---
 
 You are Wildcard. Someone is stuck — not enough ideas, or one idea that's gone stale — and your job is to expand what's possible. Not to evaluate what you generate (that's Choosey's job) and not to strengthen any single idea on its own (that's Pushback's job). Diverge.

--- a/src/features/experiments/ExperimentsSettings.tsx
+++ b/src/features/experiments/ExperimentsSettings.tsx
@@ -278,13 +278,17 @@ export function ExperimentsSettings({
       if (!starterTasksEnabled || !berdyEnabled) {
         throw new Error("Unable to enable onboarding experiments");
       }
-      const didReset = await resetHomeForOnboardingExperience();
-      if (didReset) {
+      const resetResult = await resetHomeForOnboardingExperience();
+      if (resetResult.itemsConfirmed) {
         resetAssistiveUxMoment("home.starterTasks");
         window.dispatchEvent(new Event("starter-tasks-state-reset"));
         setResetAllConfirmationOpen(false);
         resetSucceeded = true;
-        toast.success(t("experiments.onboarding.resetAllSuccess"));
+        if (resetResult.starterAgentsConfirmed === false) {
+          toast.warning(t("experiments.onboarding.resetAllPartial"));
+        } else if (resetResult.cameraConfirmed) {
+          toast.success(t("experiments.onboarding.resetAllSuccess"));
+        }
       } else {
         toast.error(t("experiments.onboarding.resetAllError"));
       }

--- a/src/features/home/lib/homeLayoutMapper.test.ts
+++ b/src/features/home/lib/homeLayoutMapper.test.ts
@@ -393,8 +393,8 @@ describe("homeLayoutMapper", () => {
     expect(item).toMatchObject({
       kind: "clock",
       targetId: `widget:${item.id}`,
-      centerX: 902.5,
-      centerY: 134.5,
+      centerX: 894,
+      centerY: 126,
     });
   });
 
@@ -415,7 +415,7 @@ describe("homeLayoutMapper", () => {
     expect(
       widgets.slice(0, 6).map((widget) => ({ x: widget.x, y: widget.y })),
     ).toEqual([
-      { x: 678.5, y: 245 },
+      { x: 670, y: 236 },
       { x: -96, y: -240 },
       { x: 168, y: -240 },
       { x: -360, y: 0 },
@@ -445,7 +445,7 @@ describe("homeLayoutMapper", () => {
   it("locates Berdy's avatar for initial camera centering", () => {
     const widget = createDefaultOnboardingTourWidget();
 
-    expect(onboardingTourAvatarCenter(widget)).toEqual({ x: 750.5, y: 335 });
+    expect(onboardingTourAvatarCenter(widget)).toEqual({ x: 742, y: 326 });
   });
 
   it("persists the completed welcome callout for Berdy", () => {
@@ -477,7 +477,7 @@ describe("homeLayoutMapper", () => {
     expect(onboardingTour.x + (onboardingTour.width ?? 0) / 2).toBeCloseTo(
       clock.x + (clock.width ?? 0) / 2,
     );
-    expect(onboardingTour.y - (clock.y + (clock.height ?? 0))).toBe(24);
+    expect(onboardingTour.y - (clock.y + (clock.height ?? 0))).toBe(32);
   });
 
   describe("clock mode persistence round-trip", () => {

--- a/src/features/home/lib/homeLayoutMapper.ts
+++ b/src/features/home/lib/homeLayoutMapper.ts
@@ -550,20 +550,17 @@ export function createDefaultClockLayoutItem(
 }
 
 export function createDefaultOnboardingTourWidget(
-  clock?: WidgetInstance,
+  clock = createDefaultClockWidget(),
 ): WidgetInstance {
   const width = 448;
   const height = 180;
-  const clockSize = clock ? widgetSizeForInstance(clock) : null;
+  const clockSize = widgetSizeForInstance(clock);
 
   return {
     id: crypto.randomUUID(),
     type: "onboardingTour",
-    x: clock && clockSize ? clock.x + clockSize.width / 2 - width / 2 : 678.5,
-    y:
-      clock && clockSize
-        ? clock.y + clockSize.height + ONBOARDING_CLOCK_GAP
-        : 245,
+    x: clock.x + clockSize.width / 2 - width / 2,
+    y: clock.y + clockSize.height + ONBOARDING_CLOCK_GAP,
     z: 1,
     width,
     height,

--- a/src/features/home/onboarding/StarterTaskList.tsx
+++ b/src/features/home/onboarding/StarterTaskList.tsx
@@ -174,7 +174,7 @@ export function StarterTaskList({
       data-starter-task-list="true"
       style={overlayStyle}
       className={cn(
-        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-blue px-4 pb-4 pt-2 text-[12px] text-sticky-note-foreground shadow-sticky-note",
+        "h-full w-full overflow-hidden rounded-xs bg-sticky-note-rose px-4 pb-4 pt-2 text-[12px] text-sticky-note-foreground shadow-sticky-note",
         mode === "overlay" &&
           "pointer-events-auto fixed right-4 bottom-28 z-[55] max-h-[min(24rem,calc(100dvh-8rem))] h-auto w-[min(16rem,calc(100vw-2rem))] overflow-y-auto smooth-shadow-sm motion-safe:animate-in motion-safe:slide-in-from-right-8 motion-safe:fade-in-0 motion-safe:duration-500 motion-safe:ease-[cubic-bezier(0.19,1,0.22,1)] motion-safe:will-change-transform motion-reduce:animate-none",
         mode === "overlay" &&

--- a/src/features/home/onboarding/createStarterHomeWidgets.test.ts
+++ b/src/features/home/onboarding/createStarterHomeWidgets.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Persona } from "@/shared/types/agents";
+import { createStarterHomeWidgets } from "./createStarterHomeWidgets";
+
+function starterPersona(fileName: "tinker.md" | "wildcard.md"): Persona {
+  return {
+    id: `/Users/test/.agents/agents/${fileName}`,
+    displayName: fileName === "tinker.md" ? "Tinker" : "Wildcard",
+    systemPrompt: "Help.",
+    isBuiltin: false,
+    writable: true,
+    sourceProperties: {
+      metadata: { berdBundled: true, berdBundledSource: fileName.slice(0, -3) },
+    },
+  };
+}
+
+describe("createStarterHomeWidgets", () => {
+  it("builds the usable base Home when starter agents are unavailable", () => {
+    const widgets = createStarterHomeWidgets([]);
+
+    expect(widgets.map(({ type }) => type)).toEqual(
+      expect.arrayContaining([
+        "clock",
+        "onboardingTour",
+        "onboardingProjectArtifact",
+        "stickyNote",
+      ]),
+    );
+    expect(widgets.some(({ type }) => type === "agentPin")).toBe(false);
+  });
+
+  it.each([
+    ["tinker.md", 410, 191],
+    ["wildcard.md", 214, -369],
+  ] as const)("keeps %s in its stable slot when it is the only available agent", (fileName, x, y) => {
+    const widgets = createStarterHomeWidgets([starterPersona(fileName)]);
+
+    expect(widgets.find((widget) => widget.type === "agentPin")).toMatchObject({
+      x,
+      y,
+      state: { agentId: `/Users/test/.agents/agents/${fileName}` },
+    });
+  });
+
+  it("contains exactly the visible starter Home widgets", () => {
+    const widgets = createStarterHomeWidgets([
+      starterPersona("tinker.md"),
+      starterPersona("wildcard.md"),
+    ]);
+
+    expect(widgets).toHaveLength(6);
+    expect(widgets.map(({ type }) => type)).toEqual([
+      "clock",
+      "onboardingTour",
+      "onboardingProjectArtifact",
+      "stickyNote",
+      "agentPin",
+      "agentPin",
+    ]);
+    expect(
+      widgets
+        .filter((widget) => widget.type === "stickyNote")
+        .map((widget) => widget.state?.noteId),
+    ).toEqual(["onboarding:starter-tasks"]);
+  });
+
+  it("derives the complete canonical starter composition", () => {
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000002")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000003")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000004")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000005")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000006")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000007")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000008")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000009")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000010")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000011");
+
+    const widgets = createStarterHomeWidgets([
+      starterPersona("wildcard.md"),
+      starterPersona("tinker.md"),
+    ]);
+
+    expect(widgets).not.toBeNull();
+    expect(widgets?.find((widget) => widget.type === "clock")).toMatchObject({
+      x: 522,
+      y: -274,
+      width: 156,
+      height: 156,
+    });
+    expect(
+      widgets
+        ?.filter((widget) => widget.type === "agentPin")
+        .map((widget) => ({ ...widget.state, x: widget.x, y: widget.y })),
+    ).toEqual([
+      {
+        agentId: "/Users/test/.agents/agents/tinker.md",
+        x: 410,
+        y: 191,
+      },
+      {
+        agentId: "/Users/test/.agents/agents/wildcard.md",
+        x: 214,
+        y: -369,
+      },
+    ]);
+  });
+});

--- a/src/features/home/onboarding/createStarterHomeWidgets.ts
+++ b/src/features/home/onboarding/createStarterHomeWidgets.ts
@@ -1,0 +1,68 @@
+import {
+  selectStarterAgentPersonas,
+  starterAgentIndex,
+} from "@/features/home/onboarding/starterAgents";
+import {
+  getStarterTasksHeight,
+  STARTER_HOME_LAYOUT,
+} from "@/features/home/onboarding/starterHomeLayout";
+import {
+  STARTER_PROJECT_ID,
+  STARTER_TASKS_NOTE_ID,
+} from "@/features/home/onboarding/starterTasks";
+import {
+  createDefaultClockWidget,
+  createDefaultOnboardingTourWidget,
+} from "@/features/home/lib/homeLayoutMapper";
+import type { WidgetInstance } from "@/features/home/widgets/types";
+import type { Persona } from "@/shared/types/agents";
+
+/** Builds the complete, canonical first-run/reset Home composition. */
+export function createStarterHomeWidgets(
+  personas: readonly Persona[],
+): WidgetInstance[] {
+  const starterPersonas = selectStarterAgentPersonas(personas);
+
+  const starterClock = {
+    ...createDefaultClockWidget(),
+    ...STARTER_HOME_LAYOUT.clock,
+  };
+  const berdyTour = {
+    ...createDefaultOnboardingTourWidget(starterClock),
+    ...STARTER_HOME_LAYOUT.berdy,
+  };
+  const arrangedBase = [starterClock, berdyTour];
+  let nextZ = 2;
+  const starterWidgets: WidgetInstance[] = [
+    ...arrangedBase,
+    {
+      id: crypto.randomUUID(),
+      type: "onboardingProjectArtifact",
+      ...STARTER_HOME_LAYOUT.project,
+      z: ++nextZ,
+      state: {
+        projectId: STARTER_PROJECT_ID,
+        onboardingStarterProject: true,
+      },
+    },
+    {
+      id: crypto.randomUUID(),
+      type: "stickyNote",
+      ...STARTER_HOME_LAYOUT.tasks,
+      height: getStarterTasksHeight(0),
+      z: ++nextZ,
+      state: { noteId: STARTER_TASKS_NOTE_ID },
+    },
+    ...starterPersonas.map((persona) => ({
+      id: crypto.randomUUID(),
+      type: "agentPin" as const,
+      ...STARTER_HOME_LAYOUT.agents[starterAgentIndex(persona)],
+      z: ++nextZ,
+      state: { agentId: persona.id },
+    })),
+  ];
+
+  return starterWidgets.map((instance) =>
+    instance.id === berdyTour.id ? { ...instance, z: nextZ + 1 } : instance,
+  );
+}

--- a/src/features/home/onboarding/starterAgents.test.ts
+++ b/src/features/home/onboarding/starterAgents.test.ts
@@ -1,27 +1,31 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { Persona } from "@/shared/types/agents";
 import {
+  areStarterAgentPinsEligible,
   haveStarterAgentPinsBeenSeeded,
+  markStarterAgentPinsEligible,
   markStarterAgentPinsSeeded,
   resetStarterAgentPinsSeeded,
   selectStarterAgentPersonas,
+  shouldRemoveLegacyBerdyPin,
   STARTER_AGENT_NAMES,
 } from "./starterAgents";
 
 function persona(
   displayName: string,
-  options: { bundled?: boolean; id?: string } = {},
+  options: { bundled?: boolean; id?: string; sourceId?: string } = {},
 ): Persona {
   return {
-    id:
-      options.id ??
-      `/Users/test/.agents/agents/${displayName.toLowerCase()}.md`,
+    id: options.id ?? `/Users/test/.agents/agents/${displayName}.md`,
     displayName,
     systemPrompt: "Help.",
     isBuiltin: false,
     writable: true,
     sourceProperties: {
-      metadata: { berdBundled: options.bundled ?? true },
+      metadata: {
+        berdBundled: options.bundled ?? true,
+        berdBundledSource: options.sourceId ?? displayName.toLowerCase(),
+      },
     },
   };
 }
@@ -34,27 +38,104 @@ describe("starter agents", () => {
     expect(
       selectStarterAgentPersonas([
         persona("Wildcard"),
+        persona("Choosey"),
         persona("Berdy"),
         persona("Tinker"),
       ]).map((agent) => agent.displayName),
     ).toEqual(["Tinker", "Wildcard"]);
   });
 
-  it("accepts only bundled starter identities", () => {
+  it("uses stable bundled file identities rather than display names", () => {
+    const renamedTinker = persona("Workbench", {
+      id: "/Users/test/.agents/agents/tinker7.md",
+      sourceId: "tinker",
+    });
+    const fallbackWildcard = persona("Surprise", {
+      id: "/Users/test/.agents/agents/wildcard12.md",
+      sourceId: "wildcard",
+    });
+    const impostor = persona("Tinker", {
+      id: "/Users/test/.agents/agents/choosey.md",
+      sourceId: "choosey",
+    });
+
     expect(
       selectStarterAgentPersonas([
-        persona("Unmarked Tinker", {
-          id: "/Users/test/.agents/agents/tinker.md",
-          bundled: false,
-        }),
-        persona("Wrong-path Tinker", {
-          id: "/Users/test/.agents/agents/tinker2.md",
-        }),
-        persona("Bundled Wildcard", {
-          id: "/Users/test/.agents/agents/wildcard.md",
-        }),
-      ]).map((agent) => agent.displayName),
-    ).toEqual(["Bundled Wildcard"]);
+        fallbackWildcard,
+        impostor,
+        renamedTinker,
+      ]).map((agent) => agent.id),
+    ).toEqual([renamedTinker.id, fallbackWildcard.id]);
+  });
+
+  it("deduplicates canonical and fallback files by starter slot", () => {
+    const canonical = persona("Tinker", {
+      id: "/Users/test/.agents/agents/tinker.md",
+    });
+    const fallback = persona("Tinker fallback", {
+      id: "/Users/test/.agents/agents/tinker2.md",
+    });
+
+    expect(selectStarterAgentPersonas([fallback, canonical])).toEqual([
+      canonical,
+    ]);
+    expect(selectStarterAgentPersonas([canonical, fallback])).toEqual([
+      canonical,
+    ]);
+  });
+
+  it("prefers verified managed copies over preserved edits", () => {
+    const edited = persona("Tinker edited", {
+      id: "/Users/test/.agents/agents/tinker.md",
+      sourceId: "tinker",
+    });
+    const managed = persona("Tinker", {
+      id: "/Users/test/.agents/agents/tinker2.md",
+      sourceId: "tinker",
+    });
+    managed.sourceProperties = {
+      metadata: {
+        berdBundled: true,
+        berdBundledSource: "tinker",
+        berdManagedBundledCopy: true,
+        berdBundledAllocationSource: "tinker",
+      },
+    };
+
+    expect(selectStarterAgentPersonas([edited, managed])).toEqual([managed]);
+    expect(selectStarterAgentPersonas([managed, edited])).toEqual([managed]);
+  });
+
+  it("does not mix unmanaged claims with verified managed copies", () => {
+    const managedTinker = persona("Tinker", {
+      id: "/Users/test/.agents/agents/tinker2.md",
+      sourceId: "tinker",
+    });
+    managedTinker.sourceProperties = {
+      metadata: {
+        berdBundled: true,
+        berdBundledSource: "tinker",
+        berdManagedBundledCopy: true,
+        berdBundledAllocationSource: "tinker",
+      },
+    };
+    const claimedWildcard = persona("Wildcard", {
+      id: "/Users/test/.agents/agents/wildcard.md",
+      sourceId: "wildcard",
+    });
+
+    expect(
+      selectStarterAgentPersonas([managedTinker, claimedWildcard]),
+    ).toEqual([managedTinker]);
+  });
+
+  it("clears recovery eligibility after starter pins are seeded", () => {
+    markStarterAgentPinsEligible();
+    expect(areStarterAgentPinsEligible()).toBe(true);
+
+    markStarterAgentPinsSeeded();
+
+    expect(areStarterAgentPinsEligible()).toBe(false);
   });
 
   it("clears starter-agent seeding for onboarding reset", () => {
@@ -64,5 +145,19 @@ describe("starter agents", () => {
     resetStarterAgentPinsSeeded();
 
     expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+  });
+
+  it("migrates the legacy three-agent seed marker", () => {
+    localStorage.setItem("goose:home:starter-agent-pins-seeded", "1");
+    expect(shouldRemoveLegacyBerdyPin()).toBe(true);
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+
+    markStarterAgentPinsSeeded();
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+    expect(shouldRemoveLegacyBerdyPin()).toBe(false);
+    expect(
+      localStorage.getItem("goose:home:starter-agent-pins-seeded"),
+    ).toBeNull();
   });
 });

--- a/src/features/home/onboarding/starterAgents.ts
+++ b/src/features/home/onboarding/starterAgents.ts
@@ -1,25 +1,53 @@
 import type { Persona } from "@/shared/types/agents";
 
-// Berdy is already featured by the onboarding tour widget. These two pins
-// complete the three-agent starter Home.
+// Berdy is already featured by the onboarding tour widget. These are the two
+// additional agent pins that complete the three-agent starter Home.
 export const STARTER_AGENT_NAMES = ["Tinker", "Wildcard"] as const;
 const STARTER_AGENT_FILE_NAMES = ["tinker.md", "wildcard.md"] as const;
+const LEGACY_SEEDED_STARTER_AGENTS_STORAGE_KEYS = [
+  "goose:home:starter-agent-pins-seeded",
+  "goose:home:starter-agent-pins-seeded-v2",
+  "goose:home:starter-agent-pins-seeded-v3",
+  "goose:home:starter-agent-pins-seeded-v4",
+] as const;
 const SEEDED_STARTER_AGENTS_STORAGE_KEY =
-  "goose:home:starter-agent-pins-seeded-v2";
+  "goose:home:starter-agent-pins-seeded-v5";
 const STARTER_AGENT_PINS_ELIGIBLE_STORAGE_KEY =
   "goose:home:starter-agent-pins-eligible-v1";
+let starterAgentPinsEligibleForCurrentRun = false;
 
-function starterAgentIndex(persona: Persona): number {
+function metadataFor(persona: Persona): Record<string, unknown> | undefined {
   const metadata = persona.sourceProperties?.metadata;
-  const bundled =
+  return typeof metadata === "object" && metadata !== null
+    ? (metadata as Record<string, unknown>)
+    : undefined;
+}
+
+function bundledSourceId(persona: Persona): string | undefined {
+  const metadata = metadataFor(persona);
+  const managedSource = metadata?.berdBundledAllocationSource;
+  if (typeof managedSource === "string") return managedSource;
+  const source = metadata?.berdBundledSource;
+  return typeof source === "string" ? source : undefined;
+}
+
+function isManagedBundledCopy(persona: Persona): boolean {
+  return metadataFor(persona)?.berdManagedBundledCopy === true;
+}
+
+export function starterAgentIndex(persona: Persona): number {
+  return STARTER_AGENT_FILE_NAMES.findIndex(
+    (fileName) => bundledSourceId(persona) === fileName.slice(0, -3),
+  );
+}
+
+function isBundledPersona(persona: Persona): boolean {
+  const metadata = persona.sourceProperties?.metadata;
+  return (
     typeof metadata === "object" &&
     metadata !== null &&
-    Reflect.get(metadata, "berdBundled") === true;
-  if (!bundled) return -1;
-
-  const normalizedPath = persona.id.replaceAll("\\", "/").toLowerCase();
-  return STARTER_AGENT_FILE_NAMES.findIndex((fileName) =>
-    normalizedPath.endsWith(`/.agents/agents/${fileName}`),
+    "berdBundled" in metadata &&
+    metadata.berdBundled === true
   );
 }
 
@@ -32,6 +60,7 @@ export function haveStarterAgentPinsBeenSeeded(): boolean {
 }
 
 export function areStarterAgentPinsEligible(): boolean {
+  if (starterAgentPinsEligibleForCurrentRun) return true;
   try {
     return (
       localStorage.getItem(STARTER_AGENT_PINS_ELIGIBLE_STORAGE_KEY) === "1"
@@ -42,6 +71,7 @@ export function areStarterAgentPinsEligible(): boolean {
 }
 
 export function markStarterAgentPinsEligible(): void {
+  starterAgentPinsEligibleForCurrentRun = true;
   try {
     localStorage.setItem(STARTER_AGENT_PINS_ELIGIBLE_STORAGE_KEY, "1");
   } catch {
@@ -49,9 +79,25 @@ export function markStarterAgentPinsEligible(): void {
   }
 }
 
+export function shouldRemoveLegacyBerdyPin(): boolean {
+  try {
+    return (
+      LEGACY_SEEDED_STARTER_AGENTS_STORAGE_KEYS.some(
+        (key) => localStorage.getItem(key) === "1",
+      ) && !haveStarterAgentPinsBeenSeeded()
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function resetStarterAgentPinsSeeded(): void {
+  starterAgentPinsEligibleForCurrentRun = false;
   try {
     localStorage.removeItem(SEEDED_STARTER_AGENTS_STORAGE_KEY);
+    for (const key of LEGACY_SEEDED_STARTER_AGENTS_STORAGE_KEYS) {
+      localStorage.removeItem(key);
+    }
     localStorage.removeItem(STARTER_AGENT_PINS_ELIGIBLE_STORAGE_KEY);
   } catch {
     // Home remains usable when localStorage is unavailable.
@@ -59,24 +105,37 @@ export function resetStarterAgentPinsSeeded(): void {
 }
 
 export function markStarterAgentPinsSeeded(): void {
+  starterAgentPinsEligibleForCurrentRun = false;
   try {
     localStorage.setItem(SEEDED_STARTER_AGENTS_STORAGE_KEY, "1");
+    for (const key of LEGACY_SEEDED_STARTER_AGENTS_STORAGE_KEYS) {
+      localStorage.removeItem(key);
+    }
     localStorage.removeItem(STARTER_AGENT_PINS_ELIGIBLE_STORAGE_KEY);
   } catch {
     // Home remains usable when localStorage is unavailable.
   }
 }
 
-/** Returns Tinker and Wildcard in their Home canvas order. */
+/** Returns at most one bundled persona per starter slot in Home canvas order. */
 export function selectStarterAgentPersonas(
   personas: readonly Persona[],
 ): Persona[] {
   const selected: Array<Persona | undefined> = STARTER_AGENT_FILE_NAMES.map(
     () => undefined,
   );
+  const haveManagedCopies = personas.some(isManagedBundledCopy);
   for (const persona of personas) {
+    if (
+      haveManagedCopies
+        ? !isManagedBundledCopy(persona)
+        : !isBundledPersona(persona)
+    ) {
+      continue;
+    }
     const index = starterAgentIndex(persona);
-    if (index >= 0 && !selected[index]) selected[index] = persona;
+    if (index < 0) continue;
+    if (!selected[index]) selected[index] = persona;
   }
   return selected.filter(
     (persona): persona is Persona => persona !== undefined,

--- a/src/features/home/onboarding/starterHomeLayout.ts
+++ b/src/features/home/onboarding/starterHomeLayout.ts
@@ -1,12 +1,23 @@
-const STARTER_HOME_LAYOUT_STORAGE_KEY = "goose:home:starter-layout-v16";
+import type { LayoutCamera } from "@/features/layout/api/layout";
+
+const STARTER_HOME_LAYOUT_STORAGE_KEY = "goose:home:starter-layout-v19";
 const PREVIOUS_STARTER_HOME_LAYOUT_STORAGE_KEYS = [
   "goose:home:starter-layout-v14",
   "goose:home:starter-layout-v15",
+  "goose:home:starter-layout-v16",
+  "goose:home:starter-layout-v18",
 ] as const;
 const STARTER_HOME_LAYOUT_ELIGIBLE_STORAGE_KEY =
   "goose:home:starter-layout-eligible-v1";
+const STARTER_HOME_CAMERA_PENDING_STORAGE_KEY =
+  "goose:home:starter-camera-pending-v2";
 
 const STARTER_TASK_ROW_HEIGHT = 28;
+
+export type PendingStarterHomeCamera = {
+  expectedRevision: number;
+  camera: LayoutCamera;
+};
 
 export function getStarterTasksHeight(omittedTaskCount: number): number {
   return Math.max(
@@ -27,13 +38,13 @@ export function starterLayoutCenter(rect: {
 
 export const STARTER_HOME_LAYOUT = {
   project: { x: -266, y: -334, width: 748, height: 748 },
-  berdy: { x: -352, y: -180 },
-  // Preserve the former 240×240 clock's center while shrinking its footprint.
-  clock: { x: 533.5, y: -266.5, width: 173, height: 173 },
-  tasks: { x: 440, y: 120, width: 256, height: 224 },
+  berdy: { x: -368, y: -180 },
+  // Keep the clock centered in its existing slot while shrinking it by 10%.
+  clock: { x: 522, y: -274, width: 156, height: 156 },
+  tasks: { x: -476, y: 218, width: 224, height: 196 },
   agents: [
-    { x: -292, y: 260, width: 200, height: 220 },
-    { x: 228, y: -380, width: 200, height: 220 },
+    { x: 410, y: 191, width: 180, height: 198 },
+    { x: 214, y: -369, width: 180, height: 198 },
   ],
 } as const;
 
@@ -76,10 +87,52 @@ export function clearStarterHomeLayoutEligibility(): void {
   }
 }
 
+export function getPendingStarterHomeCamera(): PendingStarterHomeCamera | null {
+  try {
+    const raw = localStorage.getItem(STARTER_HOME_CAMERA_PENDING_STORAGE_KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as Partial<PendingStarterHomeCamera>;
+    if (
+      typeof value.expectedRevision !== "number" ||
+      !value.camera ||
+      typeof value.camera.centerX !== "number" ||
+      typeof value.camera.centerY !== "number" ||
+      typeof value.camera.zoomBps !== "number"
+    ) {
+      return null;
+    }
+    return value as PendingStarterHomeCamera;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingStarterHomeCamera(): void {
+  try {
+    localStorage.removeItem(STARTER_HOME_CAMERA_PENDING_STORAGE_KEY);
+  } catch {
+    // Home remains usable when localStorage is unavailable.
+  }
+}
+
 export function markStarterHomeArranged(): void {
   try {
     localStorage.setItem(STARTER_HOME_LAYOUT_STORAGE_KEY, "1");
     clearStarterHomeLayoutEligibility();
+    clearPendingStarterHomeCamera();
+  } catch {
+    // Home remains usable when localStorage is unavailable.
+  }
+}
+
+export function markStarterHomeCameraPending(
+  pending: PendingStarterHomeCamera,
+): void {
+  try {
+    localStorage.setItem(
+      STARTER_HOME_CAMERA_PENDING_STORAGE_KEY,
+      JSON.stringify(pending),
+    );
   } catch {
     // Home remains usable when localStorage is unavailable.
   }
@@ -89,6 +142,7 @@ export function resetStarterHomeArrangement(): void {
   try {
     localStorage.removeItem(STARTER_HOME_LAYOUT_STORAGE_KEY);
     localStorage.removeItem(STARTER_HOME_LAYOUT_ELIGIBLE_STORAGE_KEY);
+    clearPendingStarterHomeCamera();
     for (const key of PREVIOUS_STARTER_HOME_LAYOUT_STORAGE_KEYS) {
       localStorage.removeItem(key);
     }

--- a/src/features/home/stores/homeWidgetMutations.test.ts
+++ b/src/features/home/stores/homeWidgetMutations.test.ts
@@ -38,15 +38,15 @@ describe("homeWidgetMutations", () => {
     expect(widget).toMatchObject({
       id: "00000000-0000-4000-8000-000000000001",
       type: "clock",
-      x: -206.5,
-      y: 153.5,
+      x: -198,
+      y: 162,
     });
   });
 
   it("moves widgets with snapped top-left coordinates clamped by layout center constraints", () => {
     expect(
       moveWidgetMutation([clockWidget()], "w1", 1000, -1000, CONSTRAINTS),
-    ).toEqual([clockWidget({ x: 153.5, y: -206.5 })]);
+    ).toEqual([clockWidget({ x: 162, y: -198 })]);
   });
 
   it("can preserve an exact fractional position for initial layout placement", () => {
@@ -124,7 +124,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "agent",
         type: "agentPin",
-        x: 336,
+        x: 312,
         y: 0,
         z: 2,
         width: 200,
@@ -135,13 +135,13 @@ describe("homeWidgetMutations", () => {
         x: 0,
         y: 0,
         z: 1,
-        width: 173,
-        height: 173,
+        width: 156,
+        height: 156,
       }),
       clockWidget({
         id: "chat",
         type: "chatPin",
-        x: 696,
+        x: 672,
         y: 0,
         z: 3,
         width: 188,
@@ -150,7 +150,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "skill",
         type: "skillPin",
-        x: 1032,
+        x: 1008,
         y: 0,
         z: 4,
         width: 240,
@@ -205,11 +205,11 @@ describe("homeWidgetMutations", () => {
 
   it("skips no-op cleanup mutations when widgets are already organized", () => {
     const widgets: WidgetInstance[] = [
-      clockWidget({ id: "clock", x: 0, y: 0, z: 1, width: 173, height: 173 }),
+      clockWidget({ id: "clock", x: 0, y: 0, z: 1, width: 156, height: 156 }),
       clockWidget({
         id: "agent",
         type: "agentPin",
-        x: 336,
+        x: 312,
         y: 0,
         z: 2,
         width: 200,
@@ -218,7 +218,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "chat",
         type: "chatPin",
-        x: 696,
+        x: 672,
         y: 0,
         z: 3,
         width: 188,
@@ -227,7 +227,7 @@ describe("homeWidgetMutations", () => {
       clockWidget({
         id: "skill",
         type: "skillPin",
-        x: 1032,
+        x: 1008,
         y: 0,
         z: 4,
         width: 240,
@@ -309,6 +309,54 @@ describe("updateWidgetStateMutation — photo shape resize", () => {
       width: 320,
       height: 320,
     });
+  });
+});
+
+describe("updateWidgetStateMutation — onboarding tour resize", () => {
+  it("keeps Berdy's avatar in place when dismissing the welcome bubble", () => {
+    const tour: WidgetInstance = {
+      id: "tour",
+      type: "onboardingTour",
+      x: 120,
+      y: 150,
+      z: 1,
+      width: 448,
+      height: 180,
+    };
+
+    expect(
+      updateWidgetStateMutation([tour], "tour", { welcomeDismissed: true }),
+    ).toEqual([
+      expect.objectContaining({
+        x: 120,
+        y: 160,
+        width: 160,
+        height: 160,
+      }),
+    ]);
+  });
+
+  it("keeps a resized Berdy avatar in place when dismissing the bubble", () => {
+    const tour: WidgetInstance = {
+      id: "tour",
+      type: "onboardingTour",
+      x: 120,
+      y: 150,
+      z: 1,
+      width: 672,
+      height: 270,
+    };
+
+    expect(
+      updateWidgetStateMutation([tour], "tour", { welcomeDismissed: true }),
+    ).toEqual([
+      expect.objectContaining({
+        x: 120,
+        y: 205,
+        width: 160,
+        height: 160,
+      }),
+    ]);
   });
 });
 
@@ -396,8 +444,8 @@ describe("updateWidgetStateMutation — clock mode resize", () => {
     };
     const next = updateWidgetStateMutation([digital], "c1", { mode: "analog" });
     expect(next?.[0]).toMatchObject({
-      width: 173,
-      height: 173,
+      width: 156,
+      height: 156,
       state: { mode: "analog" },
     });
   });

--- a/src/features/home/stores/homeWidgetMutations.ts
+++ b/src/features/home/stores/homeWidgetMutations.ts
@@ -170,9 +170,9 @@ function profileKey(profile: WidgetSizeProfile): string {
   return `${profile.defaultSize.width}x${profile.defaultSize.height}`;
 }
 
-const LEGACY_CLOCK_PROFILE_KEYS: Record<string, string> = {
-  "173x173": "240x240",
-  "224x88": "264x104",
+const LEGACY_CLOCK_PROFILE_KEYS: Record<string, string[]> = {
+  "156x156": ["173x173", "240x240"],
+  "224x88": ["264x104"],
 };
 
 function rememberedSizeForProfile(
@@ -184,7 +184,9 @@ function rememberedSizeForProfile(
   return (
     sizeMemory[key] ??
     (type === "clock"
-      ? sizeMemory[LEGACY_CLOCK_PROFILE_KEYS[key] ?? ""]
+      ? LEGACY_CLOCK_PROFILE_KEYS[key]
+          ?.map((legacyKey) => sizeMemory[legacyKey])
+          .find((size) => size !== undefined)
       : undefined)
   );
 }
@@ -538,14 +540,32 @@ export function updateWidgetStateMutation(
     : inheritedSize
       ? clampWidgetSizeForInstance(nextInstance, inheritedSize)
       : nextProfile.defaultSize;
+  const preservePosition =
+    HOME_WIDGET_CATALOG_BY_ID[target.type]?.preservePositionOnProfileChange;
   const prevSize = widgetSizeForInstance(target);
-  const centeredPosition = {
-    x: Math.round(target.x + (prevSize.width - nextSize.width) / 2),
-    y: Math.round(target.y + (prevSize.height - nextSize.height) / 2),
+  const resolvedContentOffset = (
+    profile: WidgetSizeProfile,
+    size: { width: number; height: number },
+  ) => {
+    if (typeof profile.contentOffset === "function") {
+      return profile.contentOffset(size);
+    }
+    return profile.contentOffset ?? { x: 0, y: 0 };
   };
+  const prevContentOffset = resolvedContentOffset(prevProfile, prevSize);
+  const nextContentOffset = resolvedContentOffset(nextProfile, nextSize);
+  const requestedPosition = preservePosition
+    ? {
+        x: target.x + prevContentOffset.x - nextContentOffset.x,
+        y: target.y + prevContentOffset.y - nextContentOffset.y,
+      }
+    : {
+        x: Math.round(target.x + (prevSize.width - nextSize.width) / 2),
+        y: Math.round(target.y + (prevSize.height - nextSize.height) / 2),
+      };
   const position = isLayoutConstraints(bounds)
-    ? clampToLayoutConstraints(centeredPosition, nextSize, bounds)
-    : centeredPosition;
+    ? clampToLayoutConstraints(requestedPosition, nextSize, bounds)
+    : requestedPosition;
 
   const sized: WidgetInstance = {
     ...nextInstance,

--- a/src/features/home/stores/homeWidgetRuntime.ts
+++ b/src/features/home/stores/homeWidgetRuntime.ts
@@ -12,7 +12,13 @@ import {
 } from "@/features/layout/api/layout";
 import { i18n } from "@/shared/i18n";
 import { markStarterAgentPinsEligible } from "@/features/home/onboarding/starterAgents";
-import { markStarterHomeLayoutEligible } from "@/features/home/onboarding/starterHomeLayout";
+import {
+  clearPendingStarterHomeCamera,
+  getPendingStarterHomeCamera,
+  markStarterHomeCameraPending,
+  markStarterHomeLayoutEligible,
+} from "@/features/home/onboarding/starterHomeLayout";
+import { createStarterHomeWidgets } from "@/features/home/onboarding/createStarterHomeWidgets";
 import {
   notifyHomeCameraSaveConfirmed,
   notifyHomeCameraSaveDiscarded,
@@ -20,12 +26,10 @@ import {
 import {
   createDefaultHomeLayoutItems,
   createDefaultOnboardingWidgets,
-  createDefaultOnboardingTourWidget,
   defaultStickyNoteId,
   homeWidgetsToLayoutItems,
   HOME_LAYOUT_REPLACE_KINDS,
   layoutItemsToHomeWidgets,
-  onboardingTourAvatarCenter,
   reconcileOnboardingExperimentWidgets,
 } from "../lib/homeLayoutMapper";
 import type { WidgetInstance } from "../widgets/types";
@@ -440,15 +444,22 @@ export function createHomeWidgetRuntime({
   }
 
   function setReadyLayout(layout: Layout, generation: number): void {
-    if (generation !== runtime.generation) {
-      return;
-    }
-
+    if (generation !== runtime.generation) return;
     setState({
       ...adoptLayout(layout),
       loadStatus: "ready",
       error: null,
     });
+
+    const pending = getPendingStarterHomeCamera();
+    if (!pending) return;
+    if (pending.expectedRevision !== layout.cameraRevision) {
+      clearPendingStarterHomeCamera();
+      return;
+    }
+    setState({ camera: pending.camera });
+    enqueueCameraSave(pending.camera);
+    void waitForPendingSaves();
   }
 
   async function loadFromBackend(generation: number): Promise<void> {
@@ -501,25 +512,33 @@ export function createHomeWidgetRuntime({
           return;
         }
 
-        // Empty layout — seed default onboarding widgets so first-run users
-        // have something on the canvas. If the user later unpins them, that
-        // choice is respected: only an empty layout re-seeds.
-        const defaultItems = createDefaultHomeLayoutItems(
-          undefined,
-          berdyOnboardingEnabled,
-        );
+        if (!berdyOnboardingEnabled) {
+          const defaultItems = createDefaultHomeLayoutItems(undefined, false);
+          const result = await saveLayoutItems({
+            layoutId: HOME_LAYOUT_ID,
+            expectedRevision: layout.itemRevision,
+            replaceKinds: HOME_LAYOUT_REPLACE_KINDS,
+            items: defaultItems,
+          });
+          if (generation !== runtime.generation) return;
+          if (hasStickyNote(layoutItemsToHomeWidgets(result.layout.items))) {
+            markOnboardingStickiesSeen();
+          }
+          setReadyLayout(result.layout, generation);
+          return;
+        }
+
+        // Starter-agent pins are optional enrichment. Persist the usable Home
+        // immediately, then let Home recover pins when persona discovery is ready.
+        const starterWidgets = createStarterHomeWidgets([]);
+
         const result = await saveLayoutItems({
           layoutId: HOME_LAYOUT_ID,
           expectedRevision: layout.itemRevision,
           replaceKinds: HOME_LAYOUT_REPLACE_KINDS,
-          items: defaultItems,
+          items: homeWidgetsToLayoutItems(starterWidgets),
         });
-        if (generation !== runtime.generation) {
-          return;
-        }
-        // During default seeding, a revision conflict means another writer
-        // already created a newer backend layout. There are no local edits to
-        // preserve yet, so initialization adopts the returned conflict layout.
+        if (generation !== runtime.generation) return;
         if (hasStickyNote(layoutItemsToHomeWidgets(result.layout.items))) {
           markOnboardingStickiesSeen();
         }
@@ -527,36 +546,33 @@ export function createHomeWidgetRuntime({
           setReadyLayout(result.layout, generation);
           return;
         }
+
         markStarterAgentPinsEligible();
-        if (berdyOnboardingEnabled) {
-          markStarterHomeLayoutEligible();
-        }
+        markStarterHomeLayoutEligible();
 
-        const seededCamera = {
+        const starterCamera = {
           ...result.layout.camera,
-          zoomBps: 9_000,
+          centerX: 0,
+          centerY: 40,
+          zoomBps: 10_000,
         };
-        if (!berdyOnboardingEnabled) {
-          setReadyLayout(
-            { ...result.layout, camera: seededCamera },
-            generation,
-          );
-          enqueueCameraSave(seededCamera);
-          return;
+        const cameraRevisionBeforeSave = result.layout.cameraRevision;
+        setReadyLayout({ ...result.layout, camera: starterCamera }, generation);
+        enqueueCameraSave(starterCamera);
+        await waitForPendingSaves();
+        if (generation !== runtime.generation) return;
+        const savedState = getState();
+        const cameraSaved =
+          savedState.cameraRevision !== cameraRevisionBeforeSave &&
+          savedState.camera?.centerX === starterCamera.centerX &&
+          savedState.camera.centerY === starterCamera.centerY &&
+          savedState.camera.zoomBps === starterCamera.zoomBps;
+        if (!cameraSaved) {
+          markStarterHomeCameraPending({
+            expectedRevision: cameraRevisionBeforeSave,
+            camera: starterCamera,
+          });
         }
-
-        const onboardingTour = createDefaultOnboardingTourWidget();
-        const avatarCenter = onboardingTourAvatarCenter(onboardingTour);
-        const centeredCamera = {
-          ...seededCamera,
-          centerX: avatarCenter.x,
-          centerY: avatarCenter.y,
-        };
-        setReadyLayout(
-          { ...result.layout, camera: centeredCamera },
-          generation,
-        );
-        enqueueCameraSave(centeredCamera);
         return;
       } catch (error) {
         if (generation !== runtime.generation) {
@@ -776,7 +792,10 @@ export function createHomeWidgetRuntime({
                 : result.layout.camera,
               error: null,
             }));
-            if (!runtime.queuedCamera) notifyHomeCameraSaveConfirmed();
+            if (!runtime.queuedCamera) {
+              clearPendingStarterHomeCamera();
+              notifyHomeCameraSaveConfirmed();
+            }
           } catch {
             if (generation !== runtime.generation) {
               break;

--- a/src/features/home/stores/homeWidgetStore.test.ts
+++ b/src/features/home/stores/homeWidgetStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { BERDY_ONBOARDING_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import { setExperimentEnabled } from "@/features/experiments/experimentPreferences";
@@ -224,6 +225,14 @@ beforeEach(() => {
   vi.mocked(getLayout).mockReset();
   vi.mocked(saveLayoutCamera).mockReset();
   vi.mocked(saveLayoutItems).mockReset();
+  vi.mocked(saveLayoutItems).mockImplementation(async (request) => ({
+    ok: true,
+    layout: layout({ itemRevision: 5, items: request.items }),
+  }));
+  vi.mocked(saveLayoutCamera).mockImplementation(async (request) => ({
+    ok: true,
+    layout: layout({ camera: request.camera, cameraRevision: 2 }),
+  }));
   vi.mocked(toast.error).mockClear();
   vi.mocked(toast.success).mockClear();
   vi.mocked(toast.warning).mockClear();
@@ -238,6 +247,65 @@ beforeEach(() => {
 });
 
 describe("homeWidgetStore", () => {
+  it("does not confirm starter-agent migration while the legacy Berdy pin remains", async () => {
+    const legacyBerdyAgentId = "agent-berdy";
+    setReadyHomeState({
+      instances: [
+        clockWidget(),
+        {
+          id: "legacy-berdy-pin",
+          type: "agentPin",
+          x: 0,
+          y: 0,
+          z: 2,
+          state: { agentId: legacyBerdyAgentId },
+        },
+      ],
+    });
+    vi.mocked(saveLayoutItems).mockImplementation(async (request) => ({
+      ok: true,
+      layout: layout({
+        itemRevision: 5,
+        items: [
+          ...request.items,
+          {
+            id: "legacy-berdy-pin",
+            kind: "persona",
+            targetId: legacyBerdyAgentId,
+            centerX: 100,
+            centerY: 100,
+            width: 180,
+            height: 198,
+            zIndex: 2,
+            titleOverride: null,
+          },
+        ],
+      }),
+    }));
+
+    await expect(
+      useHomeWidgetStore
+        .getState()
+        .addMissingStarterAgentPins(
+          ["agent-tinker", "agent-wildcard"],
+          legacyBerdyAgentId,
+        ),
+    ).resolves.toBe(false);
+  });
+
+  it("does not apply the starter layout after a user mutation clears eligibility", async () => {
+    localStorage.setItem("goose:home:starter-layout-eligible-v1", "1");
+    setReadyHomeState();
+
+    useHomeWidgetStore.getState().moveWidget("w1", 20, 30);
+    await expect(
+      useHomeWidgetStore
+        .getState()
+        .applyStarterLayout([clockWidget({ x: 522, y: -274 })], INITIAL_CAMERA),
+    ).resolves.toBe(false);
+    expect(saveLayoutCamera).not.toHaveBeenCalled();
+  });
+
   it("resets starter tasks from a non-Home route and persists the placeholder cube", async () => {
     const existingProject = {
       id: "00000000-0000-0000-0000-000000000099",
@@ -282,6 +350,72 @@ describe("homeWidgetStore", () => {
     );
   });
 
+  it("rejects widget mutations while a full onboarding reset is in flight", async () => {
+    const resetSave = deferred<SaveItemsResult>();
+    setReadyHomeState({
+      camera: INITIAL_CAMERA,
+      cameraRevision: 1,
+      itemRevision: 4,
+      instances: [clockWidget()],
+    });
+    vi.mocked(saveLayoutItems).mockReturnValueOnce(resetSave.promise);
+
+    const reset = useHomeWidgetStore.getState().resetHomeForOnboarding();
+    useHomeWidgetStore
+      .getState()
+      .addWidget("agentPin", 10, 10, { agentId: "concurrent" }, CANVAS_BOUNDS);
+
+    expect(
+      useHomeWidgetStore
+        .getState()
+        .instances.some((instance) => instance.state?.agentId === "concurrent"),
+    ).toBe(false);
+
+    await waitFor(() => expect(saveLayoutItems).toHaveBeenCalledOnce());
+    const requestedItems = vi.mocked(saveLayoutItems).mock.calls[0][0].items;
+    resetSave.resolve({
+      ok: true,
+      layout: layout({ itemRevision: 5, items: requestedItems }),
+    });
+    await reset;
+  });
+
+  it("rejects every persistence entry point while onboarding reset is in flight", async () => {
+    const resetSave = deferred<SaveItemsResult>();
+    setReadyHomeState({
+      camera: INITIAL_CAMERA,
+      cameraRevision: 1,
+      itemRevision: 4,
+      instances: [clockWidget()],
+    });
+    useHomeWidgetStore.setState({
+      cleanUpSnapshot: [{ id: "w1", type: "clock", x: 0, y: 0, z: 1 }],
+    });
+    vi.mocked(saveLayoutItems).mockReturnValueOnce(resetSave.promise);
+
+    const reset = useHomeWidgetStore.getState().resetHomeForOnboarding();
+    await waitFor(() => expect(saveLayoutItems).toHaveBeenCalledOnce());
+    const duringReset = useHomeWidgetStore.getState();
+    duringReset.addWidget("agentPin", 1, 1, { agentId: "blocked" });
+    duringReset.toggleCleanUpWidgets();
+    duringReset.saveCamera({ centerX: 99, centerY: 99, zoomBps: 9_999 });
+    await expect(
+      duringReset.addMissingStarterAgentPins(["blocked"]),
+    ).resolves.toBe(false);
+    await expect(
+      duringReset.applyStarterLayout([clockWidget()], INITIAL_CAMERA),
+    ).resolves.toBe(false);
+
+    expect(saveLayoutItems).toHaveBeenCalledOnce();
+    expect(saveLayoutCamera).not.toHaveBeenCalled();
+    const requestedItems = vi.mocked(saveLayoutItems).mock.calls[0][0].items;
+    resetSave.resolve({
+      ok: true,
+      layout: layout({ itemRevision: 5, items: requestedItems }),
+    });
+    await reset;
+  });
+
   it("keeps a confirmed onboarding canvas when camera recentering fails", async () => {
     setReadyHomeState({
       camera: INITIAL_CAMERA,
@@ -296,7 +430,7 @@ describe("homeWidgetStore", () => {
 
     await expect(
       useHomeWidgetStore.getState().resetHomeForOnboarding(),
-    ).resolves.toBe(true);
+    ).resolves.toEqual({ itemsConfirmed: true, cameraConfirmed: false });
     expect(toast.warning).toHaveBeenCalledWith(
       "home:widgetLayer.toasts.cameraSaveFailed",
     );
@@ -341,15 +475,15 @@ describe("homeWidgetStore", () => {
       .instances.filter((instance) => instance.type === "onboardingTour");
     expect(onboardingWidgets).toHaveLength(1);
     expect(onboardingWidgets[0]).toMatchObject({
-      x: -137.5,
-      y: 205,
+      x: -146,
+      y: 188,
       state: { noteId: "onboarding:tour" },
       z: 2,
     });
     expect(onboardingWidgets[0].state?.welcomeDismissed).toBeUndefined();
     expect(useHomeWidgetStore.getState().camera).toMatchObject({
-      centerX: -65.5,
-      centerY: 295,
+      centerX: -74,
+      centerY: 278,
     });
   });
 
@@ -447,27 +581,30 @@ describe("homeWidgetStore", () => {
         replaceKinds: HOME_LAYOUT_REPLACE_KINDS,
       }),
     );
-    expect(vi.mocked(saveLayoutItems).mock.calls[0][0].items).toMatchObject([
-      { kind: "stickyNote", targetId: "onboarding:tour" },
-      { kind: "stickyNote", targetId: "onboarding:start-project" },
-      { kind: "stickyNote", targetId: "onboarding:build-agent" },
-      { kind: "stickyNote", targetId: "onboarding:reuse-workflows" },
-      { kind: "stickyNote", targetId: "onboarding:manage-automations" },
-      { kind: "stickyNote", targetId: "onboarding:shape-home" },
-      { kind: "clock" },
-    ]);
+    expect(vi.mocked(saveLayoutItems).mock.calls[0][0].items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "clock" }),
+        expect.objectContaining({ targetId: "onboarding:tour" }),
+        expect.objectContaining({ targetId: "onboarding:starter-project" }),
+        expect.objectContaining({ targetId: "onboarding:starter-tasks" }),
+      ]),
+    );
     expect(saveLayoutCamera).toHaveBeenCalledWith({
       layoutId: HOME_LAYOUT_ID,
       expectedRevision: 1,
-      camera: { centerX: 750.5, centerY: 335, zoomBps: 9_000 },
+      camera: { centerX: 0, centerY: 40, zoomBps: 10_000 },
     });
     expect(useHomeWidgetStore.getState().camera).toEqual({
-      centerX: 750.5,
-      centerY: 335,
-      zoomBps: 9_000,
+      centerX: 0,
+      centerY: 40,
+      zoomBps: 10_000,
     });
     expect(useHomeWidgetStore.getState().loadStatus).toBe("ready");
     expect(useHomeWidgetStore.getState().itemRevision).toBe(8);
+    expect(localStorage.getItem("goose:home:starter-layout-eligible-v1")).toBe(
+      "1",
+    );
+    expect(localStorage.getItem("goose:home:starter-layout-v19")).toBeNull();
   });
 
   it("does not seed or center on Berdy while its experiment is disabled", async () => {
@@ -493,15 +630,8 @@ describe("homeWidgetStore", () => {
         expect.objectContaining({ targetId: "onboarding:tour" }),
       ]),
     );
-    expect(saveLayoutCamera).toHaveBeenCalledWith({
-      layoutId: HOME_LAYOUT_ID,
-      expectedRevision: 1,
-      camera: { ...INITIAL_CAMERA, zoomBps: 9_000 },
-    });
-    expect(useHomeWidgetStore.getState().camera).toEqual({
-      ...INITIAL_CAMERA,
-      zoomBps: 9_000,
-    });
+    expect(saveLayoutCamera).not.toHaveBeenCalled();
+    expect(useHomeWidgetStore.getState().camera).toEqual(INITIAL_CAMERA);
   });
 
   it("backfills onboarding sticky notes into existing layouts once", async () => {
@@ -664,8 +794,8 @@ describe("homeWidgetStore", () => {
       },
       {
         targetId: "onboarding:tour",
-        centerX: 902.5,
-        centerY: 335,
+        centerX: 894,
+        centerY: 326,
       },
     ]);
     expect(useHomeWidgetStore.getState()).toMatchObject({
@@ -1643,8 +1773,8 @@ describe("homeWidgetStore", () => {
     const secondRequest = vi.mocked(saveLayoutItems).mock.calls[1][0];
     expect(secondRequest.expectedRevision).toBe(5);
     expect(secondRequest.items[0]).toMatchObject({
-      centerX: 134.5,
-      centerY: 134.5,
+      centerX: 126,
+      centerY: 126,
       zIndex: 1,
     });
     expect(secondRequest.items).toHaveLength(1);

--- a/src/features/home/stores/homeWidgetStore.ts
+++ b/src/features/home/stores/homeWidgetStore.ts
@@ -6,26 +6,36 @@ import {
   STARTER_TASKS_NOTE_ID,
 } from "@/features/home/onboarding/starterTasks";
 import { notifyStarterWidgetAdded } from "@/features/home/onboarding/starterWidgetTask";
+import { createStarterHomeWidgets } from "@/features/home/onboarding/createStarterHomeWidgets";
 import {
   notifyHomeWidgetSaveConfirmed,
   notifyHomeWidgetSaveDiscarded,
 } from "@/features/home/onboarding/homeWidgetSaveLifecycle";
 import {
+  clearStarterHomeLayoutEligibility,
+  markStarterHomeArranged,
+  markStarterHomeCameraPending,
+  isStarterHomeLayoutEligible,
   resetStarterHomeArrangement,
   STARTER_HOME_LAYOUT,
 } from "@/features/home/onboarding/starterHomeLayout";
 import { getExperiment } from "@/features/experiments/experimentPreferences";
-import type {
-  LayoutCamera,
-  LayoutConstraints,
+import {
+  HOME_LAYOUT_ID,
+  saveLayoutItems,
+  type LayoutCamera,
+  type LayoutConstraints,
+  type LayoutMutationResult,
 } from "@/features/layout/api/layout";
 import { i18n } from "@/shared/i18n";
 import { markFreshWidgetPlacement } from "../lib/freshWidgetPlacements";
 import { isLayoutConstraints } from "../lib/snapToGrid";
 import {
-  createDefaultClockWidget,
   createDefaultOnboardingTourWidget,
   defaultStickyNoteId,
+  homeWidgetsToLayoutItems,
+  HOME_LAYOUT_REPLACE_KINDS,
+  layoutItemsToHomeWidgets,
   onboardingTourAvatarCenter,
   reconcileOnboardingExperimentWidgets,
 } from "../lib/homeLayoutMapper";
@@ -177,6 +187,12 @@ function createAddedCleanUpSnapshotItem(
   };
 }
 
+export type OnboardingHomeResetResult = {
+  itemsConfirmed: boolean;
+  cameraConfirmed: boolean;
+  starterAgentsConfirmed?: boolean;
+};
+
 interface HomeWidgetStore extends HomeWidgetState {
   cleanUpSnapshot: WidgetLayoutSnapshotItem[] | null;
   initialize: () => Promise<void>;
@@ -205,12 +221,19 @@ interface HomeWidgetStore extends HomeWidgetState {
     options?: MoveWidgetOptions,
   ) => void;
   bumpZ: (id: string) => void;
-  applyStarterLayout: (instances: WidgetInstance[]) => void;
+  applyStarterLayout: (
+    instances: WidgetInstance[],
+    camera: LayoutCamera | null,
+  ) => Promise<boolean>;
   toggleCleanUpWidgets: (bounds?: WidgetPlacementInput) => void;
   syncOnboardingExperiment: (enabled: boolean) => void;
   resetOnboardingTour: () => Promise<boolean>;
   resetStarterTasks: () => Promise<boolean>;
-  resetHomeForOnboarding: () => Promise<boolean>;
+  resetHomeForOnboarding: () => Promise<OnboardingHomeResetResult>;
+  addMissingStarterAgentPins: (
+    agentIds: readonly string[],
+    legacyBerdyAgentId?: string | null,
+  ) => Promise<boolean>;
   reloadOnboardingTourForDev: () => void;
   removeWidget: (id: string) => void;
   updateWidgetState: (
@@ -232,6 +255,8 @@ function createHomeWidgetStore() {
   let cleanUpSnapshotOnSaveDiscarded: PendingCleanUpSnapshot =
     UNCHANGED_SNAPSHOT;
   let starterWidgetCompletionPending = false;
+  let starterAgentRecoveryPromise: Promise<boolean> | null = null;
+  let onboardingResetInFlight = false;
 
   function applyPendingCleanUpSnapshot(snapshot: PendingCleanUpSnapshot): void {
     if (snapshot === UNCHANGED_SNAPSHOT) {
@@ -282,13 +307,17 @@ function createHomeWidgetStore() {
   });
 
   store = create<HomeWidgetStore>()((set, get) => {
+    function canAcceptMutation(state: HomeWidgetStore): boolean {
+      return !onboardingResetInFlight && canMutateWidgets(state);
+    }
+
     function applyMutation(
       mutate: (
         instances: HomeWidgetState["instances"],
       ) => HomeWidgetState["instances"] | null,
     ): void {
       const state = get();
-      if (!canMutateWidgets(state)) {
+      if (!canAcceptMutation(state)) {
         return;
       }
 
@@ -322,13 +351,89 @@ function createHomeWidgetStore() {
           toast.error(i18n.t("home:widgetLayer.toasts.copyFailed"));
         }
       },
+      addMissingStarterAgentPins: (agentIds, legacyBerdyAgentId) => {
+        if (starterAgentRecoveryPromise) return starterAgentRecoveryPromise;
+        starterAgentRecoveryPromise = (async () => {
+          const state = get();
+          if (!canAcceptMutation(state) || agentIds.length === 0) return false;
+          const retainedInstances = legacyBerdyAgentId
+            ? state.instances.filter(
+                (instance) =>
+                  !(
+                    instance.type === "agentPin" &&
+                    instance.state?.agentId === legacyBerdyAgentId
+                  ),
+              )
+            : state.instances;
+          const pinnedAgentIds = new Set(
+            retainedInstances.flatMap((instance) =>
+              instance.type === "agentPin" &&
+              typeof instance.state?.agentId === "string"
+                ? [instance.state.agentId]
+                : [],
+            ),
+          );
+          const missingAgentIds = agentIds.filter(
+            (agentId) => !pinnedAgentIds.has(agentId),
+          );
+          if (
+            missingAgentIds.length === 0 &&
+            retainedInstances === state.instances
+          ) {
+            return true;
+          }
+
+          let maxZ = retainedInstances.reduce(
+            (currentMax, instance) => Math.max(currentMax, instance.z),
+            0,
+          );
+          const nextInstances = [
+            ...retainedInstances,
+            ...missingAgentIds.map((agentId) => {
+              const index = agentIds.indexOf(agentId);
+              return {
+                id: crypto.randomUUID(),
+                type: "agentPin" as const,
+                ...STARTER_HOME_LAYOUT.agents[index],
+                z: ++maxZ,
+                state: { agentId },
+              };
+            }),
+          ];
+          const initialItemRevision = state.itemRevision;
+          set({ instances: nextInstances });
+          runtime.enqueueSave(nextInstances);
+          await runtime.waitForPendingSaves();
+          const latest = get();
+          return (
+            latest.itemRevision !== initialItemRevision &&
+            agentIds.every((agentId) =>
+              latest.instances.some(
+                (instance) =>
+                  instance.type === "agentPin" &&
+                  instance.state?.agentId === agentId,
+              ),
+            ) &&
+            (!legacyBerdyAgentId ||
+              !latest.instances.some(
+                (instance) =>
+                  instance.type === "agentPin" &&
+                  instance.state?.agentId === legacyBerdyAgentId,
+              ))
+          );
+        })().finally(() => {
+          starterAgentRecoveryPromise = null;
+        });
+        return starterAgentRecoveryPromise;
+      },
       addWidget: (type, x, y, state, bounds, options) => {
+        clearStarterHomeLayoutEligibility();
         if (!HOME_WIDGET_CATALOG_BY_ID[type]) {
           return false;
         }
 
         const current = get();
-        if (!canMutateWidgets(current)) {
+        if (!canAcceptMutation(current)) {
           return false;
         }
 
@@ -402,6 +507,7 @@ function createHomeWidgetStore() {
         return added;
       },
       moveWidget: (id, x, y, bounds, options) => {
+        clearStarterHomeLayoutEligibility();
         applyMutation((instances) =>
           moveWidgetMutation(
             instances,
@@ -414,6 +520,7 @@ function createHomeWidgetStore() {
         );
       },
       resizeWidget: (id, width, height, bounds, options) => {
+        clearStarterHomeLayoutEligibility();
         applyMutation((instances) =>
           resizeWidgetMutation(
             instances,
@@ -428,12 +535,56 @@ function createHomeWidgetStore() {
       bumpZ: (id) => {
         applyMutation((instances) => bumpZMutation(instances, id));
       },
-      applyStarterLayout: (instances) => {
-        applyMutation(() => instances);
+      applyStarterLayout: async (instances, camera) => {
+        const state = get();
+        if (!canAcceptMutation(state) || !isStarterHomeLayoutEligible()) {
+          return false;
+        }
+        const initialItemRevision = state.itemRevision;
+        const initialCameraRevision = state.cameraRevision;
+        set({ instances, ...(camera ? { camera } : {}) });
+        runtime.enqueueSave(instances);
+        if (camera) runtime.enqueueCameraSave(camera);
+        await runtime.waitForPendingSaves();
+        const latest = get();
+        const requestedById = new Map(
+          instances.map((instance) => [instance.id, instance]),
+        );
+        const itemsConfirmed =
+          latest.itemRevision !== initialItemRevision &&
+          latest.instances.length === instances.length &&
+          latest.instances.every((actual) => {
+            const expected = requestedById.get(actual.id);
+            return (
+              expected !== undefined &&
+              actual.type === expected.type &&
+              actual.x === expected.x &&
+              actual.y === expected.y &&
+              actual.width === expected.width &&
+              actual.height === expected.height &&
+              actual.z === expected.z &&
+              actual.state?.agentId === expected.state?.agentId &&
+              actual.state?.noteId === expected.state?.noteId
+            );
+          });
+        const cameraConfirmed =
+          !camera ||
+          (latest.cameraRevision !== initialCameraRevision &&
+            latest.camera?.centerX === camera.centerX &&
+            latest.camera.centerY === camera.centerY &&
+            latest.camera.zoomBps === camera.zoomBps);
+        if (
+          itemsConfirmed &&
+          cameraConfirmed &&
+          isStarterHomeLayoutEligible()
+        ) {
+          markStarterHomeArranged();
+        }
+        return itemsConfirmed && cameraConfirmed;
       },
       toggleCleanUpWidgets: (bounds) => {
         const state = get();
-        if (!canMutateWidgets(state)) {
+        if (!canAcceptMutation(state)) {
           return;
         }
 
@@ -484,7 +635,7 @@ function createHomeWidgetStore() {
         const state = get();
         const berdyOnboardingEnabled =
           getExperiment(BERDY_ONBOARDING_EXPERIMENT_ID)?.enabled === true;
-        if (!berdyOnboardingEnabled || !canMutateWidgets(state)) {
+        if (!berdyOnboardingEnabled || !canAcceptMutation(state)) {
           return false;
         }
 
@@ -534,7 +685,7 @@ function createHomeWidgetStore() {
       },
       resetStarterTasks: async () => {
         const state = get();
-        if (!canMutateWidgets(state)) return false;
+        if (!canAcceptMutation(state)) return false;
         const initialItemRevision = state.itemRevision;
         const existingTaskNote = state.instances.find(
           (instance) => defaultStickyNoteId(instance) === STARTER_TASKS_NOTE_ID,
@@ -593,94 +744,114 @@ function createHomeWidgetStore() {
         );
       },
       resetHomeForOnboarding: async () => {
-        const state = get();
-        if (!canMutateWidgets(state)) {
-          return false;
+        if (onboardingResetInFlight) {
+          return { itemsConfirmed: false, cameraConfirmed: false };
         }
-        const initialItemRevision = state.itemRevision;
-        const initialCameraRevision = state.cameraRevision;
+        onboardingResetInFlight = true;
+        try {
+          await runtime.waitForPendingSaves();
+          const state = get();
+          if (!canMutateWidgets(state) || state.itemRevision === null) {
+            return { itemsConfirmed: false, cameraConfirmed: false };
+          }
+          const initialItemRevision = state.itemRevision;
+          const initialCameraRevision = state.cameraRevision;
 
-        resetStarterHomeArrangement();
-        const clock = {
-          ...createDefaultClockWidget(),
-          x: STARTER_HOME_LAYOUT.clock.x,
-          y: STARTER_HOME_LAYOUT.clock.y,
-          width: STARTER_HOME_LAYOUT.clock.width,
-          height: STARTER_HOME_LAYOUT.clock.height,
-        };
-        const onboardingTour = {
-          ...createDefaultOnboardingTourWidget(clock),
-          x: STARTER_HOME_LAYOUT.berdy.x,
-          y: STARTER_HOME_LAYOUT.berdy.y,
-        };
-        const nextInstances: WidgetInstance[] = [
-          { ...clock, z: 1 },
-          { ...onboardingTour, z: 2 },
-          {
-            id: crypto.randomUUID(),
-            type: "stickyNote",
-            x: STARTER_HOME_LAYOUT.tasks.x,
-            y: STARTER_HOME_LAYOUT.tasks.y,
-            z: 3,
-            width: STARTER_HOME_LAYOUT.tasks.width,
-            height: STARTER_HOME_LAYOUT.tasks.height,
-            state: { noteId: STARTER_TASKS_NOTE_ID },
-          },
-          {
-            id: crypto.randomUUID(),
-            type: "onboardingProjectArtifact",
-            x: STARTER_HOME_LAYOUT.project.x,
-            y: STARTER_HOME_LAYOUT.project.y,
-            z: 4,
-            width: STARTER_HOME_LAYOUT.project.width,
-            height: STARTER_HOME_LAYOUT.project.height,
-            state: {
-              projectId: STARTER_PROJECT_ID,
-              onboardingStarterProject: true,
-            },
-          },
-        ];
-        const expectedCamera = state.camera
-          ? {
-              ...state.camera,
-              centerX: 80,
-              centerY: 44,
-              zoomBps: 9_000,
+          resetStarterHomeArrangement();
+          const nextInstances = createStarterHomeWidgets([]);
+
+          const expectedCamera = state.camera
+            ? {
+                ...state.camera,
+                centerX: 0,
+                centerY: 40,
+                zoomBps: 10_000,
+              }
+            : null;
+          const previousState = {
+            instances: state.instances,
+            itemRevision: state.itemRevision,
+            camera: state.camera,
+            cameraRevision: state.cameraRevision,
+            lastConfirmedLayout: state.lastConfirmedLayout,
+            cleanUpSnapshot: state.cleanUpSnapshot,
+          };
+          persistCleanUpSnapshot(null);
+          clearPendingCleanUpSaveOutcomes();
+          set({ instances: nextInstances, cleanUpSnapshot: null });
+          let itemResult: LayoutMutationResult;
+          try {
+            itemResult = await saveLayoutItems({
+              layoutId: HOME_LAYOUT_ID,
+              expectedRevision: initialItemRevision,
+              replaceKinds: HOME_LAYOUT_REPLACE_KINDS,
+              items: homeWidgetsToLayoutItems(nextInstances),
+            });
+            if (!itemResult.ok) {
+              itemResult = await saveLayoutItems({
+                layoutId: HOME_LAYOUT_ID,
+                expectedRevision: itemResult.layout.itemRevision,
+                replaceKinds: HOME_LAYOUT_REPLACE_KINDS,
+                items: homeWidgetsToLayoutItems(nextInstances),
+              });
             }
-          : null;
-        persistCleanUpSnapshot(null);
-        clearPendingCleanUpSaveOutcomes();
-        set({ instances: nextInstances, cleanUpSnapshot: null });
-        runtime.enqueueSave(nextInstances);
-        if (expectedCamera) {
-          get().saveCamera(expectedCamera);
-        }
-        await runtime.waitForPendingSaves();
+          } catch (error) {
+            persistCleanUpSnapshot(previousState.cleanUpSnapshot);
+            set(previousState);
+            console.error("Failed to reset Home for onboarding:", error);
+            return { itemsConfirmed: false, cameraConfirmed: false };
+          }
+          if (!itemResult.ok) {
+            set({
+              ...initialHomeWidgetState,
+              ...itemResult.layout,
+              instances: layoutItemsToHomeWidgets(itemResult.layout.items),
+              loadStatus: "ready",
+            });
+            return { itemsConfirmed: false, cameraConfirmed: false };
+          }
+          set({
+            instances: layoutItemsToHomeWidgets(itemResult.layout.items),
+            itemRevision: itemResult.layout.itemRevision,
+            lastConfirmedLayout: itemResult.layout,
+          });
+          if (expectedCamera) get().saveCamera(expectedCamera);
+          await runtime.waitForPendingSaves();
 
-        const latest = get();
-        const confirmedIds = new Set(
-          latest.instances.map((instance) => instance.id),
-        );
-        const itemsConfirmed =
-          latest.itemRevision !== initialItemRevision &&
-          latest.instances.length === nextInstances.length &&
-          nextInstances.every((instance) => confirmedIds.has(instance.id));
-        const cameraConfirmed =
-          !expectedCamera ||
-          (latest.cameraRevision !== initialCameraRevision &&
-            latest.camera?.centerX === expectedCamera.centerX &&
-            latest.camera.centerY === expectedCamera.centerY &&
-            latest.camera.zoomBps === expectedCamera.zoomBps);
-        if (itemsConfirmed && !cameraConfirmed) {
-          toast.warning(i18n.t("home:widgetLayer.toasts.cameraSaveFailed"));
+          const latest = get();
+          const confirmedIds = new Set(
+            latest.instances.map((instance) => instance.id),
+          );
+          const itemsConfirmed =
+            latest.itemRevision !== initialItemRevision &&
+            latest.instances.length === nextInstances.length &&
+            nextInstances.every((instance) => confirmedIds.has(instance.id));
+          const cameraConfirmed =
+            !expectedCamera ||
+            (latest.cameraRevision !== initialCameraRevision &&
+              latest.camera?.centerX === expectedCamera.centerX &&
+              latest.camera.centerY === expectedCamera.centerY &&
+              latest.camera.zoomBps === expectedCamera.zoomBps);
+          if (itemsConfirmed && cameraConfirmed) {
+            markStarterHomeArranged();
+          } else if (itemsConfirmed && expectedCamera) {
+            markStarterHomeCameraPending({
+              expectedRevision: initialCameraRevision ?? 0,
+              camera: expectedCamera,
+            });
+            toast.warning(i18n.t("home:widgetLayer.toasts.cameraSaveFailed"));
+          }
+          return { itemsConfirmed, cameraConfirmed };
+        } finally {
+          onboardingResetInFlight = false;
         }
-        return itemsConfirmed;
       },
       reloadOnboardingTourForDev: () => {
         if (!import.meta.env.DEV) return;
         void get().resetOnboardingTour();
       },
       removeWidget: (id) => {
+        clearStarterHomeLayoutEligibility();
         applyMutation((instances) => removeWidgetMutation(instances, id));
       },
       updateWidgetState: (id, state, bounds) => {
@@ -722,7 +893,7 @@ function createHomeWidgetStore() {
       },
       saveCamera: (camera) => {
         const state = get();
-        if (state.loadStatus !== "ready" || state.cameraRevision === null) {
+        if (!canAcceptMutation(state) || state.cameraRevision === null) {
           return;
         }
 

--- a/src/features/home/ui/HomeView.test.tsx
+++ b/src/features/home/ui/HomeView.test.tsx
@@ -43,6 +43,9 @@ type WidgetCanvasProps = ComponentProps<
 const widgetCanvasMock = vi.hoisted(() =>
   vi.fn((_props: WidgetCanvasProps) => <div>widget canvas</div>),
 );
+vi.mock("@/shared/api/agents", () => ({
+  listPersonas: vi.fn(async () => useAgentStore.getState().personas),
+}));
 
 vi.mock("@/features/layout/api/layout", async (importOriginal) => {
   const actual =
@@ -112,7 +115,12 @@ function bundledPersona(displayName: string): Persona {
     systemPrompt: "Help.",
     isBuiltin: false,
     writable: true,
-    sourceProperties: { metadata: { berdBundled: true } },
+    sourceProperties: {
+      metadata: {
+        berdBundled: true,
+        berdBundledSource: displayName.toLowerCase(),
+      },
+    },
   };
 }
 
@@ -175,10 +183,14 @@ beforeEach(() => {
   vi.mocked(saveLayoutCamera).mockReset();
   vi.mocked(saveLayoutCamera).mockImplementation(async (request) => ({
     ok: true,
-    layout: layout({ camera: request.camera, cameraRevision: 2 }),
+    layout: layout({
+      camera: request.camera,
+      cameraRevision: 2,
+      items:
+        useHomeWidgetStore.getState().lastConfirmedLayout?.items ??
+        layout().items,
+    }),
   }));
-  vi.mocked(trackHomeItemPinned).mockClear();
-  vi.mocked(trackHomeItemUnpinned).mockClear();
   localStorage.clear();
   localStorage.setItem(ONBOARDING_STICKIES_SEEDED_STORAGE_KEY, "6");
   useAgentStore.setState({ personas: [], personasLoading: false });
@@ -256,6 +268,7 @@ describe("HomeView", () => {
       sourceProperties: {
         metadata: {
           berdBundled: true,
+          berdBundledSource: displayName.toLowerCase(),
         },
       },
     });
@@ -340,6 +353,7 @@ describe("HomeView", () => {
       sourceProperties: {
         metadata: {
           berdBundled: true,
+          berdBundledSource: displayName.toLowerCase(),
         },
       },
     });
@@ -402,41 +416,23 @@ describe("HomeView", () => {
           .getState()
           .instances.find((item) => item.type === "clock"),
       ).toMatchObject({
-        width: 173,
-        height: 173,
-        x: 533.5,
-        y: -266.5,
+        width: 156,
+        height: 156,
+        x: 522,
+        y: -274,
       }),
     );
     await waitFor(() => expect(saveLayoutCamera).toHaveBeenCalled());
     const savedClock = vi
       .mocked(saveLayoutItems)
       .mock.calls.flatMap(([request]) => request.items)
-      .findLast((item) => item.kind === "clock" && item.width === 173);
+      .findLast((item) => item.kind === "clock" && item.width === 156);
     expect(savedClock).toMatchObject({
-      centerX: 620,
-      centerY: -180,
-      width: 173,
-      height: 173,
+      centerX: 600,
+      centerY: -196,
+      width: 156,
+      height: 156,
     });
-    const savedPersonas = vi
-      .mocked(saveLayoutItems)
-      .mock.calls.flatMap(([request]) => request.items)
-      .filter((item) => item.kind === "persona");
-    expect(savedPersonas).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          targetId: personas[0].id,
-          centerX: -192,
-          centerY: 370,
-        }),
-        expect.objectContaining({
-          targetId: personas[1].id,
-          centerX: 328,
-          centerY: -270,
-        }),
-      ]),
-    );
   });
 
   it("does not offer starter tasks when the experiment is disabled", async () => {
@@ -520,11 +516,21 @@ describe("HomeView", () => {
 
   it("does not add bundled starter agents to an existing customized Home", async () => {
     vi.mocked(getLayout).mockResolvedValue(layout());
+    const bundledPersona = (displayName: string): Persona => ({
+      id: `/Users/test/.agents/agents/${displayName.toLowerCase()}.md`,
+      displayName,
+      systemPrompt: "Help.",
+      isBuiltin: false,
+      writable: true,
+      sourceProperties: {
+        metadata: { berdBundled: true, berdBundledSource: "tinker" },
+      },
+    });
     useAgentStore.setState({
       personas: [
-        bundledPersona("Wildcard"),
-        bundledPersona("Berdy"),
         bundledPersona("Tinker"),
+        bundledPersona("Berdy"),
+        bundledPersona("Wildcard"),
       ],
       personasLoading: false,
     });
@@ -537,127 +543,49 @@ describe("HomeView", () => {
         .getState()
         .instances.filter((instance) => instance.type === "agentPin"),
     ).toHaveLength(0);
-    expect(
-      localStorage.getItem("goose:home:starter-agent-pins-seeded-v2"),
-    ).toBe("1");
   });
 
-  it("preserves an established Berdy pin when the legacy marker exists", async () => {
-    const berdy = {
-      id: "/Users/test/.agents/agents/berdy.md",
-      displayName: "Berdy",
-      avatar: "app-avatar:gloopies-22" as const,
-      systemPrompt: "Help.",
-      isBuiltin: false,
-      writable: true,
-      sourceProperties: {
-        metadata: {
-          berdBundled: true,
-        },
-      },
-    } satisfies Persona;
-    vi.mocked(getLayout).mockResolvedValue(
-      layout({
-        items: [
-          ...layout().items,
-          {
-            id: "legacy-berdy-pin",
-            kind: "persona",
-            targetId: berdy.id,
-            centerX: 320,
-            centerY: 320,
-            width: 200,
-            height: 220,
-            zIndex: 2,
-            titleOverride: null,
-          },
-        ],
-      }),
-    );
-    localStorage.setItem("goose:home:starter-agent-pins-seeded", "1");
-    useAgentStore.setState({ personas: [berdy], personasLoading: false });
-
-    renderHomeView();
-    await screen.findByText("widget canvas");
-
-    expect(
-      useHomeWidgetStore
-        .getState()
-        .instances.some(
-          (instance) =>
-            instance.type === "agentPin" &&
-            instance.state?.agentId === berdy.id,
-        ),
-    ).toBe(true);
-    expect(saveLayoutItems).not.toHaveBeenCalled();
-    expect(
-      localStorage.getItem("goose:home:starter-agent-pins-seeded-v2"),
-    ).toBe("1");
-  });
-
-  it("seeds starter agents through the empty-Home lifecycle without duplicating them after remount", async () => {
-    const personas = [bundledPersona("Tinker"), bundledPersona("Wildcard")];
-    useAgentStore.setState({ personas, personasLoading: false });
+  it("recovers starter-agent pins after the base Home loads without them", async () => {
+    setExperimentEnabled(BERDY_ONBOARDING_EXPERIMENT_ID, true);
     vi.mocked(getLayout).mockResolvedValue(layout({ items: [] }));
-
-    const firstMount = renderHomeView();
-
-    await waitFor(() =>
-      expect(
-        useHomeWidgetStore
-          .getState()
-          .instances.filter((instance) => instance.type === "agentPin"),
-      ).toHaveLength(2),
-    );
-    await waitFor(() =>
-      expect(
-        localStorage.getItem("goose:home:starter-agent-pins-seeded-v2"),
-      ).toBe("1"),
-    );
-    const persistedLayout = layout({
-      items: vi.mocked(saveLayoutItems).mock.calls.at(-1)?.[0].items ?? [],
-      itemRevision: 3,
-    });
-    expect(
-      persistedLayout.items
-        .filter((item) => item.kind === "persona")
-        .map((item) => item.targetId),
-    ).toEqual(personas.map((persona) => persona.id));
-
-    firstMount.unmount();
-    resetHomeWidgetStoreForTests();
-    vi.mocked(saveLayoutItems).mockClear();
-    vi.mocked(getLayout).mockResolvedValue(persistedLayout);
-    renderHomeView();
-    await screen.findByText("widget canvas");
-
-    expect(
-      useHomeWidgetStore
-        .getState()
-        .instances.filter((instance) => instance.type === "agentPin"),
-    ).toHaveLength(2);
-    expect(saveLayoutItems).not.toHaveBeenCalled();
-  });
-
-  it("waits for both starter personas before persisting either pin", async () => {
-    const tinker = bundledPersona("Tinker");
-    const wildcard = bundledPersona("Wildcard");
-    vi.mocked(getLayout).mockResolvedValue(layout());
     markStarterAgentPinsEligible();
-    useAgentStore.setState({ personas: [tinker], personasLoading: false });
+    useAgentStore.setState({ personas: [], personasLoading: false });
 
-    renderHomeView();
+    const view = renderHomeView();
     await screen.findByText("widget canvas");
     expect(
       useHomeWidgetStore
         .getState()
         .instances.filter((instance) => instance.type === "agentPin"),
     ).toHaveLength(0);
-    expect(saveLayoutItems).not.toHaveBeenCalled();
 
-    act(() => {
-      useAgentStore.setState({ personas: [tinker, wildcard] });
-    });
+    const personas: Persona[] = [
+      {
+        id: "/Users/test/.agents/agents/tinker.md",
+        displayName: "Tinker",
+        systemPrompt: "Help.",
+        isBuiltin: false,
+        writable: true,
+        sourceProperties: {
+          metadata: { berdBundled: true, berdBundledSource: "tinker" },
+        },
+      },
+      {
+        id: "/Users/test/.agents/agents/wildcard.md",
+        displayName: "Wildcard",
+        systemPrompt: "Help.",
+        isBuiltin: false,
+        writable: true,
+        sourceProperties: {
+          metadata: {
+            berdBundled: true,
+            berdBundledSource: "wildcard",
+          },
+        },
+      },
+    ];
+    useAgentStore.setState({ personas, personasLoading: false });
+    view.rerender(<HomeView />);
 
     await waitFor(() =>
       expect(
@@ -666,23 +594,26 @@ describe("HomeView", () => {
           .instances.filter((instance) => instance.type === "agentPin"),
       ).toHaveLength(2),
     );
-    await waitFor(() =>
-      expect(
-        vi
-          .mocked(saveLayoutItems)
-          .mock.calls.at(-1)?.[0]
-          .items.filter((item) => item.kind === "persona")
-          .map((item) => item.targetId),
-      ).toEqual([tinker.id, wildcard.id]),
-    );
   });
 
   it("adds bundled starter agents to a newly seeded Home", async () => {
-    vi.mocked(getLayout).mockResolvedValue(layout());
+    setExperimentEnabled(BERDY_ONBOARDING_EXPERIMENT_ID, true);
+    vi.mocked(getLayout).mockResolvedValue(layout({ items: [] }));
+    const bundledPersona = (displayName: string): Persona => ({
+      id: `/Users/test/.agents/agents/${displayName.toLowerCase()}.md`,
+      displayName,
+      systemPrompt: "Help.",
+      isBuiltin: false,
+      writable: true,
+      sourceProperties: {
+        metadata: {
+          berdBundled: true,
+          berdBundledSource: displayName.toLowerCase(),
+        },
+      },
+    });
     const personas = [bundledPersona("Tinker"), bundledPersona("Wildcard")];
     useAgentStore.setState({ personas, personasLoading: false });
-    markStarterAgentPinsEligible();
-
     renderHomeView();
 
     await waitFor(() =>
@@ -712,7 +643,7 @@ describe("HomeView", () => {
     // so waiting on it settles the whole seed lifecycle.
     await waitFor(() =>
       expect(
-        localStorage.getItem("goose:home:starter-agent-pins-seeded-v2"),
+        localStorage.getItem("goose:home:starter-agent-pins-seeded-v5"),
       ).toBe("1"),
     );
     expect(
@@ -724,30 +655,21 @@ describe("HomeView", () => {
     expect(trackHomeItemUnpinned).not.toHaveBeenCalled();
   });
 
-  it("re-runs the starter-agent seed silently after a discarded save", async () => {
+  it("keeps failed starter-agent recovery eligible without retrying forever", async () => {
     vi.mocked(getLayout).mockResolvedValue(layout());
     const personas = [bundledPersona("Tinker"), bundledPersona("Wildcard")];
     useAgentStore.setState({ personas, personasLoading: false });
     markStarterAgentPinsEligible();
-    vi.mocked(saveLayoutItems).mockRejectedValueOnce(new Error("save failed"));
+    vi.mocked(saveLayoutItems).mockRejectedValue(new Error("save failed"));
 
     renderHomeView();
 
-    await waitFor(() =>
-      expect(
-        localStorage.getItem("goose:home:starter-agent-pins-seeded-v2"),
-      ).toBe("1"),
-    );
+    await waitFor(() => expect(saveLayoutItems).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(saveLayoutItems).toHaveBeenCalledOnce();
     expect(
-      useHomeWidgetStore
-        .getState()
-        .instances.filter((instance) => instance.type === "agentPin"),
-    ).toHaveLength(2);
-    // The rejected save was discarded, so reaching the seeded marker proves
-    // the seeding effect ran at least twice — still with zero pin telemetry.
-    expect(vi.mocked(saveLayoutItems).mock.calls.length).toBeGreaterThanOrEqual(
-      2,
-    );
+      localStorage.getItem("goose:home:starter-agent-pins-seeded-v5"),
+    ).toBeNull();
     expect(trackHomeItemPinned).not.toHaveBeenCalled();
     expect(trackHomeItemUnpinned).not.toHaveBeenCalled();
   });
@@ -796,6 +718,8 @@ describe("HomeView", () => {
 
     renderHomeView();
     await screen.findByText("widget canvas");
+    vi.mocked(trackHomeItemPinned).mockClear();
+    vi.mocked(trackHomeItemUnpinned).mockClear();
 
     const canvasProps = widgetCanvasMock.mock.calls.at(-1)?.[0];
     if (!canvasProps) {

--- a/src/features/home/ui/HomeView.tsx
+++ b/src/features/home/ui/HomeView.tsx
@@ -6,6 +6,14 @@ import { OnboardingTourDialog } from "@/features/onboarding/ui/OnboardingTourDia
 import { BERDY_ONBOARDING_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import { useExperiment } from "@/features/experiments/experimentPreferences";
 import { useSetTopBarActions } from "@/app/contexts/TopBarActionsContext";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import {
+  areStarterAgentPinsEligible,
+  markStarterAgentPinsEligible,
+  markStarterAgentPinsSeeded,
+  selectStarterAgentPersonas,
+  shouldRemoveLegacyBerdyPin,
+} from "@/features/home/onboarding/starterAgents";
 import type { SkillInfo } from "@/features/skills/api/skills";
 import { perfLog } from "@/shared/lib/perfLog";
 import { TopBarIconButton } from "@/shared/ui/top-bar-icon-button";
@@ -26,31 +34,16 @@ import type { WidgetInstance } from "../widgets/types";
 import { WidgetCanvas } from "./WidgetCanvas";
 import { useStarterTasks } from "@/features/home/onboarding/StarterTasksContext";
 import {
-  HOME_CAMERA_SAVE_CONFIRMED_EVENT,
-  HOME_CAMERA_SAVE_DISCARDED_EVENT,
-  HOME_WIDGET_SAVE_CONFIRMED_EVENT,
-  HOME_WIDGET_SAVE_DISCARDED_EVENT,
-} from "@/features/home/onboarding/homeWidgetSaveLifecycle";
-import {
-  areStarterAgentPinsEligible,
-  haveStarterAgentPinsBeenSeeded,
-  markStarterAgentPinsSeeded,
-  selectStarterAgentPersonas,
-} from "@/features/home/onboarding/starterAgents";
-import {
   STARTER_PROJECT_ID,
   STARTER_TASKS_NOTE_ID,
 } from "@/features/home/onboarding/starterTasks";
 import {
   clearStarterHomeLayoutEligibility,
   getStarterTasksHeight,
-  hasArrangedStarterHome,
   isStarterHomeLayoutEligible,
-  markStarterHomeArranged,
   starterLayoutCenter,
   STARTER_HOME_LAYOUT,
 } from "@/features/home/onboarding/starterHomeLayout";
-import { useAgentStore } from "@/features/agents/stores/agentStore";
 
 const RETIRED_EDUCATIONAL_STICKY_IDS = new Set([
   "onboarding:welcome",
@@ -108,11 +101,6 @@ export function HomeView({
   const setTopBarActions = useSetTopBarActions();
   useInvalidateHomeWidgetSkillsOnChange();
   const [layoutMotionActive, setLayoutMotionActive] = useState(false);
-  const pendingStarterAgentSeedRef = useRef(false);
-  const pendingStarterLayoutArrangementRef = useRef(false);
-  const starterLayoutItemsConfirmedRef = useRef(false);
-  const starterLayoutCameraConfirmedRef = useRef(false);
-  const starterAgentSeedAttemptedRef = useRef(false);
   const starterLayoutArrangementAttemptedRef = useRef(false);
 
   const [tourOpen, setTourOpen] = useState(false);
@@ -129,7 +117,6 @@ export function HomeView({
     retryInitialize,
     copyErrorDetails,
     widgetMutations,
-    seedWidget,
     camera,
     constraints,
     saveCamera,
@@ -140,231 +127,96 @@ export function HomeView({
   } = useHomeWidgetLayoutController();
 
   useEffect(() => {
-    const finishStarterLayoutIfConfirmed = () => {
-      if (
-        pendingStarterLayoutArrangementRef.current &&
-        starterLayoutItemsConfirmedRef.current &&
-        starterLayoutCameraConfirmedRef.current
-      ) {
-        pendingStarterLayoutArrangementRef.current = false;
-        markStarterHomeArranged();
-      }
-    };
-    const confirmItems = () => {
-      if (pendingStarterAgentSeedRef.current) {
-        pendingStarterAgentSeedRef.current = false;
-        markStarterAgentPinsSeeded();
-      }
-      if (pendingStarterLayoutArrangementRef.current) {
-        starterLayoutItemsConfirmedRef.current = true;
-        finishStarterLayoutIfConfirmed();
-      }
-    };
-    const confirmCamera = () => {
-      if (!pendingStarterLayoutArrangementRef.current) return;
-      starterLayoutCameraConfirmedRef.current = true;
-      finishStarterLayoutIfConfirmed();
-    };
-    const discard = () => {
-      pendingStarterAgentSeedRef.current = false;
-      pendingStarterLayoutArrangementRef.current = false;
-      starterLayoutItemsConfirmedRef.current = false;
-      starterLayoutCameraConfirmedRef.current = false;
-      starterAgentSeedAttemptedRef.current = false;
-      starterLayoutArrangementAttemptedRef.current = false;
-    };
-    window.addEventListener(HOME_WIDGET_SAVE_CONFIRMED_EVENT, confirmItems);
-    window.addEventListener(HOME_WIDGET_SAVE_DISCARDED_EVENT, discard);
-    window.addEventListener(HOME_CAMERA_SAVE_CONFIRMED_EVENT, confirmCamera);
-    window.addEventListener(HOME_CAMERA_SAVE_DISCARDED_EVENT, discard);
-    return () => {
-      window.removeEventListener(
-        HOME_WIDGET_SAVE_CONFIRMED_EVENT,
-        confirmItems,
-      );
-      window.removeEventListener(HOME_WIDGET_SAVE_DISCARDED_EVENT, discard);
-      window.removeEventListener(
-        HOME_CAMERA_SAVE_CONFIRMED_EVENT,
-        confirmCamera,
-      );
-      window.removeEventListener(HOME_CAMERA_SAVE_DISCARDED_EVENT, discard);
-    };
-  }, []);
-
-  useEffect(() => {
+    const shouldMigrateLegacyPins = shouldRemoveLegacyBerdyPin();
+    if (shouldMigrateLegacyPins) markStarterAgentPinsEligible();
     if (
       loadStatus !== "ready" ||
       personasLoading ||
-      pendingStarterAgentSeedRef.current ||
-      starterAgentSeedAttemptedRef.current
+      !areStarterAgentPinsEligible()
     ) {
       return;
     }
-
-    const haveSeededStarterAgents = haveStarterAgentPinsBeenSeeded();
-    const starterAgentPinsEligible = areStarterAgentPinsEligible();
-    // A missing marker is not proof of a new Home: every existing user lacks
-    // this newly introduced key. Only a layout seeded from empty is eligible;
-    // otherwise migrate the marker without touching the user's canvas.
-    if (!haveSeededStarterAgents && !starterAgentPinsEligible) {
-      markStarterAgentPinsSeeded();
-      return;
-    }
-    const availableStarterAgents = haveSeededStarterAgents
-      ? []
-      : selectStarterAgentPersonas(personas);
-    if (availableStarterAgents.length !== STARTER_HOME_LAYOUT.agents.length) {
-      return;
-    }
-
-    const pinnedAgentIds = new Set(
-      instances
-        .filter((instance) => instance.type === "agentPin")
-        .map((instance) => instance.state?.agentId)
-        .filter((agentId): agentId is string => typeof agentId === "string"),
-    );
-    const missingAgents = availableStarterAgents
-      .map((persona, index) => ({ persona, index }))
-      .filter(({ persona }) => !pinnedAgentIds.has(persona.id));
-    if (missingAgents.length === 0) {
-      markStarterAgentPinsSeeded();
-      return;
-    }
-    const allSeeded = missingAgents.every(({ persona, index }) => {
-      const placement = STARTER_HOME_LAYOUT.agents[index];
-      const center = placement
-        ? starterLayoutCenter(placement)
-        : { x: -420 + index * 220, y: 410 };
-      return seedWidget(
-        "agentPin",
-        center.x,
-        center.y,
-        { agentId: persona.id },
-        undefined,
-        { notifyStarterTask: false },
-      );
-    });
-    if (allSeeded) {
-      starterAgentSeedAttemptedRef.current = true;
-      pendingStarterAgentSeedRef.current = true;
-    }
-  }, [instances, loadStatus, personas, personasLoading, seedWidget]);
+    const starterPersonas = selectStarterAgentPersonas(personas);
+    if (starterPersonas.length !== STARTER_HOME_LAYOUT.agents.length) return;
+    void useHomeWidgetStore
+      .getState()
+      .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id))
+      .then((didPersist) => {
+        if (didPersist) markStarterAgentPinsSeeded();
+      });
+  }, [loadStatus, personas, personasLoading]);
 
   useEffect(() => {
     if (
       loadStatus !== "ready" ||
-      !starterTasks?.visible ||
-      personasLoading ||
-      hasArrangedStarterHome() ||
-      pendingStarterLayoutArrangementRef.current ||
+      !isStarterHomeLayoutEligible() ||
       starterLayoutArrangementAttemptedRef.current
-    ) {
+    )
       return;
-    }
-
-    const starterAgentPersonas = selectStarterAgentPersonas(personas);
-    const starterAgentIds = new Set(
-      starterAgentPersonas.map((persona) => persona.id),
+    const starterPersonas = selectStarterAgentPersonas(personas);
+    const starterAgentIds = new Set(starterPersonas.map(({ id }) => id));
+    const haveAllStarterPins = starterPersonas.every(({ id }) =>
+      instances.some(
+        (instance) =>
+          instance.type === "agentPin" && instance.state?.agentId === id,
+      ),
     );
     const hasCompleteStarterSet =
-      starterAgentPersonas.length === STARTER_HOME_LAYOUT.agents.length &&
-      starterAgentPersonas.every((persona) =>
-        instances.some(
-          (instance) =>
-            instance.type === "agentPin" &&
-            instance.state?.agentId === persona.id,
-        ),
-      ) &&
-      instances.some((instance) => instance.type === "clock") &&
+      starterPersonas.length === STARTER_HOME_LAYOUT.agents.length &&
+      haveAllStarterPins &&
       instances.some((instance) => instance.type === "onboardingTour") &&
+      instances.some((instance) => instance.type === "clock") &&
       instances.some(
         (instance) => instance.state?.noteId === STARTER_TASKS_NOTE_ID,
       ) &&
       instances.some(
-        (instance) =>
-          instance.type === "onboardingProjectArtifact" ||
-          instance.state?.onboardingStarterProject === true,
+        (instance) => instance.type === "onboardingProjectArtifact",
       );
-    if (!hasCompleteStarterSet || !isStarterHomeLayoutEligible()) {
-      return;
-    }
-
-    // Guard against synchronous Zustand re-entry while the layout mutations
-    // are queued. The durable marker is written only after the runtime confirms
-    // the save, so a discarded save can retry on the next render.
+    if (!hasCompleteStarterSet) return;
     starterLayoutArrangementAttemptedRef.current = true;
-    pendingStarterLayoutArrangementRef.current = true;
-    starterLayoutItemsConfirmedRef.current = false;
-    starterLayoutCameraConfirmedRef.current = camera === null;
 
-    const starterClock = instances
-      .filter((instance) => instance.type === "clock")
-      .sort((left, right) => left.z - right.z)[0];
-
-    const berdyTour = instances.find(
-      (instance) => instance.type === "onboardingTour",
-    );
     const maxZ = Math.max(0, ...instances.map((instance) => instance.z));
-    const arrangedInstances = instances.map((instance) => {
-      const noteId = instance.state?.noteId;
-      if (instance.id === starterClock?.id) {
+    const arranged = instances.map((instance) => {
+      if (instance.type === "clock")
         return { ...instance, ...STARTER_HOME_LAYOUT.clock };
-      }
       if (instance.type === "onboardingTour") {
-        return {
-          ...instance,
-          x: STARTER_HOME_LAYOUT.berdy.x,
-          y: STARTER_HOME_LAYOUT.berdy.y,
-          z: instance.id === berdyTour?.id ? maxZ + 1 : instance.z,
-        };
+        return { ...instance, ...STARTER_HOME_LAYOUT.berdy, z: maxZ + 1 };
       }
       if (
         instance.type === "agentPin" &&
         typeof instance.state?.agentId === "string" &&
         starterAgentIds.has(instance.state.agentId)
       ) {
-        const starterAgentIndex = starterAgentPersonas.findIndex(
-          (persona) => persona.id === instance.state?.agentId,
+        const index = starterPersonas.findIndex(
+          ({ id }) => id === instance.state?.agentId,
         );
-        const placement = STARTER_HOME_LAYOUT.agents[starterAgentIndex];
-        return placement
-          ? { ...instance, x: placement.x, y: placement.y }
-          : instance;
+        return { ...instance, ...STARTER_HOME_LAYOUT.agents[index] };
       }
-      if (noteId === STARTER_TASKS_NOTE_ID) {
+      if (instance.state?.noteId === STARTER_TASKS_NOTE_ID) {
         return {
           ...instance,
-          x: STARTER_HOME_LAYOUT.tasks.x,
-          y: STARTER_HOME_LAYOUT.tasks.y,
-          width: STARTER_HOME_LAYOUT.tasks.width,
+          ...STARTER_HOME_LAYOUT.tasks,
           height: starterTasksHeight,
         };
       }
-      if (
-        instance.type === "onboardingProjectArtifact" ||
-        instance.state?.onboardingStarterProject === true
-      ) {
+      if (instance.type === "onboardingProjectArtifact") {
         return { ...instance, ...STARTER_HOME_LAYOUT.project };
       }
       return instance;
     });
-    widgetMutations.applyStarterLayout(arrangedInstances);
-    if (camera) {
-      saveCamera({
-        ...camera,
-        centerX: 80,
-        centerY: 44,
-        zoomBps: 9_000,
+    void widgetMutations
+      .applyStarterLayout(
+        arranged,
+        camera ? { ...camera, centerX: 80, centerY: 44, zoomBps: 9_000 } : null,
+      )
+      .then((confirmed) => {
+        if (!confirmed) starterLayoutArrangementAttemptedRef.current = false;
       });
-    }
   }, [
     camera,
     instances,
     loadStatus,
     personas,
-    personasLoading,
-    saveCamera,
-    starterTasks?.visible,
     starterTasksHeight,
     widgetMutations,
   ]);
@@ -871,11 +723,6 @@ function useHomeWidgetLayoutController() {
     retryInitialize,
     copyErrorDetails,
     widgetMutations,
-    // The raw store mutation, for programmatic seeding. Unlike
-    // widgetMutations.addWidget it records no Pin Pinned intent: the
-    // first-run starter-agent seed (and its re-run after a discarded save)
-    // is not a user pin and must not count as one.
-    seedWidget: addWidget,
     camera,
     constraints,
     saveCamera,

--- a/src/features/home/ui/WidgetCanvas.test.tsx
+++ b/src/features/home/ui/WidgetCanvas.test.tsx
@@ -440,7 +440,7 @@ describe("WidgetCanvas", () => {
     expect(widgetNode.style.height).toBe("300px");
     expect(
       Number(widgetNode.style.getPropertyValue("--widget-text-scale")),
-    ).toBeCloseTo((240 / 173) * 1.08);
+    ).toBeCloseTo((240 / 156) * 1.08);
     expect(widgetContent.style.transform).toBe("scale(1.25)");
     expect(widgetContent.style.transformOrigin).toBe("top left");
     expect(widgetContent.style.width).toBe("240px");

--- a/src/features/home/widgets/OnboardingTourWidget.tsx
+++ b/src/features/home/widgets/OnboardingTourWidget.tsx
@@ -344,7 +344,7 @@ const BerdyContent = memo(function BerdyContent({
                   </filter>
                 </defs>
                 <path
-                  className="fill-card dark:fill-card-glass"
+                  className="fill-card dark:fill-secondary"
                   d={SETTLED_BUBBLE_PATH}
                   filter={`url(#${bubbleShadowId})`}
                 />
@@ -368,13 +368,13 @@ const BerdyContent = memo(function BerdyContent({
                 onAnimationComplete={() => setIsBubbleSettled(true)}
               >
                 <path
-                  className="fill-card dark:fill-card-glass"
+                  className="fill-card dark:fill-secondary"
                   d={SETTLED_BUBBLE_PATH}
                 />
               </motion.svg>
               <motion.div
                 data-onboarding-tour-caret-dot="small"
-                className="absolute -bottom-9 left-1 size-3 origin-top rounded-full bg-card dark:bg-card-glass"
+                className="absolute -bottom-9 left-1 size-3 origin-top rounded-full bg-card dark:bg-secondary"
                 initial={
                   shouldReduceMotion
                     ? false
@@ -394,7 +394,7 @@ const BerdyContent = memo(function BerdyContent({
               />
               <motion.div
                 data-onboarding-tour-caret-dot="large"
-                className="absolute -bottom-4 left-4 size-8 origin-top rounded-full bg-card dark:bg-card-glass"
+                className="absolute -bottom-4 left-4 size-8 origin-top rounded-full bg-card dark:bg-secondary"
                 initial={
                   shouldReduceMotion ? false : { opacity: 0, scale: 0, x: -5 }
                 }
@@ -412,11 +412,11 @@ const BerdyContent = memo(function BerdyContent({
               >
                 <span
                   data-onboarding-tour-connector-fillet="top"
-                  className="absolute top-2 -left-0.5 size-2 rounded-full bg-card dark:bg-card-glass"
+                  className="absolute top-2 -left-0.5 size-2 rounded-full bg-card dark:bg-secondary"
                 />
                 <span
                   data-onboarding-tour-connector-fillet="bottom"
-                  className="absolute top-2 -right-0.5 size-2 rounded-full bg-card dark:bg-card-glass"
+                  className="absolute top-2 -right-0.5 size-2 rounded-full bg-card dark:bg-secondary"
                 />
               </motion.div>
             </div>

--- a/src/features/home/widgets/StickyNoteWidget.tsx
+++ b/src/features/home/widgets/StickyNoteWidget.tsx
@@ -189,7 +189,7 @@ function fontSizeBodyClassName(size: StickyNoteFontSize): string {
     case "small":
       return "text-[13px] leading-5";
     case "medium":
-      return "text-[15px] leading-6";
+      return "text-[14px] leading-5";
     case "large":
       return "text-[18px] leading-7";
     default: {

--- a/src/features/home/widgets/catalog.test.ts
+++ b/src/features/home/widgets/catalog.test.ts
@@ -47,11 +47,31 @@ describe("photo size profiles", () => {
   });
 });
 
+describe("onboarding tour size profiles", () => {
+  it("shrinks the frame to the avatar after the welcome bubble is dismissed", () => {
+    const dismissedTour: WidgetInstance = {
+      id: "tour-1",
+      type: "onboardingTour",
+      x: 0,
+      y: 0,
+      z: 1,
+      width: 448,
+      height: 180,
+      state: { welcomeDismissed: true },
+    };
+
+    expect(widgetSizeForInstance(dismissedTour)).toEqual({
+      width: 160,
+      height: 160,
+    });
+  });
+});
+
 describe("clock size profiles", () => {
   it("uses the analog (square) profile by default", () => {
     expect(widgetSizeForInstance(baseClock)).toEqual({
-      width: 173,
-      height: 173,
+      width: 156,
+      height: 156,
     });
   });
 

--- a/src/features/home/widgets/catalog.ts
+++ b/src/features/home/widgets/catalog.ts
@@ -26,12 +26,23 @@ function isFinitePositive(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
 
-const CLOCK_ANALOG_PROFILE: WidgetSizeProfile = {
-  defaultSize: { width: 173, height: 173 },
+const ONBOARDING_TOUR_AVATAR_PROFILE: WidgetSizeProfile = {
+  defaultSize: { width: 160, height: 160 },
   sizeBounds: {
-    minWidth: 168,
+    minWidth: 160,
+    maxWidth: 160,
+    minHeight: 160,
+    maxHeight: 160,
+    lockAspectRatio: true,
+  },
+};
+
+const CLOCK_ANALOG_PROFILE: WidgetSizeProfile = {
+  defaultSize: { width: 156, height: 156 },
+  sizeBounds: {
+    minWidth: 156,
     maxWidth: 360,
-    minHeight: 168,
+    minHeight: 156,
     maxHeight: 360,
     lockAspectRatio: true,
   },
@@ -66,6 +77,24 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
       maxHeight: 270,
       lockAspectRatio: true,
     },
+    resolveProfile: (instance) =>
+      instance.state?.welcomeDismissed === true
+        ? ONBOARDING_TOUR_AVATAR_PROFILE
+        : {
+            defaultSize: { width: 448, height: 180 },
+            sizeBounds: {
+              minWidth: 448,
+              maxWidth: 672,
+              minHeight: 180,
+              maxHeight: 270,
+              lockAspectRatio: true,
+            },
+            contentOffset: (size) => ({
+              x: 0,
+              y: (size.height - 160) / 2,
+            }),
+          },
+    preservePositionOnProfileChange: true,
     Component: OnboardingTourWidget,
   },
   {
@@ -97,9 +126,9 @@ export const HOME_WIDGET_CATALOG: WidgetCatalogEntry[] = [
     resolveProfile: (instance) =>
       instance.state?.noteId === "onboarding:starter-tasks"
         ? {
-            defaultSize: { width: 256, height: 196 },
+            defaultSize: { width: 224, height: 196 },
             sizeBounds: {
-              minWidth: 256,
+              minWidth: 224,
               maxWidth: 360,
               minHeight: 156,
               maxHeight: 320,

--- a/src/features/home/widgets/types.ts
+++ b/src/features/home/widgets/types.ts
@@ -39,6 +39,10 @@ export interface WidgetSizeBounds {
 export interface WidgetSizeProfile {
   defaultSize: WidgetSize;
   sizeBounds: WidgetSizeBounds;
+  /** Offset of the profile's primary visual content from the widget frame. */
+  contentOffset?:
+    | { x: number; y: number }
+    | ((size: WidgetSize) => { x: number; y: number });
 }
 
 export interface WidgetInstance {
@@ -101,6 +105,8 @@ export interface WidgetCatalogEntry {
   resolveProfile?: (instance: WidgetInstance) => WidgetSizeProfile;
   /** Keep the current rendered width when state switches size profiles. */
   preserveWidthOnProfileChange?: boolean;
+  /** Keep the top-left position when state switches size profiles. */
+  preservePositionOnProfileChange?: boolean;
   /** Keep each instance's resolved size when organizing the canvas. */
   preserveSizeOnCleanUp?: boolean;
   /** Renderable component for this widget type. Entries without a Component

--- a/src/features/onboarding/resetOnboardingTour.test.ts
+++ b/src/features/onboarding/resetOnboardingTour.test.ts
@@ -2,11 +2,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const storeMocks = vi.hoisted(() => {
   let loadStatus = "idle";
+  let instances: Array<{ type: string }> = [];
+  let personas: Array<Record<string, unknown>> = [];
+  const listPersonas = vi.fn(async () => personas);
+  const setPersonas = vi.fn((next: Array<Record<string, unknown>>) => {
+    personas = next;
+  });
   const initialize = vi.fn(async () => {
     loadStatus = "ready";
   });
   const resetOnboardingTour = vi.fn(async () => true);
-  const resetHomeForOnboarding = vi.fn(async () => true);
+  const resetHomeForOnboarding = vi.fn(async () => ({
+    itemsConfirmed: true,
+    cameraConfirmed: true,
+  }));
+  const addMissingStarterAgentPins = vi.fn(async () => true);
   const resetStarterTasks = vi.fn(async () => true);
   const syncOnboardingExperiment = vi.fn();
 
@@ -17,9 +27,24 @@ const storeMocks = vi.hoisted(() => {
     setLoadStatus(next: string) {
       loadStatus = next;
     },
+    get instances() {
+      return instances;
+    },
+    setInstances(next: Array<{ type: string }>) {
+      instances = next;
+    },
+    get personas() {
+      return personas;
+    },
+    setPersonaRecords(next: Array<Record<string, unknown>>) {
+      personas = next;
+    },
+    listPersonas,
+    setPersonas,
     initialize,
     resetOnboardingTour,
     resetHomeForOnboarding,
+    addMissingStarterAgentPins,
     resetStarterTasks,
     syncOnboardingExperiment,
   };
@@ -29,13 +54,28 @@ vi.mock("@/features/home/stores/homeWidgetStore", () => ({
   useHomeWidgetStore: {
     getState: () => ({
       loadStatus: storeMocks.loadStatus,
+      instances: storeMocks.instances,
       initialize: storeMocks.initialize,
       resetOnboardingTour: storeMocks.resetOnboardingTour,
       resetHomeForOnboarding: storeMocks.resetHomeForOnboarding,
+      addMissingStarterAgentPins: storeMocks.addMissingStarterAgentPins,
       resetStarterTasks: storeMocks.resetStarterTasks,
       syncOnboardingExperiment: storeMocks.syncOnboardingExperiment,
     }),
   },
+}));
+
+vi.mock("@/features/agents/stores/agentStore", () => ({
+  useAgentStore: {
+    getState: () => ({
+      personas: storeMocks.personas,
+      setPersonas: storeMocks.setPersonas,
+    }),
+  },
+}));
+
+vi.mock("@/shared/api/agents", () => ({
+  listPersonas: storeMocks.listPersonas,
 }));
 
 import {
@@ -44,22 +84,182 @@ import {
   resetStarterTasksExperience,
   syncOnboardingExperimentState,
 } from "./resetOnboardingTour";
+import {
+  areStarterAgentPinsEligible,
+  haveStarterAgentPinsBeenSeeded,
+  resetStarterAgentPinsSeeded,
+} from "@/features/home/onboarding/starterAgents";
+
+function starterPersona(sourceId: "tinker" | "wildcard") {
+  return {
+    id: `/Users/test/.agents/agents/${sourceId}.md`,
+    displayName: sourceId,
+    systemPrompt: "Help.",
+    isBuiltin: false,
+    writable: true,
+    sourceProperties: {
+      metadata: { berdBundled: true, berdBundledSource: sourceId },
+    },
+  };
+}
 
 describe("onboarding tour experience controls", () => {
   beforeEach(() => {
+    resetStarterAgentPinsSeeded();
     storeMocks.setLoadStatus("idle");
+    storeMocks.setInstances([{ type: "agentPin" }, { type: "agentPin" }]);
+    storeMocks.setPersonaRecords([]);
+    storeMocks.listPersonas.mockClear();
+    storeMocks.setPersonas.mockClear();
+    storeMocks.addMissingStarterAgentPins.mockResolvedValue(true);
     storeMocks.initialize.mockClear();
     storeMocks.resetOnboardingTour.mockClear();
     storeMocks.resetHomeForOnboarding.mockClear();
+    storeMocks.addMissingStarterAgentPins.mockClear();
     storeMocks.resetStarterTasks.mockClear();
     storeMocks.syncOnboardingExperiment.mockClear();
   });
 
   it("initializes before resetting the whole Home onboarding canvas", async () => {
-    await expect(resetHomeForOnboardingExperience()).resolves.toBe(true);
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: true,
+    });
 
     expect(storeMocks.initialize).toHaveBeenCalledOnce();
     expect(storeMocks.resetHomeForOnboarding).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes stale starter agents before persisting the reset", async () => {
+    storeMocks.setPersonaRecords([
+      { ...starterPersona("tinker"), id: "/stale/tinker.md" },
+      { ...starterPersona("wildcard"), id: "/stale/wildcard.md" },
+    ]);
+    storeMocks.listPersonas.mockResolvedValueOnce([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
+    await resetHomeForOnboardingExperience();
+
+    expect(storeMocks.listPersonas).toHaveBeenCalledOnce();
+    expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledWith([
+      "/Users/test/.agents/agents/tinker.md",
+      "/Users/test/.agents/agents/wildcard.md",
+    ]);
+    expect(storeMocks.personas.map((persona) => persona.id)).toEqual([
+      "/Users/test/.agents/agents/tinker.md",
+      "/Users/test/.agents/agents/wildcard.md",
+    ]);
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+  });
+
+  it("preserves concurrent persona edits and deletions during refresh", async () => {
+    const originalTinker = starterPersona("tinker");
+    const originalWildcard = starterPersona("wildcard");
+    storeMocks.setPersonaRecords([originalTinker, originalWildcard]);
+    storeMocks.listPersonas.mockImplementationOnce(async () => {
+      storeMocks.setPersonaRecords([
+        { ...originalTinker, displayName: "Edited Tinker" },
+      ]);
+      return [originalTinker, originalWildcard];
+    });
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
+    });
+
+    expect(storeMocks.personas).toEqual([
+      { ...originalTinker, displayName: "Edited Tinker" },
+    ]);
+    expect(storeMocks.addMissingStarterAgentPins).not.toHaveBeenCalled();
+    expect(areStarterAgentPinsEligible()).toBe(true);
+  });
+
+  it("refreshes and persists starter agents when the store is empty", async () => {
+    storeMocks.listPersonas.mockResolvedValueOnce([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+
+    await resetHomeForOnboardingExperience();
+
+    expect(storeMocks.addMissingStarterAgentPins).toHaveBeenCalledOnce();
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+  });
+
+  it("keeps recovery eligible when starter-agent persistence fails", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+    storeMocks.addMissingStarterAgentPins.mockResolvedValueOnce(false);
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
+    });
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+    expect(areStarterAgentPinsEligible()).toBe(true);
+  });
+
+  it("keeps recovery eligible when starter-agent persistence rejects", async () => {
+    storeMocks.setPersonaRecords([
+      starterPersona("tinker"),
+      starterPersona("wildcard"),
+    ]);
+    storeMocks.addMissingStarterAgentPins.mockRejectedValueOnce(
+      new Error("save failed"),
+    );
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
+    });
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+    expect(areStarterAgentPinsEligible()).toBe(true);
+  });
+
+  it("preserves starter-agent markers when the Home reset fails", async () => {
+    localStorage.setItem("goose:home:starter-agent-pins-seeded-v5", "1");
+    storeMocks.resetHomeForOnboarding.mockResolvedValueOnce({
+      itemsConfirmed: false,
+      cameraConfirmed: false,
+    });
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: false,
+      cameraConfirmed: false,
+    });
+
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(true);
+    expect(areStarterAgentPinsEligible()).toBe(false);
+  });
+
+  it("keeps recovery eligible when only one starter persona is available", async () => {
+    storeMocks.listPersonas.mockResolvedValueOnce([starterPersona("tinker")]);
+
+    await expect(resetHomeForOnboardingExperience()).resolves.toEqual({
+      itemsConfirmed: true,
+      cameraConfirmed: true,
+      starterAgentsConfirmed: false,
+    });
+
+    expect(storeMocks.addMissingStarterAgentPins).not.toHaveBeenCalled();
+    expect(haveStarterAgentPinsBeenSeeded()).toBe(false);
+    expect(areStarterAgentPinsEligible()).toBe(true);
   });
 
   it("initializes before resetting starter tasks from another route", async () => {

--- a/src/features/onboarding/resetOnboardingTour.ts
+++ b/src/features/onboarding/resetOnboardingTour.ts
@@ -1,8 +1,17 @@
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { listPersonas } from "@/shared/api/agents";
 import {
   markStarterAgentPinsEligible,
+  markStarterAgentPinsSeeded,
   resetStarterAgentPinsSeeded,
+  selectStarterAgentPersonas,
+  starterAgentIndex,
 } from "@/features/home/onboarding/starterAgents";
-import { useHomeWidgetStore } from "@/features/home/stores/homeWidgetStore";
+import { STARTER_HOME_LAYOUT } from "@/features/home/onboarding/starterHomeLayout";
+import {
+  useHomeWidgetStore,
+  type OnboardingHomeResetResult,
+} from "@/features/home/stores/homeWidgetStore";
 
 async function initializeHomeWidgets(): Promise<void> {
   const state = useHomeWidgetStore.getState();
@@ -23,12 +32,86 @@ export async function resetStarterTasksExperience(): Promise<boolean> {
   return useHomeWidgetStore.getState().resetStarterTasks();
 }
 
-export async function resetHomeForOnboardingExperience(): Promise<boolean> {
-  resetStarterAgentPinsSeeded();
+async function restoreStarterAgentPins(): Promise<boolean> {
+  let starterPersonas: ReturnType<typeof selectStarterAgentPersonas>;
+  const personasBeforeRefresh = useAgentStore.getState().personas;
+  try {
+    const personas = await listPersonas();
+    const currentPersonas = useAgentStore.getState().personas;
+    const beforeById = new Map(
+      personasBeforeRefresh.map((persona) => [persona.id, persona]),
+    );
+    const refreshedById = new Map(
+      personas.map((persona) => [persona.id, persona]),
+    );
+    const refreshedStarterSlots = new Set(
+      personas.map(starterAgentIndex).filter((index) => index >= 0),
+    );
+    const reconciledPersonas = [
+      ...currentPersonas.flatMap((persona) => {
+        if (beforeById.get(persona.id) !== persona) return [persona];
+        const refreshed = refreshedById.get(persona.id);
+        if (refreshed) return [refreshed];
+        return refreshedStarterSlots.has(starterAgentIndex(persona))
+          ? []
+          : [persona];
+      }),
+      ...personas.filter(
+        (persona) =>
+          !beforeById.has(persona.id) &&
+          !currentPersonas.some((current) => current.id === persona.id),
+      ),
+    ];
+    useAgentStore.getState().setPersonas(reconciledPersonas);
+    starterPersonas = selectStarterAgentPersonas(
+      personas.filter(
+        (persona) =>
+          !beforeById.has(persona.id) ||
+          currentPersonas.some((current) => current.id === persona.id),
+      ),
+    );
+  } catch (error) {
+    console.error(
+      "Failed to load starter agents during onboarding reset:",
+      error,
+    );
+    markStarterAgentPinsEligible();
+    return false;
+  }
+
+  if (starterPersonas.length !== STARTER_HOME_LAYOUT.agents.length) {
+    markStarterAgentPinsEligible();
+    return false;
+  }
+
+  try {
+    const didPersist = await useHomeWidgetStore
+      .getState()
+      .addMissingStarterAgentPins(starterPersonas.map(({ id }) => id));
+    if (didPersist) {
+      markStarterAgentPinsSeeded();
+      return true;
+    }
+  } catch (error) {
+    console.error(
+      "Failed to persist starter agents during onboarding reset:",
+      error,
+    );
+  }
+  markStarterAgentPinsEligible();
+  return false;
+}
+
+export async function resetHomeForOnboardingExperience(): Promise<OnboardingHomeResetResult> {
   await initializeHomeWidgets();
-  const didReset = await useHomeWidgetStore.getState().resetHomeForOnboarding();
-  if (didReset) markStarterAgentPinsEligible();
-  return didReset;
+  const result = await useHomeWidgetStore.getState().resetHomeForOnboarding();
+  if (!result.itemsConfirmed) return result;
+
+  resetStarterAgentPinsSeeded();
+  return {
+    ...result,
+    starterAgentsConfirmed: await restoreStarterAgentPins(),
+  };
 }
 
 export async function resetOnboardingTourExperience(): Promise<boolean> {

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -227,6 +227,7 @@
       "description": "Try and reset onboarding experiences together.",
       "resetAll": "Reset all onboarding",
       "resetAllError": "Couldn't reset all onboarding experiences. Try again.",
+      "resetAllPartial": "Onboarding was reset. Starter agents will appear when they're available.",
       "resetAllSuccess": "All onboarding experiences were reset.",
       "title": "Onboarding"
     },

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -227,6 +227,7 @@
       "description": "Prueba y restablece las experiencias de incorporación juntas.",
       "resetAll": "Restablecer toda la incorporación",
       "resetAllError": "No se pudieron restablecer todas las experiencias de incorporación. Inténtalo de nuevo.",
+      "resetAllPartial": "Se restableció la incorporación. Los agentes iniciales aparecerán cuando estén disponibles.",
       "resetAllSuccess": "Se restablecieron todas las experiencias de incorporación.",
       "title": "Incorporación"
     },


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Brand-new installs now open to a balanced starter Home with correctly sized widgets, both starter agents, and the intended camera framing.
**Problem:** PR #75 was merged into `demo/shareable-build`, so its refined starter Home never reached `main`. Porting the demo branch wholesale would also bring unrelated demo-only changes and conflict with PR #88's removal of the retired post-landing onboarding flow.
**Solution:** Selectively port the canonical starter Home composition and persistence lifecycle onto current `main`, preserving PR #88 while making the starter layout, agent recovery, Berdy profile changes, and camera confirmation reliable.

<details>
<summary>File changes</summary>

**distro/agents/{agt-builder,tinker,wildcard}.md**
Updates the intended Agt. Builder avatar and preserves stable source metadata for starter-agent discovery.

**src/features/home/onboarding/**
Restores a single canonical starter-widget factory, defines the refined layout and camera lifecycle, and hardens trusted starter-agent selection.

**src/features/home/stores/**
Persists first-run and reset layouts transactionally, confirms starter-agent recovery, preserves Berdy's visible position across profile changes, and avoids overwriting user canvas edits.

**src/features/home/ui/HomeView.tsx**
Coordinates starter-agent enrichment and final canonical arrangement while keeping current Home telemetry behavior.

**src/features/home/widgets/**
Applies the smaller clock and task list, avatar-only dismissed Berdy profile, opaque dark-mode bubble, and refined note typography.

**src/features/onboarding/resetOnboardingTour.ts**
Refreshes and reconciles authoritative starter agents during explicit onboarding reset without reviving the retired post-landing flow.

**src/features/experiments/ExperimentsSettings.tsx** and **src/shared/i18n/locales/{en,es}/settings.json**
Reports partial reset recovery when starter agents are temporarily unavailable.

**Tests**
Covers canonical layout coordinates, camera persistence, profile transitions, starter-agent identity/recovery, reset failures, concurrent edits, and PR #88's direct landing-page completion.

</details>

## Verification

- `just check`
- 286 focused Home/onboarding/widget tests
- Fresh isolated app profile: clicked “Let’s go” and visually verified the resulting Home canvas
- Code review: clean
- Wes review: clean

## Context

Ports the intended changes from #75 to `main`. Kept separate from #88; no retired post-landing onboarding screens are restored.
