### PR TITLE
chore: enforce a seven-day crate cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"]
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "packageRules": [
+    {
+      "description": "Wait seven days before proposing Rust crate updates",
+      "matchDatasources": ["crate"],
+      "minimumReleaseAge": "7 days",
+      "minimumReleaseAgeBehaviour": "timestamp-required",
+      "internalChecksFilter": "strict"
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to delay Rust crate update proposals by seven days after a new release. This change helps prevent disruptions from adopting unstable or very new Rust crate versions too quickly.

Dependency update management:

* Added a `packageRules` entry to the `renovate.json` file to set a minimum release age of seven days for Rust crate updates, ensuring updates are only proposed after the release has matured.<!--
  Berd does not accept pull requests from outside authorized repository
  collaborators, and outside PRs are closed automatically. If that's you: please don't
  spend time on a patch. Open an issue instead — https://github.com/block/berd/blob/main/CONTRIBUTING.md
-->

## Summary
<!-- What does this change and why? -->

### Related issue
<!-- Fixes #1234, or N/A. Before opening: search existing issues/PRs for duplicates — link the closest one, or say "none found". -->

### Testing
<!-- How was this verified? UI change? Include before/after screenshots (or a short recording). -->
