### PR TITLE
fix(home): keep Berdy avatar visible when clicked

### DIFF
--- a/src/features/home/widgets/OnboardingTourWidget.test.tsx
+++ b/src/features/home/widgets/OnboardingTourWidget.test.tsx
@@ -87,7 +87,7 @@ describe("OnboardingTourWidget", () => {
 
     expect(screen.getByTestId("animated-berdy")).toHaveAttribute(
       "data-loading-strategy",
-      "lazy-once",
+      "eager",
     );
     expect(screen.getByTestId("animated-berdy")).toHaveAttribute(
       "data-playback-mode",

--- a/src/features/home/widgets/OnboardingTourWidget.tsx
+++ b/src/features/home/widgets/OnboardingTourWidget.tsx
@@ -249,7 +249,7 @@ const BerdyContent = memo(function BerdyContent({
               media={gloopyMedia}
               poster={gloopyPoster.data}
               alt={t("onboarding.callout.avatarAlt")}
-              loadingStrategy="lazy-once"
+              loadingStrategy="eager"
               playbackMode="occasional"
               className="size-full object-contain"
             />


### PR DESCRIPTION
## Summary

Clicking Berdy on Home could briefly blank the avatar while the composer tagged the agent. Berdy was the only Home agent using lazy video loading, so an interaction-driven media lifecycle update could temporarily detach its source while waiting for visibility observation.

Berdy now loads its avatar eagerly, matching the other Home agent pins and keeping the avatar painted through activation. The existing widget test pins the eager-loading contract.

## Reviewer-reproducible example

1. Launch Berd and open Home with Berdy's welcome callout dismissed.
2. Click Berdy's avatar several times to tag Berdy in the Home composer.
3. Confirm the avatar remains continuously visible while the composer receives the Berdy tag.

## Regression proof

- Red on `origin/main`: the eager-loading contract fails with `Received: data-loading-strategy="lazy-once"` (1 failed, 11 passed).
- Green on this branch: the same focused suite passes all 12 tests.
