### PR TITLE
test: align smoke assertions with current home

### DIFF
--- a/tests/e2e/fixtures/tauri-mock.ts
+++ b/tests/e2e/fixtures/tauri-mock.ts
@@ -674,6 +674,8 @@ export function buildInitScript(options?: {
             // ---- ACP transport ----
             case "get_goose_serve_url":
               return Promise.resolve(FAKE_ACP_URL);
+            case "get_installation_cohort":
+              return Promise.resolve("established-before-landing-v1");
             case "get_voice_conversation_status":
             case "get_native_voice_conversation_status":
               return Promise.resolve(clone(VOICE_CONVERSATION_STATUS));

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,28 +1,26 @@
 import { expect, test } from "./fixtures/tauri-mock";
 
 test.describe("Smoke tests", () => {
-  test("app loads and shows home screen", async ({ tauriMocked: page }) => {
-    await page.goto("/");
-
-    await expect(page.getByText("Welcome to Goose for Block")).toBeVisible({
-      timeout: 10_000,
-    });
-  });
-
-  test("home screen shows onboarding actions", async ({
+  test("app loads and shows the provider setup home screen", async ({
     tauriMocked: page,
   }) => {
     await page.goto("/");
 
-    await expect(page.getByRole("button", { name: "New project" })).toBeVisible(
-      { timeout: 10_000 },
-    );
     await expect(
-      page.getByRole("button", { name: "Build agent" }),
-    ).toBeVisible();
+      page.getByRole("heading", {
+        name: "Choose an AI provider to start chatting",
+      }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("home screen shows provider setup action", async ({
+    tauriMocked: page,
+  }) => {
+    await page.goto("/");
+
     await expect(
-      page.getByRole("button", { name: "Explore skills" }),
-    ).toBeVisible();
+      page.getByRole("button", { name: "Open AI providers" }),
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test("home screen shows chat controls", async ({ tauriMocked: page }) => {


### PR DESCRIPTION
🤖

## Summary
The browser smoke suite was asserting a home screen that no longer renders, so it could not describe the shipped provider-setup experience. This updates the smoke coverage to match the current home screen and graduates the mocked install through the app's established-install path.

### Related issue
None found.

### Testing
- `pnpm test:e2e:smoke` — 3 passed on Blox at `31c16f3da83d117212762967b936e2b77469230a`.
- `ci.yml` runs only `test:transcript-virtualization:ci` and does not invoke `test:e2e:smoke`, so the reported Blox run is the sole validation for this suite.
- `pnpm test:e2e:drafts` — 6 failures, all blocked by the existing `waitForHome` expectation; baseline without this fixture change produced the same failures.
- `pnpm test:e2e:skills` — 6 failures, all blocked by the existing `navigateToSkills` home expectation; baseline without this fixture change produced the same failures. These pre-existing failures are out of scope for this assertion-only change.
- `git diff --check` — passed.
