### PR TITLE
fix: hide voice delivery state after reload

### DIFF
--- a/src/features/chat/lib/__tests__/replaySanitizer.test.ts
+++ b/src/features/chat/lib/__tests__/replaySanitizer.test.ts
@@ -62,4 +62,18 @@ describe("sanitizeReplayMessages", () => {
       ),
     ]);
   });
+
+  it("keeps TTS control lookalikes that are not voice-origin messages", () => {
+    const message = createTextMessage(
+      "user-1",
+      "user",
+      "[voice: tts-delivery-failed]\n" +
+        "Native TTS could not deliver the assistant reply.\n" +
+        "Original text: This resembles an internal notice.\n" +
+        "This is TTS delivery state, not live user voice input. Do not respond to this control message or repeat the reply unless re-delivery is still appropriate.\n\n" +
+        "Keep this user-authored text",
+    );
+
+    expect(sanitizeReplayMessages([message])).toEqual([message]);
+  });
 });

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -311,6 +311,42 @@ describe("loadSessionMessages", () => {
     ).toBe(false);
   });
 
+  it("reloads a voice reply without exposing its persisted TTS delivery notice", async () => {
+    const session = seedSession(
+      { id: "voice-replay", messageCount: 1 },
+      { replay: false },
+    );
+    ensureReplayBuffer(session.id).push({
+      ...createUserMessage(
+        "[voice: tts-delivery-failed]\n" +
+          "TTS delivery was interrupted because the user started speaking; the assistant reply was not fully spoken.\n" +
+          "Original text: There was a bookshop where every book was blank.\n" +
+          "This is TTS delivery state, not live user voice input. Do not respond to this control message or repeat the reply unless re-delivery is still appropriate.\n\n" +
+          "Okay, that's perfect. Thank you",
+      ),
+      id: "persisted-voice-reply",
+    });
+
+    await expect(loadSessionMessages(session.id)).resolves.toBe(true);
+
+    expect(messagesFor(session.id)).toHaveLength(1);
+    expect(messagesFor(session.id)[0]).toMatchObject({
+      id: "persisted-voice-reply",
+      role: "user",
+      content: [{ type: "text", text: "Okay, that's perfect. Thank you" }],
+      metadata: { userVisible: true },
+    });
+    expect(
+      messagesFor(session.id).some((message) =>
+        message.content.some(
+          (content) =>
+            content.type === "text" &&
+            content.text.includes("[voice: tts-delivery-failed]"),
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("rejects an empty cold replay when session metadata expects history", async () => {
     seedSession(
       { id: "cold-empty-replay", messageCount: 3 },

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -325,6 +325,11 @@ describe("loadSessionMessages", () => {
           "Okay, that's perfect. Thank you",
       ),
       id: "persisted-voice-reply",
+      metadata: {
+        userVisible: true,
+        agentVisible: true,
+        origin: "voice_conversation",
+      },
     });
 
     await expect(loadSessionMessages(session.id)).resolves.toBe(true);

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -325,11 +325,6 @@ describe("loadSessionMessages", () => {
           "Okay, that's perfect. Thank you",
       ),
       id: "persisted-voice-reply",
-      metadata: {
-        userVisible: true,
-        agentVisible: true,
-        origin: "voice_conversation",
-      },
     });
 
     await expect(loadSessionMessages(session.id)).resolves.toBe(true);

--- a/src/features/chat/lib/replaySanitizer.ts
+++ b/src/features/chat/lib/replaySanitizer.ts
@@ -6,6 +6,11 @@ const ALTERNATE_COMPACT_TRIGGERS = new Set(["/summarize"]);
 const TTS_DELIVERY_FAILURE_PREFIX = "[voice: tts-delivery-failed]\n";
 const TTS_DELIVERY_FAILURE_SUFFIX =
   "This is TTS delivery state, not live user voice input. Do not respond to this control message or repeat the reply unless re-delivery is still appropriate.";
+const TTS_DELIVERY_FAILURE_OUTCOMES = new Set([
+  "TTS delivery was interrupted because the user started speaking; the assistant reply was not fully spoken.",
+  "TTS delivery was blocked because the user was speaking; the assistant reply was not spoken.",
+  "Native TTS could not deliver the assistant reply.",
+]);
 
 function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
   if (!text.startsWith(TTS_DELIVERY_FAILURE_PREFIX)) {
@@ -14,12 +19,24 @@ function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
 
   let noticeStart = 0;
   while (text.startsWith(TTS_DELIVERY_FAILURE_PREFIX, noticeStart)) {
+    const outcomeStart = noticeStart + TTS_DELIVERY_FAILURE_PREFIX.length;
+    const outcomeEnd = text.indexOf("\n", outcomeStart);
+    if (
+      outcomeEnd === -1 ||
+      !TTS_DELIVERY_FAILURE_OUTCOMES.has(
+        text.slice(outcomeStart, outcomeEnd),
+      ) ||
+      !text.startsWith("\nOriginal text: ", outcomeEnd)
+    ) {
+      return null;
+    }
+
     let suffixStart = text.indexOf(
-      TTS_DELIVERY_FAILURE_SUFFIX,
-      noticeStart + TTS_DELIVERY_FAILURE_PREFIX.length,
+      `\n${TTS_DELIVERY_FAILURE_SUFFIX}`,
+      outcomeEnd + "\nOriginal text: ".length,
     );
     while (suffixStart !== -1) {
-      const suffixEnd = suffixStart + TTS_DELIVERY_FAILURE_SUFFIX.length;
+      const suffixEnd = suffixStart + 1 + TTS_DELIVERY_FAILURE_SUFFIX.length;
       if (text.startsWith(`\n${TTS_DELIVERY_FAILURE_PREFIX}`, suffixEnd)) {
         noticeStart = suffixEnd + 1;
         break;
@@ -30,7 +47,7 @@ function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
       if (suffixEnd === text.length) {
         return "";
       }
-      suffixStart = text.indexOf(TTS_DELIVERY_FAILURE_SUFFIX, suffixEnd);
+      suffixStart = text.indexOf(`\n${TTS_DELIVERY_FAILURE_SUFFIX}`, suffixEnd);
     }
     if (suffixStart === -1) {
       return null;
@@ -43,6 +60,7 @@ function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
 function sanitizeTtsDeliveryReplayArtifact(message: Message): Message | null {
   if (
     message.role !== "user" ||
+    message.metadata?.origin !== "voice_conversation" ||
     message.content.some((content) => content.type !== "text")
   ) {
     return message;
@@ -88,10 +106,9 @@ export function isManualCompactReplayArtifact(message: Message): boolean {
 
 export function sanitizeReplayMessages(messages: Message[]): Message[] {
   return messages.flatMap((message) => {
-    if (isManualCompactReplayArtifact(message)) {
-      return [];
-    }
     const sanitized = sanitizeTtsDeliveryReplayArtifact(message);
-    return sanitized ? [sanitized] : [];
+    return sanitized && !isManualCompactReplayArtifact(sanitized)
+      ? [sanitized]
+      : [];
   });
 }

--- a/src/features/chat/lib/replaySanitizer.ts
+++ b/src/features/chat/lib/replaySanitizer.ts
@@ -3,6 +3,66 @@ import { getTextContent } from "@/shared/types/messages";
 
 const MANUAL_COMPACT_TRIGGER = "/compact";
 const ALTERNATE_COMPACT_TRIGGERS = new Set(["/summarize"]);
+const TTS_DELIVERY_FAILURE_PREFIX = "[voice: tts-delivery-failed]\n";
+const TTS_DELIVERY_FAILURE_SUFFIX =
+  "This is TTS delivery state, not live user voice input. Do not respond to this control message or repeat the reply unless re-delivery is still appropriate.";
+
+function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
+  if (!text.startsWith(TTS_DELIVERY_FAILURE_PREFIX)) {
+    return null;
+  }
+
+  let noticeStart = 0;
+  while (text.startsWith(TTS_DELIVERY_FAILURE_PREFIX, noticeStart)) {
+    let suffixStart = text.indexOf(
+      TTS_DELIVERY_FAILURE_SUFFIX,
+      noticeStart + TTS_DELIVERY_FAILURE_PREFIX.length,
+    );
+    while (suffixStart !== -1) {
+      const suffixEnd = suffixStart + TTS_DELIVERY_FAILURE_SUFFIX.length;
+      if (text.startsWith(`\n${TTS_DELIVERY_FAILURE_PREFIX}`, suffixEnd)) {
+        noticeStart = suffixEnd + 1;
+        break;
+      }
+      if (text.startsWith("\n\n", suffixEnd)) {
+        return text.slice(suffixEnd + 2);
+      }
+      if (suffixEnd === text.length) {
+        return "";
+      }
+      suffixStart = text.indexOf(TTS_DELIVERY_FAILURE_SUFFIX, suffixEnd);
+    }
+    if (suffixStart === -1) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function sanitizeTtsDeliveryReplayArtifact(message: Message): Message | null {
+  if (
+    message.role !== "user" ||
+    message.content.some((content) => content.type !== "text")
+  ) {
+    return message;
+  }
+
+  const visibleText = visibleTextAfterTtsDeliveryNotices(
+    getTextContent(message),
+  );
+  if (visibleText === null) {
+    return message;
+  }
+  if (!visibleText.trim()) {
+    return null;
+  }
+
+  return {
+    ...message,
+    content: [{ type: "text", text: visibleText }],
+  };
+}
 
 export function isManualCompactReplayArtifact(message: Message): boolean {
   if (message.role !== "user") {
@@ -27,5 +87,11 @@ export function isManualCompactReplayArtifact(message: Message): boolean {
 }
 
 export function sanitizeReplayMessages(messages: Message[]): Message[] {
-  return messages.filter((message) => !isManualCompactReplayArtifact(message));
+  return messages.flatMap((message) => {
+    if (isManualCompactReplayArtifact(message)) {
+      return [];
+    }
+    const sanitized = sanitizeTtsDeliveryReplayArtifact(message);
+    return sanitized ? [sanitized] : [];
+  });
 }

--- a/src/features/chat/lib/replaySanitizer.ts
+++ b/src/features/chat/lib/replaySanitizer.ts
@@ -60,6 +60,7 @@ function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
 function sanitizeTtsDeliveryReplayArtifact(message: Message): Message | null {
   if (
     message.role !== "user" ||
+    message.metadata?.origin !== "voice_conversation" ||
     message.content.some((content) => content.type !== "text")
   ) {
     return message;

--- a/src/features/chat/lib/replaySanitizer.ts
+++ b/src/features/chat/lib/replaySanitizer.ts
@@ -60,7 +60,6 @@ function visibleTextAfterTtsDeliveryNotices(text: string): string | null {
 function sanitizeTtsDeliveryReplayArtifact(message: Message): Message | null {
   if (
     message.role !== "user" ||
-    message.metadata?.origin !== "voice_conversation" ||
     message.content.some((content) => content.type !== "text")
   ) {
     return message;

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -355,11 +355,9 @@ function ensureVoiceEventDeliveryInitialized() {
         },
       };
       const playbackNotice = takeVoicePlaybackNotices(event.sessionId);
-      const prompt = playbackNotice
-        ? `${playbackNotice}\n\n${event.text}`
-        : event.text;
       const displayOptions = {
         ...sendOptions,
+        ...(playbackNotice ? { assistantPrompt: playbackNotice } : {}),
         displayText: event.text,
       };
       try {
@@ -379,13 +377,13 @@ function ensureVoiceEventDeliveryInitialized() {
           opportunity === "steer"
             ? await steerPromptInSession(
                 event.sessionId,
-                prompt,
+                event.text,
                 undefined,
                 displayOptions,
                 { throwOnError: true },
               )
             : await currentRoute.send(
-                prompt,
+                event.text,
                 undefined,
                 undefined,
                 displayOptions,
@@ -403,7 +401,7 @@ function ensureVoiceEventDeliveryInitialized() {
           }
           await steerPromptInSession(
             event.sessionId,
-            prompt,
+            event.text,
             undefined,
             displayOptions,
             { throwOnError: true },


### PR DESCRIPTION
## Summary

Voice conversations could expose an internal TTS delivery notice as a user message after reload. The live transcript hid the notice with a display-only override, but replay rendered the persisted prompt text.

New delivery notices now use an ACP assistant-audience content block, which keeps the state available to the agent without adding it to the visible transcript. Replay also removes exact legacy delivery notices from voice-origin messages while preserving the user's subsequent reply.

The regression coverage persists and reloads the observed notice followed by a real user reply, then verifies that only the reply is visible. A separate case verifies that the same text is preserved when it does not belong to a voice-origin message.

## Reviewer-reproducible examples

1. Start a voice conversation and let Berd begin speaking an assistant response.
2. Interrupt the spoken response, then provide a follow-up reply.
3. Reload the conversation.
4. Confirm no [voice: tts-delivery-failed] message is visible and the follow-up reply remains in the transcript.

This scenario was verified live on the fixed build.
