### PR TITLE
show custom avatars throughout chat

### DIFF
--- a/src/features/chat/ui/ConversationEmptyAvatar.tsx
+++ b/src/features/chat/ui/ConversationEmptyAvatar.tsx
@@ -1,7 +1,6 @@
 import { AnimatePresence, motion } from "motion/react";
 import { resolveAgentIcon } from "@/features/agents/lib/resolveAgentIcon";
-import { useAvatarImage, useAvatarMedia } from "@/shared/hooks/useAvatarSrc";
-import { AvatarMedia } from "@/shared/ui/avatar-media";
+import { AvatarVisual } from "@/shared/ui/avatar-visual";
 import type { Persona } from "@/shared/types/agents";
 
 /**
@@ -10,28 +9,19 @@ import type { Persona } from "@/shared/types/agents";
  * which lets an outgoing avatar keep rendering correctly while it fades out.
  */
 function PersonaAvatarMedia({ persona }: { persona: Persona }) {
-  const avatarMedia = useAvatarMedia(persona.avatar);
-  const avatarImage = useAvatarImage(persona.avatar);
-  const fallbackIconSrc = resolveAgentIcon(persona.id);
-
-  if (avatarMedia) {
-    return (
-      <AvatarMedia
-        media={avatarMedia}
-        alt=""
-        loadingStrategy="eager"
-        poster={avatarImage}
-        className="h-full w-full object-contain"
-      />
-    );
-  }
-
   return (
-    <img
-      aria-hidden="true"
-      alt=""
-      src={avatarImage ?? fallbackIconSrc}
+    <AvatarVisual
+      avatar={persona.avatar}
+      loadingStrategy="eager"
       className="h-full w-full object-contain"
+      fallback={
+        <img
+          aria-hidden="true"
+          alt=""
+          src={resolveAgentIcon(persona.id)}
+          className="h-full w-full object-contain"
+        />
+      }
     />
   );
 }

--- a/src/features/chat/ui/MentionAutocomplete.tsx
+++ b/src/features/chat/ui/MentionAutocomplete.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Sparkles, User } from "lucide-react";
 import { IconBook, IconFile, IconFolder } from "@tabler/icons-react";
 import { cn } from "@/shared/lib/cn";
-import { useAvatarImage } from "@/shared/hooks/useAvatarSrc";
+import { AvatarVisual } from "@/shared/ui/avatar-visual";
 import { PopoverContent } from "@/shared/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import type { Persona } from "@/shared/types/agents";
