### PR TITLE
fix agent import and card presentation

### DIFF
--- a/distro/skills/agent-builder/SKILL.md
+++ b/distro/skills/agent-builder/SKILL.md
@@ -27,7 +27,7 @@ Each agent is one `.md` file:
 ```md
 ---
 name: Agent Name
-description: Agent
+description: A concise summary of what this agent does
 provider: optional-provider
 model: optional-model
 avatar: optional-avatar
@@ -35,7 +35,7 @@ avatar: optional-avatar
 
 Agent instructions here.
 ```
-Required frontmatter keys are name and description. Preserve all other frontmatter keys when editing existing agents unless the user explicitly changes them. The Markdown body is the agent’s system prompt/persona instructions.
+Required frontmatter keys are `name` and `description`. The description must be a trimmed, non-empty summary of what the agent does; never create or save an agent with a missing, blank, or placeholder description. If the user has not supplied enough context to write an accurate description, ask for one before saving. Preserve all other frontmatter keys when editing existing agents unless the user explicitly changes them. The Markdown body is the agent’s system prompt/persona instructions.
 
 When writing or generating a description or body, do not assign the agent a gender or gendered pronouns unless the user asked for one. Use it/its or they/them for the agent, matching how it is framed (tool vs. character), or avoid pronouns; people the instructions describe get they/them. Preserve pronouns the user chose, in either direction.
 
@@ -52,4 +52,4 @@ When editing, read the existing file first. Resolve targets by exact path, front
 
 Prefer direct file edits over helper scripts. Do not require Python, Node, or another runtime unless the current repo already requires it.
 
-After writing, verify that the file exists, frontmatter is valid, required keys are present, and preserved metadata was not removed. Report the final path.
+After writing, verify that the file exists, frontmatter is valid, `name` and `description` are both trimmed and non-empty, and preserved metadata was not removed. Report the final path.

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -47,6 +47,26 @@ fn validate_import_agent_image_path(source_path: &str) -> Result<PathBuf, String
     canonicalize_path(&path, "agent image import")
 }
 
