### PR TITLE
start Databricks sign-in when saving provider setup

### DIFF
--- a/src/features/providers/api/catalog.test.ts
+++ b/src/features/providers/api/catalog.test.ts
@@ -154,7 +154,7 @@ describe("selectSetupCatalogModelProviders", () => {
     ).toEqual(["openai", "databricks_v2", "anthropic", "ollama"]);
   });
 
-  it("selects only the editable Databricks host field", () => {
+  it("selects the Databricks setup fields when an editable host is available", () => {
     expect(
       selectDatabricksHostConfigProvider([
         {
@@ -175,6 +175,6 @@ describe("selectSetupCatalogModelProviders", () => {
           ],
         },
       ])?.fields?.map((field) => field.key),
-    ).toEqual(["DATABRICKS_HOST"]);
+    ).toEqual(["DATABRICKS_HOST", "DATABRICKS_TOKEN"]);
   });
 });

--- a/src/features/providers/api/catalog.test.ts
+++ b/src/features/providers/api/catalog.test.ts
@@ -55,7 +55,7 @@ describe("provider setup catalog API", () => {
       docsUrl: "https://docs.anthropic.com/en/docs/claude-code",
       group: "default",
       showOnlyWhenInstalled: false,
-      aliases: ["claude-acp", "claude_code", "claude"],
+      aliases: ["claude-acp", "claude_code", "claude-code", "claude"],
       supportsInstall: true,
       supportsAuth: true,
       supportsAuthStatus: true,

--- a/src/features/providers/api/catalog.ts
+++ b/src/features/providers/api/catalog.ts
@@ -68,10 +68,10 @@ export function selectDatabricksHostConfigProvider(
   const entry = entries.find(
     (candidate) => candidate.id === SETUP_CATALOG_DATABRICKS_PROVIDER_ID,
   );
-  const fields = entry?.fields?.filter(
+  const hasHostField = entry?.fields?.some(
     (field) => field.key === SETUP_CATALOG_DATABRICKS_HOST_FIELD_KEY,
   );
-  return entry && fields?.length ? { ...entry, fields } : null;
+  return entry && hasHostField ? entry : null;
 }
 
 export async function listProviderSetupCatalog(): Promise<

--- a/src/features/providers/api/catalog.ts
+++ b/src/features/providers/api/catalog.ts
@@ -1,4 +1,5 @@
 import type { ProviderSetupCatalogEntryDto } from "@aaif/goose-sdk";
+import { CURATED_PROVIDER_CATALOG_BY_ID } from "@/features/providers/curatedProviders";
 import { getClient } from "@/shared/api/acpConnection";
 import type { ProviderCatalogEntry } from "@/shared/types/providers";
 import { perfLog } from "@/shared/lib/perfLog";
@@ -6,21 +7,29 @@ import { perfLog } from "@/shared/lib/perfLog";
 export function mapProviderSetupCatalogEntryDto(
   dto: ProviderSetupCatalogEntryDto,
 ): ProviderCatalogEntry {
+  // Goose owns current setup data, while Berd's curated catalog carries stable
+  // client identity and native-connect capabilities. A fetched same-id entry
+  // must add to that metadata rather than make credentials and actions vanish.
+  const curatedEntry = CURATED_PROVIDER_CATALOG_BY_ID.get(dto.providerId);
+  const aliases = [
+    ...new Set([...(curatedEntry?.aliases ?? []), ...(dto.aliases ?? [])]),
+  ];
+  const nativeConnectQuery =
+    dto.nativeConnectQuery ?? curatedEntry?.nativeConnectQuery;
+
   return {
     id: dto.providerId,
     displayName: dto.name,
     category: dto.category,
     description: dto.description,
     setupMethod: dto.setupMethod,
-    ...(dto.nativeConnectQuery
-      ? { nativeConnectQuery: dto.nativeConnectQuery }
-      : {}),
+    ...(nativeConnectQuery ? { nativeConnectQuery } : {}),
     ...(dto.fields?.length ? { fields: dto.fields } : {}),
     ...(dto.binaryName ? { binaryName: dto.binaryName } : {}),
     ...(dto.docUrl ? { docsUrl: dto.docUrl } : {}),
     group: dto.group,
     showOnlyWhenInstalled: dto.showOnlyWhenInstalled,
-    ...(dto.aliases?.length ? { aliases: dto.aliases } : {}),
+    ...(aliases.length ? { aliases } : {}),
     supportsInstall: dto.supportsInstall,
     supportsAuth: dto.supportsAuth,
     supportsAuthStatus: dto.supportsAuthStatus,

--- a/src/features/providers/runtimeProviderConfig.test.ts
+++ b/src/features/providers/runtimeProviderConfig.test.ts
@@ -4,6 +4,8 @@ import {
   type RuntimeConfig,
 } from "@/shared/runtime-config/schema";
 import type { ProviderCatalogEntry } from "@/shared/types/providers";
+import { mapProviderSetupCatalogEntryDto } from "./api/catalog";
+import { isCredentialedProvider } from "./lib/providerConnectionPolicy";
 import { getModelCacheRefreshProviderIds } from "./modelCacheRefresh";
 import {
   applyRuntimeProviderConfig,
@@ -212,6 +214,66 @@ describe("mergeRuntimeProviderCatalog", () => {
     expect(openai.fields?.map((field) => field.key)).toEqual([
       "OPENAI_API_KEY",
     ]);
+  });
+
+  it("preserves curated Databricks identity through setup and runtime catalog composition", () => {
+    const fetchedSetupEntry = mapProviderSetupCatalogEntryDto({
+      providerId: "databricks_v2",
+      name: "Databricks AI Gateway",
+      category: "model",
+      description: "Databricks AI Gateway models",
+      setupMethod: "host_with_oauth_fallback",
+      fields: [
+        {
+          key: "DATABRICKS_HOST",
+          label: "Host",
+          secret: false,
+          required: true,
+        },
+        {
+          key: "DATABRICKS_TOKEN",
+          label: "Token",
+          secret: true,
+          required: false,
+        },
+      ],
+      group: "default",
+      showOnlyWhenInstalled: false,
+      aliases: ["databricks_ai_gateway"],
+      supportsInstall: false,
+      supportsAuth: true,
+      supportsAuthStatus: false,
+    });
+
+    const merged = mergeRuntimeProviderCatalog(
+      [fetchedSetupEntry],
+      MANAGED_RUNTIME_CONFIG,
+    );
+    const databricks = merged.find((entry) => entry.id === "databricks_v2");
+    if (!databricks) {
+      throw new Error("Expected Databricks in the composed provider catalog");
+    }
+    expect(databricks.nativeConnectQuery).toBe("databricks");
+    expect(databricks.aliases).toEqual(
+      expect.arrayContaining([
+        "databricks_v2",
+        "databricks",
+        "databricks_ai_gateway",
+      ]),
+    );
+
+    const credentialed = isCredentialedProvider(
+      databricks,
+      new Set(["databricks"]),
+    );
+    expect(credentialed).toBe(true);
+    expect(
+      getModelCacheRefreshProviderIds(MANAGED_RUNTIME_CONFIG, {
+        byoKeyProvidersEnabled: true,
+        catalogEntries: merged,
+        configuredProviderIds: credentialed ? ["databricks_v2"] : [],
+      }),
+    ).toContain("databricks_v2");
   });
 
   it("keeps managed Databricks setup fields hidden", () => {

--- a/src/features/providers/runtimeProviderConfig.test.ts
+++ b/src/features/providers/runtimeProviderConfig.test.ts
@@ -261,7 +261,7 @@ describe("mergeRuntimeProviderCatalog", () => {
     expect(databricks.displayName).toBe("Databricks AI Gateway");
   });
 
-  it("keeps only the Databricks host field when runtime config has no endpoint env", () => {
+  it("keeps Databricks host and token fields when runtime config has no endpoint env", () => {
     const configWithoutEndpointEnv: RuntimeConfig = {
       ...DEFAULT_RUNTIME_CONFIG,
       goose: {
@@ -301,6 +301,7 @@ describe("mergeRuntimeProviderCatalog", () => {
 
     expect(databricks?.fields?.map((field) => field.key)).toEqual([
       "DATABRICKS_HOST",
+      "DATABRICKS_TOKEN",
     ]);
   });
 });

--- a/src/features/providers/runtimeProviderConfig.ts
+++ b/src/features/providers/runtimeProviderConfig.ts
@@ -16,7 +16,6 @@ import type { ProviderCatalogEntry } from "@/shared/types/providers";
 
 const GOOSE_AGENT_PROVIDER_ID = "goose";
 const DATABRICKS_PROVIDER_ID = "databricks_v2";
-const DATABRICKS_HOST_FIELD_KEY = "DATABRICKS_HOST";
 const DEFAULT_MODEL_INVENTORY_MODE: RuntimeModelInventoryMode = "authoritative";
 
 export function defaultModelInventoryModeForLoadResult(
@@ -108,9 +107,7 @@ export function mergeRuntimeProviderCatalog(
     if (databricksCatalogEntry) {
       databricksCatalogEntry.fields = databricks.endpointEnv
         ? undefined
-        : databricksSetupEntry.fields.filter(
-            (field) => field.key === DATABRICKS_HOST_FIELD_KEY,
-          );
+        : databricksSetupEntry.fields;
     }
   }
 

--- a/src/features/providers/ui/ModelProviderRow.tsx
+++ b/src/features/providers/ui/ModelProviderRow.tsx
@@ -330,7 +330,7 @@ export function ModelProviderRow({
     panelRef.current?.focus({ preventScroll: true });
   });
 
-  function runNativeConnect() {
+  async function runNativeConnect() {
     if (!provider.nativeConnectQuery) {
       return;
     }
@@ -340,13 +340,22 @@ export function ModelProviderRow({
     setError("");
     setShowSavedState(false);
 
-    // Kick off the backend-owned `goose configure` sign-in; the store mirrors
-    // its progress and the success effect runs the post-success refresh. The
-    // operation keeps running (and is observable) even if this row unmounts or
-    // the window reloads.
-    void startSetup(provider.id, {
-      providerLabel: provider.nativeConnectQuery,
-    });
+    try {
+      // Kick off the backend-owned Berd sign-in; the store mirrors its progress
+      // and the success effect runs the post-success refresh. The operation
+      // keeps running (and is observable) even if this row unmounts or the
+      // window reloads.
+      await startSetup(provider.id, {
+        providerLabel: provider.nativeConnectQuery,
+      });
+    } catch (nextError) {
+      setOperation(provider.id, {
+        phase: "idle",
+        status: "failed",
+        output: setupOutputLines,
+        error: formatAcpErrorMessage(nextError, "Couldn't start sign-in"),
+      });
+    }
   }
 
   function handleExpandedChange(nextExpanded: boolean) {
@@ -438,24 +447,39 @@ export function ModelProviderRow({
       return nextValue !== (currentValue.value ?? "");
     });
 
-    if (fieldsToSave.length === 0) {
-      setError("");
-      return;
-    }
+    const shouldStartNativeAuthentication =
+      provider.setupMethod === "host_with_oauth_fallback" &&
+      supportsNativeConnect &&
+      !fields.some(
+        (field) =>
+          field.secret && (draftValues[field.key]?.trim() ?? "").length > 0,
+      );
 
     setError("");
     try {
-      await onSaveFields(
-        fieldsToSave.map((field) => ({
-          key: field.key,
-          value: draftValues[field.key]?.trim() ?? "",
-          isSecret: field.secret,
-        })),
-      );
-      fieldsToSave.forEach((field) => {
-        dirtyDraftKeys.current.delete(field.key);
-      });
-      void loadConfig();
+      if (fieldsToSave.length > 0) {
+        await onSaveFields(
+          fieldsToSave.map((field) => ({
+            key: field.key,
+            value: draftValues[field.key]?.trim() ?? "",
+            isSecret: field.secret,
+          })),
+        );
+        fieldsToSave.forEach((field) => {
+          dirtyDraftKeys.current.delete(field.key);
+        });
+        void loadConfig();
+      }
+
+      if (shouldStartNativeAuthentication) {
+        await runNativeConnect();
+        return;
+      }
+
+      if (fieldsToSave.length === 0) {
+        return;
+      }
+
       onProviderConnected?.(provider.id);
       setShowSavedState(false);
     } catch (nextError) {
@@ -602,6 +626,10 @@ export function ModelProviderRow({
           error={error}
           setupMethod={provider.setupMethod}
           setupMessage={setupMessage}
+          authenticating={authenticating}
+          setupOutputLines={setupOutputLines}
+          setupOutputRef={outputRef}
+          setupError={setupError}
           onDraftChange={handleDraftChange}
           onSaveSetup={() => void handleSaveSetup()}
         />

--- a/src/features/settings/ui/ModelProviderPanels.tsx
+++ b/src/features/settings/ui/ModelProviderPanels.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/shared/ui/button";
 import { Input } from "@/shared/ui/input";
 import { Spinner } from "@/shared/ui/spinner";
+import { ProviderSetupOutput } from "@/features/settings/ui/ProviderSetupOutput";
 import type {
   ProviderField,
   ProviderFieldValue,
@@ -240,6 +241,10 @@ interface SetupFieldsPanelProps {
   error: string;
   setupMethod: ProviderSetupMethod;
   setupMessage: string | null;
+  authenticating: boolean;
+  setupOutputLines: string[];
+  setupOutputRef: RefObject<HTMLDivElement | null>;
+  setupError: string;
   onDraftChange: (key: string, value: string) => void;
   onSaveSetup: () => void;
 }
@@ -256,23 +261,30 @@ export function SetupFieldsPanel({
   error,
   setupMethod,
   setupMessage,
+  authenticating,
+  setupOutputLines,
+  setupOutputRef,
+  setupError,
   onDraftChange,
   onSaveSetup,
 }: SetupFieldsPanelProps) {
   const { t } = useTranslation(["settings", "common"]);
   const showInlineSave = fields.length === 1;
+  const busy = saving || authenticating;
   const saveButton = (
     <Button
       type="button"
-      feedbackState={saving ? "loading" : showSavedState ? "success" : "idle"}
-      loadingLabel={t("providers.saving")}
+      feedbackState={busy ? "loading" : showSavedState ? "success" : "idle"}
+      loadingLabel={
+        authenticating ? t("providers.waitingForSignIn") : t("providers.saving")
+      }
       successLabel={t("providers.saved")}
       loadingVisual="text"
       loadingDelayMs={250}
       preserveWidth
       size="sm"
       onClick={() => onSaveSetup()}
-      disabled={saving || showSavedState}
+      disabled={busy || showSavedState}
       className="h-8"
     >
       {t("common:actions.save")}
@@ -311,7 +323,7 @@ export function SetupFieldsPanel({
                 onChange={(event) =>
                   onDraftChange(field.key, event.target.value)
                 }
-                disabled={saving}
+                disabled={busy}
                 className="h-8 flex-1 text-sm"
               />
               {showInlineSave ? saveButton : null}
@@ -325,13 +337,29 @@ export function SetupFieldsPanel({
       ) : null}
       {setupMethod === "host_with_oauth_fallback"
         ? renderInlineCodeMessage(
-            t("providers.models.setup.hostWithOauthFallbackTerminal"),
+            t("providers.models.setup.hostWithOauthFallbackNative"),
           )
         : null}
       {setupMethod === "cloud_credentials" && setupMessage
         ? renderSetupMessage(setupMessage)
         : null}
       <ModelRefreshMessage syncing={modelSyncing} warning={modelWarning} />
+      {authenticating ? (
+        <p
+          role="status"
+          className="flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <Spinner className="size-3.5 text-primary" />
+          <span>{t("providers.waitingForSignIn")}</span>
+        </p>
+      ) : null}
+      <ProviderSetupOutput
+        lines={setupOutputLines.map((text, index) => ({ id: index, text }))}
+        scrollRef={setupOutputRef}
+      />
+      {setupError ? (
+        <p className="text-sm text-destructive">{setupError}</p>
+      ) : null}
       {error && <p className="text-sm text-destructive">{error}</p>}
     </div>
   );

--- a/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
+++ b/src/features/settings/ui/__tests__/ModelProviderRow.test.tsx
@@ -57,6 +57,7 @@ const providerCatalog: ProviderCatalogEntry[] = [
     category: "model",
     description: "Databricks Foundation Models",
     setupMethod: "host_with_oauth_fallback",
+    nativeConnectQuery: "databricks",
     fields: [
       {
         key: "DATABRICKS_HOST",
@@ -120,6 +121,18 @@ const providerCatalog: ProviderCatalogEntry[] = [
   },
 ];
 
+function hostWithOauthProvider() {
+  const provider = providerCatalog.find((entry) => entry.id === "databricks");
+  if (!provider) {
+    throw new Error("missing host-with-OAuth provider fixture");
+  }
+  return {
+    ...provider,
+    id: "databricks_v2",
+    status: "not_configured" as const,
+  };
+}
+
 describe("ModelProviderRow", () => {
   const onGetConfig = vi.fn();
   const onSaveFields = vi.fn();
@@ -139,6 +152,12 @@ describe("ModelProviderRow", () => {
     onSaveFields.mockResolvedValue(undefined);
     onRemoveConfig.mockResolvedValue(undefined);
     onCompleteNativeSetup.mockResolvedValue(undefined);
+    vi.mocked(startModelSetup).mockResolvedValue({
+      phase: "authenticating",
+      status: "running",
+      output: [],
+      error: null,
+    });
   });
 
   it("shows setup placeholders while provider config loads", async () => {
@@ -355,12 +374,83 @@ describe("ModelProviderRow", () => {
     expect(controlledRegion).not.toHaveAttribute("inert");
   });
 
-  it("saves all changed setup fields from one setup submit", async () => {
+  it("saves a changed host before starting native authentication", async () => {
     const user = userEvent.setup();
 
     render(
       <ModelProviderRow
-        provider={modelProvider("databricks", "not_configured")}
+        provider={hostWithOauthProvider()}
+        onGetConfig={onGetConfig}
+        onSaveFields={onSaveFields}
+        onRemoveConfig={onRemoveConfig}
+        onCompleteNativeSetup={onCompleteNativeSetup}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /databricks/i }));
+    await user.type(
+      await screen.findByPlaceholderText(/cloud\.databricks\.com/i),
+      "https://dbc-test.cloud.databricks.com",
+    );
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(startModelSetup).toHaveBeenCalledTimes(1));
+    expect(onSaveFields).toHaveBeenCalledWith([
+      {
+        key: "DATABRICKS_HOST",
+        value: "https://dbc-test.cloud.databricks.com",
+        isSecret: false,
+      },
+    ]);
+    expect(startModelSetup).toHaveBeenCalledWith("databricks_v2", {
+      providerLabel: "databricks",
+    });
+    expect(onSaveFields.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(startModelSetup).mock.invocationCallOrder[0],
+    );
+    expect(
+      await screen.findByText(/waiting for sign-in/i, { selector: "p span" }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts native authentication when the host is already saved", async () => {
+    const user = userEvent.setup();
+    onGetConfig.mockResolvedValue([
+      {
+        key: "DATABRICKS_HOST",
+        value: "https://dbc-saved.cloud.databricks.com",
+        isSet: true,
+        isSecret: false,
+        required: true,
+      },
+    ]);
+
+    render(
+      <ModelProviderRow
+        provider={hostWithOauthProvider()}
+        onGetConfig={onGetConfig}
+        onSaveFields={onSaveFields}
+        onRemoveConfig={onRemoveConfig}
+        onCompleteNativeSetup={onCompleteNativeSetup}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /databricks/i }));
+    expect(
+      await screen.findByDisplayValue("https://dbc-saved.cloud.databricks.com"),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(startModelSetup).toHaveBeenCalledTimes(1));
+    expect(onSaveFields).not.toHaveBeenCalled();
+  });
+
+  it("saves an access token without starting native authentication", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelProviderRow
+        provider={hostWithOauthProvider()}
         onGetConfig={onGetConfig}
         onSaveFields={onSaveFields}
         onRemoveConfig={onRemoveConfig}
@@ -392,6 +482,48 @@ describe("ModelProviderRow", () => {
         isSecret: true,
       },
     ]);
+    expect(startModelSetup).not.toHaveBeenCalled();
+  });
+
+  it("surfaces native authentication failure in the field setup row", async () => {
+    const user = userEvent.setup();
+    onGetConfig.mockResolvedValue([
+      {
+        key: "DATABRICKS_HOST",
+        value: "https://dbc-saved.cloud.databricks.com",
+        isSet: true,
+        isSecret: false,
+        required: true,
+      },
+    ]);
+
+    render(
+      <ModelProviderRow
+        provider={hostWithOauthProvider()}
+        onGetConfig={onGetConfig}
+        onSaveFields={onSaveFields}
+        onRemoveConfig={onRemoveConfig}
+        onCompleteNativeSetup={onCompleteNativeSetup}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /databricks/i }));
+    await screen.findByDisplayValue("https://dbc-saved.cloud.databricks.com");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() => expect(startModelSetup).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useModelSetupStore.getState().setOperation("databricks_v2", {
+        phase: "idle",
+        status: "failed",
+        output: ["Authentication failed"],
+        error: "Databricks sign-in was cancelled",
+      });
+    });
+
+    expect(
+      await screen.findByText(/databricks sign-in was cancelled/i),
+    ).toBeInTheDocument();
   });
 
   it("pre-fills and saves provider field defaults", async () => {

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -647,7 +647,7 @@
           "hostWithOauthFallback": "Add your host details to use this provider.",
           "singleApiKey": "Add your API key to use this provider."
         },
-        "hostWithOauthFallbackTerminal": "Leave **access token** blank, save your host URL, then run `goose configure` in your terminal to sign in.",
+        "hostWithOauthFallbackNative": "Leave **access token** blank to sign in through Berd after you save, or enter a token to connect directly.",
         "nativeConnectDescription": "Sign in with your existing account.",
         "pending": {
           "cloudCredentials": "Configure your cloud credentials in your terminal before using this provider.",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -650,7 +650,7 @@
           "hostWithOauthFallback": "Agrega los datos requeridos para usar este proveedor.",
           "singleApiKey": "Agrega tu clave API para usar este proveedor."
         },
-        "hostWithOauthFallbackTerminal": "Deja en blanco el token de acceso, guarda la URL del host y luego ejecuta `goose configure` en tu terminal para iniciar sesión.",
+        "hostWithOauthFallbackNative": "Deja en blanco el **token de acceso** para iniciar sesión mediante Berd después de guardar, o introduce un token para conectarte directamente.",
         "nativeConnectDescription": "Inicia sesión con tu cuenta existente.",
         "pending": {
           "cloudCredentials": "Configura tus credenciales de nube en el entorno de tu terminal antes de usar este proveedor.",


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** Databricks users with an existing OAuth credential stay recognized, and users completing setup can save workspace details and sign in through one Berd-native flow.
**Problem:** Goose setup-catalog data replaced the same-id curated `databricks_v2` entry, dropping Berd identity and capability metadata. That hid the stored `provider_cache:databricks` OAuth credential, excluded Databricks from model refresh, and removed the native sign-in action. Save also stopped after host persistence and left terminal-oriented guidance. **Solution:** Fetched setup data now augments curated aliases and native-connect capability before runtime composition. Save then persists changed setup fields first and starts the existing backend-owned authentication flow when no token is entered; entering an access token continues to save directly without OAuth.

## Changes

<details>
<summary>File changes</summary>

**src/features/providers/api/catalog.ts**
Composes fetched setup data with stable curated aliases and native-connect capability, and preserves the complete Databricks host-and-token field set.

**src/features/providers/api/catalog.test.ts**
Protects curated alias augmentation and the host-and-token setup field contract.

**src/features/providers/runtimeProviderConfig.ts**
Keeps setup-catalog fields for unmanaged Databricks providers while continuing to hide them when a managed endpoint is injected.

**src/features/providers/runtimeProviderConfig.test.ts**
Covers the fetched setup to runtime catalog boundary, including recognition of the shared `databricks` OAuth cache alias and model-refresh eligibility, plus managed and unmanaged field behavior.

**src/features/providers/ui/ModelProviderRow.tsx**
Sequences changed-field persistence before native authentication, starts authentication even when the host is already saved, and routes startup failures into the existing model setup state.

**src/features/settings/ui/ModelProviderPanels.tsx**
Shows authentication progress, streamed output, and failures inside the existing field-backed setup row while disabling edits during the operation.

**src/features/settings/ui/__tests__/ModelProviderRow.test.tsx**
Adds regressions for changed host plus OAuth, saved host plus OAuth, token save without OAuth, and authentication failure; existing API-key provider coverage remains intact.

**src/shared/i18n/locales/en/settings.json**
Replaces terminal setup instructions with Berd-native Save and sign-in guidance.

**src/shared/i18n/locales/es/settings.json**
Updates the matching Spanish guidance.

</details>

## Validation

- `just check`
- Focused provider and Save regressions: 60 passed
- `just test`: 6,722 passed and 1 skipped; the one failure is the unchanged local telemetry session-store test under jsdom, which passed in the prior PR CI run
