### PR TITLE
fix(chat): scroll to voice-submitted messages

### DIFF
--- a/src/features/chat/ui/MessageTimeline.tsx
+++ b/src/features/chat/ui/MessageTimeline.tsx
@@ -40,6 +40,7 @@ import {
   MessageTimelineJumpToResponseStartGutterButton,
   REDUCED_MOTION_QUERY,
   RESPONSE_START_HINT_HIDE_DELAY_MS,
+  getTimelineMessageIdentity,
   getVoiceSubmissionKey,
   isResponseStartHintInRelevanceBand,
   useStickyFlag,
@@ -934,8 +935,10 @@ export function MessageTimeline({
 
   const latestVisibleMessage = visibleMessages.at(-1);
   const latestVisibleMessageId = latestVisibleMessage?.id;
-  const latestVisibleVoiceSubmissionKey =
-    getVoiceSubmissionKey(latestVisibleMessage);
+  const visibleMessageIdentities = useMemo(
+    () => visibleMessages.map(getTimelineMessageIdentity),
+    [visibleMessages],
+  );
   const visibleVoiceSubmissionKeys = useMemo(
     () =>
       visibleMessages
@@ -945,6 +948,9 @@ export function MessageTimeline({
   );
   const seenVoiceSubmissionKeysRef = useRef(
     new Set(visibleVoiceSubmissionKeys),
+  );
+  const previousVisibleTailIdentityRef = useRef(
+    visibleMessageIdentities.at(-1),
   );
 
   useEffect(() => {
@@ -969,13 +975,27 @@ export function MessageTimeline({
   ]);
 
   useEffect(() => {
-    const hasSeenLatest =
-      latestVisibleVoiceSubmissionKey === null ||
-      seenVoiceSubmissionKeysRef.current.has(latestVisibleVoiceSubmissionKey);
+    let latestUnseenVoiceSubmissionIndex = -1;
+    for (let index = 0; index < visibleMessages.length; index += 1) {
+      const key = getVoiceSubmissionKey(visibleMessages[index]);
+      if (key && !seenVoiceSubmissionKeysRef.current.has(key)) {
+        latestUnseenVoiceSubmissionIndex = index;
+      }
+    }
+    const previousTailIdentity = previousVisibleTailIdentityRef.current;
+    const previousTailIndex = previousTailIdentity
+      ? visibleMessageIdentities.indexOf(previousTailIdentity)
+      : -1;
     for (const key of visibleVoiceSubmissionKeys) {
       seenVoiceSubmissionKeysRef.current.add(key);
     }
-    if (hasSeenLatest) {
+    previousVisibleTailIdentityRef.current = visibleMessageIdentities.at(-1);
+    if (
+      latestUnseenVoiceSubmissionIndex < 0 ||
+      (previousTailIdentity &&
+        (previousTailIndex < 0 ||
+          latestUnseenVoiceSubmissionIndex <= previousTailIndex))
+    ) {
       return;
     }
     clearProgrammaticFollowResumeSuppression();
@@ -983,9 +1003,10 @@ export function MessageTimeline({
     schedulePinnedBottomBurst();
   }, [
     clearProgrammaticFollowResumeSuppression,
-    latestVisibleVoiceSubmissionKey,
     schedulePinnedBottomBurst,
     setDetachedFromLatest,
+    visibleMessageIdentities,
+    visibleMessages,
     visibleVoiceSubmissionKeys,
   ]);
 

--- a/src/features/chat/ui/MessageTimeline.tsx
+++ b/src/features/chat/ui/MessageTimeline.tsx
@@ -40,6 +40,7 @@ import {
   MessageTimelineJumpToResponseStartGutterButton,
   REDUCED_MOTION_QUERY,
   RESPONSE_START_HINT_HIDE_DELAY_MS,
+  getVoiceSubmissionKey,
   isResponseStartHintInRelevanceBand,
   useStickyFlag,
   type MessageBubbleCallbacks,
@@ -933,12 +934,18 @@ export function MessageTimeline({
 
   const latestVisibleMessage = visibleMessages.at(-1);
   const latestVisibleMessageId = latestVisibleMessage?.id;
-  const latestVisibleVoiceUserMessageId = visibleMessages.findLast(
-    (message) =>
-      message.role === "user" &&
-      message.metadata?.origin === "voice_conversation",
-  )?.id;
-  const lastVoiceUserAutoScrollIdRef = useRef(latestVisibleVoiceUserMessageId);
+  const latestVisibleVoiceSubmissionKey =
+    getVoiceSubmissionKey(latestVisibleMessage);
+  const visibleVoiceSubmissionKeys = useMemo(
+    () =>
+      visibleMessages
+        .map(getVoiceSubmissionKey)
+        .filter((key): key is string => key !== null),
+    [visibleMessages],
+  );
+  const seenVoiceSubmissionKeysRef = useRef(
+    new Set(visibleVoiceSubmissionKeys),
+  );
 
   useEffect(() => {
     if (
@@ -962,21 +969,24 @@ export function MessageTimeline({
   ]);
 
   useEffect(() => {
-    if (
-      !latestVisibleVoiceUserMessageId ||
-      lastVoiceUserAutoScrollIdRef.current === latestVisibleVoiceUserMessageId
-    ) {
+    const hasSeenLatest =
+      latestVisibleVoiceSubmissionKey === null ||
+      seenVoiceSubmissionKeysRef.current.has(latestVisibleVoiceSubmissionKey);
+    for (const key of visibleVoiceSubmissionKeys) {
+      seenVoiceSubmissionKeysRef.current.add(key);
+    }
+    if (hasSeenLatest) {
       return;
     }
-    lastVoiceUserAutoScrollIdRef.current = latestVisibleVoiceUserMessageId;
     clearProgrammaticFollowResumeSuppression();
     setDetachedFromLatest(false);
     schedulePinnedBottomBurst();
   }, [
     clearProgrammaticFollowResumeSuppression,
-    latestVisibleVoiceUserMessageId,
+    latestVisibleVoiceSubmissionKey,
     schedulePinnedBottomBurst,
     setDetachedFromLatest,
+    visibleVoiceSubmissionKeys,
   ]);
 
   const scheduleResponseStartHint = useCallback(

--- a/src/features/chat/ui/MessageTimeline.tsx
+++ b/src/features/chat/ui/MessageTimeline.tsx
@@ -969,8 +969,15 @@ export function MessageTimeline({
       return;
     }
     lastVoiceUserAutoScrollIdRef.current = latestVisibleVoiceUserMessageId;
-    scrollToBottomIfNearBottom("auto");
-  }, [latestVisibleVoiceUserMessageId, scrollToBottomIfNearBottom]);
+    clearProgrammaticFollowResumeSuppression();
+    setDetachedFromLatest(false);
+    schedulePinnedBottomBurst();
+  }, [
+    clearProgrammaticFollowResumeSuppression,
+    latestVisibleVoiceUserMessageId,
+    schedulePinnedBottomBurst,
+    setDetachedFromLatest,
+  ]);
 
   const scheduleResponseStartHint = useCallback(
     (messageId: string) => {

--- a/src/features/chat/ui/MessageTimeline.tsx
+++ b/src/features/chat/ui/MessageTimeline.tsx
@@ -933,9 +933,19 @@ export function MessageTimeline({
 
   const latestVisibleMessage = visibleMessages.at(-1);
   const latestVisibleMessageId = latestVisibleMessage?.id;
+  const latestVisibleVoiceUserMessageId = visibleMessages.findLast(
+    (message) =>
+      message.role === "user" &&
+      message.metadata?.origin === "voice_conversation",
+  )?.id;
+  const lastVoiceUserAutoScrollIdRef = useRef(latestVisibleVoiceUserMessageId);
 
   useEffect(() => {
-    if (!latestVisibleMessageId || latestVisibleMessage?.role !== "user") {
+    if (
+      !latestVisibleMessageId ||
+      latestVisibleMessage?.role !== "user" ||
+      latestVisibleMessage.metadata?.origin === "voice_conversation"
+    ) {
       return;
     }
 
@@ -945,10 +955,22 @@ export function MessageTimeline({
   }, [
     clearProgrammaticFollowResumeSuppression,
     latestVisibleMessageId,
+    latestVisibleMessage?.metadata?.origin,
     latestVisibleMessage?.role,
     scrollToBottom,
     setDetachedFromLatest,
   ]);
+
+  useEffect(() => {
+    if (
+      !latestVisibleVoiceUserMessageId ||
+      lastVoiceUserAutoScrollIdRef.current === latestVisibleVoiceUserMessageId
+    ) {
+      return;
+    }
+    lastVoiceUserAutoScrollIdRef.current = latestVisibleVoiceUserMessageId;
+    scrollToBottomIfNearBottom("auto");
+  }, [latestVisibleVoiceUserMessageId, scrollToBottomIfNearBottom]);
 
   const scheduleResponseStartHint = useCallback(
     (messageId: string) => {

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -73,6 +73,7 @@ import {
   MessageTimelineJumpToResponseStartGutterButton,
   REDUCED_MOTION_QUERY,
   RESPONSE_START_HINT_HIDE_DELAY_MS,
+  getTimelineMessageIdentity,
   getVoiceSubmissionKey,
   isResponseStartHintInRelevanceBand,
   useStickyFlag,
@@ -2436,15 +2437,34 @@ function VirtualMessageTimelineSession({
   }, [stableMessageByRowId, stableRows]);
   const latestMessage = latestMessageEntry?.message;
   const latestMessageId = latestMessageEntry?.messageId;
-  const latestVoiceSubmissionKey = getVoiceSubmissionKey(latestMessage);
+  const timelineMessages = useMemo(() => {
+    const result: Message[] = [];
+    for (const row of stableRows) {
+      if (!isMessageTurnRow(row)) {
+        continue;
+      }
+      const message = stableMessageByRowId.get(row.rowId);
+      if (message) {
+        result.push(message);
+      }
+    }
+    return result;
+  }, [stableMessageByRowId, stableRows]);
+  const timelineMessageIdentities = useMemo(
+    () => timelineMessages.map(getTimelineMessageIdentity),
+    [timelineMessages],
+  );
   const voiceSubmissionKeys = useMemo(
     () =>
-      messages
+      timelineMessages
         .map(getVoiceSubmissionKey)
         .filter((key): key is string => key !== null),
-    [messages],
+    [timelineMessages],
   );
   const seenVoiceSubmissionKeysRef = useRef(new Set(voiceSubmissionKeys));
+  const previousTimelineTailIdentityRef = useRef(
+    timelineMessageIdentities.at(-1),
+  );
   const latestAssistantMessageEntry = useMemo(() => {
     for (let index = stableRows.length - 1; index >= 0; index -= 1) {
       const row = stableRows[index];
@@ -2947,13 +2967,27 @@ function VirtualMessageTimelineSession({
   ]);
 
   useEffect(() => {
-    const hasSeenLatest =
-      latestVoiceSubmissionKey === null ||
-      seenVoiceSubmissionKeysRef.current.has(latestVoiceSubmissionKey);
+    let latestUnseenVoiceSubmissionIndex = -1;
+    for (let index = 0; index < timelineMessages.length; index += 1) {
+      const key = getVoiceSubmissionKey(timelineMessages[index]);
+      if (key && !seenVoiceSubmissionKeysRef.current.has(key)) {
+        latestUnseenVoiceSubmissionIndex = index;
+      }
+    }
+    const previousTailIdentity = previousTimelineTailIdentityRef.current;
+    const previousTailIndex = previousTailIdentity
+      ? timelineMessageIdentities.indexOf(previousTailIdentity)
+      : -1;
     for (const key of voiceSubmissionKeys) {
       seenVoiceSubmissionKeysRef.current.add(key);
     }
-    if (hasSeenLatest) {
+    previousTimelineTailIdentityRef.current = timelineMessageIdentities.at(-1);
+    if (
+      latestUnseenVoiceSubmissionIndex < 0 ||
+      (previousTailIdentity &&
+        (previousTailIndex < 0 ||
+          latestUnseenVoiceSubmissionIndex <= previousTailIndex))
+    ) {
       return;
     }
     clearProgrammaticFollowResumeSuppression();
@@ -2962,10 +2996,11 @@ function VirtualMessageTimelineSession({
     requestBottomScroll();
   }, [
     clearProgrammaticFollowResumeSuppression,
-    latestVoiceSubmissionKey,
     requestBottomScroll,
     scrollToBottom,
     setDetachedFromLatest,
+    timelineMessageIdentities,
+    timelineMessages,
     voiceSubmissionKeys,
   ]);
 

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -73,6 +73,7 @@ import {
   MessageTimelineJumpToResponseStartGutterButton,
   REDUCED_MOTION_QUERY,
   RESPONSE_START_HINT_HIDE_DELAY_MS,
+  getVoiceSubmissionKey,
   isResponseStartHintInRelevanceBand,
   useStickyFlag,
   type MessageBubbleCallbacks,
@@ -2435,24 +2436,15 @@ function VirtualMessageTimelineSession({
   }, [stableMessageByRowId, stableRows]);
   const latestMessage = latestMessageEntry?.message;
   const latestMessageId = latestMessageEntry?.messageId;
-  const latestVoiceUserMessageId = useMemo(() => {
-    for (let index = stableRows.length - 1; index >= 0; index -= 1) {
-      const row = stableRows[index];
-      if (!row?.messageId || !isMessageTurnRow(row)) {
-        continue;
-      }
-
-      const message = stableMessageByRowId.get(row.rowId);
-      if (
-        message?.role === "user" &&
-        message.metadata?.origin === "voice_conversation"
-      ) {
-        return row.messageId;
-      }
-    }
-    return null;
-  }, [stableMessageByRowId, stableRows]);
-  const lastVoiceUserAutoScrollIdRef = useRef(latestVoiceUserMessageId);
+  const latestVoiceSubmissionKey = getVoiceSubmissionKey(latestMessage);
+  const voiceSubmissionKeys = useMemo(
+    () =>
+      messages
+        .map(getVoiceSubmissionKey)
+        .filter((key): key is string => key !== null),
+    [messages],
+  );
+  const seenVoiceSubmissionKeysRef = useRef(new Set(voiceSubmissionKeys));
   const latestAssistantMessageEntry = useMemo(() => {
     for (let index = stableRows.length - 1; index >= 0; index -= 1) {
       const row = stableRows[index];
@@ -2955,23 +2947,26 @@ function VirtualMessageTimelineSession({
   ]);
 
   useEffect(() => {
-    if (
-      !latestVoiceUserMessageId ||
-      lastVoiceUserAutoScrollIdRef.current === latestVoiceUserMessageId
-    ) {
+    const hasSeenLatest =
+      latestVoiceSubmissionKey === null ||
+      seenVoiceSubmissionKeysRef.current.has(latestVoiceSubmissionKey);
+    for (const key of voiceSubmissionKeys) {
+      seenVoiceSubmissionKeysRef.current.add(key);
+    }
+    if (hasSeenLatest) {
       return;
     }
-    lastVoiceUserAutoScrollIdRef.current = latestVoiceUserMessageId;
     clearProgrammaticFollowResumeSuppression();
     setDetachedFromLatest(false);
     scrollToBottom("auto");
     requestBottomScroll();
   }, [
     clearProgrammaticFollowResumeSuppression,
-    latestVoiceUserMessageId,
+    latestVoiceSubmissionKey,
     requestBottomScroll,
     scrollToBottom,
     setDetachedFromLatest,
+    voiceSubmissionKeys,
   ]);
 
   const requestMcpAppAutoScroll = useCallback(

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -2435,6 +2435,24 @@ function VirtualMessageTimelineSession({
   }, [stableMessageByRowId, stableRows]);
   const latestMessage = latestMessageEntry?.message;
   const latestMessageId = latestMessageEntry?.messageId;
+  const latestVoiceUserMessageId = useMemo(() => {
+    for (let index = stableRows.length - 1; index >= 0; index -= 1) {
+      const row = stableRows[index];
+      if (!row?.messageId || !isMessageTurnRow(row)) {
+        continue;
+      }
+
+      const message = stableMessageByRowId.get(row.rowId);
+      if (
+        message?.role === "user" &&
+        message.metadata?.origin === "voice_conversation"
+      ) {
+        return row.messageId;
+      }
+    }
+    return null;
+  }, [stableMessageByRowId, stableRows]);
+  const lastVoiceUserAutoScrollIdRef = useRef(latestVoiceUserMessageId);
   const latestAssistantMessageEntry = useMemo(() => {
     for (let index = stableRows.length - 1; index >= 0; index -= 1) {
       const row = stableRows[index];
@@ -2909,7 +2927,11 @@ function VirtualMessageTimelineSession({
   }, [pulsingMessageId]);
 
   useEffect(() => {
-    if (!latestMessageId || latestMessage?.role !== "user") {
+    if (
+      !latestMessageId ||
+      latestMessage?.role !== "user" ||
+      latestMessage.metadata?.origin === "voice_conversation"
+    ) {
       return;
     }
 
@@ -2925,11 +2947,23 @@ function VirtualMessageTimelineSession({
   }, [
     clearProgrammaticFollowResumeSuppression,
     latestMessageId,
+    latestMessage?.metadata?.origin,
     latestMessage?.role,
     sessionId,
     scrollToBottom,
     setDetachedFromLatest,
   ]);
+
+  useEffect(() => {
+    if (
+      !latestVoiceUserMessageId ||
+      lastVoiceUserAutoScrollIdRef.current === latestVoiceUserMessageId
+    ) {
+      return;
+    }
+    lastVoiceUserAutoScrollIdRef.current = latestVoiceUserMessageId;
+    scrollToBottomIfNearBottom("auto");
+  }, [latestVoiceUserMessageId, scrollToBottomIfNearBottom]);
 
   const requestMcpAppAutoScroll = useCallback(
     (element: HTMLElement | null) => {

--- a/src/features/chat/ui/VirtualMessageTimeline.tsx
+++ b/src/features/chat/ui/VirtualMessageTimeline.tsx
@@ -2962,8 +2962,17 @@ function VirtualMessageTimelineSession({
       return;
     }
     lastVoiceUserAutoScrollIdRef.current = latestVoiceUserMessageId;
-    scrollToBottomIfNearBottom("auto");
-  }, [latestVoiceUserMessageId, scrollToBottomIfNearBottom]);
+    clearProgrammaticFollowResumeSuppression();
+    setDetachedFromLatest(false);
+    scrollToBottom("auto");
+    requestBottomScroll();
+  }, [
+    clearProgrammaticFollowResumeSuppression,
+    latestVoiceUserMessageId,
+    requestBottomScroll,
+    scrollToBottom,
+    setDetachedFromLatest,
+  ]);
 
   const requestMcpAppAutoScroll = useCallback(
     (element: HTMLElement | null) => {

--- a/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
@@ -1481,6 +1481,90 @@ describe("MessageTimeline", () => {
     });
   });
 
+  it("follows a new voice user turn when an assistant turn remains latest", async () => {
+    const messages = [
+      message("user-1", "user", "Question"),
+      message("assistant-1", "assistant", "Answer"),
+    ];
+    const { rerender } = renderWithProviders(
+      <MessageTimeline messages={messages} />,
+    );
+    const scroller = getTimelineScroller();
+    setScrollMetrics(scroller, { scrollTop: 500 });
+    const scrollTo = attachScrollTo(scroller);
+    scrollTo.mockClear();
+
+    setScrollMetrics(scroller, {
+      scrollTop: 500,
+      scrollHeight: 1200,
+      clientHeight: 500,
+    });
+    rerender(
+      <MessageTimeline
+        messages={[
+          ...messages,
+          {
+            ...message("voice-1", "user", "Spoken follow-up"),
+            metadata: {
+              userVisible: true,
+              origin: "voice_conversation",
+            },
+          },
+          message("assistant-2", "assistant", "Working"),
+        ]}
+        streamingMessageId="assistant-2"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(scrollTo).toHaveBeenCalledWith({
+        top: 700,
+        behavior: "auto",
+      }),
+    );
+  });
+
+  it("does not follow a new voice user turn while the reader is detached", async () => {
+    const messages = [
+      message("user-1", "user", "Question"),
+      message("assistant-1", "assistant", "Answer"),
+    ];
+    const { rerender } = renderWithProviders(
+      <MessageTimeline messages={messages} />,
+    );
+    const scroller = getTimelineScroller();
+    setScrollMetrics(scroller, { scrollTop: 500 });
+    const scrollTo = attachScrollTo(scroller);
+
+    fireEvent.wheel(scroller, { deltaY: -120 });
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+    scrollTo.mockClear();
+
+    rerender(
+      <MessageTimeline
+        messages={[
+          ...messages,
+          {
+            ...message("voice-1", "user", "Spoken follow-up"),
+            metadata: {
+              userVisible: true,
+              origin: "voice_conversation",
+            },
+          },
+          message("assistant-2", "assistant", "Working"),
+        ]}
+        streamingMessageId="assistant-2"
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBe(100));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("keeps manual position stable and shows Jump when resize leaves latest behind", () => {
     const animationFrame = mockRequestAnimationFrame();
     const messages = [

--- a/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
@@ -1543,6 +1543,65 @@ describe("MessageTimeline", () => {
     ).toBeInTheDocument();
   });
 
+  it("follows a new voice turn appended with an assistant continuation", async () => {
+    const messages = [
+      message("user-1", "user", "Question"),
+      message("assistant-1", "assistant", "Answer"),
+    ];
+    const { rerender } = renderWithProviders(
+      <MessageTimeline messages={messages} />,
+    );
+    const scroller = getTimelineScroller();
+    setScrollMetrics(scroller, {
+      scrollTop: 500,
+      scrollHeight: 1000,
+      clientHeight: 500,
+    });
+    const scrollTo = attachScrollTo(scroller);
+    fireEvent.wheel(scroller, { deltaY: -120 });
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+    scrollTo.mockClear();
+
+    setScrollMetrics(scroller, {
+      scrollTop: 100,
+      scrollHeight: 1200,
+      clientHeight: 500,
+    });
+    rerender(
+      <MessageTimeline
+        messages={[
+          ...messages,
+          {
+            ...message("voice-local", "user", "Spoken follow-up"),
+            metadata: {
+              userVisible: true,
+              origin: "voice_conversation",
+              voiceConversationLifecycleId: "lifecycle-1",
+              voiceUtteranceId: "utterance-1",
+              voiceConversationRevision: 0,
+            },
+          },
+          message("assistant-2", "assistant", "Working"),
+        ]}
+        streamingMessageId="assistant-2"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(scrollTo).toHaveBeenCalledWith({
+        top: 700,
+        behavior: "auto",
+      }),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps manual position stable and shows Jump when resize leaves latest behind", () => {
     const animationFrame = mockRequestAnimationFrame();
     const messages = [

--- a/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
@@ -1481,7 +1481,7 @@ describe("MessageTimeline", () => {
     });
   });
 
-  it("follows a new voice user turn when an assistant turn remains latest", async () => {
+  it("follows a new voice user turn like a composer submission", async () => {
     const messages = [
       message("user-1", "user", "Question"),
       message("assistant-1", "assistant", "Answer"),
@@ -1492,50 +1492,6 @@ describe("MessageTimeline", () => {
     const scroller = getTimelineScroller();
     setScrollMetrics(scroller, { scrollTop: 500 });
     const scrollTo = attachScrollTo(scroller);
-    scrollTo.mockClear();
-
-    setScrollMetrics(scroller, {
-      scrollTop: 500,
-      scrollHeight: 1200,
-      clientHeight: 500,
-    });
-    rerender(
-      <MessageTimeline
-        messages={[
-          ...messages,
-          {
-            ...message("voice-1", "user", "Spoken follow-up"),
-            metadata: {
-              userVisible: true,
-              origin: "voice_conversation",
-            },
-          },
-          message("assistant-2", "assistant", "Working"),
-        ]}
-        streamingMessageId="assistant-2"
-      />,
-    );
-
-    await waitFor(() =>
-      expect(scrollTo).toHaveBeenCalledWith({
-        top: 700,
-        behavior: "auto",
-      }),
-    );
-  });
-
-  it("does not follow a new voice user turn while the reader is detached", async () => {
-    const messages = [
-      message("user-1", "user", "Question"),
-      message("assistant-1", "assistant", "Answer"),
-    ];
-    const { rerender } = renderWithProviders(
-      <MessageTimeline messages={messages} />,
-    );
-    const scroller = getTimelineScroller();
-    setScrollMetrics(scroller, { scrollTop: 500 });
-    const scrollTo = attachScrollTo(scroller);
-
     fireEvent.wheel(scroller, { deltaY: -120 });
     scroller.scrollTop = 100;
     fireEvent.scroll(scroller);
@@ -1555,14 +1511,19 @@ describe("MessageTimeline", () => {
               origin: "voice_conversation",
             },
           },
-          message("assistant-2", "assistant", "Working"),
         ]}
-        streamingMessageId="assistant-2"
       />,
     );
 
-    await waitFor(() => expect(scroller.scrollTop).toBe(100));
-    expect(scrollTo).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Jump to latest" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 500,
+      behavior: "auto",
+    });
   });
 
   it("keeps manual position stable and shows Jump when resize leaves latest behind", () => {

--- a/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/MessageTimeline.test.tsx
@@ -1499,21 +1499,18 @@ describe("MessageTimeline", () => {
       await screen.findByRole("button", { name: "Jump to latest" }),
     ).toBeInTheDocument();
     scrollTo.mockClear();
+    const voiceMessage = {
+      ...message("voice-local", "user", "Spoken follow-up"),
+      metadata: {
+        userVisible: true,
+        origin: "voice_conversation" as const,
+        voiceConversationLifecycleId: "lifecycle-1",
+        voiceUtteranceId: "utterance-1",
+        voiceConversationRevision: 0,
+      },
+    };
 
-    rerender(
-      <MessageTimeline
-        messages={[
-          ...messages,
-          {
-            ...message("voice-1", "user", "Spoken follow-up"),
-            metadata: {
-              userVisible: true,
-              origin: "voice_conversation",
-            },
-          },
-        ]}
-      />,
-    );
+    rerender(<MessageTimeline messages={[...messages, voiceMessage]} />);
 
     await waitFor(() =>
       expect(
@@ -1524,6 +1521,26 @@ describe("MessageTimeline", () => {
       top: 500,
       behavior: "auto",
     });
+
+    fireEvent.wheel(scroller, { deltaY: -120 });
+    scroller.scrollTop = 100;
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+    scrollTo.mockClear();
+
+    rerender(
+      <MessageTimeline
+        messages={[...messages, { ...voiceMessage, id: "voice-backend" }]}
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBe(100));
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps manual position stable and shows Jump when resize leaves latest behind", () => {

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -1821,16 +1821,22 @@ describe("VirtualMessageTimeline", () => {
     expect(
       await screen.findByRole("button", { name: "Jump to latest" }),
     ).toBeInTheDocument();
+    const voiceMessage = textMessage(
+      "voice-local",
+      "user",
+      "Spoken follow-up",
+      {
+        userVisible: true,
+        origin: "voice_conversation",
+        voiceConversationLifecycleId: "lifecycle-1",
+        voiceUtteranceId: "utterance-1",
+        voiceConversationRevision: 0,
+      },
+    );
     rerender(
       <VirtualMessageTimeline
         sessionId="session-1"
-        messages={[
-          ...messages,
-          textMessage("voice-1", "user", "Spoken follow-up", {
-            userVisible: true,
-            origin: "voice_conversation",
-          }),
-        ]}
+        messages={[...messages, voiceMessage]}
       />,
     );
 
@@ -1838,6 +1844,29 @@ describe("VirtualMessageTimeline", () => {
     expect(
       screen.queryByRole("button", { name: "Jump to latest" }),
     ).not.toBeInTheDocument();
+
+    fireEvent.wheel(scroller, { deltaY: -300 });
+    setScrollMetrics(scroller, {
+      scrollTop: 200,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={[...messages, { ...voiceMessage, id: "voice-backend" }]}
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBe(200));
+    expect(
+      screen.getByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps following latest after an intent-less upward scroll correction", async () => {

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -1869,6 +1869,62 @@ describe("VirtualMessageTimeline", () => {
     ).toBeInTheDocument();
   });
 
+  it("follows a new voice turn appended with an assistant continuation", async () => {
+    mockTranscriptElementMeasurements();
+    const messages = [
+      textMessage("user-1", "user", "Question"),
+      textMessage(
+        "assistant-1",
+        "assistant",
+        `${longText("history", 80)}\n[height:900]`,
+      ),
+    ];
+    const { rerender } = renderWithProviders(
+      <VirtualMessageTimeline sessionId="session-1" messages={messages} />,
+    );
+    const scroller = screen.getByTestId("message-timeline-scroll");
+    attachScrollTo(scroller);
+    setScrollMetrics(scroller, {
+      scrollTop: 700,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+    fireEvent.wheel(scroller, { deltaY: -300 });
+    setScrollMetrics(scroller, {
+      scrollTop: 200,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={[
+          ...messages,
+          textMessage("voice-local", "user", "Spoken follow-up", {
+            userVisible: true,
+            origin: "voice_conversation",
+            voiceConversationLifecycleId: "lifecycle-1",
+            voiceUtteranceId: "utterance-1",
+            voiceConversationRevision: 0,
+          }),
+          textMessage("assistant-2", "assistant", "Working"),
+        ]}
+        streamingMessageId="assistant-2"
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(200));
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps following latest after an intent-less upward scroll correction", async () => {
     const messages = [
       textMessage("user-1", "user", "Question"),

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -1789,6 +1789,103 @@ describe("VirtualMessageTimeline", () => {
     await waitFor(() => expect(scroller.scrollTop).toBe(detachedScrollTop));
   });
 
+  it("follows a new voice user turn when an assistant turn remains latest", async () => {
+    mockTranscriptElementMeasurements();
+    const messages = [
+      textMessage("user-1", "user", "Question"),
+      textMessage(
+        "assistant-1",
+        "assistant",
+        `${longText("history", 80)}\n[height:900]`,
+      ),
+    ];
+    const { rerender } = renderWithProviders(
+      <VirtualMessageTimeline sessionId="session-1" messages={messages} />,
+    );
+    const scroller = screen.getByTestId("message-timeline-scroll");
+    const scrollTo = attachScrollTo(scroller);
+    setScrollMetrics(scroller, {
+      scrollTop: 700,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+    scrollTo.mockClear();
+
+    setScrollMetrics(scroller, {
+      scrollTop: 700,
+      scrollHeight: 1200,
+      clientHeight: 300,
+    });
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={[
+          ...messages,
+          textMessage("voice-1", "user", "Spoken follow-up", {
+            userVisible: true,
+            origin: "voice_conversation",
+          }),
+          textMessage("assistant-2", "assistant", "Working"),
+        ]}
+        streamingMessageId="assistant-2"
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(700));
+  });
+
+  it("does not follow a new voice user turn while the reader is detached", async () => {
+    mockTranscriptElementMeasurements();
+    const messages = [
+      textMessage("user-1", "user", "Question"),
+      textMessage(
+        "assistant-1",
+        "assistant",
+        `${longText("history", 80)}\n[height:900]`,
+      ),
+    ];
+    const { rerender } = renderWithProviders(
+      <VirtualMessageTimeline sessionId="session-1" messages={messages} />,
+    );
+    const scroller = screen.getByTestId("message-timeline-scroll");
+    const scrollTo = attachScrollTo(scroller);
+    setScrollMetrics(scroller, {
+      scrollTop: 700,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+
+    fireEvent.wheel(scroller, { deltaY: -300 });
+    setScrollMetrics(scroller, {
+      scrollTop: 200,
+      scrollHeight: 1000,
+      clientHeight: 300,
+    });
+    fireEvent.scroll(scroller);
+    expect(
+      await screen.findByRole("button", { name: "Jump to latest" }),
+    ).toBeInTheDocument();
+    scrollTo.mockClear();
+
+    rerender(
+      <VirtualMessageTimeline
+        sessionId="session-1"
+        messages={[
+          ...messages,
+          textMessage("voice-1", "user", "Spoken follow-up", {
+            userVisible: true,
+            origin: "voice_conversation",
+          }),
+        ]}
+      />,
+    );
+
+    await waitFor(() => expect(scroller.scrollTop).toBe(200));
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
   it("keeps following latest after an intent-less upward scroll correction", async () => {
     const messages = [
       textMessage("user-1", "user", "Question"),

--- a/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
+++ b/src/features/chat/ui/__tests__/VirtualMessageTimeline.test.tsx
@@ -1789,7 +1789,7 @@ describe("VirtualMessageTimeline", () => {
     await waitFor(() => expect(scroller.scrollTop).toBe(detachedScrollTop));
   });
 
-  it("follows a new voice user turn when an assistant turn remains latest", async () => {
+  it("follows a new voice user turn like a composer submission", async () => {
     mockTranscriptElementMeasurements();
     const messages = [
       textMessage("user-1", "user", "Question"),
@@ -1803,53 +1803,7 @@ describe("VirtualMessageTimeline", () => {
       <VirtualMessageTimeline sessionId="session-1" messages={messages} />,
     );
     const scroller = screen.getByTestId("message-timeline-scroll");
-    const scrollTo = attachScrollTo(scroller);
-    setScrollMetrics(scroller, {
-      scrollTop: 700,
-      scrollHeight: 1000,
-      clientHeight: 300,
-    });
-    fireEvent.scroll(scroller);
-    scrollTo.mockClear();
-
-    setScrollMetrics(scroller, {
-      scrollTop: 700,
-      scrollHeight: 1200,
-      clientHeight: 300,
-    });
-    rerender(
-      <VirtualMessageTimeline
-        sessionId="session-1"
-        messages={[
-          ...messages,
-          textMessage("voice-1", "user", "Spoken follow-up", {
-            userVisible: true,
-            origin: "voice_conversation",
-          }),
-          textMessage("assistant-2", "assistant", "Working"),
-        ]}
-        streamingMessageId="assistant-2"
-      />,
-    );
-
-    await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(700));
-  });
-
-  it("does not follow a new voice user turn while the reader is detached", async () => {
-    mockTranscriptElementMeasurements();
-    const messages = [
-      textMessage("user-1", "user", "Question"),
-      textMessage(
-        "assistant-1",
-        "assistant",
-        `${longText("history", 80)}\n[height:900]`,
-      ),
-    ];
-    const { rerender } = renderWithProviders(
-      <VirtualMessageTimeline sessionId="session-1" messages={messages} />,
-    );
-    const scroller = screen.getByTestId("message-timeline-scroll");
-    const scrollTo = attachScrollTo(scroller);
+    attachScrollTo(scroller);
     setScrollMetrics(scroller, {
       scrollTop: 700,
       scrollHeight: 1000,
@@ -1867,8 +1821,6 @@ describe("VirtualMessageTimeline", () => {
     expect(
       await screen.findByRole("button", { name: "Jump to latest" }),
     ).toBeInTheDocument();
-    scrollTo.mockClear();
-
     rerender(
       <VirtualMessageTimeline
         sessionId="session-1"
@@ -1882,8 +1834,10 @@ describe("VirtualMessageTimeline", () => {
       />,
     );
 
-    await waitFor(() => expect(scroller.scrollTop).toBe(200));
-    expect(scrollTo).not.toHaveBeenCalled();
+    await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(200));
+    expect(
+      screen.queryByRole("button", { name: "Jump to latest" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps following latest after an intent-less upward scroll correction", async () => {

--- a/src/features/chat/ui/messageTimelineShared.tsx
+++ b/src/features/chat/ui/messageTimelineShared.tsx
@@ -11,7 +11,30 @@ import {
 } from "@/shared/ui/tooltip";
 import { cn } from "@/shared/lib/cn";
 import { SIDEBAR_GROUP_LABEL_TEXT_CLASS } from "@/shared/ui/sidebar-tokens";
+import type { Message } from "@/shared/types/messages";
 import type { McpAppMessageHandler } from "./mcpAppTypes";
+
+export function getVoiceSubmissionKey(
+  message: Message | undefined,
+): string | null {
+  if (
+    message?.role !== "user" ||
+    message.metadata?.origin !== "voice_conversation"
+  ) {
+    return null;
+  }
+
+  const utteranceId = message.metadata.voiceUtteranceId;
+  if (!utteranceId) {
+    return message.id;
+  }
+
+  return [
+    message.metadata.voiceConversationLifecycleId ?? "",
+    utteranceId,
+    message.metadata.voiceConversationRevision ?? "",
+  ].join(":");
+}
 
 export interface MessageBubbleCallbacks {
   onRetryMessage?: (messageId: string) => void;

--- a/src/features/chat/ui/messageTimelineShared.tsx
+++ b/src/features/chat/ui/messageTimelineShared.tsx
@@ -36,6 +36,13 @@ export function getVoiceSubmissionKey(
   ].join(":");
 }
 
+export function getTimelineMessageIdentity(message: Message): string {
+  const voiceSubmissionKey = getVoiceSubmissionKey(message);
+  return voiceSubmissionKey
+    ? `voice:${voiceSubmissionKey}`
+    : `message:${message.id}`;
+}
+
 export interface MessageBubbleCallbacks {
   onRetryMessage?: (messageId: string) => void;
   onEditMessage?: (messageId: string) => void;


### PR DESCRIPTION
## Summary

Submitting a message through voice conversation could render the new user turn without scrolling the transcript to it. The conversation stayed above the new message until assistant output arrived, even though composer submissions follow immediately.

Newly appended voice submissions now use the same reattach behavior as composer submissions in both transcript renderers. Stable voice-utterance identity prevents history replay, failed-delivery rollback, and backend message-ID acknowledgement from causing unrelated or repeated jumps.

## Reviewer-reproducible example

1. Open a chat with enough history to scroll, then scroll up until **Jump to latest** appears.
2. Submit a new message through voice conversation.
3. Confirm the user transcript appears and the chat follows it immediately, before the assistant responds.
4. Scroll up again while the turn is being acknowledged. Confirm acknowledgement does not cause a second jump.

## Manual verification

John confirmed in the Berd daily driver that a voice-submitted user turn scrolls into view immediately, before the assistant responds.
