### PR TITLE
refine skills toolbar actions

### DIFF
--- a/src/features/skills/ui/SkillsView.tsx
+++ b/src/features/skills/ui/SkillsView.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
+  IconArrowDownToArc,
   IconChevronDown,
-  IconDownload,
   IconRefresh,
   IconPlus,
   IconSearch,
@@ -671,7 +671,7 @@ export function SkillsView({
     <PageShell contentWidth="full">
       <section
         aria-labelledby="skills-heading"
-        className="flex flex-col gap-10"
+        className="mx-auto flex w-full max-w-[70rem] flex-col gap-10"
       >
         <Tabs
           value={viewMode}
@@ -861,7 +861,7 @@ export function SkillsView({
                 tooltip={t("common:actions.import")}
                 onClick={openFilePicker}
               >
-                <IconDownload className="!size-4" />
+                <IconArrowDownToArc className="!size-4" />
               </PageToolbarButton>
               <PageToolbarButton
                 type="button"

--- a/src/features/skills/ui/__tests__/SkillsView.test.tsx
+++ b/src/features/skills/ui/__tests__/SkillsView.test.tsx
@@ -431,6 +431,19 @@ describe("SkillsView", () => {
     expect(revealItems[2]).toHaveStyle({ animationDelay: "110ms" });
   });
 
+  it("keeps toolbar actions within the wide-screen skill grid", async () => {
+    listSkills.mockResolvedValue(mockSkills);
+
+    const { container } = renderSkillsViewWithTopBarActions();
+    await screen.findByText("code-review");
+
+    expect(container.querySelector("section")).toHaveClass(
+      "mx-auto",
+      "w-full",
+      "max-w-[70rem]",
+    );
+  });
+
   it("filters skills with page-local search", async () => {
     listSkills.mockResolvedValue(mockSkills);
     const user = userEvent.setup();

--- a/src/shared/ui/SearchBar.test.tsx
+++ b/src/shared/ui/SearchBar.test.tsx
@@ -4,6 +4,35 @@ import { describe, expect, it } from "vitest";
 import { SearchBar } from "./SearchBar";
 
 describe("SearchBar", () => {
+  it("hides the native clear control for pill-card search", () => {
+    render(
+      <SearchBar
+        size="pill-card"
+        value="query"
+        onChange={() => undefined}
+        aria-label="Search skills"
+      />,
+    );
+
+    expect(
+      screen.getByRole("searchbox", { name: "Search skills" }),
+    ).toHaveClass("[&::-webkit-search-cancel-button]:hidden");
+  });
+
+  it("keeps the native clear control for default search", () => {
+    render(
+      <SearchBar
+        value="query"
+        onChange={() => undefined}
+        aria-label="Search projects"
+      />,
+    );
+
+    expect(
+      screen.getByRole("searchbox", { name: "Search projects" }),
+    ).not.toHaveClass("[&::-webkit-search-cancel-button]:hidden");
+  });
+
   it("provides a visible focus-within treatment for pill-card search", async () => {
     const user = userEvent.setup();
     render(

--- a/src/shared/ui/SearchBar.tsx
+++ b/src/shared/ui/SearchBar.tsx
@@ -52,7 +52,7 @@ const searchBarSizes = {
       "flex h-[30px] items-center rounded-full bg-card pl-3 pr-4 ring-1 ring-transparent transition-shadow focus-within:ring-ring",
     icon: "left-3 size-4",
     input:
-      "h-auto appearance-none border-none bg-transparent px-0 pl-5 text-sm font-normal leading-none text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-foreground! placeholder:opacity-40",
+      "h-auto appearance-none border-none bg-transparent px-0 pl-5 text-sm font-normal leading-none text-foreground shadow-none focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-foreground! placeholder:opacity-40 [&::-webkit-search-cancel-button]:hidden",
     inputVariant: "ghost" as const,
     hideIcon: false,
   },


### PR DESCRIPTION
**Category:** fix
**User Impact:** Skills search has one clear control, import uses a clearer icon, and toolbar actions stay aligned with the skill grid on wide screens.
**Problem:** The Skills search displayed both the browser-native clear control and Berd's close action, while the import affordance and wide-screen toolbar alignment did not clearly match the content area.
**Solution:** Hide the native clear control for the pill-card search variant, use a downward-to-container import icon, and constrain the Skills toolbar and grid within the same centered width.

<details>
<summary>File changes</summary>

**src/features/skills/ui/SkillsView.tsx**
Updates the import icon and constrains the Skills toolbar and grid to a shared centered width on wide screens.

**src/features/skills/ui/__tests__/SkillsView.test.tsx**
Adds coverage for the wide-screen content constraint.

**src/shared/ui/SearchBar.tsx**
Hides WebKit's native clear control specifically for pill-card searches that provide their own close action.

**src/shared/ui/SearchBar.test.tsx**
Verifies that pill-card searches hide the native clear control while default searches retain it.

</details>