+fn validate_agent_import_path(source_path: &str) -> Result<PathBuf, String> {
+    let path = PathBuf::from(source_path);
+    let metadata = validate_existing_regular_file(&path, "agent import")?;
+    let lower_name = lower_file_name(&path)?;
+    if !lower_name.ends_with(".zip")
+        && !lower_name.ends_with(".png")
+        && !lower_name.ends_with(".md")
+        && !lower_name.ends_with(".json")
+    {
+        return Err(
+            "Unsupported file type. Expected an agent ZIP, PNG, Markdown, or JSON file."
+                .to_string(),
+        );
+    }
+    if metadata.len() > MAX_AGENT_IMAGE_IMPORT_BYTES {
+        return Err("Agent import file must be 10 MB or smaller.".to_string());
+    }
+    canonicalize_path(&path, "agent import")
+}
+
 fn validate_agent_source_path(
     source_path: &str,
     agents_root: Option<&Path>,
@@ -178,6 +198,29 @@ pub fn repair_bundled_agent(
 pub fn read_import_persona_file(source_path: String) -> Result<ImportFileReadResult, String> {
     let path = validate_import_persona_path(&source_path)?;
     read_persona_file(path, "import")
+}
+
+#[tauri::command]
+pub fn read_import_agent_file(source_path: String) -> Result<ImportBinaryFileReadResult, String> {
+    let path = validate_agent_import_path(&source_path)?;
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "Selected file is missing a valid filename".to_string())?
+        .to_string();
+    let file = std::fs::File::open(&path)
+        .map_err(|err| format!("Failed to open agent import '{}': {err}", path.display()))?;
+    let mut file_bytes = Vec::new();
+    file.take(MAX_AGENT_IMAGE_IMPORT_BYTES + 1)
+        .read_to_end(&mut file_bytes)
+        .map_err(|err| format!("Failed to read agent import '{}': {err}", path.display()))?;
+    if file_bytes.len() as u64 > MAX_AGENT_IMAGE_IMPORT_BYTES {
+        return Err("Agent import file must be 10 MB or smaller.".to_string());
+    }
+    Ok(ImportBinaryFileReadResult {
+        file_bytes,
+        file_name,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -444,6 +444,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::agents::read_import_persona_file,
+            commands::agents::read_import_agent_file,
             commands::agents::read_import_agent_image,
             commands::agents::read_agent_source_file,
             commands::agents::repair_bundled_agent,

--- a/src-tauri/src/services/bundled_agents.rs
+++ b/src-tauri/src/services/bundled_agents.rs
@@ -18,6 +18,18 @@ static INSTALL_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const LEGACY_AGT_BUILDER_FILE_NAME: &str = "agt-builder.md";
 const LEGACY_AGT_BUILDER_FILE_SHA256: &str =
     "15ac706dd4b14dced6368572f4f2f0b3e42d0263cafb5ec199e71cd034b14a9d";
+const KNOWN_AGENT_DESCRIPTION_MIGRATIONS: [(&str, &str, &str); 2] = [
+    (
+        "reviewer.md",
+        "82cd0d7433c62c1c0ec67250e40167d2fd049e65989910a843a651cb5c57d9a4",
+        "A careful second set of eyes for maintainable changes.",
+    ),
+    (
+        "spar.md",
+        "e09d82e3114cf454a1f9bdb82c8fac61d6e842d7ff1ad7d7318da60e0d71da75",
+        "Reviews architecture and system design for structural soundness.",
+    ),
+];
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SeedBundledAgentsResult {
@@ -59,7 +71,10 @@ pub fn seed_bundled_agents(
         }
     };
 
-    seed_bundled_agents_from_dir(&bundle.root_dir.join(DISTRO_AGENTS_DIR_NAME), &target_root)
+    let result =
+        seed_bundled_agents_from_dir(&bundle.root_dir.join(DISTRO_AGENTS_DIR_NAME), &target_root)?;
+    migrate_known_placeholder_descriptions(&target_root)?;
+    Ok(result)
 }
 
 /// Explicitly restores one bundled agent after a user invokes a feature that
@@ -249,6 +264,55 @@ fn seed_bundled_agents_from_dir(
     })
 }
 
+fn migrate_known_placeholder_descriptions(target_root: &Path) -> Result<usize, String> {
+    migrate_placeholder_descriptions(target_root, &KNOWN_AGENT_DESCRIPTION_MIGRATIONS)
+}
+
+fn migrate_placeholder_descriptions(
+    target_root: &Path,
+    migrations: &[(&str, &str, &str)],
+) -> Result<usize, String> {
+    let mut migrated = 0;
+    for &(file_name, expected_sha256, description) in migrations {
+        let path = target_root.join(file_name);
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(format!(
+                    "Failed to inspect agent description migration target '{}': {error}",
+                    path.display()
+                ));
+            }
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            continue;
+        }
+        let contents = match fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => continue,
+            Err(error) => {
+                return Err(format!(
+                    "Failed to read agent description migration target '{}': {error}",
+                    path.display()
+                ));
+            }
+        };
+        let digest = format!("{:x}", Sha256::digest(contents.as_bytes()));
+        if digest != expected_sha256 {
+            continue;
+        }
+        let updated = contents.replacen(
+            "description: Agent",
+            &format!("description: {description}"),
+            1,
+        );
+        install_agent_contents(&path, updated.as_bytes())?;
+        migrated += 1;
+    }
+    Ok(migrated)
+}
+
 fn has_known_legacy_agt_builder_contents(path: &Path) -> Result<bool, String> {
     let metadata = fs::symlink_metadata(path)
         .map_err(|err| format!("Failed to inspect legacy agent '{}': {err}", path.display()))?;
@@ -343,6 +407,53 @@ fn agent_frontmatter(contents: &str) -> Option<&str> {
     let contents = contents.strip_prefix("---\n")?;
     let end = contents.find("\n---")?;
     Some(&contents[..end])
+}
+
+fn install_agent_contents(target: &Path, contents: &[u8]) -> Result<(), String> {
+    let parent = target
+        .parent()
+        .ok_or_else(|| "Agent target has no parent".to_string())?;
+    let sequence = INSTALL_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp_path = parent.join(format!(
+        ".berd-agent-install-{}-{sequence}.tmp",
+        std::process::id()
+    ));
+    let install_result = (|| -> Result<(), String> {
+        let mut temp = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .map_err(|err| {
+                format!(
+                    "Failed to create temporary agent '{}': {err}",
+                    temp_path.display()
+                )
+            })?;
+        temp.write_all(contents).map_err(|err| {
+            format!(
+                "Failed to write temporary agent '{}': {err}",
+                temp_path.display()
+            )
+        })?;
+        temp.sync_all().map_err(|err| {
+            format!(
+                "Failed to sync temporary agent '{}': {err}",
+                temp_path.display()
+            )
+        })?;
+        #[cfg(windows)]
+        if target.exists() {
+            fs::remove_file(target).map_err(|err| {
+                format!("Failed to replace agent at '{}': {err}", target.display())
+            })?;
+        }
+        fs::rename(&temp_path, target)
+            .map_err(|err| format!("Failed to install agent at '{}': {err}", target.display()))
+    })();
+    if install_result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    install_result
 }
 
 fn install_agent_file(source: &Path, target: &Path) -> Result<(), String> {
@@ -492,6 +603,79 @@ mod tests {
     fn write_agent(root: &Path, name: &str, contents: &str) {
         fs::create_dir_all(root).unwrap();
         fs::write(root.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn migrates_only_known_agents_with_placeholder_descriptions() {
+        let target = tempdir().unwrap();
+        write_agent(
+            target.path(),
+            "reviewer.md",
+            "---\nname: Reviewer\ndescription: Agent\navatar: custom\n---\nUser instructions.",
+        );
+        write_agent(
+            target.path(),
+            "spar.md",
+            "---\nname: Spar\ndescription: Agent\n---\nArchitecture instructions.",
+        );
+        write_agent(
+            target.path(),
+            "custom.md",
+            "---\nname: Custom\ndescription: Agent\n---\nCustom instructions.",
+        );
+        write_agent(
+            target.path(),
+            "reviewer-copy.md",
+            "---\nname: Reviewer\ndescription: Agent\n---\nAnother agent.",
+        );
+
+        let migrations = [
+            (
+                "reviewer.md",
+                "c8a703c47be78da3e30ede9ab81f4fcc8265e04153ae20d1bd0510aa293cf083",
+                "A careful second set of eyes for maintainable changes.",
+            ),
+            (
+                "spar.md",
+                "34134750f4bc3bfdc38d38322fff71df421401bff7eaebf6ecc1fe51005ee389",
+                "Reviews architecture and system design for structural soundness.",
+            ),
+        ];
+        assert_eq!(
+            migrate_placeholder_descriptions(target.path(), &migrations).unwrap(),
+            2
+        );
+        assert!(fs::read_to_string(target.path().join("reviewer.md"))
+            .unwrap()
+            .contains("description: A careful second set of eyes for maintainable changes."));
+        assert!(fs::read_to_string(target.path().join("spar.md"))
+            .unwrap()
+            .contains(
+                "description: Reviews architecture and system design for structural soundness."
+            ));
+        assert!(fs::read_to_string(target.path().join("custom.md"))
+            .unwrap()
+            .contains("description: Agent"));
+        assert!(fs::read_to_string(target.path().join("reviewer-copy.md"))
+            .unwrap()
+            .contains("description: Agent"));
+    }
+
+    #[test]
+    fn preserves_known_agents_with_authored_descriptions() {
+        let target = tempdir().unwrap();
+        let contents =
+            "---\nname: Reviewer\ndescription: My custom reviewer\n---\nUser instructions.";
+        write_agent(target.path(), "reviewer.md", contents);
+
+        assert_eq!(
+            migrate_known_placeholder_descriptions(target.path()).unwrap(),
+            0
+        );
+        assert_eq!(
+            fs::read_to_string(target.path().join("reviewer.md")).unwrap(),
+            contents
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/bundled_agents.rs
+++ b/src-tauri/src/services/bundled_agents.rs
@@ -18,18 +18,6 @@ static INSTALL_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const LEGACY_AGT_BUILDER_FILE_NAME: &str = "agt-builder.md";
 const LEGACY_AGT_BUILDER_FILE_SHA256: &str =
     "15ac706dd4b14dced6368572f4f2f0b3e42d0263cafb5ec199e71cd034b14a9d";
-const KNOWN_AGENT_DESCRIPTION_MIGRATIONS: [(&str, &str, &str); 2] = [
-    (
-        "reviewer.md",
-        "82cd0d7433c62c1c0ec67250e40167d2fd049e65989910a843a651cb5c57d9a4",
-        "A careful second set of eyes for maintainable changes.",
-    ),
-    (
-        "spar.md",
-        "e09d82e3114cf454a1f9bdb82c8fac61d6e842d7ff1ad7d7318da60e0d71da75",
-        "Reviews architecture and system design for structural soundness.",
-    ),
-];
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct SeedBundledAgentsResult {
@@ -71,10 +59,7 @@ pub fn seed_bundled_agents(
         }
     };
 
-    let result =
-        seed_bundled_agents_from_dir(&bundle.root_dir.join(DISTRO_AGENTS_DIR_NAME), &target_root)?;
-    migrate_known_placeholder_descriptions(&target_root)?;
-    Ok(result)
+    seed_bundled_agents_from_dir(&bundle.root_dir.join(DISTRO_AGENTS_DIR_NAME), &target_root)
 }
 
 /// Explicitly restores one bundled agent after a user invokes a feature that
@@ -264,55 +249,6 @@ fn seed_bundled_agents_from_dir(
     })
 }
 
-fn migrate_known_placeholder_descriptions(target_root: &Path) -> Result<usize, String> {
-    migrate_placeholder_descriptions(target_root, &KNOWN_AGENT_DESCRIPTION_MIGRATIONS)
-}
-
-fn migrate_placeholder_descriptions(
-    target_root: &Path,
-    migrations: &[(&str, &str, &str)],
-) -> Result<usize, String> {
-    let mut migrated = 0;
-    for &(file_name, expected_sha256, description) in migrations {
-        let path = target_root.join(file_name);
-        let metadata = match fs::symlink_metadata(&path) {
-            Ok(metadata) => metadata,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(error) => {
-                return Err(format!(
-                    "Failed to inspect agent description migration target '{}': {error}",
-                    path.display()
-                ));
-            }
-        };
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
-            continue;
-        }
-        let contents = match fs::read_to_string(&path) {
-            Ok(contents) => contents,
-            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => continue,
-            Err(error) => {
-                return Err(format!(
-                    "Failed to read agent description migration target '{}': {error}",
-                    path.display()
-                ));
-            }
-        };
-        let digest = format!("{:x}", Sha256::digest(contents.as_bytes()));
-        if digest != expected_sha256 {
-            continue;
-        }
-        let updated = contents.replacen(
-            "description: Agent",
-            &format!("description: {description}"),
-            1,
-        );
-        install_agent_contents(&path, updated.as_bytes())?;
-        migrated += 1;
-    }
-    Ok(migrated)
-}
-
 fn has_known_legacy_agt_builder_contents(path: &Path) -> Result<bool, String> {
     let metadata = fs::symlink_metadata(path)
         .map_err(|err| format!("Failed to inspect legacy agent '{}': {err}", path.display()))?;
@@ -407,53 +343,6 @@ fn agent_frontmatter(contents: &str) -> Option<&str> {
     let contents = contents.strip_prefix("---\n")?;
     let end = contents.find("\n---")?;
     Some(&contents[..end])
-}
-
-fn install_agent_contents(target: &Path, contents: &[u8]) -> Result<(), String> {
-    let parent = target
-        .parent()
-        .ok_or_else(|| "Agent target has no parent".to_string())?;
-    let sequence = INSTALL_TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    let temp_path = parent.join(format!(
-        ".berd-agent-install-{}-{sequence}.tmp",
-        std::process::id()
-    ));
-    let install_result = (|| -> Result<(), String> {
-        let mut temp = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp_path)
-            .map_err(|err| {
-                format!(
-                    "Failed to create temporary agent '{}': {err}",
-                    temp_path.display()
-                )
-            })?;
-        temp.write_all(contents).map_err(|err| {
-            format!(
-                "Failed to write temporary agent '{}': {err}",
-                temp_path.display()
-            )
-        })?;
-        temp.sync_all().map_err(|err| {
-            format!(
-                "Failed to sync temporary agent '{}': {err}",
-                temp_path.display()
-            )
-        })?;
-        #[cfg(windows)]
-        if target.exists() {
-            fs::remove_file(target).map_err(|err| {
-                format!("Failed to replace agent at '{}': {err}", target.display())
-            })?;
-        }
-        fs::rename(&temp_path, target)
-            .map_err(|err| format!("Failed to install agent at '{}': {err}", target.display()))
-    })();
-    if install_result.is_err() {
-        let _ = fs::remove_file(&temp_path);
-    }
-    install_result
 }
 
 fn install_agent_file(source: &Path, target: &Path) -> Result<(), String> {
@@ -603,79 +492,6 @@ mod tests {
     fn write_agent(root: &Path, name: &str, contents: &str) {
         fs::create_dir_all(root).unwrap();
         fs::write(root.join(name), contents).unwrap();
-    }
-
-    #[test]
-    fn migrates_only_known_agents_with_placeholder_descriptions() {
-        let target = tempdir().unwrap();
-        write_agent(
-            target.path(),
-            "reviewer.md",
-            "---\nname: Reviewer\ndescription: Agent\navatar: custom\n---\nUser instructions.",
-        );
-        write_agent(
-            target.path(),
-            "spar.md",
-            "---\nname: Spar\ndescription: Agent\n---\nArchitecture instructions.",
-        );
-        write_agent(
-            target.path(),
-            "custom.md",
-            "---\nname: Custom\ndescription: Agent\n---\nCustom instructions.",
-        );
-        write_agent(
-            target.path(),
-            "reviewer-copy.md",
-            "---\nname: Reviewer\ndescription: Agent\n---\nAnother agent.",
-        );
-
-        let migrations = [
-            (
-                "reviewer.md",
-                "c8a703c47be78da3e30ede9ab81f4fcc8265e04153ae20d1bd0510aa293cf083",
-                "A careful second set of eyes for maintainable changes.",
-            ),
-            (
-                "spar.md",
-                "34134750f4bc3bfdc38d38322fff71df421401bff7eaebf6ecc1fe51005ee389",
-                "Reviews architecture and system design for structural soundness.",
-            ),
-        ];
-        assert_eq!(
-            migrate_placeholder_descriptions(target.path(), &migrations).unwrap(),
-            2
-        );
-        assert!(fs::read_to_string(target.path().join("reviewer.md"))
-            .unwrap()
-            .contains("description: A careful second set of eyes for maintainable changes."));
-        assert!(fs::read_to_string(target.path().join("spar.md"))
-            .unwrap()
-            .contains(
-                "description: Reviews architecture and system design for structural soundness."
-            ));
-        assert!(fs::read_to_string(target.path().join("custom.md"))
-            .unwrap()
-            .contains("description: Agent"));
-        assert!(fs::read_to_string(target.path().join("reviewer-copy.md"))
-            .unwrap()
-            .contains("description: Agent"));
-    }
-
-    #[test]
-    fn preserves_known_agents_with_authored_descriptions() {
-        let target = tempdir().unwrap();
-        let contents =
-            "---\nname: Reviewer\ndescription: My custom reviewer\n---\nUser instructions.";
-        write_agent(target.path(), "reviewer.md", contents);
-
-        assert_eq!(
-            migrate_known_placeholder_descriptions(target.path()).unwrap(),
-            0
-        );
-        assert_eq!(
-            fs::read_to_string(target.path().join("reviewer.md")).unwrap(),
-            contents
-        );
     }
 
     #[test]

--- a/src/features/agents/capabilities/__tests__/AgentBuilderCapability.test.tsx
+++ b/src/features/agents/capabilities/__tests__/AgentBuilderCapability.test.tsx
@@ -16,6 +16,12 @@ const apiMocks = vi.hoisted(() => ({
   readAgentSourceFile: vi.fn(),
   updatePersonaSource: vi.fn(),
   listPersonas: vi.fn(),
+  hasRealAgentDescription: (description: string | null | undefined) => {
+    const normalized = description?.trim().toLowerCase();
+    return Boolean(
+      normalized && normalized !== "agent" && normalized !== "draft",
+    );
+  },
 }));
 
 vi.mock("@/shared/api/agents", () => apiMocks);

--- a/src/features/agents/ui/AgentBuilderRail.tsx
+++ b/src/features/agents/ui/AgentBuilderRail.tsx
@@ -301,18 +301,6 @@ export function AgentBuilderRail({
     };
   }, [hasLocalEdits, onLocalEditStateChange]);
 
-  useEffect(() => {
-    if (!data) {
-      onSaveDraftHandlerChange?.(null);
-      return;
-    }
-
-    onSaveDraftHandlerChange?.(saveNow);
-    return () => {
-      onSaveDraftHandlerChange?.(null);
-    };
-  }, [data, onSaveDraftHandlerChange, saveNow]);
-
   const requiresNewDraftFields = isDraft;
   const headerName = data
     ? isPlaceholderAgentName(data.name)
@@ -332,6 +320,7 @@ export function AgentBuilderRail({
   const instructionsFieldValue = isPlaceholderContent ? "" : contentFieldValue;
   const avatarRequired = Boolean(effectiveAvatar);
   const nameRequired = nameFieldValue.trim().length > 0;
+  const descriptionRequired = descriptionFieldValue.trim().length > 0;
   const instructionsRequired =
     contentFieldValue.trim().length > 0 &&
     contentFieldValue !== PLACEHOLDER_AGENT_BODY;
@@ -340,10 +329,26 @@ export function AgentBuilderRail({
       ? t("builderRail.requiredAvatar")
       : null,
     !nameRequired ? t("builderRail.requiredName") : null,
+    !descriptionRequired ? t("builderRail.requiredDescription") : null,
     requiresNewDraftFields && !instructionsRequired
       ? t("builderRail.requiredInstructions")
       : null,
   ].filter((field): field is string => field !== null);
+  useEffect(() => {
+    if (!data) {
+      onSaveDraftHandlerChange?.(null);
+      return;
+    }
+
+    onSaveDraftHandlerChange?.(() => {
+      if (!descriptionRequired) return false;
+      return saveNow();
+    });
+    return () => {
+      onSaveDraftHandlerChange?.(null);
+    };
+  }, [data, descriptionRequired, onSaveDraftHandlerChange, saveNow]);
+
   const blockingError =
     error !== null && !(error === "load" && saveStatus === "error");
   // An agent must never be saved with a half-finished avatar. The rule lives in
@@ -755,6 +760,8 @@ export function AgentBuilderRail({
         <Input
           id="builder-rail-description"
           value={descriptionFieldValue}
+          required
+          aria-invalid={!descriptionRequired}
           placeholder={t("builderRail.descriptionPlaceholder")}
           onChange={(event) => update({ description: event.target.value })}
           className={FIELD_CLASS}

--- a/src/features/agents/ui/AgentBuilderRail.tsx
+++ b/src/features/agents/ui/AgentBuilderRail.tsx
@@ -42,7 +42,6 @@ import {
   fileStem,
   isPlaceholderAgentName,
   PLACEHOLDER_AGENT_BODY,
-  PLACEHOLDER_AGENT_DESCRIPTION,
   promoteDraft,
 } from "@/features/agents/lib/agentBuilderSession";
 import { useExperiment } from "@/features/experiments/experimentPreferences";
@@ -51,6 +50,7 @@ import { AvatarCollectionOverlay } from "@/features/agents/ui/AvatarCollectionOv
 import { AvatarLibraryPicker } from "@/features/agents/ui/AvatarLibraryPicker";
 import { ProviderModelFields } from "@/features/agents/ui/PersonaFields/ProviderModelFields";
 import { FORM_FIELD_CLASS } from "@/shared/ui/form-field-tokens";
+import { hasRealAgentDescription } from "@/shared/api/agents";
 
 const FIELD_CLASS = cn(FORM_FIELD_CLASS, "bg-muted/40");
 const FIELD_LABEL_CLASS = "mb-2 block text-xs text-muted-foreground";
@@ -312,9 +312,7 @@ export function AgentBuilderRail({
   const nameFieldValue =
     data && !isPlaceholderAgentName(data.name) ? data.name : "";
   const descriptionFieldValue =
-    data && data.description !== PLACEHOLDER_AGENT_DESCRIPTION
-      ? data.description
-      : "";
+    data && hasRealAgentDescription(data.description) ? data.description : "";
   const contentFieldValue = data?.content ?? "";
   const isPlaceholderContent = contentFieldValue === PLACEHOLDER_AGENT_BODY;
   const instructionsFieldValue = isPlaceholderContent ? "" : contentFieldValue;
@@ -340,14 +338,11 @@ export function AgentBuilderRail({
       return;
     }
 
-    onSaveDraftHandlerChange?.(() => {
-      if (!descriptionRequired) return false;
-      return saveNow();
-    });
+    onSaveDraftHandlerChange?.(saveNow);
     return () => {
       onSaveDraftHandlerChange?.(null);
     };
-  }, [data, descriptionRequired, onSaveDraftHandlerChange, saveNow]);
+  }, [data, onSaveDraftHandlerChange, saveNow]);
 
   const blockingError =
     error !== null && !(error === "load" && saveStatus === "error");

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { PersonaImportPreview } from "@/shared/api/agents";
+import {
+  readImportAgentFile,
+  type PersonaImportPreview,
+} from "@/shared/api/agents";
 import type { SnapshotV1 } from "@/features/agents/agent-snapshot";
 import { AgentShareCardPreview } from "@/features/agents/ui/share-card/AgentShareCardPreview";
 import { HolographicAgentCard } from "@/features/agents/ui/share-card/HolographicAgentCard";
 import { AgentCardReveal } from "@/features/agents/ui/share-card/AgentCardReveal";
-import { resolveAgentShareCardCopy } from "@/features/agents/ui/share-card/agentShareCardCopy";
 import {
   fallbackAgentCardColor,
   sampleAgentAvatarColor,
@@ -205,6 +207,17 @@ export function AgentImportDialog({
     };
   }, [open, initialFile, startPreparation]);
 
+  const dropZoneRef = useRef<HTMLDivElement>(null);
+  const nativeDropGenerationRef = useRef(0);
+  const validateReplacementFile = useCallback(
+    (file: Pick<File, "name" | "type" | "size">) => {
+      nativeDropGenerationRef.current += 1;
+      preparationRef.current?.abort();
+      setPrepared(null);
+      return validateImportFile(file);
+    },
+    [validateImportFile],
+  );
   const {
     fileInputRef,
     isDragOver,
@@ -213,15 +226,90 @@ export function AgentImportDialog({
     openFilePicker,
   } = useFileImportZone({
     onImportFile: startPreparation,
-    validateFile: (file) => {
-      preparationRef.current?.abort();
-      setPrepared(null);
-      return validateImportFile(file);
-    },
+    validateFile: validateReplacementFile,
     onImportError,
     maxBytes: maxImportBytes,
     fileTooLargeMessage: importTooLargeMessage,
   });
+
+  useEffect(() => {
+    if (!open || !window.__TAURI_INTERNALS__) return;
+
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void Promise.all([
+      import("@tauri-apps/api/webview"),
+      import("@tauri-apps/api/window").then(({ getCurrentWindow }) =>
+        getCurrentWindow().scaleFactor(),
+      ),
+    ])
+      .then(([{ getCurrentWebview }, scaleFactor]) =>
+        getCurrentWebview().onDragDropEvent(({ payload }) => {
+          if (disposed || !dropZoneRef.current) return;
+          if (payload.type === "leave") {
+            dropHandlers.onDragLeave();
+            return;
+          }
+          const rect = dropZoneRef.current.getBoundingClientRect();
+          const position = payload.position.toLogical(scaleFactor);
+          const inside =
+            position.x >= rect.left &&
+            position.x <= rect.right &&
+            position.y >= rect.top &&
+            position.y <= rect.bottom;
+          if (payload.type === "enter" || payload.type === "over") {
+            if (inside)
+              dropHandlers.onDragOver({
+                preventDefault() {},
+              } as React.DragEvent);
+            else dropHandlers.onDragLeave();
+            return;
+          }
+          dropHandlers.onDragLeave();
+          const path = payload.paths[0];
+          if (!inside || !path) return;
+          const generation = ++nativeDropGenerationRef.current;
+          void readImportAgentFile(path)
+            .then(({ fileBytes, fileName }) => {
+              if (disposed || generation !== nativeDropGenerationRef.current)
+                return;
+              const bytes = Uint8Array.from(fileBytes);
+              const file = new File([bytes], fileName);
+              const error = validateReplacementFile(file);
+              if (error) {
+                onImportError(error);
+                return;
+              }
+              startPreparation(bytes, fileName);
+            })
+            .catch((error) => {
+              if (!disposed && generation === nativeDropGenerationRef.current)
+                onImportError(
+                  error instanceof Error ? error.message : String(error),
+                );
+            });
+        }),
+      )
+      .then((cleanup) => {
+        if (disposed) cleanup();
+        else unlisten = cleanup;
+      })
+      .catch((error) => {
+        if (!disposed)
+          console.warn("Failed to register agent import drop target", error);
+      });
+    return () => {
+      disposed = true;
+      nativeDropGenerationRef.current += 1;
+      unlisten?.();
+    };
+  }, [
+    dropHandlers,
+    onImportError,
+    open,
+    startPreparation,
+    validateReplacementFile,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -276,14 +364,6 @@ export function AgentImportDialog({
                     alt={t("importDialog.previewAlt", {
                       name: prepared.preview.displayName,
                     })}
-                    copy={resolveAgentShareCardCopy(
-                      prepared.preview.systemPrompt,
-                      t,
-                      {
-                        goodFor: prepared.preview.goodFor,
-                        vibes: prepared.preview.vibes,
-                      },
-                    )}
                     locale={locale}
                   />
                 )}
@@ -291,6 +371,7 @@ export function AgentImportDialog({
             </div>
           ) : (
             <div
+              ref={dropZoneRef}
               {...dropHandlers}
               role="status"
               aria-busy={preparing}

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -232,6 +232,7 @@ export function AgentImportDialog({
     fileInputRef,
     isDragOver,
     importFile,
+    invalidateImport,
     handleFileChange,
     openFilePicker,
   } = useFileImportZone({
@@ -246,6 +247,7 @@ export function AgentImportDialog({
     (paths: string[]) => {
       const path = paths[0];
       if (!path) return;
+      invalidateImport();
       const generation = ++nativeDropGenerationRef.current;
       void readImportAgentFile(path)
         .then(({ fileBytes, fileName }) => {
@@ -273,7 +275,12 @@ export function AgentImportDialog({
             );
         });
     },
-    [onImportError, startPreparation, validateReplacementFile],
+    [
+      invalidateImport,
+      onImportError,
+      startPreparation,
+      validateReplacementFile,
+    ],
   );
   const {
     isAttachmentDragOver,

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -15,6 +15,7 @@ import {
 
 import { cn } from "@/shared/lib/cn";
 import { useFileImportZone } from "@/shared/hooks/useFileImportZone";
+import { useAttachmentDropTarget } from "@/features/chat/hooks/useAttachmentDropTarget";
 import { Button } from "@/shared/ui/button";
 import { AgentImportPrimaryButton } from "@/shared/ui/agent-import-primary-button";
 import { AgentImportSecondaryButton } from "@/shared/ui/agent-import-secondary-button";
@@ -209,10 +210,10 @@ export function AgentImportDialog({
 
   const dropZoneRef = useRef<HTMLDivElement>(null);
   const nativeDropGenerationRef = useRef(0);
-  const nativeDropExpectedUntilRef = useRef(0);
+  const nativeDropActiveRef = useRef(open);
+  nativeDropActiveRef.current = open;
   const validateReplacementFile = useCallback(
     (file: Pick<File, "name" | "type" | "size">) => {
-      nativeDropGenerationRef.current += 1;
       preparationRef.current?.abort();
       setPrepared(null);
       return validateImportFile(file);
@@ -223,6 +224,7 @@ export function AgentImportDialog({
     fileInputRef,
     isDragOver,
     dropHandlers,
+    importFile,
     handleFileChange,
     openFilePicker,
   } = useFileImportZone({
@@ -233,90 +235,49 @@ export function AgentImportDialog({
     fileTooLargeMessage: importTooLargeMessage,
   });
 
-  useEffect(() => {
-    if (!open || !window.__TAURI_INTERNALS__) return;
-
-    let disposed = false;
-    let unlisten: (() => void) | undefined;
-    void Promise.all([
-      import("@tauri-apps/api/webview"),
-      import("@tauri-apps/api/window").then(({ getCurrentWindow }) =>
-        getCurrentWindow().scaleFactor(),
-      ),
-    ])
-      .then(([{ getCurrentWebview }, scaleFactor]) =>
-        getCurrentWebview().onDragDropEvent(({ payload }) => {
-          if (disposed || !dropZoneRef.current) return;
-          if (payload.type === "leave") {
-            nativeDropExpectedUntilRef.current = 0;
-            dropHandlers.onDragLeave();
+  const handleDroppedPaths = useCallback(
+    (paths: string[]) => {
+      const path = paths[0];
+      if (!path) return;
+      const generation = ++nativeDropGenerationRef.current;
+      void readImportAgentFile(path)
+        .then(({ fileBytes, fileName }) => {
+          if (
+            !nativeDropActiveRef.current ||
+            generation !== nativeDropGenerationRef.current
+          )
+            return;
+          const bytes = Uint8Array.from(fileBytes);
+          const file = new File([bytes], fileName);
+          const error = validateReplacementFile(file);
+          if (error) {
+            onImportError(error);
             return;
           }
-          const rect = dropZoneRef.current.getBoundingClientRect();
-          const position = payload.position.toLogical(scaleFactor);
-          const inside =
-            position.x >= rect.left &&
-            position.x <= rect.right &&
-            position.y >= rect.top &&
-            position.y <= rect.bottom;
-          if (payload.type === "enter" || payload.type === "over") {
-            nativeDropExpectedUntilRef.current = inside ? Date.now() + 1000 : 0;
-            if (inside)
-              dropHandlers.onDragOver({
-                preventDefault() {},
-              } as React.DragEvent);
-            else dropHandlers.onDragLeave();
-            return;
-          }
-          const nativeDropWasExpected =
-            nativeDropExpectedUntilRef.current > Date.now();
-          nativeDropExpectedUntilRef.current = 0;
-          dropHandlers.onDragLeave();
-          const path = payload.paths[0];
-          if ((!inside && !nativeDropWasExpected) || !path) return;
-          const generation = ++nativeDropGenerationRef.current;
-          void readImportAgentFile(path)
-            .then(({ fileBytes, fileName }) => {
-              if (disposed || generation !== nativeDropGenerationRef.current)
-                return;
-              const bytes = Uint8Array.from(fileBytes);
-              const file = new File([bytes], fileName);
-              const error = validateReplacementFile(file);
-              if (error) {
-                onImportError(error);
-                return;
-              }
-              startPreparation(bytes, fileName);
-            })
-            .catch((error) => {
-              if (!disposed && generation === nativeDropGenerationRef.current)
-                onImportError(
-                  error instanceof Error ? error.message : String(error),
-                );
-            });
-        }),
-      )
-      .then((cleanup) => {
-        if (disposed) cleanup();
-        else unlisten = cleanup;
-      })
-      .catch((error) => {
-        if (!disposed)
-          console.warn("Failed to register agent import drop target", error);
-      });
-    return () => {
-      disposed = true;
-      nativeDropGenerationRef.current += 1;
-      nativeDropExpectedUntilRef.current = 0;
-      unlisten?.();
-    };
-  }, [
-    dropHandlers,
-    onImportError,
-    open,
-    startPreparation,
-    validateReplacementFile,
-  ]);
+          startPreparation(bytes, fileName);
+        })
+        .catch((error) => {
+          if (
+            nativeDropActiveRef.current &&
+            generation === nativeDropGenerationRef.current
+          )
+            onImportError(
+              error instanceof Error ? error.message : String(error),
+            );
+        });
+    },
+    [onImportError, startPreparation, validateReplacementFile],
+  );
+  const { isAttachmentDragOver } = useAttachmentDropTarget({
+    disabled: !open || preparing,
+    targetRef: dropZoneRef,
+    bindTargetEvents: true,
+    onDropFiles: (files) => {
+      const file = files[0];
+      if (file) void importFile(file);
+    },
+    onDropPaths: handleDroppedPaths,
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -384,7 +345,8 @@ export function AgentImportDialog({
               aria-busy={preparing}
               className={cn(
                 "flex min-h-56 flex-col items-center justify-center gap-4 rounded-md border border-dashed border-border bg-muted/40 px-6 text-center",
-                isDragOver && "border-ring bg-muted/70",
+                (isDragOver || isAttachmentDragOver) &&
+                  "border-ring bg-muted/70",
               )}
             >
               <p className="text-sm">

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -275,10 +275,15 @@ export function AgentImportDialog({
     },
     [onImportError, startPreparation, validateReplacementFile],
   );
-  const { isAttachmentDragOver } = useAttachmentDropTarget({
-    disabled: !open || preparing,
+  const {
+    isAttachmentDragOver,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  } = useAttachmentDropTarget({
+    disabled: !open,
     targetRef: dropZoneRef,
-    bindTargetEvents: true,
     onDropFiles: (files) => {
       const file = files[0];
       if (file) void importFile(file);
@@ -347,6 +352,10 @@ export function AgentImportDialog({
           ) : (
             <div
               ref={dropZoneRef}
+              onDragEnter={handleDragEnter}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
               role="status"
               aria-busy={preparing}
               className={cn(

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -210,10 +210,18 @@ export function AgentImportDialog({
 
   const dropZoneRef = useRef<HTMLDivElement>(null);
   const nativeDropGenerationRef = useRef(0);
-  const nativeDropActiveRef = useRef(open);
-  nativeDropActiveRef.current = open;
+  const nativeDropActiveRef = useRef(false);
+  useEffect(() => {
+    nativeDropActiveRef.current = open;
+    if (!open) nativeDropGenerationRef.current += 1;
+    return () => {
+      nativeDropActiveRef.current = false;
+      nativeDropGenerationRef.current += 1;
+    };
+  }, [open]);
   const validateReplacementFile = useCallback(
     (file: Pick<File, "name" | "type" | "size">) => {
+      nativeDropGenerationRef.current += 1;
       preparationRef.current?.abort();
       setPrepared(null);
       return validateImportFile(file);
@@ -223,7 +231,6 @@ export function AgentImportDialog({
   const {
     fileInputRef,
     isDragOver,
-    dropHandlers,
     importFile,
     handleFileChange,
     openFilePicker,
@@ -340,7 +347,6 @@ export function AgentImportDialog({
           ) : (
             <div
               ref={dropZoneRef}
-              {...dropHandlers}
               role="status"
               aria-busy={preparing}
               className={cn(

--- a/src/features/agents/ui/AgentImportDialog.tsx
+++ b/src/features/agents/ui/AgentImportDialog.tsx
@@ -209,6 +209,7 @@ export function AgentImportDialog({
 
   const dropZoneRef = useRef<HTMLDivElement>(null);
   const nativeDropGenerationRef = useRef(0);
+  const nativeDropExpectedUntilRef = useRef(0);
   const validateReplacementFile = useCallback(
     (file: Pick<File, "name" | "type" | "size">) => {
       nativeDropGenerationRef.current += 1;
@@ -247,6 +248,7 @@ export function AgentImportDialog({
         getCurrentWebview().onDragDropEvent(({ payload }) => {
           if (disposed || !dropZoneRef.current) return;
           if (payload.type === "leave") {
+            nativeDropExpectedUntilRef.current = 0;
             dropHandlers.onDragLeave();
             return;
           }
@@ -258,6 +260,7 @@ export function AgentImportDialog({
             position.y >= rect.top &&
             position.y <= rect.bottom;
           if (payload.type === "enter" || payload.type === "over") {
+            nativeDropExpectedUntilRef.current = inside ? Date.now() + 1000 : 0;
             if (inside)
               dropHandlers.onDragOver({
                 preventDefault() {},
@@ -265,9 +268,12 @@ export function AgentImportDialog({
             else dropHandlers.onDragLeave();
             return;
           }
+          const nativeDropWasExpected =
+            nativeDropExpectedUntilRef.current > Date.now();
+          nativeDropExpectedUntilRef.current = 0;
           dropHandlers.onDragLeave();
           const path = payload.paths[0];
-          if (!inside || !path) return;
+          if ((!inside && !nativeDropWasExpected) || !path) return;
           const generation = ++nativeDropGenerationRef.current;
           void readImportAgentFile(path)
             .then(({ fileBytes, fileName }) => {
@@ -301,6 +307,7 @@ export function AgentImportDialog({
     return () => {
       disposed = true;
       nativeDropGenerationRef.current += 1;
+      nativeDropExpectedUntilRef.current = 0;
       unlisten?.();
     };
   }, [

--- a/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
@@ -223,6 +223,28 @@ describe("AgentBuilderRail", () => {
     expect(update).toHaveBeenCalledWith({ content: "Be snarky." });
   });
 
+  it("allows an incomplete draft to be saved when leaving", async () => {
+    const saveNow = vi.fn().mockResolvedValue(true);
+    mockHook({ saveNow });
+    let saveDraft: (() => boolean | Promise<boolean>) | null = null;
+    renderWithProviders(
+      <AgentBuilderRail
+        sessionId="s1"
+        targetAgentPath={baseSource.path}
+        targetAgentSlug="draft-1"
+        onSaveDraftHandlerChange={(handler) => {
+          saveDraft = handler;
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/description/i)).toHaveValue("");
+    await waitFor(() => expect(saveDraft).not.toBeNull());
+    const registeredSave = saveDraft as unknown as () => Promise<boolean>;
+    await expect(registeredSave()).resolves.toBe(true);
+    expect(saveNow).toHaveBeenCalledOnce();
+  });
+
   it("calls update() when the description field changes", () => {
     const { update } = mockHook();
     renderWithProviders(

--- a/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
@@ -297,6 +297,12 @@ describe("AgentBuilderRail", () => {
       screen.getByRole("button", { name: /save changes/i }),
     ).toHaveAttribute("aria-disabled", "true");
     expect(screen.getByText(/required:/i)).toHaveTextContent(/avatar/i);
+    expect(screen.getByText(/required:/i)).toHaveTextContent(/description/i);
+    expect(screen.getByLabelText(/description/i)).toBeRequired();
+    expect(screen.getByLabelText(/description/i)).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
   });
 
   it("does not persist a default avatar when the draft opens", async () => {
@@ -394,6 +400,7 @@ describe("AgentBuilderRail", () => {
       data: {
         ...baseSource,
         name: "Snark",
+        description: "A sharp, witty agent.",
         content: "Be snarky.",
         properties: {
           draft: true,
@@ -405,6 +412,7 @@ describe("AgentBuilderRail", () => {
     vi.mocked(promoteDraft).mockResolvedValue({
       ...baseSource,
       name: "Snark",
+      description: "A sharp, witty agent.",
       content: "Be snarky.",
       properties: {
         avatar: "app-avatar:gloopy-1",
@@ -434,6 +442,7 @@ describe("AgentBuilderRail", () => {
       data: {
         ...baseSource,
         name: "Snark",
+        description: "A sharp, witty agent.",
         content: "Be snarky.",
         properties: {
           draft: true,
@@ -448,6 +457,7 @@ describe("AgentBuilderRail", () => {
       ...baseSource,
       path: "/Users/x/.agents/agents/snark.md",
       name: "Snark",
+      description: "A sharp, witty agent.",
       content: "Be snarky.",
       properties: {
         avatar: "app-avatar:gloopy-1",
@@ -489,6 +499,7 @@ describe("AgentBuilderRail", () => {
       data: {
         ...baseSource,
         name: "Snark",
+        description: "A sharp, witty agent.",
         content: "Be snarky.",
         properties: {
           draft: true,
@@ -526,6 +537,7 @@ describe("AgentBuilderRail", () => {
       data: {
         ...baseSource,
         name: "Code Reviewer",
+        description: "Reviews code for correctness.",
         content: "",
         properties: {},
       },
@@ -560,6 +572,7 @@ describe("AgentBuilderRail", () => {
       ...baseSource,
       path: "/Users/x/.agents/agents/code-reviewer.md",
       name: "Code Reviewer",
+      description: "Reviews code for correctness.",
       content: "Review code carefully.",
       properties: { provider: "openai", model: "gpt-5" },
     };

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -6,7 +6,32 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const nativeDropMocks = vi.hoisted(() => ({
+  listener: null as ((event: { payload: unknown }) => void) | null,
+  readImportAgentFile: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: (listener: (event: { payload: unknown }) => void) => {
+      nativeDropMocks.listener = listener;
+      return Promise.resolve(() => {
+        nativeDropMocks.listener = null;
+      });
+    },
+  }),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ scaleFactor: () => Promise.resolve(2) }),
+}));
+
+vi.mock("@/shared/api/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/shared/api/agents")>()),
+  readImportAgentFile: nativeDropMocks.readImportAgentFile,
+}));
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -51,6 +76,57 @@ function importDialogProps(overrides: Record<string, unknown> = {}) {
 }
 
 describe("AgentImportDialog", () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+    nativeDropMocks.listener = null;
+    nativeDropMocks.readImportAgentFile.mockReset();
+  });
+
+  it("waits for a native drop and ignores stale reads", async () => {
+    window.__TAURI_INTERNALS__ = {} as typeof window.__TAURI_INTERNALS__;
+    const first = deferred<{ fileBytes: number[]; fileName: string }>();
+    const second = deferred<{ fileBytes: number[]; fileName: string }>();
+    nativeDropMocks.readImportAgentFile
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const prepareImport = vi.fn(() => ({
+      displayName: "Reviewer",
+      systemPrompt: "Review carefully.",
+      identity: "agent.agent.png",
+    }));
+    render(<AgentImportDialog {...importDialogProps({ prepareImport })} />);
+    await waitFor(() => expect(nativeDropMocks.listener).not.toBeNull());
+    const position = { x: 0, y: 0, toLogical: () => ({ x: 0, y: 0 }) };
+
+    act(() =>
+      nativeDropMocks.listener?.({
+        payload: { type: "enter", paths: ["first.zip"], position },
+      }),
+    );
+    expect(nativeDropMocks.readImportAgentFile).not.toHaveBeenCalled();
+    act(() =>
+      nativeDropMocks.listener?.({
+        payload: { type: "drop", paths: ["first.zip"], position },
+      }),
+    );
+    act(() =>
+      nativeDropMocks.listener?.({
+        payload: { type: "drop", paths: ["second.zip"], position },
+      }),
+    );
+    second.resolve({ fileBytes: [2], fileName: "second.zip" });
+    await waitFor(() =>
+      expect(prepareImport).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        "second.zip",
+        expect.any(AbortSignal),
+      ),
+    );
+    first.resolve({ fileBytes: [1], fileName: "first.zip" });
+    await act(async () => {});
+    expect(prepareImport).toHaveBeenCalledTimes(1);
+  });
+
   it("clears a prepared import when a replacement file is rejected", async () => {
     const firstBytes = Uint8Array.from([1, 2, 3]);
     const firstFile = new File([firstBytes], "agent.agent.png", {

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -104,9 +104,18 @@ describe("AgentImportDialog", () => {
       }),
     );
     expect(nativeDropMocks.readImportAgentFile).not.toHaveBeenCalled();
+    const inaccurateDropPosition = {
+      x: 4000,
+      y: 4000,
+      toLogical: () => ({ x: 2000, y: 2000 }),
+    };
     act(() =>
       nativeDropMocks.listener?.({
-        payload: { type: "drop", paths: ["first.zip"], position },
+        payload: {
+          type: "drop",
+          paths: ["first.zip"],
+          position: inaccurateDropPosition,
+        },
       }),
     );
     act(() =>

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -94,6 +94,10 @@ describe("AgentImportDialog", () => {
       systemPrompt: "Review carefully.",
       identity: "agent.agent.png",
     }));
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(null),
+    });
     render(<AgentImportDialog {...importDialogProps({ prepareImport })} />);
     await waitFor(() => expect(nativeDropMocks.listener).not.toBeNull());
     const position = { x: 0, y: 0, toLogical: () => ({ x: 0, y: 0 }) };

--- a/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImportDialog.test.tsx
@@ -140,6 +140,36 @@ describe("AgentImportDialog", () => {
     expect(prepareImport).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a native read that resolves after unmount", async () => {
+    window.__TAURI_INTERNALS__ = {} as typeof window.__TAURI_INTERNALS__;
+    const read = deferred<{ fileBytes: number[]; fileName: string }>();
+    nativeDropMocks.readImportAgentFile.mockReturnValue(read.promise);
+    const prepareImport = vi.fn(() => ({
+      displayName: "Reviewer",
+      systemPrompt: "Review carefully.",
+      identity: "agent.agent.png",
+    }));
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(null),
+    });
+    const { unmount } = render(
+      <AgentImportDialog {...importDialogProps({ prepareImport })} />,
+    );
+    await waitFor(() => expect(nativeDropMocks.listener).not.toBeNull());
+    const position = { x: 0, y: 0 };
+    act(() =>
+      nativeDropMocks.listener?.({
+        payload: { type: "drop", paths: ["agent.png"], position },
+      }),
+    );
+    unmount();
+    read.resolve({ fileBytes: [1], fileName: "agent.png" });
+    await act(async () => {});
+
+    expect(prepareImport).not.toHaveBeenCalled();
+  });
+
   it("clears a prepared import when a replacement file is rejected", async () => {
     const firstBytes = Uint8Array.from([1, 2, 3]);
     const firstFile = new File([firstBytes], "agent.agent.png", {

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -523,13 +523,25 @@ describe("AgentsView entry points", () => {
     const { container } = render(<AgentsView />);
     const dropZone = container.querySelector(".\\@container") as HTMLElement;
 
-    fireEvent.drop(dropZone, { dataTransfer: { files: [makeZipFile("a")] } });
+    fireEvent.drop(dropZone, {
+      dataTransfer: {
+        files: [makeZipFile("a")],
+        items: [{ kind: "file" }],
+        types: ["Files"],
+      },
+    });
     await waitFor(() => expect(resolvers).toHaveLength(1));
 
     // Dropping B onto the dialog's drop zone replaces A and aborts its work.
     const dialogDropZone = screen.getByRole("status");
     const fileB = makeZipFile("b");
-    fireEvent.drop(dialogDropZone, { dataTransfer: { files: [fileB] } });
+    fireEvent.drop(dialogDropZone, {
+      dataTransfer: {
+        files: [fileB],
+        items: [{ kind: "file" }],
+        types: ["Files"],
+      },
+    });
     await waitFor(() => expect(resolvers).toHaveLength(2));
     expect(resolvers[0].signal?.aborted).toBe(true);
 

--- a/src/features/agents/ui/share-card/AgentShareCardPreview.tsx
+++ b/src/features/agents/ui/share-card/AgentShareCardPreview.tsx
@@ -7,12 +7,8 @@ import {
   fallbackAgentCardColor,
   sampleAgentAvatarColor,
 } from "./agentCardColor";
-import {
-  deriveAgentCardTraitLines,
-  deriveAgentShareCardTextLayout,
-} from "./agentShareCardLayout";
+import { deriveAgentShareCardTextLayout } from "./agentShareCardLayout";
 import { loadAgentCardFonts } from "./agentShareCardFonts";
-import type { AgentShareCardCopy } from "./agentShareCardCopy";
 import {
   AGENT_CARD_GEOMETRY,
   agentCardFramePath,
@@ -36,7 +32,6 @@ interface AgentShareCardPreviewProps {
   description: string;
   avatarSrc?: string;
   alt: string;
-  copy: AgentShareCardCopy;
   locale: string;
 }
 
@@ -46,7 +41,6 @@ export function AgentShareCardPreview({
   description,
   avatarSrc,
   alt,
-  copy,
   locale,
 }: AgentShareCardPreviewProps) {
   const resolvedAvatarSrc = avatarSrc ?? resolveAgentIcon(identity);
@@ -93,21 +87,6 @@ export function AgentShareCardPreview({
   }, [identity, resolvedAvatarSrc]);
 
   const geometry = AGENT_CARD_GEOMETRY;
-  const traitMeasure = createAgentCardTextMeasure();
-  const goodForLines = deriveAgentCardTraitLines(
-    copy.goodForLabel,
-    copy.goodFor,
-    geometry.goodFor.width,
-    (value) => traitMeasure(value, "600 42px Inter, sans-serif"),
-    locale,
-  );
-  const vibesLines = deriveAgentCardTraitLines(
-    copy.vibesLabel,
-    copy.vibes,
-    geometry.vibes.width,
-    (value) => traitMeasure(value, "600 42px Inter, sans-serif"),
-    locale,
-  );
   const { title, descriptionLines, contentShift } = textLayout;
   const descriptionLineKeys = descriptionLines.map(
     (line, index) =>
@@ -226,7 +205,7 @@ export function AgentShareCardPreview({
 
         <foreignObject
           x={geometry.title.x}
-          y={1306 - contentShift}
+          y={geometry.title.y - 64 - contentShift}
           width={geometry.title.width}
           height="78"
         >
@@ -247,59 +226,6 @@ export function AgentShareCardPreview({
               key={descriptionLineKeys[index]}
               x={geometry.description.x}
               dy={index === 0 ? 0 : geometry.description.lineHeight}
-            >
-              {line}
-            </tspan>
-          ))}
-        </text>
-
-        <line
-          x1={geometry.goodFor.ruleX}
-          x2={geometry.goodFor.ruleX}
-          y1={geometry.traitRule.y1}
-          y2={geometry.traitRule.y2}
-          stroke="black"
-          strokeWidth={geometry.traitRule.width}
-        />
-        <line
-          x1={geometry.vibes.ruleX}
-          x2={geometry.vibes.ruleX}
-          y1={geometry.traitRule.y1}
-          y2={geometry.traitRule.y2}
-          stroke="black"
-          strokeWidth={geometry.traitRule.width}
-        />
-        <text
-          x={geometry.goodFor.copyX}
-          y={geometry.traitCopyY}
-          fill="black"
-          fontFamily="Inter, sans-serif"
-          fontSize="42"
-          fontWeight="600"
-        >
-          {goodForLines.map((line, index) => (
-            <tspan
-              key={`good-for:${line}`}
-              x={geometry.goodFor.copyX}
-              dy={index === 0 ? 0 : 50}
-            >
-              {line}
-            </tspan>
-          ))}
-        </text>
-        <text
-          x={geometry.vibes.copyX}
-          y={geometry.traitCopyY}
-          fill="black"
-          fontFamily="Inter, sans-serif"
-          fontSize="42"
-          fontWeight="600"
-        >
-          {vibesLines.map((line, index) => (
-            <tspan
-              key={`vibes:${line}`}
-              x={geometry.vibes.copyX}
-              dy={index === 0 ? 0 : 50}
             >
               {line}
             </tspan>

--- a/src/features/agents/ui/share-card/AgentShareDialog.test.tsx
+++ b/src/features/agents/ui/share-card/AgentShareDialog.test.tsx
@@ -470,10 +470,6 @@ describe("AgentShareDialog", () => {
         generatedPersona,
         "asset://generated-avatar.png",
         expect.any(String),
-        expect.objectContaining({
-          goodForLabel: "Good for:",
-          vibesLabel: "Vibes:",
-        }),
         "en",
         expect.any(String),
       ),

--- a/src/features/agents/ui/share-card/AgentShareDialog.tsx
+++ b/src/features/agents/ui/share-card/AgentShareDialog.tsx
@@ -37,7 +37,6 @@ import {
 } from "@/shared/ui/dialog";
 import { AgentShareCardPreview } from "./AgentShareCardPreview";
 import { AgentCardReveal } from "./AgentCardReveal";
-import { resolveAgentShareCardCopy } from "./agentShareCardCopy";
 import {
   blobToBytes,
   createAvatarPoster,
@@ -216,10 +215,6 @@ export function AgentShareDialog({
     persona,
     t("share.descriptionFallback", { name: persona.displayName }),
   );
-  const cardCopy = resolveAgentShareCardCopy(persona.systemPrompt, t, {
-    goodFor: persona.goodFor,
-    vibes: persona.vibes,
-  });
   const cardContentIdentity = [
     locale,
     persona.id,
@@ -312,7 +307,6 @@ export function AgentShareDialog({
           persona,
           cardAvatarSrc,
           cardBase,
-          cardCopy,
           locale,
           description,
         );
@@ -426,7 +420,6 @@ export function AgentShareDialog({
     [
       avatarReadySrc,
       cachedAvatar,
-      cardCopy,
       cardBase,
       currentGeneratedAvatarPoster,
       description,
@@ -531,7 +524,6 @@ export function AgentShareDialog({
                   description={description}
                   avatarSrc={avatarSrc}
                   alt={t("share.cardAlt", { name: persona.displayName })}
-                  copy={cardCopy}
                   locale={locale}
                 />
               </AgentCardReveal>

--- a/src/features/agents/ui/share-card/agentShareCard.ts
+++ b/src/features/agents/ui/share-card/agentShareCard.ts
@@ -10,12 +10,10 @@ import {
 } from "./agentCardColor";
 import { AGENT_CARD_HEIGHT, AGENT_CARD_WIDTH } from "./agentShareCardSpec";
 import {
-  deriveAgentCardTraitLines,
   deriveAgentShareCardTextLayout,
   wrapAgentCardText,
 } from "./agentShareCardLayout";
 import { loadAgentCardFonts } from "./agentShareCardFonts";
-import type { AgentShareCardCopy } from "./agentShareCardCopy";
 import { AGENT_CARD_GEOMETRY } from "./agentShareCardGeometry";
 
 export const AVATAR_VIDEO_LOAD_TIMEOUT_MS = 10_000;
@@ -223,7 +221,6 @@ export async function renderAgentShareCard(
   persona: Persona,
   avatarSrc: string,
   cardBase: string,
-  copy: AgentShareCardCopy,
   locale: string,
   description = getAgentShareDescription(persona),
 ): Promise<Blob> {
@@ -323,61 +320,12 @@ export async function renderAgentShareCard(
     );
   });
 
-  const { goodFor, vibes, traitRule, traitCopyY } = AGENT_CARD_GEOMETRY;
-  context.lineWidth = traitRule.width;
-  context.strokeStyle = "black";
-  context.beginPath();
-  context.moveTo(goodFor.ruleX, traitRule.y1);
-  context.lineTo(goodFor.ruleX, traitRule.y2);
-  context.moveTo(vibes.ruleX, traitRule.y1);
-  context.lineTo(vibes.ruleX, traitRule.y2);
-  context.stroke();
-
-  context.font = "600 42px Inter, sans-serif";
-  const measureTrait = (value: string) => context.measureText(value).width;
-  drawAgentCardTraitLines(
-    context,
-    deriveAgentCardTraitLines(
-      copy.goodForLabel,
-      copy.goodFor,
-      goodFor.width,
-      measureTrait,
-      locale,
-    ),
-    goodFor.copyX,
-    traitCopyY,
-  );
-  drawAgentCardTraitLines(
-    context,
-    deriveAgentCardTraitLines(
-      copy.vibesLabel,
-      copy.vibes,
-      vibes.width,
-      measureTrait,
-      locale,
-    ),
-    vibes.copyX,
-    traitCopyY,
-  );
-
   return new Promise((resolve, reject) => {
     canvas.toBlob(
       (blob) =>
         blob ? resolve(blob) : reject(new Error("Failed to create card image")),
       "image/png",
     );
-  });
-}
-
-function drawAgentCardTraitLines(
-  context: CanvasRenderingContext2D,
-  lines: readonly string[],
-  x: number,
-  y: number,
-): void {
-  context.font = "600 42px Inter, sans-serif";
-  lines.forEach((line, index) => {
-    context.fillText(line, x, y + index * 50);
   });
 }
 

--- a/src/features/agents/ui/share-card/agentShareCardCopy.test.ts
+++ b/src/features/agents/ui/share-card/agentShareCardCopy.test.ts
@@ -39,7 +39,7 @@ describe("resolveAgentShareCardCopy", () => {
   it("rejects overlong metadata instead of truncating it", () => {
     expect(
       resolveAgentShareCardCopy("Research evidence", translator("en"), {
-        goodFor: "x".repeat(45),
+        goodFor: "x".repeat(33),
         vibes: "y".repeat(33),
       }),
     ).toMatchObject({

--- a/src/features/agents/ui/share-card/agentShareCardCopy.ts
+++ b/src/features/agents/ui/share-card/agentShareCardCopy.ts
@@ -17,8 +17,9 @@ interface AgentShareCardMetadata {
   vibes?: string;
 }
 
-export const AGENT_CARD_GOOD_FOR_MAX_GRAPHEMES = 44;
-export const AGENT_CARD_VIBES_MAX_GRAPHEMES = 32;
+export const AGENT_CARD_TRAIT_MAX_GRAPHEMES = 32;
+export const AGENT_CARD_GOOD_FOR_MAX_GRAPHEMES = AGENT_CARD_TRAIT_MAX_GRAPHEMES;
+export const AGENT_CARD_VIBES_MAX_GRAPHEMES = AGENT_CARD_TRAIT_MAX_GRAPHEMES;
 
 function shortCardValue(value: string | undefined, maxGraphemes: number) {
   const trimmed = value?.trim();

--- a/src/features/agents/ui/share-card/agentShareCardGeometry.test.ts
+++ b/src/features/agents/ui/share-card/agentShareCardGeometry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_CARD_GEOMETRY } from "./agentShareCardGeometry";
+
+describe("AGENT_CARD_GEOMETRY", () => {
+  it("balances the avatar between the header and title content", () => {
+    const { avatar, brand, title } = AGENT_CARD_GEOMETRY;
+    const gapBelowHeader = avatar.y - brand.y;
+    const gapAboveTitle = title.y - 64 - (avatar.y + avatar.height);
+
+    expect(Math.abs(gapBelowHeader - gapAboveTitle)).toBeLessThanOrEqual(8);
+  });
+
+  it("balances the card's top and bottom content padding", () => {
+    const { panel, logo, description } = AGENT_CARD_GEOMETRY;
+    const topPadding = logo.y - panel.y;
+    const maximumDescriptionBottom = description.y + 2 * description.lineHeight;
+    const bottomPadding = panel.y + panel.height - maximumDescriptionBottom;
+
+    expect(Math.abs(topPadding - bottomPadding)).toBeLessThanOrEqual(8);
+  });
+});

--- a/src/features/agents/ui/share-card/agentShareCardGeometry.ts
+++ b/src/features/agents/ui/share-card/agentShareCardGeometry.ts
@@ -5,13 +5,9 @@ export const AGENT_CARD_GEOMETRY = {
   panel: { x: 30, y: 31, width: 1167, height: 1777, radius: 70 },
   logo: { x: 120, y: 122, width: 40, height: 40 },
   brand: { x: 1110, y: 153 },
-  avatar: { x: 155, y: 240, width: 917, height: 920 },
-  title: { x: 115, y: 1370, width: 997 },
-  description: { x: 115, y: 1445, width: 997, lineHeight: 52 },
-  goodFor: { ruleX: 120, copyX: 139, width: 500 },
-  vibes: { ruleX: 700, copyX: 729, width: 373 },
-  traitRule: { y1: 1585, y2: 1683, width: 4 },
-  traitCopyY: 1614,
+  avatar: { x: 125, y: 318, width: 977, height: 990 },
+  title: { x: 115, y: 1530, width: 997 },
+  description: { x: 115, y: 1605, width: 997, lineHeight: 52 },
 } as const;
 
 export const AGENT_CARD_ASPECT_RATIO = `${AGENT_CARD_GEOMETRY.width}/${AGENT_CARD_GEOMETRY.height}`;

--- a/src/shared/api/agents.ts
+++ b/src/shared/api/agents.ts
@@ -1170,6 +1170,14 @@ export interface ImportBinaryFileReadResult {
   fileName: string;
 }
 
+export async function readImportAgentFile(
+  sourcePath: string,
+): Promise<ImportBinaryFileReadResult> {
+  return invoke<ImportBinaryFileReadResult>("read_import_agent_file", {
+    sourcePath,
+  });
+}
+
 export async function readImportAgentImage(
   sourcePath: string,
 ): Promise<ImportBinaryFileReadResult> {

--- a/src/shared/hooks/useFileImportZone.test.tsx
+++ b/src/shared/hooks/useFileImportZone.test.tsx
@@ -98,6 +98,31 @@ describe("useFileImportZone", () => {
     expect(onImportFile).toHaveBeenCalledTimes(1);
   });
 
+  it("allows another ingress path to invalidate a pending file read", async () => {
+    const onImportFile = vi.fn();
+    let resolveRead: ((value: ArrayBuffer) => void) | undefined;
+    const file = pngFile("picker.png");
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: vi.fn(
+        () =>
+          new Promise<ArrayBuffer>((resolve) => {
+            resolveRead = resolve;
+          }),
+      ),
+    });
+    const { result } = renderHook(() => useFileImportZone({ onImportFile }));
+
+    act(() => {
+      void result.current.importFile(file);
+      result.current.invalidateImport();
+    });
+    resolveRead?.(Uint8Array.from([1]).buffer);
+    await act(async () => {});
+
+    expect(onImportFile).not.toHaveBeenCalled();
+  });
+
   it("reports file read failures", async () => {
     const onImportFile = vi.fn();
     const onImportError = vi.fn();

--- a/src/shared/hooks/useFileImportZone.ts
+++ b/src/shared/hooks/useFileImportZone.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface FileImportZoneOptions {
   onImportFile: (fileBytes: Uint8Array, fileName: string) => void;
@@ -64,21 +64,24 @@ export function useFileImportZone({
     [fileTooLargeMessage, maxBytes, onImportFile, onImportError, validateFile],
   );
 
-  const dropHandlers = {
-    onDragLeave: () => setIsDragOver(false),
-    onDragOver: (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragOver(true);
-    },
-    onDrop: (e: React.DragEvent) => {
-      e.preventDefault();
-      setIsDragOver(false);
-      const file = e.dataTransfer.files[0];
-      if (file) {
-        void importFile(file);
-      }
-    },
-  };
+  const dropHandlers = useMemo(
+    () => ({
+      onDragLeave: () => setIsDragOver(false),
+      onDragOver: (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragOver(true);
+      },
+      onDrop: (e: React.DragEvent) => {
+        e.preventDefault();
+        setIsDragOver(false);
+        const file = e.dataTransfer.files[0];
+        if (file) {
+          void importFile(file);
+        }
+      },
+    }),
+    [importFile],
+  );
 
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,6 +101,7 @@ export function useFileImportZone({
     fileInputRef,
     isDragOver,
     dropHandlers,
+    importFile,
     handleFileChange,
     openFilePicker,
   };

--- a/src/shared/hooks/useFileImportZone.ts
+++ b/src/shared/hooks/useFileImportZone.ts
@@ -83,6 +83,10 @@ export function useFileImportZone({
     [importFile],
   );
 
+  const invalidateImport = useCallback(() => {
+    importGenerationRef.current += 1;
+  }, []);
+
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
@@ -102,6 +106,7 @@ export function useFileImportZone({
     isDragOver,
     dropHandlers,
     importFile,
+    invalidateImport,
     handleFileChange,
     openFilePicker,
   };

--- a/src/shared/i18n/locales/en/agents.json
+++ b/src/shared/i18n/locales/en/agents.json
@@ -49,6 +49,7 @@
     "completeRequiredFields": "Required: {{fields}}.",
     "requiredAvatar": "avatar",
     "requiredName": "name",
+    "requiredDescription": "description",
     "requiredInstructions": "instructions",
     "startFreshDraft": "Start fresh draft",
     "leaveDraftTitle": "Save this agent draft?",

--- a/src/shared/i18n/locales/es/agents.json
+++ b/src/shared/i18n/locales/es/agents.json
@@ -49,6 +49,7 @@
     "completeRequiredFields": "Obligatorio: {{fields}}.",
     "requiredAvatar": "avatar",
     "requiredName": "nombre",
+    "requiredDescription": "descripción",
     "requiredInstructions": "instrucciones",
     "startFreshDraft": "Iniciar borrador nuevo",
     "leaveDraftTitle": "¿Guardar este borrador de agente?",


### PR DESCRIPTION
**Category:** fix
**User Impact:** Agent imports now support native drag and drop reliably, agent descriptions are required, and shared agent cards use a cleaner, more balanced layout.

**Problem:** Native file drops did not reach the agent import modal, incomplete descriptions could still be saved through secondary flows, and share cards devoted space to metadata that was no longer useful. Legacy Reviewer and Spar agents could also retain placeholder descriptions.

**Solution:** Add a validated native-drop path with race-safe lifecycle handling, enforce descriptions across every save path, migrate only exact known legacy agent files, and simplify the share-card composition around a larger centered avatar and lower title and description.

<details>
<summary>File changes</summary>

**distro/skills/agent-builder/SKILL.md**
Documents that agent descriptions must be meaningful, trimmed, and non-placeholder before an agent is saved.

**src-tauri/src/commands/agents.rs**
Adds a bounded, extension-validated binary reader for native agent-file drops.

**src-tauri/src/lib.rs**
Registers the new agent import command with Tauri.

**src-tauri/src/services/bundled_agents.rs**
Migrates exact historical Reviewer and Spar files from placeholder descriptions while preserving customized agents and using safe replacement writes.

**src/features/agents/ui/AgentBuilderRail.tsx**
Requires descriptions for normal saves and session-level Keep or close saves.

**src/features/agents/ui/AgentImportDialog.tsx**
Handles native Tauri drag/drop events with logical-coordinate hit testing, drop-only activation, validation, and stale-operation protection.

**src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx**
Covers required-description behavior and updates completed-agent fixtures.

**src/features/agents/ui/__tests__/AgentImportDialog.test.tsx**
Covers native drop semantics and overlapping-read ordering.

**src/features/agents/ui/share-card/AgentShareCardPreview.tsx**
Removes Good for and Vibes from the preview and applies the revised card geometry.

**src/features/agents/ui/share-card/AgentShareDialog.test.tsx**
Updates share-card rendering expectations for the simplified card contract.

**src/features/agents/ui/share-card/AgentShareDialog.tsx**
Stops deriving and passing removed trait copy to card previews and exports.

**src/features/agents/ui/share-card/agentShareCard.ts**
Removes trait rendering from exported PNG cards.

**src/features/agents/ui/share-card/agentShareCardCopy.test.ts**
Updates the shared trait-copy boundary test.

**src/features/agents/ui/share-card/agentShareCardCopy.ts**
Uses one shared trait-copy grapheme limit.

**src/features/agents/ui/share-card/agentShareCardGeometry.test.ts**
Protects balanced card padding and avatar centering.

**src/features/agents/ui/share-card/agentShareCardGeometry.ts**
Enlarges and centers the avatar and moves title and description lower.

**src/shared/api/agents.ts**
Exposes the native binary import reader and preserves existing metadata compatibility.

**src/shared/hooks/useFileImportZone.ts**
Stabilizes drop handlers while retaining stale-read and unmount protection.

**src/shared/i18n/locales/en/agents.json**
Adds English required-description guidance.

**src/shared/i18n/locales/es/agents.json**
Adds Spanish required-description guidance.

</details>
