### PR TITLE
fix(chat): show speech status across tool calls

### DIFF
--- a/src/features/chat/transcript/projection/buildTranscriptItems.ts
+++ b/src/features/chat/transcript/projection/buildTranscriptItems.ts
@@ -946,9 +946,13 @@ function compactWorkContent(
 
       const previous = compacted[compacted.length - 1];
 
-      if (previous?.type === "text" && sanitizedBlock.type === "text") {
+      if (
+        previous?.type === "text" &&
+        sanitizedBlock.type === "text" &&
+        previous.speech?.status === sanitizedBlock.speech?.status
+      ) {
         compacted[compacted.length - 1] = {
-          type: "text",
+          ...previous,
           text: `${previous.text}${sanitizedBlock.text}`,
         };
         continue;
@@ -1020,12 +1024,24 @@ function getCompanionIdentity(block: MessageContent): string {
 function compactTextContent(
   content: readonly TextLikeContent[],
 ): MessageContent[] {
-  const text = content
-    .map((block) => block.text.trim())
-    .filter(Boolean)
-    .join("\n\n");
+  const compacted: TextLikeContent[] = [];
+  for (const block of content) {
+    const text = block.text.trim();
+    if (!text) continue;
 
-  return text ? [{ type: "text", text }] : [];
+    const previous = compacted[compacted.length - 1];
+    if (previous && previous.speech?.status === block.speech?.status) {
+      compacted[compacted.length - 1] = {
+        ...previous,
+        text: `${previous.text}\n\n${text}`,
+      };
+      continue;
+    }
+
+    compacted.push({ ...block, text });
+  }
+
+  return compacted;
 }
 
 function estimateAgentWorkHeight(content: readonly MessageContent[]): number {

--- a/src/features/chat/transcript/projection/transcriptProjectionCache.test.ts
+++ b/src/features/chat/transcript/projection/transcriptProjectionCache.test.ts
@@ -1166,6 +1166,102 @@ describe("transcript projection cache", () => {
     }
   });
 
+  it("preserves speech state across agent-work and final-answer projection", () => {
+    const cache = createTranscriptProjectionCache();
+    const assistant = messageWithContent(
+      "assistant-voice-work",
+      "assistant",
+      [
+        {
+          type: "text",
+          text: "First spoken block.",
+          speech: { status: "spoken" },
+        },
+        toolRequest("tool-1"),
+        {
+          type: "thinking",
+          text: "Considering the result.",
+        },
+        {
+          type: "text",
+          text: "Final speaking block.",
+          speech: { status: "speaking" },
+        },
+      ],
+      utc(2026, 6, 4, 10),
+    );
+
+    const snapshot = update(cache, [assistant]);
+    const work = snapshot.items.find(
+      (item) => item.itemId === "message:assistant-voice-work:agent-work",
+    );
+    const answer = snapshot.items.find(
+      (item) => item.itemId === "message:assistant-voice-work:answer",
+    );
+
+    expect(work?.kind).toBe("agent-work");
+    if (work?.kind === "agent-work") {
+      expect(work.content).toContainEqual({
+        type: "text",
+        text: "First spoken block.",
+        speech: { status: "spoken" },
+      });
+    }
+    expect(answer?.kind).toBe("message");
+    if (answer?.kind === "message") {
+      expect(answer.visibleContent).toEqual([
+        {
+          type: "text",
+          text: "Final speaking block.",
+          speech: { status: "speaking" },
+        },
+      ]);
+    }
+  });
+
+  it("keeps adjacent final text with different speech states separate", () => {
+    const cache = createTranscriptProjectionCache();
+    const assistant = messageWithContent(
+      "assistant-voice-segments",
+      "assistant",
+      [
+        { type: "thinking", text: "Preparing two segments." },
+        {
+          type: "text",
+          text: "Already spoken.",
+          speech: { status: "spoken" },
+        },
+        {
+          type: "text",
+          text: "Speaking now.",
+          speech: { status: "speaking" },
+        },
+      ],
+      utc(2026, 6, 4, 10),
+    );
+
+    const snapshot = update(cache, [assistant]);
+    const answer = snapshot.items.find(
+      (item) => item.itemId === "message:assistant-voice-segments:answer",
+    );
+
+    expect(answer?.kind).toBe("message");
+    if (answer?.kind === "message") {
+      expect(answer.visibleContent).toEqual([
+        {
+          type: "text",
+          text: "Already spoken.",
+          speech: { status: "spoken" },
+        },
+        {
+          type: "text",
+          text: "Speaking now.",
+          speech: { status: "speaking" },
+        },
+      ]);
+    }
+  });
+
   it("keeps an MCP companion row identity stable when another app is inserted", () => {
     const cache = createTranscriptProjectionCache();
     const mcpApp = (id: string): McpAppContent => ({

--- a/src/features/chat/ui/AgentWorkPanel.tsx
+++ b/src/features/chat/ui/AgentWorkPanel.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/shared/ui/button";
 import type {
   MessageContent,
+  TextContent,
   ThinkingContent,
   ReasoningContent,
   ToolRequestContent,
@@ -29,6 +30,7 @@ import type {
 import type { TranscriptAgentWorkPayload } from "@/features/chat/transcript/projection/transcriptItemTypes";
 import { useTranscriptRowStateAdapter } from "@/features/chat/transcript/row-state";
 import { ToolCallAdapter } from "./ToolCallAdapter";
+import { VoiceSpeechStatusIndicator } from "./VoiceSpeechStatusIndicator";
 
 interface ToolTimelineItem {
   kind: "tool";
@@ -51,7 +53,7 @@ interface RedactedThoughtTimelineItem {
 interface ProgressTimelineItem {
   kind: "progress";
   key: string;
-  text: string;
+  content: TextContent;
 }
 
 interface ActivePreviewState {
@@ -141,13 +143,19 @@ function buildAgentWorkTimeline(
 
     if (block.type === "text") {
       const previous = items[items.length - 1];
-      if (previous?.kind === "progress") {
-        previous.text += block.text;
+      if (
+        previous?.kind === "progress" &&
+        previous.content.speech?.status === block.speech?.status
+      ) {
+        previous.content = {
+          ...previous.content,
+          text: previous.content.text + block.text,
+        };
       } else if (block.text.trim()) {
         items.push({
           kind: "progress",
           key: `progress-${index}`,
-          text: block.text,
+          content: block,
         });
       }
       continue;
@@ -298,16 +306,34 @@ function AgentWorkItemRow({
   }
 
   if (item.kind === "progress") {
+    const speechStatus = item.content.speech?.status;
+    const speechLabel = speechStatus
+      ? {
+          speaking: t("message.voiceSpeechSpeakingLabel"),
+          spoken: t("message.voiceSpeechSpokenLabel"),
+          interrupted: t("message.voiceSpeechInterruptedLabel"),
+          notSpoken: t("message.voiceSpeechNotSpokenLabel"),
+          failed: t("message.voiceSpeechFailedLabel"),
+        }[speechStatus]
+      : null;
     return (
       <div className="flex gap-2.5">
         <WorkRail isLast={isLast} status="progress" primary={usePrimaryText} />
         <div
+          data-voice-speech-status={speechStatus}
           className={cn(
             "min-w-0 flex-1 pb-2 text-sm leading-relaxed",
             usePrimaryText ? "text-foreground" : "text-muted-foreground",
+            speechStatus === "interrupted" && "line-through opacity-70",
           )}
         >
-          <MessageResponse mode="static">{item.text}</MessageResponse>
+          {speechStatus && speechLabel ? (
+            <VoiceSpeechStatusIndicator
+              status={speechStatus}
+              label={speechLabel}
+            />
+          ) : null}
+          <MessageResponse mode="static">{item.content.text}</MessageResponse>
         </div>
       </div>
     );

--- a/src/features/chat/ui/MessageBubble.tsx
+++ b/src/features/chat/ui/MessageBubble.tsx
@@ -1,12 +1,6 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Check,
-  FileText,
-  FolderClosed,
-  ImageIcon,
-  Volume2,
-} from "lucide-react";
+import { Check, FileText, FolderClosed, ImageIcon } from "lucide-react";
 import { IconRobot } from "@tabler/icons-react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { openPath, openUrl } from "@tauri-apps/plugin-opener";
@@ -69,6 +63,7 @@ import {
   UserMessageClamp,
 } from "./UserMessageClamp";
 import { ImageLightbox } from "@/shared/ui/ImageLightbox";
+import { VoiceSpeechStatusIndicator } from "./VoiceSpeechStatusIndicator";
 
 interface MessageAttachmentPreviewItem {
   key: string;
@@ -554,17 +549,11 @@ function renderContentBlock(
             speechStatus === "interrupted" && "line-through opacity-70",
           )}
         >
-          {speechLabel ? (
-            <div
-              className={cn(
-                "mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground",
-                speechStatus === "failed" && "text-destructive",
-                speechStatus === "interrupted" && "text-warning",
-              )}
-            >
-              <Volume2 aria-hidden="true" className="size-3.5" />
-              <span>{speechLabel}</span>
-            </div>
+          {speechStatus && speechLabel ? (
+            <VoiceSpeechStatusIndicator
+              status={speechStatus}
+              label={speechLabel}
+            />
           ) : null}
           <MessageResponse
             isAnimating={isStreamingMsg}

--- a/src/features/chat/ui/VoiceSpeechStatusIndicator.tsx
+++ b/src/features/chat/ui/VoiceSpeechStatusIndicator.tsx
@@ -1,0 +1,25 @@
+import { Volume2 } from "lucide-react";
+
+import { cn } from "@/shared/lib/cn";
+import type { VoiceSpeechStatus } from "@/shared/types/messages";
+
+export function VoiceSpeechStatusIndicator({
+  status,
+  label,
+}: {
+  status: VoiceSpeechStatus;
+  label: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "mb-1 flex items-center gap-1.5 text-xs font-medium text-muted-foreground",
+        status === "failed" && "text-destructive",
+        status === "interrupted" && "text-warning",
+      )}
+    >
+      <Volume2 aria-hidden="true" className="size-3.5" />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/src/features/chat/ui/__tests__/AgentWorkPanel.test.tsx
+++ b/src/features/chat/ui/__tests__/AgentWorkPanel.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { TranscriptAgentWorkPayload } from "@/features/chat/transcript/projection/transcriptItemTypes";
+import { renderWithProviders } from "@/test/render";
+import { AgentWorkPanel } from "../AgentWorkPanel";
+
+describe("AgentWorkPanel", () => {
+  it("renders independent speech states for progress text", () => {
+    const content = [
+      {
+        type: "text" as const,
+        text: "Already spoken.",
+        speech: { status: "spoken" as const },
+      },
+      {
+        type: "text" as const,
+        text: "Speaking now.",
+        speech: { status: "speaking" as const },
+      },
+    ];
+    const payload: TranscriptAgentWorkPayload = {
+      workId: "work-1",
+      message: {
+        id: "assistant-1",
+        role: "assistant",
+        created: Date.UTC(2026, 7, 19, 15, 0),
+        content,
+      },
+      content,
+      isActiveWork: true,
+      hasFinalAnswer: false,
+      thoughtCount: 0,
+      toolCount: 0,
+      textCount: 2,
+    };
+
+    const { container } = renderWithProviders(
+      <AgentWorkPanel payload={payload} />,
+    );
+
+    expect(
+      container.querySelector('[data-voice-speech-status="spoken"]'),
+    ).toHaveTextContent("Spoken");
+    expect(
+      container.querySelector('[data-voice-speech-status="speaking"]'),
+    ).toHaveTextContent("Speaking");
+    expect(screen.getByText("Already spoken.")).toBeInTheDocument();
+    expect(screen.getByText("Speaking now.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Voice speech status labels could disappear when an assistant response mixed text with thinking or tool calls. Transcript projection rebuilt text blocks without their `speech` metadata, and the previous-steps renderer reduced progress blocks to plain strings.

This preserves each text block's speech state through agent-work and final-answer compaction, renders the same localized status indicator in previous steps and normal messages, and keeps adjacent text with different speech phases separate.

### Related issue

None found.

### Testing

A focused two-case reproduction was run unchanged against `origin/main` and this branch:

- `origin/main`: 2 failed. Final-answer projection dropped `speech.status`, and the previous-steps panel rendered no `Spoken` or `Speaking` status element.
- This branch: 2 passed. Projection retained the status metadata and both labels rendered.

Regression coverage is included for agent-work projection, final-answer projection, adjacent speech phases, and previous-step status rendering.

## Screenshots

### After

<img width="688" height="344" alt="After: Spoken status shown for previous steps and the final answer" src="https://github.com/user-attachments/assets/ce8a5f4e-8ae3-494b-a99b-f5be8aa0e3d5" />

### Before

<img width="694" height="229" alt="Before: voice speech status missing from previous steps and the final answer" src="https://github.com/user-attachments/assets/b6cddd97-7a99-48c6-a6f7-8abe647157f3" />