### PR TITLE
Remove obsolete Builder, Debugger, and Generalist definitions

### DIFF
--- a/src/features/onboarding/model/catalog.test.ts
+++ b/src/features/onboarding/model/catalog.test.ts
@@ -7,9 +7,9 @@ import {
 } from "./catalog";
 
 describe("onboarding catalog", () => {
-  it("provides seven placeholder agents backed by app avatar references", () => {
-    expect(RECOMMENDED_AGENTS).toHaveLength(7);
-    expect(new Set(RECOMMENDED_AGENTS.map((agent) => agent.id)).size).toBe(7);
+  it("provides four placeholder agents backed by app avatar references", () => {
+    expect(RECOMMENDED_AGENTS).toHaveLength(4);
+    expect(new Set(RECOMMENDED_AGENTS.map((agent) => agent.id)).size).toBe(4);
     expect(
       RECOMMENDED_AGENTS.every((agent) =>
         agent.avatar.startsWith("app-avatar:"),
@@ -23,10 +23,6 @@ describe("onboarding catalog", () => {
       "design",
     ]);
     expect(recommendations).toHaveLength(3);
-    expect(recommendations.slice(0, 2).map((agent) => agent.id)).toEqual([
-      "reviewer",
-      "generalist",
-    ]);
     expect(recommendationsForWorkTypes([])).toHaveLength(3);
   });
 

--- a/src/features/onboarding/model/catalog.ts
+++ b/src/features/onboarding/model/catalog.ts
@@ -37,22 +37,6 @@ export interface RecommendedAgent {
 
 export const RECOMMENDED_AGENTS: readonly RecommendedAgent[] = [
   {
-    id: "builder",
-    canonicalName: "Builder",
-    canonicalPromptDescription:
-      "A practical partner for implementing product work.",
-    avatar: "app-avatar:gloopies-1",
-    workTypeIds: ["engineering", "product"],
-  },
-  {
-    id: "debugger",
-    canonicalName: "Debugger",
-    canonicalPromptDescription:
-      "A methodical investigator for curious failures.",
-    avatar: "app-avatar:gloopies-2",
-    workTypeIds: ["engineering", "legal"],
-  },
-  {
     id: "planner",
     canonicalName: "Planner",
     canonicalPromptDescription:
@@ -83,14 +67,6 @@ export const RECOMMENDED_AGENTS: readonly RecommendedAgent[] = [
       "A research companion for unfamiliar systems and choices.",
     avatar: "app-avatar:gloopies-15",
     workTypeIds: ["legal", "design"],
-  },
-  {
-    id: "generalist",
-    canonicalName: "Generalist",
-    canonicalPromptDescription:
-      "A flexible collaborator for a little of everything.",
-    avatar: "app-avatar:gloopies-19",
-    workTypeIds: [...WORK_TYPE_IDS],
   },
 ];
 

--- a/src/features/onboarding/model/onboardingState.test.ts
+++ b/src/features/onboarding/model/onboardingState.test.ts
@@ -36,7 +36,7 @@ describe("onboardingReducer", () => {
     );
     state = onboardingReducer(state, {
       type: "select-agent",
-      agentId: "builder",
+      agentId: "test-agent",
     });
     state = onboardingReducer(state, {
       type: "select-harness",
@@ -49,7 +49,7 @@ describe("onboardingReducer", () => {
       lifecycle: "in-progress",
       step: "recommendations",
       selectedWorkTypeIds: ["write-code"],
-      selectedAgentId: "builder",
+      selectedAgentId: "test-agent",
       selectedHarnessId: "goose",
       completedHarnessSetupIds: [],
     });
@@ -86,7 +86,7 @@ describe("onboardingReducer", () => {
       {
         ...INITIAL_ONBOARDING_STATE,
         selectedWorkTypeIds: ["engineering"],
-        selectedAgentId: "builder",
+        selectedAgentId: "test-agent",
         selectedHarnessId: "goose",
         completedHarnessSetupIds: ["goose"],
         shareUsageData: false,

--- a/src/features/onboarding/model/onboardingStore.test.ts
+++ b/src/features/onboarding/model/onboardingStore.test.ts
@@ -77,6 +77,36 @@ describe("onboarding persistence", () => {
     );
   });
 
+  it.each([
+    ["in-progress", "recommendations"],
+    ["completed", "complete"],
+  ] as const)("preserves established %s records with retired recommendation selections", (lifecycle, step) => {
+    for (const selectedAgentId of ["builder", "debugger", "generalist"]) {
+      const state = {
+        ...INITIAL_ONBOARDING_STATE,
+        lifecycle,
+        step,
+        selectedWorkTypeIds: ["engineering"],
+        selectedAgentId,
+        selectedHarnessId: "goose",
+        completedHarnessSetupIds: ["goose"],
+        shareUsageData: false,
+      };
+      window.localStorage.setItem(
+        ONBOARDING_STORAGE_KEY,
+        JSON.stringify({ version: ONBOARDING_STORAGE_VERSION, state }),
+      );
+
+      initializeOnboardingGraduation("established-before-landing-v1");
+      resetOnboardingStoreForTests();
+
+      expect(getOnboardingSnapshot()).toEqual({
+        ...state,
+        selectedAgentId: null,
+      });
+    }
+  });
+
   it("does not graduate when the cohort is unknown", () => {
     initializeOnboardingGraduation("unknown");
     resetOnboardingStoreForTests();
@@ -97,20 +127,18 @@ describe("onboarding persistence", () => {
 
   it("persists versioned state and hydrates it on a new lifecycle", () => {
     dispatchOnboarding({ type: "start" });
-    dispatchOnboarding({ type: "select-agent", agentId: "builder" });
-
     const persisted = JSON.parse(
       window.localStorage.getItem(ONBOARDING_STORAGE_KEY) ?? "null",
     );
     expect(persisted).toMatchObject({
       version: ONBOARDING_STORAGE_VERSION,
-      state: { lifecycle: "in-progress", selectedAgentId: "builder" },
+      state: { lifecycle: "in-progress", selectedAgentId: null },
     });
 
     resetOnboardingStoreForTests();
     expect(getOnboardingSnapshot()).toMatchObject({
       lifecycle: "in-progress",
-      selectedAgentId: "builder",
+      selectedAgentId: null,
     });
   });
 
@@ -183,7 +211,7 @@ describe("onboarding persistence", () => {
         state: {
           ...INITIAL_ONBOARDING_STATE,
           selectedWorkTypeIds: ["engineering", "engineering"],
-          selectedAgentId: "builder",
+          selectedAgentId: null,
           selectedHarnessId: "goose",
           completedHarnessSetupIds: ["goose", "goose", "claude-acp"],
         },
@@ -192,9 +220,43 @@ describe("onboarding persistence", () => {
 
     expect(getOnboardingSnapshot()).toMatchObject({
       selectedWorkTypeIds: ["engineering"],
-      selectedAgentId: "builder",
+      selectedAgentId: null,
       selectedHarnessId: "goose",
       completedHarnessSetupIds: ["goose", "claude-acp"],
+    });
+  });
+
+  it.each([
+    "builder",
+    "debugger",
+    "generalist",
+  ])("hydrates a completed record with retired %s selection", (selectedAgentId) => {
+    window.localStorage.setItem(
+      ONBOARDING_STORAGE_KEY,
+      JSON.stringify({
+        version: ONBOARDING_STORAGE_VERSION,
+        state: {
+          ...INITIAL_ONBOARDING_STATE,
+          lifecycle: "completed",
+          step: "complete",
+          selectedWorkTypeIds: ["engineering"],
+          selectedAgentId,
+          selectedHarnessId: "goose",
+          completedHarnessSetupIds: ["goose"],
+          shareUsageData: false,
+        },
+      }),
+    );
+
+    expect(getOnboardingSnapshot()).toEqual({
+      ...INITIAL_ONBOARDING_STATE,
+      lifecycle: "completed",
+      step: "complete",
+      selectedWorkTypeIds: ["engineering"],
+      selectedAgentId: null,
+      selectedHarnessId: "goose",
+      completedHarnessSetupIds: ["goose"],
+      shareUsageData: false,
     });
   });
 

--- a/src/features/onboarding/model/onboardingStore.ts
+++ b/src/features/onboarding/model/onboardingStore.ts
@@ -38,6 +38,11 @@ let storageOverrideForTests: Storage | null | undefined;
 
 const workTypeIds = new Set<string>(WORK_TYPE_IDS);
 const agentIds = new Set(RECOMMENDED_AGENTS.map((agent) => agent.id));
+const retiredRecommendedAgentIds = new Set([
+  "builder",
+  "debugger",
+  "generalist",
+]);
 const harnessIds = new Set<string>(CURATED_HARNESS_IDS);
 
 function storage(): Storage | null {
@@ -81,7 +86,9 @@ export function initializeOnboardingGraduation(
             record.version > ONBOARDING_STORAGE_VERSION) ||
           (record.version === ONBOARDING_STORAGE_VERSION &&
             isValidPersistedState(
-              record.state as Partial<OnboardingState> | undefined,
+              normalizeRetiredRecommendedAgent(
+                (record.state as Partial<OnboardingState> | undefined) ?? {},
+              ),
             ))
         );
       } catch {
@@ -152,6 +159,14 @@ function isValidPersistedState(
   );
 }
 
+function normalizeRetiredRecommendedAgent(
+  state: Partial<OnboardingState>,
+): Partial<OnboardingState> {
+  return retiredRecommendedAgentIds.has(state.selectedAgentId ?? "")
+    ? { ...state, selectedAgentId: null }
+    : state;
+}
+
 function parsePersisted(raw: string | null): OnboardingState {
   hasUnsupportedNewerRecord = false;
   if (raw === null) return { ...INITIAL_ONBOARDING_STATE };
@@ -168,7 +183,9 @@ function parsePersisted(raw: string | null): OnboardingState {
         record.version > ONBOARDING_STORAGE_VERSION;
       return { ...INITIAL_ONBOARDING_STATE };
     }
-    const state = record.state as Partial<OnboardingState> | undefined;
+    const state = normalizeRetiredRecommendedAgent(
+      (record.state as Partial<OnboardingState> | undefined) ?? {},
+    );
     if (!isValidPersistedState(state)) {
       return { ...INITIAL_ONBOARDING_STATE };
     }

--- a/src/features/onboarding/ui/RecommendationsStep.test.tsx
+++ b/src/features/onboarding/ui/RecommendationsStep.test.tsx
@@ -29,10 +29,10 @@ vi.mock("@/shared/ui/avatar-media", () => ({
 }));
 
 const agent: RecommendedAgent = {
-  id: "builder",
-  canonicalName: "Builder",
+  id: "test-agent",
+  canonicalName: "Test Agent",
   canonicalPromptDescription: "Builds things.",
-  avatar: "app-avatar:gloopies-01",
+  avatar: "app-avatar:test-fixture",
   workTypeIds: ["engineering"],
 };
 

--- a/src/shared/i18n/locales/en/onboarding.json
+++ b/src/shared/i18n/locales/en/onboarding.json
@@ -57,14 +57,6 @@
     "genericError": "Some agents could not be adopted. Try again.",
     "adoptionError": "Couldn’t adopt {{names}}. The other agents were kept; try again for the rest.",
     "agents": {
-      "builder": {
-        "name": "Builder",
-        "description": "A practical partner for implementing product work."
-      },
-      "debugger": {
-        "name": "Debugger",
-        "description": "A methodical investigator for curious failures."
-      },
       "planner": {
         "name": "Planner",
         "description": "A structured thinker for research and technical plans."
@@ -80,10 +72,6 @@
       "explorer": {
         "name": "Explorer",
         "description": "A research companion for unfamiliar systems and choices."
-      },
-      "generalist": {
-        "name": "Generalist",
-        "description": "A flexible collaborator for a little of everything."
       }
     },
     "partialAdoptionWarning": "Some agents were kept, but {{names}} could not be added. You can continue and try again later."

--- a/src/shared/i18n/locales/es/onboarding.json
+++ b/src/shared/i18n/locales/es/onboarding.json
@@ -57,14 +57,6 @@
     "genericError": "No se pudieron añadir algunos agentes. Inténtalo de nuevo.",
     "adoptionError": "No se pudo añadir a {{names}}. Los demás agentes se conservaron; inténtalo de nuevo para añadir el resto.",
     "agents": {
-      "builder": {
-        "name": "Builder",
-        "description": "Un aliado práctico para implementar productos."
-      },
-      "debugger": {
-        "name": "Debugger",
-        "description": "Un investigador metódico para fallos desconcertantes."
-      },
       "planner": {
         "name": "Planner",
         "description": "Un pensador estructurado para investigaciones y planes técnicos."
@@ -80,10 +72,6 @@
       "explorer": {
         "name": "Explorer",
         "description": "Un compañero de investigación para sistemas y decisiones desconocidos."
-      },
-      "generalist": {
-        "name": "Generalist",
-        "description": "Un colaborador flexible para un poco de todo."
       }
     },
     "partialAdoptionWarning": "Se conservaron algunos agentes, pero no se pudo añadir a {{names}}. Puedes continuar e intentarlo de nuevo más tarde."


### PR DESCRIPTION
🤖 Brother Darryl

## Summary

Remove Builder, Debugger, and Generalist from Berd’s retired onboarding recommendation catalog while preserving valid version-1 onboarding records that selected one of those retired IDs.

## Details

- Deletes only the three obsolete recommendation definitions and their English/Spanish onboarding copy.
- During version-1 hydration **and established-install startup graduation**, normalizes only `builder`, `debugger`, and `generalist` selections to `null` before existing validation. Lifecycle, consent, provider/harness setup, work types, and all unrelated valid fields remain intact.
- Unknown agent IDs remain invalid and continue to reset the malformed record.
- Bundled agents, avatars, and current visible onboarding behavior are unchanged.

## Verification

- Blox full onboarding suite: `pnpm vitest run src/features/onboarding` — 13 files, 80 passed at `598957205be228617ceaac95bf0b749f5600132a`.
- Direct-hydration discriminator covers all three retired IDs.
- Startup-order discriminator covers all three retired IDs across `in-progress/recommendations` and `completed/complete` lifecycle states with work types, harness/setup, and consent populated. It fails at `5d4aac1` and passes at the final head.