### PR TITLE
fix: open saved agent after creation

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -569,6 +569,7 @@ vi.mock("./ui/AppShellContent", () => ({
     onBuilderbotBreadcrumbLabelChange,
     onAutomationBuilderLeaveActionChange,
     onCreatePersona,
+    onAgentBuilderCompleted,
     onExitSearch,
     onArchiveChat,
     onOpenAgent,
@@ -816,6 +817,14 @@ vi.mock("./ui/AppShellContent", () => ({
         {activeView === "agents" ? (
           <button type="button" onClick={onCreatePersona}>
             Create agent
+          </button>
+        ) : null}
+        {activeView === "chat" ? (
+          <button
+            type="button"
+            onClick={() => onAgentBuilderCompleted?.("/saved-agent.md")}
+          >
+            Complete agent builder
           </button>
         ) : null}
         {activeView === "search" ? (
@@ -3832,6 +3841,28 @@ describe("AppShell global navigation", () => {
       screen.queryByText("Save this agent draft?"),
     ).not.toBeInTheDocument();
     await waitForCreatedAgentBuilderTarget();
+  });
+
+  it("opens the saved agent detail after finishing the agent builder", async () => {
+    const user = userEvent.setup();
+    renderAppShell();
+
+    await user.click(screen.getByRole("button", { name: "Sidebar agents" }));
+    await user.click(screen.getByRole("button", { name: "Create agent" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Complete agent builder" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-view")).toHaveTextContent("agents");
+      expect(screen.getByTestId("agent-route")).toHaveTextContent(
+        "/saved-agent.md",
+      );
+    });
   });
 
   it("shows the new agent builder before the draft target is ready", async () => {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -4070,6 +4070,12 @@ export function AppShell({
     },
     [guardAppNavigation, navigateAgentsDirect],
   );
+  const handleAgentBuilderCompleted = useCallback(
+    (agentId: string) => {
+      navigateAgentsDirect(agentId);
+    },
+    [navigateAgentsDirect],
+  );
 
   const navigateAutomations = useCallback(
     (
@@ -5144,6 +5150,7 @@ export function AppShell({
                 handleAutomationBuilderLeaveActionChange
               }
               onCreatePersona={agentBuilder.create}
+              onAgentBuilderCompleted={handleAgentBuilderCompleted}
               onStartAgentBuilderSession={agentBuilder.start}
               onArchiveChat={handleArchiveChat}
               onCreateProject={(options) => {

--- a/src/app/ui/AppShellContent.tsx
+++ b/src/app/ui/AppShellContent.tsx
@@ -83,6 +83,7 @@ interface AppShellContentProps {
     action: AutomationBuilderLeaveAction | null,
   ) => void;
   onCreatePersona: () => void;
+  onAgentBuilderCompleted: (agentId: string) => void;
   onStartAgentBuilderSession: (args?: { path?: string; slug?: string }) => void;
   onArchiveChat: (sessionId: string) => Promise<CommandOutcome>;
   onCreateProject: (options?: {
@@ -153,6 +154,7 @@ export function AppShellContent({
   onBuilderbotBreadcrumbLabelChange,
   onAutomationBuilderLeaveActionChange,
   onCreatePersona,
+  onAgentBuilderCompleted,
   onStartAgentBuilderSession,
   onArchiveChat,
   onCreateProject,
@@ -252,6 +254,7 @@ export function AppShellContent({
     onChatComposerHandoffTarget,
     onWorkspaceNameRequest,
     onCreatePersona,
+    onAgentBuilderCompleted,
     onCreateProject,
     onExitSearch,
     onNavigateAgents,
@@ -335,6 +338,7 @@ interface RenderRouteContentOptions {
     action: AutomationBuilderLeaveAction | null,
   ) => void;
   onCreatePersona: () => void;
+  onAgentBuilderCompleted: (agentId: string) => void;
   onStartAgentBuilderSession: (args?: { path?: string; slug?: string }) => void;
   onArchiveChat: (sessionId: string) => Promise<CommandOutcome>;
   onCreateProject: (options?: {
@@ -391,6 +395,7 @@ function renderRouteContent({
   onWorkspaceNameRequest,
   onCloseDesignSystem,
   onCreatePersona,
+  onAgentBuilderCompleted,
   onCreateProject,
   onDesignSystemInspectorVisibleChange,
   onDesignSystemSectionChange,
@@ -523,6 +528,7 @@ function renderRouteContent({
           composerHandoffInProgress={chatComposerHandoffInProgress}
           onComposerHandoffTarget={onChatComposerHandoffTarget}
           onWorkspaceNameRequest={onWorkspaceNameRequest}
+          onAgentBuilderCompleted={onAgentBuilderCompleted}
         />
       ) : (
         (setupRequiredContent ?? (

--- a/src/features/agents/capabilities/AgentBuilderCapability.tsx
+++ b/src/features/agents/capabilities/AgentBuilderCapability.tsx
@@ -15,7 +15,11 @@ import {
 } from "@/features/agents/ui/AgentBuilderRail";
 import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
-import { listPersonas, type AgentSourceEntry } from "@/shared/api/agents";
+import {
+  agentSourceToPersona,
+  listPersonas,
+  type AgentSourceEntry,
+} from "@/shared/api/agents";
 
 /** Design width hosts should use when laying out the chat-rail render mode. */
 export const AGENT_BUILDER_RAIL_DESIGN_WIDTH =
@@ -33,6 +37,7 @@ export interface AgentBuilderCapabilityProps {
   /** Reopens the collapsed chat column while in full-page mode. */
   onExpandChat?: () => void;
   onDraftPromoted?: (source: AgentSourceEntry) => void;
+  onAgentBuilderCompleted?: (agentId: string) => void;
 }
 
 export function AgentBuilderCapability({
@@ -41,6 +46,7 @@ export function AgentBuilderCapability({
   fullPage = false,
   onExpandChat,
   onDraftPromoted,
+  onAgentBuilderCompleted,
 }: AgentBuilderCapabilityProps) {
   const { t } = useTranslation("agents");
   const patchSession = useChatSessionStore((state) => state.patchSession);
@@ -54,15 +60,28 @@ export function AgentBuilderCapability({
     (source: AgentSourceEntry, refreshErrorMessage: string) => {
       clearBuilderSessionState(session.id);
 
-      void refreshPersonas()
-        .catch((error) => {
-          console.error(refreshErrorMessage, error);
-        })
-        .finally(() => {
-          onDraftPromoted?.(source);
-        });
+      // Promotion is the durable source of truth. Seed the store immediately
+      // so the destination profile exists even if the follow-up disk refresh
+      // fails or has not observed the promoted source yet.
+      const promotedPersona = agentSourceToPersona(source);
+      const agentStore = useAgentStore.getState();
+      const existingPersona = agentStore.personas.find(
+        (persona) => persona.id === promotedPersona.id,
+      );
+      if (existingPersona) {
+        agentStore.updatePersona(promotedPersona.id, promotedPersona);
+      } else {
+        agentStore.addPersona(promotedPersona);
+      }
+
+      onDraftPromoted?.(source);
+      onAgentBuilderCompleted?.(promotedPersona.id);
+
+      void refreshPersonas().catch((error) => {
+        console.error(refreshErrorMessage, error);
+      });
     },
-    [onDraftPromoted, refreshPersonas, session.id],
+    [onAgentBuilderCompleted, onDraftPromoted, refreshPersonas, session.id],
   );
 
   const handleDraftPromoted = useCallback(

--- a/src/features/agents/ui/AgentDetailPage.tsx
+++ b/src/features/agents/ui/AgentDetailPage.tsx
@@ -167,7 +167,7 @@ export function AgentDetailPage({
   const metadata = [
     descriptionValue
       ? {
-          label: t("view.description"),
+          label: t("view.description", { defaultValue: "Description" }),
           value: descriptionValue,
           multiline: true,
         }

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -64,10 +64,14 @@ vi.mock("@/features/agents/lib/agentZipImport", async (importOriginal) => {
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string, options?: Record<string, unknown>) =>
-      key === "view.exportedTo" && typeof options?.filename === "string"
-        ? `${key}:${options.filename}`
-        : key,
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === "view.exportedTo" && typeof options?.filename === "string") {
+        return `${key}:${options.filename}`;
+      }
+      return typeof options?.defaultValue === "string"
+        ? options.defaultValue
+        : key;
+    },
   }),
 }));
 
@@ -791,7 +795,7 @@ describe("AgentsView entry points", () => {
 
     render(<AgentsView activePersonaId={persona.id} />);
 
-    expect(screen.getByText("view.description")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
     expect(
       screen.getByText("Reviews your code carefully."),
     ).toBeInTheDocument();
@@ -802,7 +806,7 @@ describe("AgentsView entry points", () => {
 
     render(<AgentsView activePersonaId={persona.id} />);
 
-    expect(screen.queryByText("view.description")).not.toBeInTheDocument();
+    expect(screen.queryByText("Description")).not.toBeInTheDocument();
   });
 
   it("shows and activates the avatar customization affordance", async () => {

--- a/src/features/chat/ui/ChatRightRail.tsx
+++ b/src/features/chat/ui/ChatRightRail.tsx
@@ -58,6 +58,7 @@ interface ChatRightRailProps {
    * builder header while the chat is hidden.
    */
   onExpandAgentBuilderChat?: () => void;
+  onAgentBuilderCompleted?: (agentId: string) => void;
   terminalOpen?: boolean;
   terminalController?: TerminalController;
   terminalDockPreview?: TerminalDockedPlacement | null;
@@ -89,6 +90,7 @@ export const ChatRightRail = forwardRef<HTMLDivElement, ChatRightRailProps>(
       agentBuilderChatCollapsed = false,
       builderRailSeparatorProps,
       onExpandAgentBuilderChat,
+      onAgentBuilderCompleted,
       terminalOpen = false,
       terminalController,
       terminalDockPreview,
@@ -313,6 +315,7 @@ export const ChatRightRail = forwardRef<HTMLDivElement, ChatRightRailProps>(
               onExpandChat={
                 agentBuilderChatCollapsed ? onExpandAgentBuilderChat : undefined
               }
+              onAgentBuilderCompleted={onAgentBuilderCompleted}
             />
           </div>
         ) : null}

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -107,6 +107,7 @@ interface ChatViewProps {
   composerHandoffInProgress?: boolean;
   onComposerHandoffTarget?: (rect: GlobalComposerHandoffRect) => void;
   onWorkspaceNameRequest?: (request: WorkspaceNameRequest) => void;
+  onAgentBuilderCompleted?: (agentId: string) => void;
 }
 
 export function ChatView({
@@ -124,6 +125,7 @@ export function ChatView({
   composerHandoffInProgress = false,
   onComposerHandoffTarget,
   onWorkspaceNameRequest,
+  onAgentBuilderCompleted,
 }: ChatViewProps) {
   const { t } = useTranslation("chat");
   useRegisterSecurityConfirmationSurface(sessionId);
@@ -1150,6 +1152,7 @@ export function ChatView({
           agentBuilderChatCollapsed={isAgentBuilderChatCollapsed}
           builderRailSeparatorProps={builderRailSeparatorProps}
           onExpandAgentBuilderChat={toggleAgentBuilderChat}
+          onAgentBuilderCompleted={onAgentBuilderCompleted}
           builderColumnClassName={
             isAgentBuilderOpen ? "agent-builder-column-enter" : undefined
           }

--- a/src/features/chat/ui/__tests__/ChatRightRail.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatRightRail.test.tsx
@@ -12,6 +12,9 @@ import { ChatRightRail } from "../ChatRightRail";
 const mocks = vi.hoisted(() => ({
   patchSession: vi.fn(),
   setPersonas: vi.fn(),
+  addPersona: vi.fn(),
+  updatePersona: vi.fn(),
+  personas: [] as Array<{ id: string }>,
   listPersonas: vi.fn(),
   recoverDraftAgent: vi.fn(),
   setAgentBuilderSessionLocalEdits: vi.fn(),
@@ -43,6 +46,7 @@ vi.mock("@/features/agents/ui/AgentBuilderRail", () => ({
     targetAgentSlug?: string | null;
     draftState?: "preparing" | "failed" | null;
     onDraftPromoted?: (source: unknown) => void;
+    onAgentBuilderCompleted?: (agentId: string) => void;
     onDraftTargetChanged?: (target: { path: string; slug: string }) => void;
     onRecoverMissingDraft?: () => void;
     onClose?: () => void;
@@ -60,7 +64,9 @@ vi.mock("@/features/agents/ui/AgentBuilderRail", () => ({
       </span>
       <button
         type="button"
-        onClick={() => props.onDraftPromoted?.({ path: "/path" })}
+        onClick={() => {
+          props.onDraftPromoted?.({ path: "/path" });
+        }}
       >
         promote
       </button>
@@ -112,11 +118,29 @@ vi.mock("@/features/agents/lib/agentBuilderSession", () => ({
 
 vi.mock("@/features/agents/stores/agentStore", () => ({
   useAgentStore: {
-    getState: () => ({ setPersonas: mocks.setPersonas }),
+    getState: () => ({
+      personas: mocks.personas,
+      setPersonas: mocks.setPersonas,
+      addPersona: mocks.addPersona,
+      updatePersona: mocks.updatePersona,
+    }),
   },
 }));
 
 vi.mock("@/shared/api/agents", () => ({
+  agentSourceToPersona: (source: {
+    path: string;
+    name?: string;
+    description?: string;
+    content?: string;
+  }) => ({
+    id: source.path,
+    displayName: source.name ?? "Saved agent",
+    sourceDescription: source.description,
+    systemPrompt: source.content ?? "",
+    isBuiltin: false,
+    writable: true,
+  }),
   listPersonas: () => mocks.listPersonas(),
 }));
 
@@ -164,7 +188,10 @@ describe("ChatRightRail", () => {
     mocks.compactViewport = false;
     mocks.reducedMotion = false;
     mocks.patchSession.mockReset();
+    mocks.personas = [];
     mocks.setPersonas.mockReset();
+    mocks.addPersona.mockReset();
+    mocks.updatePersona.mockReset();
     mocks.listPersonas.mockReset();
     mocks.listPersonas.mockResolvedValue([]);
     mocks.recoverDraftAgent.mockReset();
@@ -683,8 +710,9 @@ describe("ChatRightRail", () => {
     expect(screen.getByTestId("rail-terminal")).toBeVisible();
   });
 
-  it("refreshes agents and closes the capability when a draft is promoted", async () => {
+  it("refreshes agents, closes the capability, and opens the saved agent when a draft is promoted", async () => {
     const personas = [{ id: "/path", displayName: "Snark" }];
+    const onAgentBuilderCompleted = vi.fn();
     mocks.listPersonas.mockResolvedValue(personas);
 
     render(
@@ -698,15 +726,57 @@ describe("ChatRightRail", () => {
             targetAgentSlug: "draft-s1",
           } as never
         }
+        onAgentBuilderCompleted={onAgentBuilderCompleted}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "promote" }));
 
+    expect(mocks.clearBuilderSessionState).toHaveBeenCalledWith("s1");
+    expect(mocks.addPersona).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "/path" }),
+    );
+    expect(onAgentBuilderCompleted).toHaveBeenCalledWith("/path");
     await waitFor(() => {
-      expect(mocks.clearBuilderSessionState).toHaveBeenCalledWith("s1");
       expect(mocks.setPersonas).toHaveBeenCalledWith(personas);
     });
+  });
+
+  it("opens the promoted agent even when refreshing agents fails", async () => {
+    const onAgentBuilderCompleted = vi.fn();
+    mocks.listPersonas.mockRejectedValue(new Error("refresh unavailable"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    render(
+      <ChatRightRail
+        contextVisible={false}
+        session={
+          {
+            id: "s1",
+            intent: "build-agent",
+            targetAgentPath: "/draft-path",
+            targetAgentSlug: "draft-s1",
+          } as never
+        }
+        onAgentBuilderCompleted={onAgentBuilderCompleted}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "promote" }));
+
+    expect(mocks.addPersona).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "/path" }),
+    );
+    expect(onAgentBuilderCompleted).toHaveBeenCalledWith("/path");
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to refresh agents after save:",
+        expect.any(Error),
+      );
+    });
+    consoleError.mockRestore();
   });
 
   it("patches only chat session target fields when the draft target moves", () => {

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -199,6 +199,7 @@ vi.mock("../ChatRightRail", () => ({
     onToggleTerminal?: () => void;
     terminalOpen?: boolean;
     contextVisible?: boolean;
+    onAgentBuilderCompleted?: (agentId: string) => void;
   }) => {
     mocks.chatRightRailSpy(props);
     if (!props.session) {
@@ -771,6 +772,36 @@ describe("ChatView MCP app messaging", () => {
     render(<ChatView sessionId="session-1" />);
 
     expect(screen.queryByTestId("conversation-empty-avatar")).toBeNull();
+  });
+
+  it("forwards agent builder completion to the app shell", () => {
+    const onAgentBuilderCompleted = vi.fn();
+    const activeSession = {
+      id: "session-1",
+      title: "Build agent",
+      createdAt: "2026-05-27T00:00:00.000Z",
+      updatedAt: "2026-05-27T00:00:00.000Z",
+      messageCount: 0,
+      intent: "build-agent",
+      agentBuilderOpen: true,
+      targetAgentPath: "/Users/test/.agents/agents/draft.md",
+      targetAgentSlug: "draft",
+    } satisfies ChatSession;
+
+    render(
+      <ChatView
+        sessionId="session-1"
+        activeSession={activeSession}
+        onAgentBuilderCompleted={onAgentBuilderCompleted}
+      />,
+    );
+
+    const railProps = mocks.chatRightRailSpy.mock.calls.at(-1)?.[0] as {
+      onAgentBuilderCompleted?: (agentId: string) => void;
+    };
+    railProps.onAgentBuilderCompleted?.("/saved-agent.md");
+
+    expect(onAgentBuilderCompleted).toHaveBeenCalledWith("/saved-agent.md");
   });
 
   it("keeps the canonical empty conversation presentation when Agent Builder is open", () => {

--- a/src/shared/api/agents.ts
+++ b/src/shared/api/agents.ts
@@ -621,7 +621,7 @@ function agentSourceFromMarkdownFile(
   };
 }
 
-function toPersona(source: AgentSourceEntry): Persona {
+export function agentSourceToPersona(source: AgentSourceEntry): Persona {
   const writable = source.writable === true;
   return {
     id: source.path,
@@ -818,7 +818,7 @@ export async function promotePersonaSource(
 export async function listPersonas(): Promise<Persona[]> {
   return (await listAgentSources())
     .filter((source) => source.properties?.draft !== true)
-    .map(toPersona);
+    .map(agentSourceToPersona);
 }
 
 export async function createPersona(
@@ -841,7 +841,7 @@ export async function createPersona(
   }
 
   const avatar = avatarToProperty(request.avatar);
-  return toPersona(
+  return agentSourceToPersona(
     avatar && normalizeAvatarUrl(response.source.properties?.avatar) !== avatar
       ? {
           ...response.source,
@@ -883,7 +883,7 @@ export async function updatePersona(
     throw new Error(`Unexpected source type returned: ${response.source.type}`);
   }
 
-  return toPersona(response.source);
+  return agentSourceToPersona(response.source);
 }
 
 export async function migratePersonaTargetIfUnchanged(
@@ -891,7 +891,7 @@ export async function migratePersonaTargetIfUnchanged(
   target: Pick<UpdatePersonaRequest, "provider" | "modelProviderId" | "model">,
 ): Promise<Persona | null> {
   const latestSource = await readExistingPersonaSource(persona.id);
-  const latestPersona = toPersona(latestSource);
+  const latestPersona = agentSourceToPersona(latestSource);
   if (
     latestPersona.provider !== persona.provider ||
     latestPersona.modelProviderId !== persona.modelProviderId ||
@@ -910,7 +910,7 @@ export async function migratePersonaTargetIfUnchanged(
     properties: mergedPersonaProperties(latestSource.properties, target),
   });
 
-  return toPersona(requireAgentSource(response.source));
+  return agentSourceToPersona(requireAgentSource(response.source));
 }
 
 export async function deletePersona(id: string): Promise<void> {
@@ -1037,7 +1037,7 @@ export async function importPersonas(
         `Unexpected source type returned: ${response.source.type}`,
       );
     }
-    return [toPersona(response.source)];
+    return [agentSourceToPersona(response.source)];
   }
 
   const parsed = readImportJson(fileContents);
@@ -1053,7 +1053,7 @@ export async function importPersonas(
         .filter(isAgentSource)
         .map((source) => preserveImportedAvatar(source, nativeImport.avatar)),
     );
-    return sources.map(toPersona);
+    return sources.map(agentSourceToPersona);
   }
 
   const response = await client.goose.GooseUnstableSourcesCreate(
@@ -1062,7 +1062,7 @@ export async function importPersonas(
   if (!isAgentSource(response.source)) {
     throw new Error(`Unexpected source type returned: ${response.source.type}`);
   }
-  return [toPersona(response.source)];
+  return [agentSourceToPersona(response.source)];
 }
 
 export interface ImportFileReadResult {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Saving a newly created agent now opens its profile immediately, and the profile shows a readable Description label.

**Problem:** Finishing the agent creation flow left users in the builder instead of taking them to the agent they had just saved. The profile could also expose the internal `view.description` translation key rather than a user-facing label.

**Solution:** Route successful agent promotions directly to the saved agent profile and seed the promoted source into the agent store before navigation, so the destination remains available even when the follow-up disk refresh is delayed or fails. Add a readable fallback for the description label and regression coverage across the completion callback chain.

<details>
<summary>File changes</summary>

**src/app/AppShell.navigation.test.tsx**
Covers the app-level transition from an active agent builder to the saved agent detail route.

**src/app/AppShell.tsx**
Handles agent builder completion by navigating directly to the saved agent profile.

**src/app/ui/AppShellContent.tsx**
Carries the completion callback from the app shell into the chat surface that hosts the builder.

**src/features/agents/capabilities/AgentBuilderCapability.tsx**
Seeds the promoted agent into the store, signals completion immediately, and leaves disk refresh as background reconciliation so navigation stays reliable.

**src/features/agents/ui/AgentDetailPage.tsx**
Adds a readable fallback for the Description metadata label.

**src/features/agents/ui/__tests__/AgentsView.entry.test.tsx**
Verifies the readable Description label and its conditional visibility.

**src/features/chat/ui/ChatRightRail.tsx**
Forwards builder completion from the agent capability toward app navigation.

**src/features/chat/ui/ChatView.tsx**
Connects the chat-hosted builder completion callback to the app shell.

**src/features/chat/ui/__tests__/ChatRightRail.test.tsx**
Covers promotion, immediate store seeding, navigation signaling, successful reconciliation, and refresh failure behavior.

**src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx**
Verifies the completion callback is preserved through the ChatView boundary.

**src/shared/api/agents.ts**
Exports and reuses the canonical agent-source-to-persona mapping for immediate store seeding.

</details>

## Reproduction steps

1. Open Agents and start creating a new agent.
2. Complete the required fields and click **Save changes**.
3. Confirm Berd opens the newly saved agent's detail page automatically.
4. Confirm the metadata rail shows **Description**, not `view.description`.
5. Optionally simulate a failed persona refresh and confirm the saved agent profile still opens from the promoted source.
