### PR TITLE
return focus to composer after closing pickers

### DIFF
--- a/src/features/chat/hooks/useComposerPickerCloseFocus.ts
+++ b/src/features/chat/hooks/useComposerPickerCloseFocus.ts
@@ -1,0 +1,80 @@
+import { useCallback, useRef, type RefObject } from "react";
+
+interface CloseAutoFocusEvent {
+  preventDefault: () => void;
+}
+
+type CloseFocusIntent = "return-to-composer" | "preserve-destination";
+
+const FOCUS_DESTINATION_SELECTOR = [
+  "a[href]",
+  "button:not(:disabled)",
+  "input:not(:disabled)",
+  "select:not(:disabled)",
+  "textarea:not(:disabled)",
+  "summary",
+  "audio[controls]",
+  "video[controls]",
+  "[contenteditable='']",
+  "[contenteditable='true']",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
+function isFocusDestination(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest(FOCUS_DESTINATION_SELECTOR) !== null
+  );
+}
+
+interface UseComposerPickerCloseFocusOptions {
+  triggerRef: RefObject<HTMLElement | null>;
+  onRequestComposerFocus?: () => void;
+}
+
+/** Owns close-focus intent for a composer picker across one open cycle. */
+export function useComposerPickerCloseFocus({
+  triggerRef,
+  onRequestComposerFocus,
+}: UseComposerPickerCloseFocusOptions) {
+  const intentRef = useRef<CloseFocusIntent>("return-to-composer");
+
+  const beginOpenCycle = useCallback(() => {
+    intentRef.current = "return-to-composer";
+  }, []);
+
+  const preserveFocusDestination = useCallback(() => {
+    intentRef.current = "preserve-destination";
+  }, []);
+
+  const classifyOutsideInteraction = useCallback(
+    (target: EventTarget | null) => {
+      if (target instanceof Node && triggerRef.current?.contains(target)) {
+        return;
+      }
+      intentRef.current = isFocusDestination(target)
+        ? "preserve-destination"
+        : "return-to-composer";
+    },
+    [triggerRef],
+  );
+
+  const handleCloseAutoFocus = useCallback(
+    (event: CloseAutoFocusEvent) => {
+      event.preventDefault();
+      const intent = intentRef.current;
+      intentRef.current = "return-to-composer";
+      if (intent === "return-to-composer") {
+        onRequestComposerFocus?.();
+      }
+    },
+    [onRequestComposerFocus],
+  );
+
+  return {
+    beginOpenCycle,
+    preserveFocusDestination,
+    classifyOutsideInteraction,
+    handleCloseAutoFocus,
+  };
+}

--- a/src/features/chat/ui/AgentModelPicker.tsx
+++ b/src/features/chat/ui/AgentModelPicker.tsx
@@ -14,6 +14,7 @@ import {
 } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
 import { requestOpenSettings } from "@/features/settings/lib/settingsEvents";