@@ -452,18 +452,7 @@ function HighlightedMatchText({
 // ---------------------------------------------------------------------------
 
 function MentionAvatar({ persona }: { persona: Persona }) {
-  const avatarImage = useAvatarImage(persona.avatar);
-  if (avatarImage) {
-    return (
-      <img
-        src={avatarImage}
-        alt={persona.displayName}
-        className="h-7 w-7 rounded-full object-cover"
-      />
-    );
-  }
-
-  return (
+  const fallback = (
     <div
       className={cn(
         "flex h-7 w-7 items-center justify-center rounded-full",
@@ -478,5 +467,14 @@ function MentionAvatar({ persona }: { persona: Persona }) {
         <User className="h-3.5 w-3.5" />
       )}
     </div>
+  );
+
+  return (
+    <AvatarVisual
+      avatar={persona.avatar}
+      alt={persona.displayName}
+      className="h-7 w-7 rounded-full object-cover"
+      fallback={fallback}
+    />
   );
 }

--- a/src/features/chat/ui/MessageBubble.tsx
+++ b/src/features/chat/ui/MessageBubble.tsx
@@ -26,7 +26,7 @@ import {
   useTranscriptRowRootAdapter,
   useTranscriptRowStateAdapter,
 } from "@/features/chat/transcript/row-state";
-import { useAvatarImage } from "@/shared/hooks/useAvatarSrc";
+import { AvatarVisual } from "@/shared/ui/avatar-visual";
 import { MessageResponse } from "@/shared/ui/ai-elements/message";
 import {
   RunnableCodeBlock,
@@ -729,7 +729,7 @@ export const MessageBubble = memo(function MessageBubble({
       : undefined,
   );
   const { isCopied: isCopyConfirmed, copyToClipboard } = useCopyToClipboard();
-  const personaGutterImage = useAvatarImage(persona?.avatar);
+  const hasPersonaAvatar = Boolean(persona?.avatar);
   const catalogEntries = useProviderCatalogStore((state) => state.entries);
   const runItCodeRenderers = useMemo<CustomRenderer[]>(
     () =>
@@ -870,7 +870,7 @@ export const MessageBubble = memo(function MessageBubble({
     ? getProviderIcon(assistantProviderId, "size-3.5")
     : null;
   const showPersonaGutterAvatar = Boolean(
-    !isUser && (message.metadata?.personaId || personaGutterImage),
+    !isUser && (message.metadata?.personaId || hasPersonaAvatar),
   );
   const isFragmentMiddleOrEnd =
     fragmentRole === "middle" || fragmentRole === "end";
@@ -898,7 +898,7 @@ export const MessageBubble = memo(function MessageBubble({
     !isUser &&
       showLeadingAssistantChrome &&
       !showPersonaGutterAvatar &&
-      (assistantDisplayName || personaGutterImage || assistantProviderIcon),
+      (assistantDisplayName || hasPersonaAvatar || assistantProviderIcon),
   );
   const isSteeredMessage = isUser && message.metadata?.delivery === "steer";
   const isBerdctlCrossSessionMessage =
@@ -933,28 +933,21 @@ export const MessageBubble = memo(function MessageBubble({
     >
       {showPersonaGutterAvatar && showLeadingAssistantChrome ? (
         <div
-          className={cn(
-            "mt-0.5 flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md",
-            // The persona PNGs are transparent — skip the muted backdrop
-            // when we're rendering an actual image so the chat surface
-            // shows through. Keep it for the icon fallback so the icon
-            // has something behind it.
-            !personaGutterImage && "bg-muted/40",
-          )}
+          className="mt-0.5 flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-md"
           data-role="assistant-persona-avatar"
         >
           {assistantDisplayName ? (
             <span className="sr-only">{assistantDisplayName}</span>
           ) : null}
-          {personaGutterImage ? (
-            <img
-              src={personaGutterImage}
-              alt=""
-              className="h-full w-full object-contain"
-            />
-          ) : (
-            <IconRobot size={16} className="text-muted-foreground" />
-          )}
+          <AvatarVisual
+            avatar={persona?.avatar}
+            className="h-full w-full object-contain"
+            fallback={
+              <div className="flex size-full items-center justify-center bg-muted/40">
+                <IconRobot size={16} className="text-muted-foreground" />
+              </div>
+            }
+          />
         </div>
       ) : showPersonaGutterAvatar && isFragmentMiddleOrEnd ? (
         <div
@@ -977,11 +970,10 @@ export const MessageBubble = memo(function MessageBubble({
       >
         {showAssistantIdentity ? (
           <div className="mb-0.5 flex items-center gap-1 text-xs">
-            {personaGutterImage ? (
-              <img
-                src={personaGutterImage}
-                alt=""
-                className="h-5 w-5 rounded-full"
+            {hasPersonaAvatar ? (
+              <AvatarVisual
+                avatar={persona?.avatar}
+                className="h-5 w-5 rounded-full object-cover"
               />
             ) : assistantProviderIcon ? (
               <span className="flex h-5 w-5 items-center justify-center">

--- a/src/features/chat/ui/MessageMetadataChip.tsx
+++ b/src/features/chat/ui/MessageMetadataChip.tsx
@@ -1,7 +1,7 @@
 import { IconRobot } from "@tabler/icons-react";
 import { SkillIcon } from "@/features/skills/ui/SkillIcon";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
-import { useAvatarImage } from "@/shared/hooks/useAvatarSrc";
+import { AvatarVisual } from "@/shared/ui/avatar-visual";
 import { cn } from "@/shared/lib/cn";
 import type { MessageChip } from "@/shared/types/messages";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
@@ -49,13 +49,13 @@ export function MessageMetadataChip({ chip }: { chip: MessageChip }) {
   const agentPersona = useAgentStore((state) =>
     chip.type === "agent" && chip.id ? state.getPersonaById(chip.id) : null,
   );
-  const agentAvatar = useAvatarImage(agentPersona?.avatar);
   const Icon =
     chip.type === "skill"
       ? SkillIcon
       : chip.type === "agent"
         ? IconRobot
         : null;
+  const leadingIcon = Icon ? <Icon className="size-3.5 shrink-0" /> : null;
   const chipLabel = getChipLabel(chip);
 
   return (
@@ -70,15 +70,15 @@ export function MessageMetadataChip({ chip }: { chip: MessageChip }) {
               "opacity-80",
           )}
         >
-          {agentAvatar ? (
-            <img
-              src={agentAvatar}
-              alt=""
+          {chip.type === "agent" ? (
+            <AvatarVisual
+              avatar={agentPersona?.avatar}
               className="size-3.5 shrink-0 object-contain"
+              fallback={leadingIcon}
             />
-          ) : Icon ? (
-            <Icon className="size-3.5 shrink-0" />
-          ) : null}
+          ) : (
+            leadingIcon
+          )}
           <span className="min-w-0 truncate">{chipLabel}</span>
         </span>
       </TooltipTrigger>

--- a/src/features/chat/ui/PersonaPicker.tsx
+++ b/src/features/chat/ui/PersonaPicker.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { AtSign, ChevronDown, Check, Plus, Sparkles, User } from "lucide-react";
 import { cn } from "@/shared/lib/cn";
-import { useAvatarImage } from "@/shared/hooks/useAvatarSrc";
+import { AvatarVisual } from "@/shared/ui/avatar-visual";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -207,20 +207,8 @@ function PersonaAvatar({
     size === "xs" ? "h-3.5 w-3.5" : size === "sm" ? "h-4 w-4" : "h-6 w-6";
   const iconDim = size === "md" ? "h-3.5 w-3.5" : "h-2.5 w-2.5";
 
-  const avatarImage = useAvatarImage(persona?.avatar);
-  if (avatarImage) {
-    return (
-      <img
-        src={avatarImage}
-        alt={persona?.displayName ?? ""}
-        className={cn(dim, "rounded-full object-cover")}
-      />
-    );
-  }
-
   const isBuiltin = persona?.isBuiltin ?? true;
-
-  return (
+  const fallback = (
     <div
       className={cn(
         dim,
@@ -236,6 +224,15 @@ function PersonaAvatar({
         <User className={iconDim} />
       )}
     </div>
+  );
+
+  return (
+    <AvatarVisual
+      avatar={persona?.avatar}
+      alt={persona?.displayName ?? ""}
+      className={cn(dim, "rounded-full object-cover")}
+      fallback={fallback}
+    />
   );
 }
 

--- a/src/features/chat/ui/__tests__/ConversationEmptyAvatar.test.tsx
+++ b/src/features/chat/ui/__tests__/ConversationEmptyAvatar.test.tsx
@@ -22,6 +22,33 @@ vi.mock("@/features/agents/lib/resolveAgentIcon", () => ({
 }));
 
 describe("ConversationEmptyAvatar", () => {
+  it("renders cached custom avatar media before falling back to the generated agent icon", () => {
+    mockUseAvatarMedia.mockReturnValue({
+      src: "asset:///avatars/custom.webm",
+      mediaType: "video",
+      posterSrc: "asset:///avatars/custom.png",
+    });
+    mockUseAvatarImage.mockReturnValue(undefined);
+
+    render(
+      <ConversationEmptyAvatar
+        persona={{
+          id: "custom",
+          displayName: "Custom",
+          systemPrompt: "Custom.",
+          avatar: "user-avatar:custom",
+          isBuiltin: false,
+          writable: true,
+        }}
+      />,
+    );
+
+    expect(document.querySelector("img")).toHaveAttribute(
+      "src",
+      "asset:///avatars/custom.png",
+    );
+  });
+
   it("uses the selected avatar image before falling back to the generated agent icon", () => {
     mockUseAvatarMedia.mockReturnValue(undefined);
     mockUseAvatarImage.mockReturnValue("asset:///avatars/polys/libra.png");

--- a/src/features/chat/ui/__tests__/MessageBubble.test.tsx
+++ b/src/features/chat/ui/__tests__/MessageBubble.test.tsx
@@ -79,6 +79,15 @@ vi.mock("@/shared/hooks/useAvatarSrc", () => ({
       ? avatar
       : undefined;
   }),
+  useAvatarMedia: vi.fn((avatar: unknown) =>
+    avatar === "user-avatar:custom"
+      ? {
+          src: "asset:///avatars/custom.webm",
+          mediaType: "video",
+          posterSrc: "asset:///avatars/custom.png",
+        }
+      : undefined,
+  ),
 }));
 
 vi.mock("@/shared/api/system", async (importOriginal) => {
@@ -1452,6 +1461,37 @@ describe("MessageBubble", () => {
       "Builder",
     );
     expectNoVisibleText(container, "Builder");
+  });
+
+  it("renders a generated custom gloopie in the assistant gutter", () => {
+    useAgentStore.setState({
+      personas: [
+        {
+          id: "persona-1",
+          displayName: "Builder",
+          avatar: "user-avatar:custom",
+          systemPrompt: "",
+          isBuiltin: false,
+          writable: true,
+        },
+      ],
+    });
+
+    const { container } = render(
+      <MessageBubble
+        message={assistantMessage([{ type: "text", text: "hi" }], {
+          metadata: { personaId: "persona-1", personaName: "Builder" },
+        })}
+      />,
+    );
+
+    const gutterAvatar = container.querySelector(
+      '[data-role="assistant-persona-avatar"]',
+    );
+    expect(gutterAvatar?.querySelector("img")).toHaveAttribute(
+      "src",
+      "asset:///avatars/custom.png",
+    );
   });
 
   it("keeps custom persona identity in the gutter while avatar media is unavailable", () => {

--- a/src/features/design-system/generated/componentManifest.ts
+++ b/src/features/design-system/generated/componentManifest.ts
@@ -294,6 +294,18 @@ export const designSystemComponentManifest = [
     sourceTokenClasses: [],
   },
   {
+    name: "Avatar Visual",
+    source: "src/shared/ui/avatar-visual.tsx",
+    description:
+      "Renders every supported avatar representation through one surface.\n\nSmall surfaces prefer a static image when one exists. User-generated and\nlegacy custom avatars may only have cached image or video media, so they\nfall back to AvatarMedia instead of disappearing when no artifacts-catalog\nimage is available.",
+    exports: ["AvatarVisual"],
+    slots: [],
+    cva: [],
+    tokenClasses: [],
+    stateClasses: [],
+    sourceTokenClasses: [],
+  },
+  {
     name: "Avatar",
     source: "src/shared/ui/avatar.tsx",
     description: "",

--- a/src/shared/ui/avatar-visual.test.tsx
+++ b/src/shared/ui/avatar-visual.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AvatarVisual } from "./avatar-visual";
+
+const avatarHooks = vi.hoisted(() => ({
+  image: undefined as string | undefined,
+  media: undefined as
+    | {
+        src: string;
+        mediaType: "image" | "video";
+        posterSrc?: string;
+      }
+    | undefined,
+}));
+
+vi.mock("@/shared/hooks/useAvatarSrc", () => ({
+  useAvatarImage: () => avatarHooks.image,
+  useAvatarMedia: () => avatarHooks.media,
+}));
+
+vi.mock("@/shared/avatars/avatarPlaybackPreferences", () => ({
+  useAnimatedAvatarsPreference: () => false,
+}));
+
+describe("AvatarVisual", () => {
+  it("prefers the static image used by default avatars", () => {
+    avatarHooks.image = "asset:///avatars/default.png";
+    avatarHooks.media = {
+      src: "asset:///avatars/default.webm",
+      mediaType: "video",
+    };
+
+    render(<AvatarVisual avatar="app-avatar:default" alt="Default" />);
+
+    expect(screen.getByRole("img", { name: "Default" })).toHaveAttribute(
+      "src",
+      "asset:///avatars/default.png",
+    );
+  });
+
+  it("uses cached custom avatar media when no catalog image exists", () => {
+    avatarHooks.image = undefined;
+    avatarHooks.media = {
+      src: "asset:///avatars/custom.webm",
+      mediaType: "video",
+      posterSrc: "asset:///avatars/custom.png",
+    };
+
+    render(<AvatarVisual avatar="user-avatar:custom" alt="Custom" />);
+
+    expect(screen.getByRole("img", { name: "Custom" })).toHaveAttribute(
+      "src",
+      "asset:///avatars/custom.png",
+    );
+  });
+
+  it("keeps image-only custom avatars visible", () => {
+    avatarHooks.image = undefined;
+    avatarHooks.media = {
+      src: "asset:///avatars/custom.png",
+      mediaType: "image",
+    };
+
+    render(<AvatarVisual avatar="user-avatar:custom" alt="Custom" />);
+
+    expect(screen.getByRole("img", { name: "Custom" })).toHaveAttribute(
+      "src",
+      "asset:///avatars/custom.png",
+    );
+  });
+
+  it("renders the caller fallback only when no avatar representation resolves", () => {
+    avatarHooks.image = undefined;
+    avatarHooks.media = undefined;
+
+    render(
+      <AvatarVisual
+        avatar="user-avatar:missing"
+        fallback={<span>Fallback</span>}
+      />,
+    );
+
+    expect(screen.getByText("Fallback")).toBeInTheDocument();
+  });
+});

--- a/src/shared/ui/avatar-visual.tsx
+++ b/src/shared/ui/avatar-visual.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import { useAvatarImage, useAvatarMedia } from "@/shared/hooks/useAvatarSrc";
+import type { Avatar } from "@/shared/types/agents";
+import { AvatarMedia } from "@/shared/ui/avatar-media";
+
+interface AvatarVisualProps {
+  avatar: Avatar | null | undefined;
+  alt?: string;
+  className?: string;
+  fallback?: ReactNode;
+  loadingStrategy?: "eager" | "lazy-once" | "visible-video";
+}
+
+/**
+ * Renders every supported avatar representation through one surface.
+ *
+ * Small surfaces prefer a static image when one exists. User-generated and
+ * legacy custom avatars may only have cached image or video media, so they
+ * fall back to AvatarMedia instead of disappearing when no artifacts-catalog
+ * image is available.
+ */
+export function AvatarVisual({
+  avatar,
+  alt = "",
+  className,
+  fallback = null,
+  loadingStrategy = "visible-video",
+}: AvatarVisualProps) {
+  const image = useAvatarImage(avatar);
+  const media = useAvatarMedia(avatar);
+
+  const staticImage = image ?? media?.posterSrc;
+  if (staticImage) {
+    return (
+      <img
+        src={staticImage}
+        alt={alt}
+        className={className}
+        data-avatar-visual="image"
+      />
+    );
+  }
+
+  if (media) {
+    return (
+      <AvatarMedia
+        media={media}
+        alt={alt}
+        poster={media.posterSrc}
+        loadingStrategy={loadingStrategy}
+        className={className}
+      />
+    );
+  }
+
+  return <>{fallback}</>;
+}


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** Custom agent avatars and generated gloopies now appear consistently throughout chat, just like default avatars.

**Problem:** Chat’s small avatar surfaces only looked for static catalog images, so generated and other cached custom avatars often fell back to generic agent icons. This made the selected agent’s identity disappear in messages, chips, pickers, and mention results.

**Solution:** Introduce one shared avatar renderer that prefers static images but falls back to cached poster or media representations. Use that renderer across every chat identity surface so default and custom avatars follow the same presentation path.

## Changes

<details>
<summary>File changes</summary>

**src/shared/ui/avatar-visual.tsx**
Adds the shared avatar presentation component that resolves catalog images, cached posters, animated media, and caller-provided fallbacks in a consistent order.

**src/shared/ui/avatar-visual.test.tsx**
Covers default catalog avatars, custom poster-backed avatars, image-only custom avatars, and unavailable-media fallbacks.

**src/features/chat/ui/ConversationEmptyAvatar.tsx**
Uses the shared renderer for the large empty-conversation avatar while preserving the deterministic default fallback.

**src/features/chat/ui/MessageBubble.tsx**
Displays custom avatars and gloopies in assistant message gutters and inline assistant identity chrome.

**src/features/chat/ui/MessageMetadataChip.tsx**
Displays custom avatars in agent chips attached to sent messages.

**src/features/chat/ui/PersonaPicker.tsx**
Displays custom avatars in the selected-agent trigger, composer chip, and persona menu.

**src/features/chat/ui/MentionAutocomplete.tsx**
Displays custom avatars in agent mention search results.

**src/features/chat/ui/__tests__/ConversationEmptyAvatar.test.tsx**
Adds regression coverage for cached custom media in the fresh-chat avatar.

**src/features/chat/ui/__tests__/MessageBubble.test.tsx**
Adds regression coverage for generated gloopies in assistant message gutters.

**src/features/design-system/generated/componentManifest.ts**
Registers the new shared avatar renderer in the generated design-system inventory.

</details>

## Reproduction Steps

1. Run the Berd dev app and select an agent that uses a generated gloopie or another custom avatar.
2. Confirm the custom avatar appears in the composer’s selected-agent chip and persona picker.
3. Type `@` and confirm the same avatar appears beside the agent in mention autocomplete.
4. Send a message with that agent and confirm its avatar appears in the sent-message agent chip.
5. Let the agent respond and confirm its avatar appears in the assistant message gutter.
6. Start a fresh chat with the agent and confirm its avatar appears above the empty-conversation prompt.

## Screenshots/Demos

Manually verified in the dev app with a custom generated gloopie across the composer and chat transcript surfaces.
