### PR TITLE
fix: dismiss composer mention popovers

### DIFF
--- a/src/features/chat/hooks/useMentionHandlers.ts
+++ b/src/features/chat/hooks/useMentionHandlers.ts
@@ -547,6 +547,7 @@ export function useMentionHandlers({
     filteredFiles,
     detectMention,
     closeMention,
+    dismissMention,
     navigateMention,
     navigateAtMentionCategory,
     setAtMentionCategory,
@@ -558,6 +559,7 @@ export function useMentionHandlers({
     skillMentionItems,
     fileMentionItems,
     defaultAtMentionCategory,
+    text,
   );
 
   const pathMentionQuery = mentionQuery.trim();
@@ -866,6 +868,7 @@ export function useMentionHandlers({
         : null,
     detectMention,
     closeMention,
+    dismissMention,
     navigateMention,
     navigateAtMentionCategory,
     setAtMentionCategory,

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -704,7 +704,7 @@ export function ChatInput({
     fileMentionsError,
     resolveSkillSlashCommand,
     detectMention,
-    closeMention,
+    dismissMention,
     navigateMention,
     setAtMentionCategory,
     handleMentionCategoryKey,
@@ -1180,7 +1180,7 @@ export function ChatInput({
       ) {
         event.preventDefault();
         event.stopPropagation();
-        closeMention();
+        dismissMention();
         return;
       }
       if (eventMatchesShortcutCommand(event.nativeEvent, "chat.mention.next")) {
@@ -1685,7 +1685,14 @@ export function ChatInput({
               : "mx-auto max-w-[var(--chat-composer-max-width)]",
           )}
         >
-          <Popover open={mentionOpen}>
+          <Popover
+            open={mentionOpen}
+            onOpenChange={(open) => {
+              if (!open && mentionOpen) {
+                dismissMention();
+              }
+            }}
+          >
             {queuedMessageAccessory ? (
               <div
                 data-slot="queued-message-accessory"
@@ -1746,7 +1753,6 @@ export function ChatInput({
                 onSelectPersona={handlePersonaMentionSelect}
                 onSelectSkill={handleSkillMentionSelect}
                 onSelectFile={handleFileMentionSelect}
-                onClose={closeMention}
                 selectedIndex={mentionSelectedIndex}
                 listboxId={mentionListboxId}
                 atCategory={atMentionCategory}

--- a/src/features/chat/ui/ChatInput.tsx
+++ b/src/features/chat/ui/ChatInput.tsx
@@ -1685,14 +1685,7 @@ export function ChatInput({
               : "mx-auto max-w-[var(--chat-composer-max-width)]",
           )}
         >
-          <Popover
-            open={mentionOpen}
-            onOpenChange={(open) => {
-              if (!open && mentionOpen) {
-                dismissMention();
-              }
-            }}
-          >
+          <Popover open={mentionOpen}>
             {queuedMessageAccessory ? (
               <div
                 data-slot="queued-message-accessory"
@@ -1753,6 +1746,7 @@ export function ChatInput({
                 onSelectPersona={handlePersonaMentionSelect}
                 onSelectSkill={handleSkillMentionSelect}
                 onSelectFile={handleFileMentionSelect}
+                onDismiss={dismissMention}
                 selectedIndex={mentionSelectedIndex}
                 listboxId={mentionListboxId}
                 atCategory={atMentionCategory}

--- a/src/features/chat/ui/MentionAutocomplete.tsx
+++ b/src/features/chat/ui/MentionAutocomplete.tsx
@@ -33,7 +33,6 @@ interface MentionAutocompleteProps {
   onSelectPersona: (persona: Persona) => void;
   onSelectSkill?: (skill: SkillMentionItem) => void;
   onSelectFile?: (file: FileMentionItem) => void;
-  onClose?: (() => void) | undefined;
   selectedIndex?: number;
   listboxId?: string;
   atCategory?: AtMentionCategory;
@@ -50,7 +49,6 @@ export function MentionAutocomplete({
   onSelectPersona,
   onSelectSkill,
   onSelectFile,
-  onClose,
   selectedIndex: controlledIndex,
   listboxId = "mention-autocomplete-listbox",
   atCategory = "agents",
@@ -62,37 +60,6 @@ export function MentionAutocomplete({
   const [internalIndex, setInternalIndex] = useState(0);
   const selectedIndex = controlledIndex ?? internalIndex;
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
-  const contentRef = useRef<HTMLDivElement>(null);
-  const onCloseRef = useRef(onClose);
-  onCloseRef.current = onClose;
-
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node)) {
-        return;
-      }
-      if (contentRef.current?.contains(target)) {
-        return;
-      }
-      if (
-        target instanceof HTMLElement &&
-        target.closest("textarea, input, [contenteditable='true']")
-      ) {
-        return;
-      }
-      onCloseRef.current?.();
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown, true);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown, true);
-    };
-  }, [isOpen]);
 
   // Scroll the active item into view when selectedIndex changes
   useEffect(() => {
@@ -181,18 +148,12 @@ export function MentionAutocomplete({
 
   return (
     <PopoverContent
-      ref={contentRef}
       side="top"
       align="start"
       sideOffset={4}
       className="w-72 p-2"
       onOpenAutoFocus={(e) => e.preventDefault()}
       onCloseAutoFocus={(e) => e.preventDefault()}
-      onEscapeKeyDown={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose?.();
-      }}
     >
       <Tabs
         value={atCategory}

--- a/src/features/chat/ui/MentionAutocomplete.tsx
+++ b/src/features/chat/ui/MentionAutocomplete.tsx
@@ -33,6 +33,7 @@ interface MentionAutocompleteProps {
   onSelectPersona: (persona: Persona) => void;
   onSelectSkill?: (skill: SkillMentionItem) => void;
   onSelectFile?: (file: FileMentionItem) => void;
+  onDismiss?: () => void;
   selectedIndex?: number;
   listboxId?: string;
   atCategory?: AtMentionCategory;
@@ -49,6 +50,7 @@ export function MentionAutocomplete({
   onSelectPersona,
   onSelectSkill,
   onSelectFile,
+  onDismiss,
   selectedIndex: controlledIndex,
   listboxId = "mention-autocomplete-listbox",
   atCategory = "agents",
@@ -154,6 +156,11 @@ export function MentionAutocomplete({
       className="w-72 p-2"
       onOpenAutoFocus={(e) => e.preventDefault()}
       onCloseAutoFocus={(e) => e.preventDefault()}
+      onPointerDownOutside={() => onDismiss?.()}
+      onEscapeKeyDown={(event) => {
+        event.preventDefault();
+        onDismiss?.();
+      }}
     >
       <Tabs
         value={atCategory}

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -1735,7 +1735,7 @@ describe("ChatInput", () => {
     await user.keyboard("{Tab}");
     expect(input).toHaveValue(`@${projectRoot}/`);
 
-    await user.type(input, "src");
+    await user.keyboard("src");
 
     await waitFor(() => {
       expect(mockSearchFilesForMentions).toHaveBeenCalledWith({
@@ -2062,7 +2062,7 @@ describe("ChatInput", () => {
 
     const input = screen.getByRole("textbox");
     await user.type(input, "@@/Users/wesb/My Project/");
-    await user.type(input, "src");
+    await user.keyboard("src");
 
     await waitFor(() => {
       expect(mockSearchFilesForMentions).toHaveBeenCalledWith({
@@ -2223,7 +2223,7 @@ describe("ChatInput", () => {
       await screen.findByRole("option", { name: /readme\.md/i }),
     ).toBeInTheDocument();
 
-    await user.type(input, "m");
+    await user.keyboard("m");
     await waitFor(() => {
       expect(mockSearchFilesForMentions).toHaveBeenCalledWith({
         roots: ["/Users/wesb/dev/goose2"],
@@ -2285,7 +2285,7 @@ describe("ChatInput", () => {
       "true",
     );
 
-    await user.type(input, "m");
+    await user.keyboard("m");
     await waitFor(() => {
       expect(screen.queryByText("reader.md")).not.toBeInTheDocument();
     });

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -1865,7 +1865,7 @@ describe("ChatInput", () => {
     ).not.toBeInTheDocument();
     expect(mockSearchFilesForMentions).not.toHaveBeenCalled();
 
-    await user.type(input, "/");
+    await user.keyboard("/");
     expect(
       await screen.findByRole("option", { name: /filesystem root/i }),
     ).toBeInTheDocument();

--- a/src/features/chat/ui/__tests__/ChatInput.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatInput.test.tsx
@@ -1776,6 +1776,56 @@ describe("ChatInput", () => {
     }
   });
 
+  it("dismisses mentions when the composer is clicked", async () => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "@missing");
+    expect(screen.getByRole("tab", { name: "Agents" })).not.toBeNull();
+
+    await user.click(input);
+
+    expect(screen.queryByRole("tab", { name: "Agents" })).toBeNull();
+    expect((input as HTMLTextAreaElement).value).toBe("@missing");
+  });
+
+  it("keeps mentions dismissed while the current token is still being typed", async () => {
+    const user = userEvent.setup();
+    renderProjectChatInput();
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "@log");
+    expect(screen.getByRole("tab", { name: "Agents" })).not.toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("tab", { name: "Agents" })).toBeNull();
+
+    await user.type(input, "fold");
+
+    expect((input as HTMLTextAreaElement).value).toBe("@logfold");
+    expect(screen.queryByRole("tab", { name: "Agents" })).toBeNull();
+  });
+
+  it("opens mentions in a new draft after the previous token was dismissed", async () => {
+    const onSend = vi.fn().mockResolvedValue(true);
+    const user = userEvent.setup();
+    renderProjectChatInput(onSend);
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "@missing");
+    expect(screen.getByRole("tab", { name: "Agents" })).not.toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("tab", { name: "Agents" })).toBeNull();
+
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect((input as HTMLTextAreaElement).value).toBe(""));
+
+    await user.type(input, "@");
+    expect(screen.getByRole("tab", { name: "Agents" })).not.toBeNull();
+  });
+
   it("attaches folder and static root references as chips", async () => {
     const user = userEvent.setup();
     mockSearchFilesForMentions.mockResolvedValue(PROJECT_FILE_MENTION_ENTRIES);

--- a/src/features/chat/ui/__tests__/MentionAutocomplete.test.tsx
+++ b/src/features/chat/ui/__tests__/MentionAutocomplete.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -72,7 +72,6 @@ function renderAutocomplete(props: {
   trigger?: "@" | "/";
   atCategory?: "agents" | "files" | "skills";
   onAtCategoryChange?: (category: "agents" | "files" | "skills") => void;
-  onClose?: () => void;
 }) {
   const atCategory =
     props.atCategory ?? (props.trigger === "/" ? "skills" : "agents");
@@ -88,7 +87,6 @@ function renderAutocomplete(props: {
         isOpen
         atCategory={atCategory}
         onAtCategoryChange={props.onAtCategoryChange}
-        onClose={props.onClose}
         onSelectPersona={vi.fn()}
         onSelectSkill={vi.fn()}
         onSelectFile={vi.fn()}
@@ -133,62 +131,6 @@ describe("MentionAutocomplete", () => {
     await user.click(screen.getByRole("tab", { name: "Agents" }));
     expect(onAtCategoryChange).toHaveBeenCalledTimes(3);
     expect(onAtCategoryChange).toHaveBeenCalledWith("agents");
-  });
-
-  it("closes when pointer interaction starts outside the menu", () => {
-    const onClose = vi.fn();
-    render(
-      <>
-        <button type="button">Outside menu</button>
-        <Popover open>
-          <PopoverAnchor asChild>
-            <div />
-          </PopoverAnchor>
-          <MentionAutocomplete
-            filteredPersonas={PERSONAS}
-            filteredSkills={[]}
-            filteredFiles={FILES}
-            isOpen
-            onClose={onClose}
-            onSelectPersona={vi.fn()}
-            onSelectSkill={vi.fn()}
-            onSelectFile={vi.fn()}
-          />
-        </Popover>
-      </>,
-    );
-
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Outside menu" }));
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it("stays open when pointer interaction returns to the textarea", () => {
-    const onClose = vi.fn();
-    render(
-      <>
-        <textarea aria-label="Composer" />
-        <Popover open>
-          <PopoverAnchor asChild>
-            <div />
-          </PopoverAnchor>
-          <MentionAutocomplete
-            filteredPersonas={PERSONAS}
-            filteredSkills={[]}
-            filteredFiles={FILES}
-            isOpen
-            onClose={onClose}
-            onSelectPersona={vi.fn()}
-            onSelectSkill={vi.fn()}
-            onSelectFile={vi.fn()}
-          />
-        </Popover>
-      </>,
-    );
-
-    fireEvent.pointerDown(screen.getByRole("textbox", { name: "Composer" }));
-
-    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("highlights matched characters from the backend matcher", () => {

--- a/src/features/chat/ui/__tests__/mentionDetection.test.ts
+++ b/src/features/chat/ui/__tests__/mentionDetection.test.ts
@@ -40,6 +40,53 @@ function openFilesMention(
 }
 
 describe("useMentionDetection file ordering", () => {
+  it("keeps a dismissed mention closed while typing in the same token", () => {
+    const { result } = renderHook(() => useMentionDetection([], [], []));
+
+    act(() => {
+      result.current.detectMention("@log", 4);
+    });
+    expect(result.current.mentionOpen).toBe(true);
+
+    act(() => {
+      result.current.dismissMention();
+      result.current.detectMention("@logfold", 8);
+    });
+    expect(result.current.mentionOpen).toBe(false);
+
+    act(() => {
+      result.current.detectMention("@logfold @new", 13);
+    });
+    expect(result.current.mentionOpen).toBe(true);
+    expect(result.current.mentionQuery).toBe("new");
+  });
+
+  it("opens a replacement token at the same position after dismissal", () => {
+    const { result } = renderHook(() => useMentionDetection([], [], []));
+
+    act(() => {
+      result.current.detectMention("@old", 4);
+      result.current.dismissMention();
+      result.current.detectMention("@new", 4);
+    });
+
+    expect(result.current.mentionOpen).toBe(true);
+    expect(result.current.mentionQuery).toBe("new");
+  });
+
+  it("closing a selected mention does not suppress a later token", () => {
+    const { result } = renderHook(() => useMentionDetection([], [], []));
+
+    act(() => {
+      result.current.detectMention("@first", 6);
+      result.current.closeMention();
+      result.current.detectMention("@new", 4);
+    });
+
+    expect(result.current.mentionOpen).toBe(true);
+    expect(result.current.mentionQuery).toBe("new");
+  });
+
   it("defaults @ mentions to agents and shows skills only for slash commands", () => {
     const skill = {
       id: "global:/skills/code-review",

--- a/src/features/chat/ui/mentionDetection.ts
+++ b/src/features/chat/ui/mentionDetection.ts
@@ -417,6 +417,7 @@ export function useMentionDetection(
   skills: SkillMentionItem[] = [],
   files: FileMentionItem[] = [],
   defaultAtMentionCategory: AtMentionDefaultCategory = "agents",
+  currentText?: string,
 ) {
   const [mentionState, setMentionState] = useState<{
     isOpen: boolean;
@@ -434,8 +435,21 @@ export function useMentionDetection(
     selectedIndex: 0,
   });
   const completedMentionsRef = useRef<Set<string>>(new Set());
+  const lastDetectedTextRef = useRef(currentText);
+  const dismissedMentionRef = useRef<{
+    trigger: MentionTrigger;
+    startIndex: number;
+    query: string;
+  } | null>(null);
   const mentionStateRef = useRef(mentionState);
   mentionStateRef.current = mentionState;
+
+  useEffect(() => {
+    if (currentText !== lastDetectedTextRef.current) {
+      dismissedMentionRef.current = null;
+      lastDetectedTextRef.current = currentText;
+    }
+  }, [currentText]);
 
   const registerCompletedMention = useCallback((mention: string) => {
     const trimmed = mention.trim();
@@ -537,17 +551,32 @@ export function useMentionDetection(
 
   const detectMention = useCallback(
     (value: string, cursorPos: number) => {
+      lastDetectedTextRef.current = value;
       const beforeCursor = value.slice(0, cursorPos);
       const lastAt = findLastAtMentionTrigger(beforeCursor);
       const lastSlash = findLastSlashMentionTrigger(beforeCursor);
 
       if (lastAt === -1 && lastSlash === -1) {
+        dismissedMentionRef.current = null;
         if (mentionState.isOpen) closeMentionState(setMentionState);
         return;
       }
 
+      const trigger: MentionTrigger = lastSlash > lastAt ? "/" : "@";
+      const startIndex = trigger === "/" ? lastSlash : lastAt;
+      const query = beforeCursor.slice(startIndex + 1);
+      const dismissedMention = dismissedMentionRef.current;
+      if (
+        dismissedMention?.trigger === trigger &&
+        dismissedMention.startIndex === startIndex &&
+        query.startsWith(dismissedMention.query)
+      ) {
+        if (mentionState.isOpen) closeMentionState(setMentionState);
+        return;
+      }
+      dismissedMentionRef.current = null;
+
       if (lastSlash > lastAt) {
-        const query = beforeCursor.slice(lastSlash + 1);
         if (
           (!isPromptStart(beforeCursor, lastSlash) && query.length === 0) ||
           query.includes(" ") ||
@@ -574,7 +603,6 @@ export function useMentionDetection(
         return;
       }
 
-      const query = beforeCursor.slice(lastAt + 1);
       if (isCompletedMentionQuery(query, completedMentionsRef.current)) {
         if (mentionState.isOpen) closeMentionState(setMentionState);
         return;
@@ -605,6 +633,18 @@ export function useMentionDetection(
   );
 
   const closeMention = useCallback(() => {
+    closeMentionState(setMentionState);
+  }, []);
+
+  const dismissMention = useCallback(() => {
+    const current = mentionStateRef.current;
+    dismissedMentionRef.current = current.isOpen
+      ? {
+          trigger: current.trigger,
+          startIndex: current.startIndex,
+          query: current.query,
+        }
+      : null;
     closeMentionState(setMentionState);
   }, []);
 
@@ -743,6 +783,7 @@ export function useMentionDetection(
     filteredFiles,
     detectMention,
     closeMention,
+    dismissMention,
     navigateMention,
     navigateAtMentionCategory,
     setAtMentionCategory,

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -749,7 +749,7 @@ export function GlobalComposerPill({
     fileMentionsLoading,
     fileMentionsError,
     detectMention,
-    closeMention,
+    dismissMention,
     navigateMention,
     setAtMentionCategory,
     handleMentionCategoryKey,
@@ -1325,7 +1325,14 @@ export function GlobalComposerPill({
             !expanded && "flex h-full items-center",
           )}
         >
-          <Popover open={mentionOpen}>
+          <Popover
+            open={mentionOpen}
+            onOpenChange={(open) => {
+              if (!open && mentionOpen) {
+                dismissMention();
+              }
+            }}
+          >
             <div
               id={mentionStatusId}
               role="status"
@@ -1368,7 +1375,7 @@ export function GlobalComposerPill({
                     if (event.key === "Escape") {
                       event.preventDefault();
                       event.stopPropagation();
-                      closeMention();
+                      dismissMention();
                       return;
                     }
                     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -1445,7 +1452,6 @@ export function GlobalComposerPill({
               atCategory={atMentionCategory}
               onAtCategoryChange={setAtMentionCategory}
               selectedIndex={mentionSelectedIndex}
-              onClose={closeMention}
               onSelectPersona={(persona) =>
                 handleMentionConfirm({ type: "persona", persona })
               }

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -1325,14 +1325,7 @@ export function GlobalComposerPill({
             !expanded && "flex h-full items-center",
           )}
         >
-          <Popover
-            open={mentionOpen}
-            onOpenChange={(open) => {
-              if (!open && mentionOpen) {
-                dismissMention();
-              }
-            }}
-          >
+          <Popover open={mentionOpen}>
             <div
               id={mentionStatusId}
               role="status"
@@ -1461,6 +1454,7 @@ export function GlobalComposerPill({
               onSelectFile={(file) =>
                 handleMentionConfirm({ type: "file", file })
               }
+              onDismiss={dismissMention}
               listboxId={mentionListboxId}
               pathsLoading={fileMentionsLoading}
               pathsError={fileMentionsError}


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users can dismiss mention suggestions with Escape or by clicking elsewhere, then continue writing without the suggestions reopening for the same reference.

**Problem:** Mention suggestions could remain in the way when text such as a Datadog query contained `@`, with no reliable way to leave the suggestion mode. Closing the menu also needed to avoid immediately reopening it as the user continued typing the same token.

**Solution:** Let the shared popover primitive own Escape and outside-click dismissal, while mention state remembers the dismissed token until the user starts a genuinely new reference or draft. The behavior is applied consistently to both composer surfaces and covered by interaction and state-lifecycle tests.

<details>
<summary>File changes</summary>

**src/features/chat/hooks/useMentionHandlers.ts**
Passes the current draft into mention detection and exposes the explicit dismissal action to composer surfaces.

**src/features/chat/ui/ChatInput.tsx**
Uses the controlled Popover dismissal lifecycle for outside clicks and routes Escape through the same mention dismissal behavior.

**src/features/chat/ui/MentionAutocomplete.tsx**
Removes document-level pointer and Escape handling so this component only renders and manages suggestion presentation.

**src/features/chat/ui/mentionDetection.ts**
Tracks intentionally dismissed mention tokens, keeps them dismissed during continued typing, and resets suppression for replacement tokens or externally changed drafts.

**src/shared/ui/GlobalComposerPill.tsx**
Applies the same Popover-owned dismissal behavior to the global composer.

**src/features/chat/ui/__tests__/ChatInput.test.tsx**
Covers composer-click dismissal, continued typing after Escape, and opening suggestions in a new draft.

**src/features/chat/ui/__tests__/MentionAutocomplete.test.tsx**
Removes interaction tests for behavior that is no longer owned by the presentation component.

**src/features/chat/ui/__tests__/mentionDetection.test.ts**
Covers same-token suppression, replacement tokens, and the distinction between dismissal and normal closure.

</details>