+import { useComposerPickerCloseFocus } from "@/features/chat/hooks/useComposerPickerCloseFocus";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { ComposerActionButton } from "@/shared/ui/composer-action-button";
@@ -59,6 +60,7 @@ interface AgentModelPickerProps {
   open?: boolean;
   onOpen?: () => void;
   onOpenChange?: (open: boolean) => void;
+  onRequestComposerFocus?: () => void;
   reasoningEffort?: ChatInputReasoningEffort;
   contentAlign?: PopoverContentAlign | "smart";
   contentCollisionPadding?: number;
@@ -178,6 +180,7 @@ export function AgentModelPicker({
   open: controlledOpen,
   onOpen,
   onOpenChange,
+  onRequestComposerFocus,
   reasoningEffort,
   contentAlign = "start",
   contentCollisionPadding = 16,
@@ -194,6 +197,15 @@ export function AgentModelPicker({
   };
   const triggerRef = useRef<HTMLButtonElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const {
+    beginOpenCycle,
+    preserveFocusDestination,
+    classifyOutsideInteraction,
+    handleCloseAutoFocus,
+  } = useComposerPickerCloseFocus({
+    triggerRef,
+    onRequestComposerFocus,
+  });
   const modelListRef = useRef<RecommendedModelListHandle>(null);
   const [providerRevealed, setProviderRevealed] = useState(false);
   const [modelBrowsing, setModelBrowsing] = useState(false);
@@ -342,6 +354,7 @@ export function AgentModelPicker({
 
   const handleAgentSelect = (agent: AgentPickerOption) => {
     if (agent.readiness && agent.readiness !== "ready") {
+      preserveFocusDestination();
       requestOpenSettings("providers");
       setOpen(false);
       return;
@@ -426,6 +439,7 @@ export function AgentModelPicker({
       open={open}
       onOpenChange={(nextOpen) => {
         if (nextOpen) {
+          beginOpenCycle();
           setResolvedContentAlign(resolveContentAlign());
         }
         setOpen(nextOpen);
@@ -486,6 +500,10 @@ export function AgentModelPicker({
           "flex max-h-[min(24rem,50vh)] flex-col overflow-hidden p-1 transition-[width] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)]",
           isWidePicker ? "w-[37.25rem]" : "w-[26.25rem]",
         )}
+        onInteractOutside={(event) => {
+          classifyOutsideInteraction(event.target);
+        }}
+        onCloseAutoFocus={handleCloseAutoFocus}
         onOpenAutoFocus={(e) => {
           // Prefer the selected row of the first visible column, then that
           // column's first enabled row, then the reveal footer. Without the

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -1967,6 +1967,7 @@ export function ChatInput({
                   onCreateProject,
                 }}
                 reasoningEffort={reasoningEffort}
+                onRequestComposerFocus={() => textareaRef.current?.focus()}
                 contextUsage={{
                   contextTokens,
                   contextLimit,

--- a/src/features/chat/ui/ChatInputSelector.tsx
+++ b/src/features/chat/ui/ChatInputSelector.tsx
@@ -12,6 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/shared/ui/dropdown-menu";
 import { cn } from "@/shared/lib/cn";
+import { useComposerPickerCloseFocus } from "@/features/chat/hooks/useComposerPickerCloseFocus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 export interface ChatInputSelectorItem {
@@ -35,6 +36,7 @@ interface ChatInputSelectorProps {
   icon?: ReactNode;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  onRequestComposerFocus?: () => void;
   triggerTabIndex?: number;
   triggerIconOnly?: boolean;
   triggerVariant?: "default" | "toolbar";
@@ -42,6 +44,7 @@ interface ChatInputSelectorProps {
   menuLabel?: string;
   sections: ChatInputSelectorSection[];
   onValueChange: (value: string) => void;
+  preservesExternalFocus?: (value: string) => boolean;
   contentWidth?: "trigger" | "wide";
   contentSide?: "top" | "right" | "bottom" | "left";
   contentAlign?: "start" | "center" | "end";
@@ -57,12 +60,14 @@ export function ChatInputSelector({
   icon,
   open,
   onOpenChange,
+  onRequestComposerFocus,
   triggerTabIndex,
   triggerVariant = "default",
   triggerSize = "default",
   menuLabel,
   sections,
   onValueChange,
+  preservesExternalFocus,
   contentWidth = "trigger",
   contentSide,
   contentAlign = "start",
@@ -70,7 +75,16 @@ export function ChatInputSelector({
   modal,
   triggerIconOnly = false,
 }: ChatInputSelectorProps) {
-  const skipCloseAutoFocusRef = useRef(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const {
+    beginOpenCycle,
+    preserveFocusDestination,
+    classifyOutsideInteraction,
+    handleCloseAutoFocus,
+  } = useComposerPickerCloseFocus({
+    triggerRef,
+    onRequestComposerFocus,
+  });
   const buttonSize = triggerIconOnly
     ? "icon-pill-sm"
     : triggerSize === "sm"
@@ -81,11 +95,19 @@ export function ChatInputSelector({
     triggerVariant === "toolbar" ? ComposerActionButton : Button;
 
   return (
-    <DropdownMenu modal={modal} open={open} onOpenChange={onOpenChange}>
+    <DropdownMenu
+      modal={modal}
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) beginOpenCycle();
+        onOpenChange?.(nextOpen);
+      }}
+    >
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger asChild>
             <TriggerButton
+              ref={triggerRef}
               type="button"
               {...(triggerVariant === "toolbar"
                 ? {}
@@ -121,16 +143,10 @@ export function ChatInputSelector({
         align={contentAlign}
         side={contentSide}
         className={cn(contentWidth === "wide" ? "w-72" : "w-56")}
-        onInteractOutside={() => {
-          skipCloseAutoFocusRef.current = true;
+        onInteractOutside={(event) => {
+          classifyOutsideInteraction(event.target);
         }}
-        onCloseAutoFocus={(event) => {
-          if (!skipCloseAutoFocusRef.current) {
-            return;
-          }
-          skipCloseAutoFocusRef.current = false;
-          event.preventDefault();
-        }}
+        onCloseAutoFocus={handleCloseAutoFocus}
       >
         {menuLabel ? (
           <>
@@ -158,7 +174,12 @@ export function ChatInputSelector({
                     <DropdownMenuItem
                       key={item.value}
                       disabled={item.disabled}
-                      onSelect={() => onValueChange(item.value)}
+                      onSelect={() => {
+                        if (preservesExternalFocus?.(item.value)) {
+                          preserveFocusDestination();
+                        }
+                        onValueChange(item.value);
+                      }}
                       className={cn(
                         "justify-between gap-2",
                         isSelected && "bg-accent",

--- a/src/features/chat/ui/ChatInputToolbar.tsx
+++ b/src/features/chat/ui/ChatInputToolbar.tsx
@@ -100,6 +100,7 @@ interface ChatInputToolbarProps {
   projectPicker: ChatInputProjectPicker;
   contextUsage: ChatInputContextUsage;
   composerActions: ChatInputToolbarComposerActions;
+  onRequestComposerFocus?: () => void;
   isCompact: boolean;
 }
 
@@ -109,6 +110,7 @@ export function ChatInputToolbar({
   projectPicker,
   contextUsage,
   composerActions,
+  onRequestComposerFocus,
   isCompact,
 }: ChatInputToolbarProps) {
   const { t } = useTranslation("chat");
@@ -367,6 +369,7 @@ export function ChatInputToolbar({
               open={openMenu === "model"}
               onOpen={onPickerOpen}
               onOpenChange={handleMenuOpenChange("model")}
+              onRequestComposerFocus={onRequestComposerFocus}
               loading={providersLoading}
               isCompact={isCompact}
               triggerIconOnly={isCompact}
@@ -383,6 +386,7 @@ export function ChatInputToolbar({
             onCreateProject={onCreateProject}
             open={openMenu === "project"}
             onOpenChange={handleMenuOpenChange("project")}
+            onRequestComposerFocus={onRequestComposerFocus}
             modal={false}
             triggerIconOnly={isCompact}
           />

--- a/src/features/chat/ui/ProjectInputSelector.tsx
+++ b/src/features/chat/ui/ProjectInputSelector.tsx
@@ -14,6 +14,7 @@ interface ProjectInputSelectorProps {
   onCreateProject?: ChatInputProjectPicker["onCreateProject"];
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  onRequestComposerFocus?: () => void;
   triggerTabIndex?: number;
   triggerIconOnly?: boolean;
   triggerVariant?: "default" | "toolbar";
@@ -32,6 +33,7 @@ export function ProjectInputSelector({
   onCreateProject,
   open,
   onOpenChange,
+  onRequestComposerFocus,
   triggerTabIndex,
   triggerVariant = "toolbar",
   triggerSize = "default",
@@ -80,6 +82,7 @@ export function ProjectInputSelector({
       }
       open={open}
       onOpenChange={onOpenChange}
+      onRequestComposerFocus={onRequestComposerFocus}
       triggerTabIndex={triggerTabIndex}
       triggerIconOnly={triggerIconOnly}
       triggerVariant={triggerVariant}
@@ -132,6 +135,7 @@ export function ProjectInputSelector({
         },
       ].filter((section) => section.items.length > 0)}
       onValueChange={handleValueChange}
+      preservesExternalFocus={(value) => value === CREATE_PROJECT_VALUE}
     />
   );
 }

--- a/src/features/chat/ui/__tests__/AgentModelPicker.test.tsx
+++ b/src/features/chat/ui/__tests__/AgentModelPicker.test.tsx
@@ -42,7 +42,10 @@ describe("AgentModelPicker", () => {
   it("routes not-ready Goose to Providers settings with a connect action", async () => {
     const user = userEvent.setup();
     const onAgentChange = vi.fn();
-    const openSettings = vi.fn();
+    const onRequestComposerFocus = vi.fn();
+    const settingsDestination = document.createElement("button");
+    document.body.appendChild(settingsDestination);
+    const openSettings = vi.fn(() => settingsDestination.focus());
     window.addEventListener(OPEN_SETTINGS_EVENT, openSettings);
 
     render(
@@ -60,6 +63,7 @@ describe("AgentModelPicker", () => {
         onAgentChange={onAgentChange}
         availableModels={[]}
         onModelChange={vi.fn()}
+        onRequestComposerFocus={onRequestComposerFocus}
       />,
     );
 
@@ -77,6 +81,8 @@ describe("AgentModelPicker", () => {
     expect(openSettings).toHaveBeenCalledWith(
       expect.objectContaining({ detail: { section: "providers" } }),
     );
+    expect(settingsDestination).toHaveFocus();
+    expect(onRequestComposerFocus).not.toHaveBeenCalled();
     window.removeEventListener(OPEN_SETTINGS_EVENT, openSettings);
   });
 

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -734,6 +734,103 @@ describe("ChatInput", () => {
     expect(screen.getByText("No project")).toBeInTheDocument();
   });
 
+  it.each([
+    ["model", /choose agent and model/i],
+    ["project", /select project/i],
+  ])("returns focus to the composer when the %s picker closes", async (_, triggerName) => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+    const composer = screen.getByRole("textbox");
+
+    await user.click(screen.getByRole("button", { name: triggerName }));
+    expect(composer).not.toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    expect(composer).toHaveFocus();
+  });
+
+  it.each([
+    ["model", /choose agent and model/i],
+    ["project", /select project/i],
+  ])("returns focus to the composer when the %s picker trigger closes it", async (_, triggerName) => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+    const composer = screen.getByRole("textbox");
+    const trigger = screen.getByRole("button", { name: triggerName });
+
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(composer).toHaveFocus();
+  });
+
+  it.each([
+    ["model", /choose agent and model/i],
+    ["project", /select project/i],
+  ])("returns focus to the composer when clicking blank space outside the %s picker", async (_, triggerName) => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+    const composer = screen.getByRole("textbox");
+    const blankSpace = document.createElement("div");
+    document.body.appendChild(blankSpace);
+
+    await user.click(screen.getByRole("button", { name: triggerName }));
+    await user.click(blankSpace);
+
+    expect(composer).toHaveFocus();
+  });
+
+  it("preserves an interactive destination when closing a picker", async () => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+    const destination = document.createElement("button");
+    destination.type = "button";
+    destination.textContent = "Outside action";
+    document.body.appendChild(destination);
+
+    await user.click(
+      screen.getByRole("button", { name: /choose agent and model/i }),
+    );
+    await user.click(destination);
+
+    expect(destination).toHaveFocus();
+  });
+
+  it("preserves a custom focusable destination when closing a picker", async () => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+    const destination = document.createElement("div");
+    destination.tabIndex = 0;
+    document.body.appendChild(destination);
+
+    await user.click(
+      screen.getByRole("button", { name: /choose agent and model/i }),
+    );
+    await user.click(destination);
+
+    expect(destination).toHaveFocus();
+  });
+
+  it("preserves project-creation focus when the picker hands off", async () => {
+    const user = userEvent.setup();
+    const projectDialog = document.createElement("button");
+    document.body.appendChild(projectDialog);
+    render(
+      <ChatInput
+        onSend={vi.fn()}
+        enabled
+        onCreateProject={() => projectDialog.focus()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select project/i }));
+    await user.click(screen.getByRole("menuitem", { name: /create project/i }));
+
+    expect(projectDialog).toHaveFocus();
+    expect(screen.getByRole("textbox")).not.toHaveFocus();
+  });
+
   it("shows project color swatches in the project selector menu", async () => {
     const user = userEvent.setup();
     render(

--- a/src/shared/ui/GlobalComposerPill.test.tsx
+++ b/src/shared/ui/GlobalComposerPill.test.tsx
@@ -429,6 +429,72 @@ describe("GlobalComposerPill", () => {
     ).toHaveAttribute("tabindex", "0");
   });
 
+  it.each([
+    ["model", /choose agent and model/i],
+    ["project", /select project/i],
+  ])("returns focus to the quick composer when the %s picker closes", async (_, triggerName) => {
+    const user = userEvent.setup();
+    renderGlobalComposer();
+    const composer = screen.getByRole("textbox");
+
+    await user.click(composer);
+    await user.click(screen.getByRole("button", { name: triggerName }));
+    expect(composer).not.toHaveFocus();
+
+    await user.keyboard("{Escape}");
+
+    expect(composer).toHaveFocus();
+  });
+
+  it("returns focus to the quick composer when the model picker trigger closes it", async () => {
+    const user = userEvent.setup();
+    renderGlobalComposer();
+    const composer = screen.getByRole("textbox");
+
+    await user.click(composer);
+    const trigger = screen.getByRole("button", {
+      name: /choose agent and model/i,
+    });
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(composer).toHaveFocus();
+  });
+
+  it.each([
+    ["model", /choose agent and model/i],
+    ["project", /select project/i],
+  ])("returns focus to the quick composer when clicking blank space outside the %s picker", async (_, triggerName) => {
+    const user = userEvent.setup();
+    renderGlobalComposer();
+    const composer = screen.getByRole("textbox");
+    const blankSpace = document.createElement("div");
+    document.body.appendChild(blankSpace);
+
+    await user.click(composer);
+    await user.click(screen.getByRole("button", { name: triggerName }));
+    await user.click(blankSpace);
+
+    expect(composer).toHaveFocus();
+  });
+
+  it("preserves an interactive destination when closing a quick-composer picker", async () => {
+    const user = userEvent.setup();
+    renderGlobalComposer();
+    const destination = document.createElement("button");
+    destination.type = "button";
+    destination.textContent = "Outside action";
+    document.body.appendChild(destination);
+
+    await user.click(screen.getByRole("textbox"));
+    await user.click(
+      screen.getByRole("button", { name: /choose agent and model/i }),
+    );
+    await user.click(destination);
+
+    expect(destination).toHaveFocus();
+  });
+
   it("toggles voice dictation with the default platform shortcut without submitting or changing the draft", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -1508,6 +1508,7 @@ export function GlobalComposerPill({
             onModelChange={handleModelChange}
             onOpen={handlePickerOpen}
             onOpenChange={setModelPickerOpen}
+            onRequestComposerFocus={() => textareaRef.current?.focus()}
             loading={providersLoading}
             isCompact
             triggerTabIndex={expanded ? 0 : -1}
@@ -1522,8 +1523,10 @@ export function GlobalComposerPill({
             onProjectChange={setSelectedProjectId}
             open={projectPickerOpen}
             onOpenChange={setProjectPickerOpen}
+            onRequestComposerFocus={() => textareaRef.current?.focus()}
             triggerTabIndex={expanded ? 0 : -1}
             contentSide="top"
+            modal={false}
           />
         </div>
 


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Closing the model or project picker now leaves the composer ready for immediate typing.
**Problem:** Model and project pickers returned focus inconsistently, often leaving users on the picker trigger or without a useful typing target after dismissal.
**Solution:** Centralize composer-picker close-focus policy so Escape, selection, trigger toggles, and blank-space dismissal return to the composer while clicks on focusable controls and handoffs to project creation or provider settings preserve their intended destination.

<details>
<summary>File changes</summary>

**src/features/chat/hooks/useComposerPickerCloseFocus.ts**
Adds the shared close-focus policy, including per-open-cycle intent and focus-destination classification.

**src/features/chat/ui/AgentModelPicker.tsx**
Routes model-picker dismissal and provider-settings handoffs through the shared focus policy.

**src/features/chat/ui/ChatInput.tsx**
Provides the docked composer textarea as the local focus destination.

**src/features/chat/ui/ChatInputSelector.tsx**
Applies the shared policy to composer dropdown selectors and supports explicit external-focus handoffs.

**src/features/chat/ui/ChatInputToolbar.tsx**
Passes the semantic composer-focus request to model and project pickers.

**src/features/chat/ui/ProjectInputSelector.tsx**
Marks project creation as an external focus handoff while ordinary project selection returns to typing.

**src/features/chat/ui/__tests__/AgentModelPicker.test.tsx**
Verifies provider setup preserves focus on the settings destination.

**src/features/chat/ui/__tests__/ChatInput.test.tsx**
Covers Escape, trigger toggles, blank-space dismissal, focusable outside targets, and project-creation handoff in the docked composer.

**src/shared/ui/GlobalComposerPill.test.tsx**
Covers the same close-focus behavior in the quick composer.

**src/shared/ui/GlobalComposerPill.tsx**
Provides the quick composer textarea as the focus destination and makes its project picker non-modal for consistent outside-click behavior.

</details>

## Verification

- `pnpm exec biome check` on changed files
- `pnpm vitest run src/features/chat/ui/__tests__/AgentModelPicker.test.tsx src/features/chat/ui/__tests__/ChatInput.test.tsx src/shared/ui/GlobalComposerPill.test.tsx` (272 tests)
- `pnpm typecheck`
- `git diff --check`
