### PR TITLE
align agent import icon with import actions

### DIFF
--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -1,6 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { IconPhotoPlus, IconUpload } from "@tabler/icons-react";
-
 import { useTranslation } from "react-i18next";
 import type { PersonaImportPreview } from "@/shared/api/agents";
 import type { SnapshotV1 } from "@/features/agents/agent-snapshot";
@@ -292,10 +290,6 @@ export function AgentImportDialog({
                 isDragOver && "border-ring bg-muted/70",
               )}
             >
-              <IconPhotoPlus
-                className="size-10 text-muted-foreground"
-                aria-hidden="true"
-              />
               <p className="text-sm">
                 {preparing
                   ? t("importDialog.preparing")
@@ -304,7 +298,6 @@ export function AgentImportDialog({
               <Button
                 type="button"
                 variant="outline"
-                leftIcon={<IconUpload />}
                 feedbackState={preparing ? "loading" : "idle"}
                 loadingLabel={t("importDialog.preparing")}
                 onClick={openFilePicker}

--- a/src/features/agents/ui/PersonaGallery.tsx
+++ b/src/features/agents/ui/PersonaGallery.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { IconPhotoPlus, IconPlus } from "@tabler/icons-react";
+import { IconArrowDownToArc, IconPlus } from "@tabler/icons-react";
 import { selectAvatarImageUrl } from "@/shared/api/artifacts";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
@@ -410,7 +410,7 @@ export function PersonaGallery({
                     onImportAgentImage();
                   }}
                 >
-                  <IconPhotoPlus />
+                  <IconArrowDownToArc className="size-3.5" />
                   {t("gallery.importViaImage")}
                 </AgentAddChoiceButton>
               ) : null}


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Agent imports now use a consistent import symbol and a cleaner file picker modal.

**Problem:** The agent import action used an add-photo icon, which suggested adding an image rather than importing an agent. The import modal also repeated decorative icons that added visual noise.

**Solution:** Use the standard `IconArrowDownToArc` import symbol in the agent gallery and remove redundant icons from the modal and its Open Finder button.

<details>
<summary>File changes</summary>

**src/features/agents/ui/PersonaGallery.tsx**
Replaces the add-photo symbol with the standard import icon and matches its size to adjacent actions.

**src/features/agents/ui/AgentImportDialog.tsx**
Removes the decorative modal icon and the icon from the Open Finder button for a simpler import flow.

</details>
