### PR TITLE
fix sidebar empty section behavior

### DIFF
--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1072,6 +1072,7 @@ export function AppShell({
   const retryFailedSessionsForProjectRef = useRef<
     (project: ProjectInfo) => void
   >(() => {});
+  const [projectCreatedRevision, setProjectCreatedRevision] = useState(0);
   const startChatForCreatedProjectRef = useRef<(project: ProjectInfo) => void>(
     () => {},
   );
@@ -1105,8 +1106,10 @@ export function AppShell({
     openEditProjectDialog,
   } = useProjectDialog({
     onProjectSaved: refreshProjectsAfterDialogSave,
-    onProjectCreated: (project) =>
-      startChatForCreatedProjectRef.current(project),
+    onProjectCreated: (project) => {
+      setProjectCreatedRevision((revision) => revision + 1);
+      startChatForCreatedProjectRef.current(project);
+    },
   });
   useEffect(() => {
     if (!createProjectOpen || selectedStarterTaskId !== "create-project")
@@ -5013,6 +5016,7 @@ export function AppShell({
           activeView,
           activeSettingsSection,
           activeSessionId,
+          projectCreatedRevision,
           projects,
           className: "h-full rounded-md",
         }}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -5016,6 +5016,10 @@ export function AppShell({
           activeView,
           activeSettingsSection,
           activeSessionId,
+          onProjectCreatedRevisionHandled: (revision) =>
+            setProjectCreatedRevision((current) =>
+              current === revision ? 0 : current,
+            ),
           projectCreatedRevision,
           projects,
           className: "h-full rounded-md",

--- a/src/app/views/NavigationPanesView.tsx
+++ b/src/app/views/NavigationPanesView.tsx
@@ -53,6 +53,7 @@ export interface NavigationPanesViewProps {
   onNavigate?: (view: AppView) => void;
   onOpenProject?: (projectId: string) => void;
   onSelectSession?: (sessionId: string) => void;
+  projectCreatedRevision?: number;
   activeView?: AppView;
   activeSettingsSection?: SectionId;
   activeSessionId?: string | null;
@@ -217,6 +218,7 @@ export function NavigationPanesView({
   onNavigate,
   onOpenProject,
   onSelectSession,
+  projectCreatedRevision,
   activeView,
   activeSettingsSection = DEFAULT_SETTINGS_SECTION,
   activeSessionId,
@@ -390,6 +392,7 @@ export function NavigationPanesView({
                   onReorderProject={onReorderProject}
                   onSelectSession={onSelectSession}
                   onSessionSelectForScroll={handleSessionSelectForScroll}
+                  projectCreatedRevision={projectCreatedRevision}
                   projects={projects}
                   surface={{
                     renderDragHandle: () => null,

--- a/src/app/views/NavigationPanesView.tsx
+++ b/src/app/views/NavigationPanesView.tsx
@@ -53,6 +53,7 @@ export interface NavigationPanesViewProps {
   onNavigate?: (view: AppView) => void;
   onOpenProject?: (projectId: string) => void;
   onSelectSession?: (sessionId: string) => void;
+  onProjectCreatedRevisionHandled?: (revision: number) => void;
   projectCreatedRevision?: number;
   activeView?: AppView;
   activeSettingsSection?: SectionId;
@@ -218,6 +219,7 @@ export function NavigationPanesView({
   onNavigate,
   onOpenProject,
   onSelectSession,
+  onProjectCreatedRevisionHandled,
   projectCreatedRevision,
   activeView,
   activeSettingsSection = DEFAULT_SETTINGS_SECTION,
@@ -392,6 +394,9 @@ export function NavigationPanesView({
                   onReorderProject={onReorderProject}
                   onSelectSession={onSelectSession}
                   onSessionSelectForScroll={handleSessionSelectForScroll}
+                  onProjectCreatedRevisionHandled={
+                    onProjectCreatedRevisionHandled
+                  }
                   projectCreatedRevision={projectCreatedRevision}
                   projects={projects}
                   surface={{

--- a/src/app/views/__tests__/NavigationPanesView.test.tsx
+++ b/src/app/views/__tests__/NavigationPanesView.test.tsx
@@ -504,12 +504,51 @@ describe("NavigationPanesView", () => {
     });
     expect(within(mainNavigation).getByText("Projects")).toBeInTheDocument();
     expect(within(mainNavigation).getByText("Chats")).toBeInTheDocument();
+    expect(
+      within(mainNavigation).queryByRole("button", { name: "Chats" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Create a project" }));
     await user.click(screen.getByRole("button", { name: "Start a chat" }));
 
     expect(onCreateProject).toHaveBeenCalledOnce();
     expect(onNewChat).toHaveBeenCalledOnce();
+  });
+
+  it("expands Projects only for an explicit local project creation", () => {
+    localStorage.setItem(
+      "goose:sidebar:section-visibility",
+      JSON.stringify({ pinned: true, projects: false, recents: true }),
+    );
+    const initialProps = sidebarProps({ projects: [mockProject()] });
+    const { rerender } = renderWithQueryClient(
+      <NavigationPanesView {...initialProps} />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Project One" })).toBeNull();
+
+    rerender(
+      <NavigationPanesView
+        {...initialProps}
+        projects={[
+          mockProject(),
+          mockProject({ id: "project-2", name: "Project Two", order: 1 }),
+        ]}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Project Two" })).toBeNull();
+
+    rerender(
+      <NavigationPanesView
+        {...initialProps}
+        projects={[
+          mockProject(),
+          mockProject({ id: "project-2", name: "Project Two", order: 1 }),
+        ]}
+        projectCreatedRevision={1}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Project Two" })).toBeVisible();
   });
 
   it("shows the projects info moment next to the header for a fresh user", async () => {

--- a/src/app/views/__tests__/NavigationPanesView.test.tsx
+++ b/src/app/views/__tests__/NavigationPanesView.test.tsx
@@ -551,6 +551,25 @@ describe("NavigationPanesView", () => {
     expect(screen.getByRole("button", { name: "Project Two" })).toBeVisible();
   });
 
+  it("handles project creation when the session list mounts after the signal", async () => {
+    localStorage.setItem(
+      "goose:sidebar:section-visibility",
+      JSON.stringify({ pinned: true, projects: false, recents: true }),
+    );
+    const onProjectCreatedRevisionHandled = vi.fn();
+
+    renderSidebar({
+      projects: [mockProject()],
+      projectCreatedRevision: 1,
+      onProjectCreatedRevisionHandled,
+    });
+
+    expect(screen.getByRole("button", { name: "Project One" })).toBeVisible();
+    await waitFor(() =>
+      expect(onProjectCreatedRevisionHandled).toHaveBeenCalledWith(1),
+    );
+  });
+
   it("shows the projects info moment next to the header for a fresh user", async () => {
     const user = userEvent.setup();
 

--- a/src/features/sessions/capabilities/SessionListCapability.tsx
+++ b/src/features/sessions/capabilities/SessionListCapability.tsx
@@ -161,6 +161,7 @@ export interface SessionListCapabilityProps {
   onReorderProject?: (fromId: string, toId: string) => void;
   onSelectSession?: (sessionId: string) => void;
   onSessionSelectForScroll?: (sessionId: string) => void;
+  onProjectCreatedRevisionHandled?: (revision: number) => void;
   projectCreatedRevision?: number;
   projects: ProjectInfo[];
   surface: SessionListSurfaceOptions;
@@ -480,6 +481,7 @@ export function SessionListCapability({
   onReorderProject,
   onSelectSession,
   onSessionSelectForScroll,
+  onProjectCreatedRevisionHandled,
   projectCreatedRevision = 0,
   projects,
   surface,
@@ -554,15 +556,17 @@ export function SessionListCapability({
     () => new Set(projects.map((project) => project.id)),
     [projects],
   );
-  const initialProjectCreatedRevisionRef = useRef(projectCreatedRevision);
   useEffect(() => {
-    if (projectCreatedRevision === initialProjectCreatedRevisionRef.current) {
-      return;
-    }
+    if (projectCreatedRevision === 0) return;
     setSectionVisibility((current) =>
       current.projects ? current : { ...current, projects: true },
     );
-  }, [projectCreatedRevision, setSectionVisibility]);
+    onProjectCreatedRevisionHandled?.(projectCreatedRevision);
+  }, [
+    onProjectCreatedRevisionHandled,
+    projectCreatedRevision,
+    setSectionVisibility,
+  ]);
   const projectsById = useMemo(
     () => new Map(projects.map((project) => [project.id, project])),
     [projects],

--- a/src/features/sessions/capabilities/SessionListCapability.tsx
+++ b/src/features/sessions/capabilities/SessionListCapability.tsx
@@ -161,6 +161,7 @@ export interface SessionListCapabilityProps {
   onReorderProject?: (fromId: string, toId: string) => void;
   onSelectSession?: (sessionId: string) => void;
   onSessionSelectForScroll?: (sessionId: string) => void;
+  projectCreatedRevision?: number;
   projects: ProjectInfo[];
   surface: SessionListSurfaceOptions;
 }
@@ -479,6 +480,7 @@ export function SessionListCapability({
   onReorderProject,
   onSelectSession,
   onSessionSelectForScroll,
+  projectCreatedRevision = 0,
   projects,
   surface,
 }: SessionListCapabilityProps) {
@@ -552,6 +554,15 @@ export function SessionListCapability({
     () => new Set(projects.map((project) => project.id)),
     [projects],
   );
+  const initialProjectCreatedRevisionRef = useRef(projectCreatedRevision);
+  useEffect(() => {
+    if (projectCreatedRevision === initialProjectCreatedRevisionRef.current) {
+      return;
+    }
+    setSectionVisibility((current) =>
+      current.projects ? current : { ...current, projects: true },
+    );
+  }, [projectCreatedRevision, setSectionVisibility]);
   const projectsById = useMemo(
     () => new Map(projects.map((project) => [project.id, project])),
     [projects],

--- a/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
+++ b/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
@@ -1,10 +1,5 @@
 import { useTranslation } from "react-i18next";
-import {
-  IconChevronDown,
-  IconCubePlus,
-  IconEdit,
-  IconPlus,
-} from "@tabler/icons-react";
+import { IconCubePlus, IconEdit, IconPlus } from "@tabler/icons-react";
 import type { AppView } from "@/app/AppShell";
 import type { ProjectInfo } from "@/features/projects/api/projects";
 import { selectHasFetchedProjects } from "@/features/projects/stores/projectSelectors";
@@ -19,7 +14,6 @@ import {
   SIDEBAR_ROW_HORIZONTAL_PADDING_CLASS,
   SIDEBAR_ROW_HEIGHT_CLASS,
   SIDEBAR_ROW_HOVER_CLASS,
-  SIDEBAR_SECTION_HEADER_ROW_CLASS,
 } from "@/shared/ui/sidebar-tokens";
 import { SidebarChatDragProvider } from "./SidebarChatDragContext";
 import {
@@ -448,42 +442,13 @@ export function SidebarProjectsSection({
           </div>
         ) : showCombinedEmptyState ? (
           <>
-            <div
-              className={cn(
-                "relative flex items-center transition-all duration-300",
-                collapsed
-                  ? "px-0 pt-0 pb-1 justify-center"
-                  : SIDEBAR_SECTION_HEADER_ROW_CLASS,
-              )}
-            >
-              {!collapsed && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  flush
-                  size="xs"
-                  onClick={onToggleRecentsSection}
-                  aria-expanded={recentsSectionOpen}
-                  className={cn(
-                    "h-7 min-w-0 flex-1 justify-start gap-1.5",
-                    labelTransition,
-                    labelVisible
-                      ? "opacity-100 w-auto"
-                      : "opacity-0 w-0 overflow-hidden",
-                  )}
-                >
-                  <IconChevronDown
-                    className={cn(
-                      "size-3 shrink-0 transition-transform duration-150",
-                      !recentsSectionOpen && "-rotate-90",
-                    )}
-                  />
-                  <span className={cn("truncate", SECTION_HEADER_TEXT_CLASS)}>
-                    {t("sections.recents")}
-                  </span>
-                </Button>
-              )}
-            </div>
+            <SidebarSectionHeader
+              label={t("sections.recents")}
+              collapsed={collapsed}
+              labelTransition={labelTransition}
+              labelVisible={labelVisible}
+              labelClassName={SECTION_HEADER_TEXT_CLASS}
+            />
             <div className="space-y-0">
               <Button
                 type="button"

--- a/src/features/sessions/ui/session-list/SidebarRecentsSection.tsx
+++ b/src/features/sessions/ui/session-list/SidebarRecentsSection.tsx
@@ -104,7 +104,7 @@ export function SidebarRecentsSection({
   const { activeSessionDropTargetKey, registerSessionDropTarget } =
     useSidebarChatDrag();
   const recentsDropTargetRef = useRef<HTMLDivElement>(null);
-  const showContent = collapsed || isOpen;
+  const showContent = collapsed || showEmptyState || isOpen;
   const recentsDropTargetKey = "recents";
 
   const handleSessionDrop = useCallback(
@@ -136,7 +136,7 @@ export function SidebarRecentsSection({
           collapsed={collapsed}
           labelTransition={labelTransition}
           labelVisible={labelVisible}
-          onToggleOpen={onToggleOpen}
+          onToggleOpen={showEmptyState ? undefined : onToggleOpen}
           isOpen={isOpen}
           labelClassName={sectionHeaderTextClass}
           actions={

--- a/src/features/sessions/ui/session-list/__tests__/SidebarRecentsSection.test.tsx
+++ b/src/features/sessions/ui/session-list/__tests__/SidebarRecentsSection.test.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,6 +27,7 @@ function renderRecents(
   showChatIcons: boolean,
   sessionOverrides: Partial<SidebarSessionItem> = {},
   collapsed = false,
+  props: Partial<ComponentProps<typeof SidebarRecentsSection>> = {},
 ) {
   return render(
     <SidebarChatDragProvider>
@@ -44,6 +46,7 @@ function renderRecents(
         isOpen
         onToggleOpen={vi.fn()}
         sectionHeaderTextClass=""
+        {...props}
       />
     </SidebarChatDragProvider>,
   );
@@ -67,6 +70,24 @@ describe("SidebarRecentsSection", () => {
         },
       ],
     });
+  });
+
+  it("renders an empty chat section as a non-collapsible label", () => {
+    const onToggleOpen = vi.fn();
+    renderRecents(false, {}, false, {
+      sessions: [],
+      showEmptyState: true,
+      isOpen: false,
+      onToggleOpen,
+      onNewChat: vi.fn(),
+    });
+
+    expect(screen.getByText("Chats")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Chats" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Start a chat" })).toBeVisible();
+    expect(onToggleOpen).not.toHaveBeenCalled();
   });
 
   it("keeps collapsed recent chat icons accessibly named", () => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Empty sidebar sections now behave consistently, and newly created projects remain immediately visible when their first chat opens.

**Problem:** The empty Chats header used different ordering and collapse behavior from its populated state, including a caret when there was nothing to collapse. Creating a project could also open its first chat without exposing the project in a previously collapsed Projects section.

**Solution:** Reuse the shared section-header treatment for empty Chats while making empty chat lists non-collapsible. Carry an explicit, window-local project-created revision to the session list so only local creation expands Projects, without treating ordinary backend list refreshes as creation.

<details>
<summary>File changes</summary>

**src/app/AppShell.tsx**
Records explicit local project creation and passes that signal into sidebar navigation while preserving the existing project-save workflow.

**src/app/views/NavigationPanesView.tsx**
Forwards the project-created revision to the session-list capability.

**src/app/views/__tests__/NavigationPanesView.test.tsx**
Covers the static empty Chats label and verifies that only explicit local project creation expands Projects.

**src/features/sessions/capabilities/SessionListCapability.tsx**
Responds to the explicit creation signal by opening Projects without inferring intent from project-list changes.

**src/features/sessions/ui/session-list/SidebarProjectsSection.tsx**
Replaces the bespoke empty Chats header with the shared non-interactive section header.

**src/features/sessions/ui/session-list/SidebarRecentsSection.tsx**
Keeps empty chat actions visible and removes collapse interaction when there are no chats.

**src/features/sessions/ui/session-list/__tests__/SidebarRecentsSection.test.tsx**
Adds regression coverage for the non-collapsible empty Chats state.

</details>
