### PR TITLE
fix(voice): allow starting voice conversation after models install

### DIFF
--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -74,6 +74,7 @@ import { usePocketVoiceSetup } from "@/features/voice-conversation/hooks/usePock
 import { PocketVoiceSetupDialog } from "@/features/voice-conversation/ui/PocketVoiceSetupDialog";
 import { useProfileCapabilities } from "@/shared/profile/capabilities";
 import { consumePendingVoiceStart } from "@/features/voice-conversation/lib/pendingVoiceStart";
+import { useVoiceConversationStore } from "@/features/voice-conversation/stores/voiceConversationStore";
 import {
   SecurityConfirmationPanel,
   useHasPendingSecurityConfirmation,
@@ -231,6 +232,9 @@ export function ChatView({
     useTerminalFallbackCwdPreference();
   const capabilities = useProfileCapabilities();
   const pocketVoiceSetup = usePocketVoiceSetup(capabilities.voiceConversation);
+  const requestVoiceConversationStart = useVoiceConversationStore(
+    (state) => state.requestStart,
+  );
   const [pocketVoiceSetupOpen, setPocketVoiceSetupOpen] = useState(false);
   const pendingPocketVoiceStartRef = useRef<string | null>(null);
   const voiceConversation = useVoiceConversationController({
@@ -262,8 +266,8 @@ export function ChatView({
     const shouldStart =
       consumePendingVoiceStart(pendingPocketVoiceStartRef) === sessionId;
     setPocketVoiceSetupOpen(false);
-    if (shouldStart) void voiceConversation.onToggle();
-  }, [sessionId, voiceConversation.onToggle]);
+    if (shouldStart) requestVoiceConversationStart(sessionId);
+  }, [requestVoiceConversationStart, sessionId]);
   const isAgentBuilderOpen = agentBuilderOpenForLayout;
   const patchSession = useChatSessionStore((s) => s.patchSession);
   const agentBuilderContextState = effectiveSession?.agentBuilderContextState;

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.test.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useVoiceConversationStore } from "../stores/voiceConversationStore";
 
@@ -14,6 +15,7 @@ import {
   shouldStartRequestedVoiceConversation,
   shouldStopVoiceWhenRouteUnmounts,
   startPendingTranscriptRecovery,
+  useVoiceConversationController,
   waitForVoiceDeliveryOpportunity,
 } from "./useVoiceConversationController";
 
@@ -265,6 +267,65 @@ describe("voice transcript delivery coordination", () => {
         routeReady: false,
       }),
     ).toBe(false);
+  });
+
+  it("starts a first-run request after Pocket installation refreshes availability", async () => {
+    const init = vi.fn().mockResolvedValue(undefined);
+    const start = vi.fn().mockResolvedValue({
+      available: true,
+      unavailableReason: null,
+      lifecycle: "starting" as const,
+      sessionId: "session-1",
+      ownerWindowLabel: "main",
+      revision: 1,
+    });
+    useVoiceConversationStore.setState({
+      status: {
+        available: false,
+        unavailableReason: "Download Pocket TTS.",
+        lifecycle: "unavailable",
+        sessionId: null,
+        ownerWindowLabel: null,
+        revision: 0,
+      },
+      hydrated: true,
+      init,
+      start,
+      requestedStartSessionId: "session-1",
+    });
+
+    const options = {
+      sessionId: "session-1",
+      onSend: vi.fn().mockResolvedValue(true),
+      enabled: true,
+      isGooseSession: true,
+      onPocketSetupRequired: vi.fn(),
+    };
+    const { rerender } = renderHook(
+      ({ pocketReady }) =>
+        useVoiceConversationController({ ...options, pocketReady }),
+      { initialProps: { pocketReady: false } },
+    );
+
+    await waitFor(() => expect(init).toHaveBeenCalledTimes(1));
+    rerender({ pocketReady: true });
+    await waitFor(() => expect(init).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      useVoiceConversationStore.setState((state) => ({
+        status: {
+          ...state.status,
+          available: true,
+          unavailableReason: null,
+          lifecycle: "stopped",
+        },
+      }));
+    });
+
+    await waitFor(() => expect(start).toHaveBeenCalledWith("session-1"));
+    expect(
+      useVoiceConversationStore.getState().requestedStartSessionId,
+    ).toBeNull();
   });
 
   it("does not let navigation steal an active voice session route", () => {

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type {
   ChatInputSendHandler,
@@ -510,6 +510,7 @@ export function useVoiceConversationController({
   const clearRequestedStart = useVoiceConversationStore(
     (state) => state.clearRequestedStart,
   );
+  const previousPocketReady = useRef(pocketReady);
 
   useEffect(
     () =>
@@ -537,6 +538,18 @@ export function useVoiceConversationController({
       addErrorNotification(sessionId, errorText(initError));
     });
   }, [enabled, init, isGooseSession, sessionId]);
+
+  useEffect(() => {
+    const becameReady = pocketReady && !previousPocketReady.current;
+    previousPocketReady.current = pocketReady;
+    if (!becameReady || !enabled || !isGooseSession) return;
+
+    // Installing the models changes native availability without a voice
+    // lifecycle event. Refresh it before consuming a pending start request.
+    void init().catch((initError) => {
+      addErrorNotification(sessionId, errorText(initError));
+    });
+  }, [enabled, init, isGooseSession, pocketReady, sessionId]);
 
   useEffect(() => {
     if (enabled && isGooseSession) ensureVoiceEventDeliveryInitialized();


### PR DESCRIPTION
## Problem

On a new installation, someone can set up Voice Conversation, download the required models, choose a voice, and click **Use selected voice**. They return to the chat, but Voice Conversation does not start and its button stays disabled. Switching to another chat and back makes it work.

## Fix

Remember that the person asked to start Voice Conversation. Once setup is fully ready, start it in the same chat automatically.

## Testing

A focused test recreates that exact sequence:

1. Voice Conversation is not ready yet.
2. The person asks to start it.
3. Setup finishes.
4. Berd refreshes its readiness and starts Voice Conversation in the original chat.

The test fails on `main` because Berd never refreshes after setup. It passes in this PR.

Manual verification also passed: clearing the voice models, downloading them again, choosing a voice, and clicking **Use selected voice** starts Voice Conversation in the original chat without switching chats.

## Screenshots

Not applicable. This fixes background setup state, not a visible layout.