### PR TITLE
fix: preserve cached provider models after empty refresh

### DIFF
--- a/src/app/lib/chatRuntimeStartup.test.ts
+++ b/src/app/lib/chatRuntimeStartup.test.ts
@@ -5,6 +5,20 @@ const mockLoadPersistedMessageQueues = vi.hoisted(() =>
 );
 const mockGetClient = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 const mockRefreshAllModelProviders = vi.hoisted(() => vi.fn());
+const mockGetModelCacheRefreshProviderIds = vi.hoisted(() => vi.fn());
+const mockIsModelInventoryAuthoritative = vi.hoisted(() => vi.fn());
+const mockPersonaTargetMigration = vi.hoisted(() => vi.fn());
+const mockAgentState = vi.hoisted(() => ({
+  personas: [] as Array<{ id: string; writable: boolean }>,
+  providers: [] as unknown[],
+}));
+const mockProviderModelState = vi.hoisted(() => ({
+  providers: new Map<
+    string,
+    { models: Array<Record<string, unknown>>; error?: string }
+  >(),
+  runtimeManagedProviderIds: new Set<string>(),
+}));
 
 // The latch under test wraps startChatRuntime, whose body touches most of the
 // startup module graph. Everything it reaches is stubbed inert (resolved,
@@ -12,12 +26,18 @@ const mockRefreshAllModelProviders = vi.hoisted(() => vi.fn());
 // getClient — the realistic startup failure point — and counts runs via
 // loadPersistedMessageQueues, the first call every run makes.
 
+vi.mock("@/features/agents/lib/personaExecutionTarget", () => ({
+  personaTargetMigration: mockPersonaTargetMigration,
+}));
+
 vi.mock("@/features/agents/stores/agentStore", () => ({
   useAgentStore: {
     getState: () => ({
+      ...mockAgentState,
       setProviders: () => {},
       setPersonas: () => {},
       setPersonasLoading: () => {},
+      updatePersona: () => {},
     }),
   },
 }));
@@ -48,7 +68,7 @@ vi.mock("@/features/providers/runtimeProviderConstraints", () => ({
 }));
 
 vi.mock("@/features/providers/modelCacheRefresh", () => ({
-  getModelCacheRefreshProviderIds: () => [],
+  getModelCacheRefreshProviderIds: mockGetModelCacheRefreshProviderIds,
 }));
 
 vi.mock("@/features/providers/providerCatalog", () => ({
@@ -110,9 +130,9 @@ vi.mock("@/features/providers/stores/defaultProviderReadinessStore", () => ({
 vi.mock("@/features/providers/stores/providerModelCacheStore", () => ({
   useProviderModelCacheStore: {
     getState: () => ({
-      providers: new Map(),
-      runtimeManagedProviderIds: new Set(),
+      ...mockProviderModelState,
       loadPersisted: () => {},
+      isModelInventoryAuthoritative: mockIsModelInventoryAuthoritative,
       refreshAllModelProviders: (...args: unknown[]) =>
         mockRefreshAllModelProviders(...args),
     }),
@@ -190,6 +210,16 @@ describe("runChatRuntimeStartup", () => {
     mockGetClient.mockResolvedValue({});
     mockRefreshAllModelProviders.mockReset();
     mockRefreshAllModelProviders.mockResolvedValue(undefined);
+    mockGetModelCacheRefreshProviderIds.mockReset();
+    mockGetModelCacheRefreshProviderIds.mockReturnValue([]);
+    mockIsModelInventoryAuthoritative.mockReset();
+    mockIsModelInventoryAuthoritative.mockReturnValue(false);
+    mockPersonaTargetMigration.mockReset();
+    mockPersonaTargetMigration.mockReturnValue(null);
+    mockAgentState.personas = [];
+    mockAgentState.providers = [];
+    mockProviderModelState.providers = new Map();
+    mockProviderModelState.runtimeManagedProviderIds = new Set();
   });
 
   it("collapses concurrent callers onto one startup run", async () => {
@@ -219,6 +249,51 @@ describe("runChatRuntimeStartup", () => {
     expect(mockRefreshAllModelProviders).toHaveBeenCalledTimes(1);
 
     inventoryRefresh.resolve();
+  });
+
+  it.each([
+    {
+      label: "authoritative",
+      authoritative: true,
+      error: undefined,
+      includesModel: true,
+    },
+    {
+      label: "provisional",
+      authoritative: false,
+      error: undefined,
+      includesModel: false,
+    },
+    {
+      label: "errored",
+      authoritative: true,
+      error: "refresh failed",
+      includesModel: false,
+    },
+  ])("uses only $label refreshed inventory for migration", async ({
+    authoritative,
+    error,
+    includesModel,
+  }) => {
+    const model = { id: "openrouter-model", providerId: "openrouter" };
+    mockAgentState.personas = [{ id: "persona-1", writable: true }];
+    mockProviderModelState.providers = new Map([
+      ["openrouter", { models: [model], ...(error ? { error } : {}) }],
+    ]);
+    mockGetModelCacheRefreshProviderIds.mockReturnValue(["openrouter"]);
+    mockIsModelInventoryAuthoritative.mockReturnValue(authoritative);
+    const { runChatRuntimeStartup } = await import("./chatRuntimeStartup");
+
+    await runChatRuntimeStartup();
+
+    await vi.waitFor(() =>
+      expect(mockPersonaTargetMigration).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "persona-1" }),
+        expect.objectContaining({
+          models: includesModel ? [model] : [],
+        }),
+      ),
+    );
   });
 
   it("stays latched after a successful run", async () => {

--- a/src/app/lib/chatRuntimeStartup.ts
+++ b/src/app/lib/chatRuntimeStartup.ts
@@ -315,7 +315,9 @@ async function startChatRuntime(
       ...modelState.runtimeManagedProviderIds,
       ...refreshProviderIds.filter((providerId) => {
         const entry = modelState.providers.get(providerId);
-        return entry != null && !entry.error;
+        return (
+          !entry?.error && modelState.isModelInventoryAuthoritative(providerId)
+        );
       }),
     ]);
   };

--- a/src/features/providers/stores/providerModelCacheStore.test.ts
+++ b/src/features/providers/stores/providerModelCacheStore.test.ts
@@ -27,7 +27,7 @@ function seededModel(overrides: Partial<ModelOption> = {}): ModelOption {
 
 describe("providerModelCacheStore", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     window.localStorage.clear();
     useProviderModelCacheStore.setState({
       providers: new Map(),
@@ -126,6 +126,174 @@ describe("providerModelCacheStore", () => {
         .getState()
         .isModelInventoryAuthoritative("databricks_v2"),
     ).toBe(true);
+  });
+
+  it.each([
+    { label: "stale", fetchedAt: 1, force: false },
+    { label: "fresh forced", fetchedAt: Date.now(), force: true },
+  ])("preserves a $label populated cache and retries after empty discovery", async ({
+    fetchedAt,
+    force,
+  }) => {
+    const cachedEntry = {
+      providerId: "openrouter",
+      models: [
+        seededModel({
+          providerId: "openrouter",
+          providerName: "OpenRouter",
+        }),
+      ],
+      fetchedAt,
+    };
+    window.localStorage.setItem(
+      "goose:providerModelCache:v1",
+      JSON.stringify([cachedEntry]),
+    );
+    useProviderModelCacheStore.getState().loadPersisted();
+    mocks.supportedModelsList
+      .mockResolvedValueOnce({ models: [] })
+      .mockResolvedValueOnce({ models: ["replacement-model"] });
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter", { force });
+
+    const retryableEntry = { ...cachedEntry, fetchedAt: 0 };
+    expect(
+      useProviderModelCacheStore.getState().providers.get("openrouter"),
+    ).toEqual(retryableEntry);
+    expect(
+      JSON.parse(
+        window.localStorage.getItem("goose:providerModelCache:v1") ?? "[]",
+      ),
+    ).toEqual([retryableEntry]);
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    expect(mocks.supportedModelsList).toHaveBeenCalledTimes(2);
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .getModelsForProvider("openrouter")
+        .map((model) => model.id),
+    ).toEqual(["replacement-model"]);
+  });
+
+  it("keeps configured models provisional and retryable after empty discovery", async () => {
+    const configuredModel = seededModel({
+      providerId: "openrouter",
+      providerName: "OpenRouter",
+    });
+    useProviderModelCacheStore
+      .getState()
+      .seedRuntimeModels(new Map([["openrouter", [configuredModel]]]), {
+        runtimeManagedProviderIds: new Set(),
+      });
+    mocks.supportedModelsList
+      .mockResolvedValueOnce({ models: [] })
+      .mockResolvedValueOnce({ models: ["discovered-model"] });
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    const provisionalEntry = useProviderModelCacheStore
+      .getState()
+      .providers.get("openrouter");
+    expect(provisionalEntry).toEqual({
+      providerId: "openrouter",
+      models: [configuredModel],
+      configuredModels: [configuredModel],
+      fetchedAt: 0,
+    });
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .isModelInventoryAuthoritative("openrouter"),
+    ).toBe(false);
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    expect(mocks.supportedModelsList).toHaveBeenCalledTimes(2);
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .getModelsForProvider("openrouter")
+        .map((model) => model.id),
+    ).toEqual(["discovered-model", configuredModel.id]);
+  });
+
+  it("retries after an empty refresh with no cached entry", async () => {
+    mocks.supportedModelsList
+      .mockResolvedValueOnce({ models: [] })
+      .mockResolvedValueOnce({ models: ["openrouter-model"] });
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+    expect(
+      useProviderModelCacheStore.getState().providers.has("openrouter"),
+    ).toBe(false);
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    expect(mocks.supportedModelsList).toHaveBeenCalledTimes(2);
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .getModelsForProvider("openrouter")
+        .map((model) => model.id),
+    ).toEqual(["openrouter-model"]);
+  });
+
+  it("recovers from a persisted fresh-empty cache entry", async () => {
+    window.localStorage.setItem(
+      "goose:providerModelCache:v1",
+      JSON.stringify([
+        {
+          providerId: "openrouter",
+          models: [],
+          fetchedAt: Date.now(),
+        },
+      ]),
+    );
+    useProviderModelCacheStore.getState().loadPersisted();
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .isModelInventoryAuthoritative("openrouter"),
+    ).toBe(false);
+    mocks.supportedModelsList
+      .mockResolvedValueOnce({ models: [] })
+      .mockResolvedValueOnce({ models: ["openrouter-model"] });
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .isModelInventoryAuthoritative("openrouter"),
+    ).toBe(false);
+
+    await useProviderModelCacheStore
+      .getState()
+      .refreshProviderModels("openrouter");
+
+    expect(mocks.supportedModelsList).toHaveBeenCalledTimes(2);
+    expect(
+      useProviderModelCacheStore
+        .getState()
+        .getModelsForProvider("openrouter")
+        .map((model) => model.id),
+    ).toEqual(["openrouter-model"]);
   });
 
   it("preserves bundled metadata while refreshing the available model list", async () => {

--- a/src/features/providers/stores/providerModelCacheStore.test.ts
+++ b/src/features/providers/stores/providerModelCacheStore.test.ts
@@ -129,11 +129,28 @@ describe("providerModelCacheStore", () => {
   });
 
   it.each([
-    { label: "stale", fetchedAt: 1, force: false },
-    { label: "fresh forced", fetchedAt: Date.now(), force: true },
+    {
+      label: "stale",
+      fetchedAt: 1,
+      force: false,
+      error: undefined,
+    },
+    {
+      label: "fresh forced with an error",
+      fetchedAt: Date.now(),
+      force: true,
+      error: "authentication failed",
+    },
+    {
+      label: "retryable with an error",
+      fetchedAt: 0,
+      force: false,
+      error: "authentication failed",
+    },
   ])("preserves a $label populated cache and retries after empty discovery", async ({
     fetchedAt,
     force,
+    error,
   }) => {
     const cachedEntry = {
       providerId: "openrouter",
@@ -144,6 +161,7 @@ describe("providerModelCacheStore", () => {
         }),
       ],
       fetchedAt,
+      ...(error ? { error } : {}),
     };
     window.localStorage.setItem(
       "goose:providerModelCache:v1",
@@ -159,6 +177,7 @@ describe("providerModelCacheStore", () => {
       .refreshProviderModels("openrouter", { force });
 
     const retryableEntry = { ...cachedEntry, fetchedAt: 0 };
+    delete retryableEntry.error;
     expect(
       useProviderModelCacheStore.getState().providers.get("openrouter"),
     ).toEqual(retryableEntry);
@@ -167,6 +186,9 @@ describe("providerModelCacheStore", () => {
         window.localStorage.getItem("goose:providerModelCache:v1") ?? "[]",
       ),
     ).toEqual([retryableEntry]);
+    expect(useProviderModelCacheStore.getState().getError("openrouter")).toBe(
+      null,
+    );
 
     await useProviderModelCacheStore
       .getState()

--- a/src/features/providers/stores/providerModelCacheStore.ts
+++ b/src/features/providers/stores/providerModelCacheStore.ts
@@ -265,15 +265,17 @@ export const useProviderModelCacheStore = create<ProviderModelCacheStore>(
           if (discoveredModels.length === 0) {
             if (
               !existing ||
-              existing.fetchedAt === 0 ||
-              versionAtStart !== refreshVersion(providerId)
+              versionAtStart !== refreshVersion(providerId) ||
+              (existing.fetchedAt === 0 && !existing.error)
             ) {
               return;
             }
+            const retryableEntry = { ...existing, fetchedAt: 0 };
+            delete retryableEntry.error;
             notifyProviderModelInventoryInvalidated(providerId);
             set((state) => {
               const providers = new Map(state.providers);
-              providers.set(providerId, { ...existing, fetchedAt: 0 });
+              providers.set(providerId, retryableEntry);
               persistModels(providers);
               return { providers };
             });

--- a/src/features/providers/stores/providerModelCacheStore.ts
+++ b/src/features/providers/stores/providerModelCacheStore.ts
@@ -124,7 +124,10 @@ async function fetchProviderSupportedModels(
 export function isCachedModelInventoryAuthoritative(
   entry: CachedProviderModels | undefined,
 ): boolean {
-  return entry != null && (entry.runtimeManaged || entry.fetchedAt > 0);
+  return (
+    entry != null &&
+    (entry.runtimeManaged || (entry.models.length > 0 && entry.fetchedAt > 0))
+  );
 }
 
 function isStale(entry: CachedProviderModels | undefined): boolean {
@@ -259,6 +262,23 @@ export const useProviderModelCacheStore = create<ProviderModelCacheStore>(
         try {
           const ids = await fetchProviderSupportedModels(providerId);
           const discoveredModels = providerModelOptionsFromIds(providerId, ids);
+          if (discoveredModels.length === 0) {
+            if (
+              !existing ||
+              existing.fetchedAt === 0 ||
+              versionAtStart !== refreshVersion(providerId)
+            ) {
+              return;
+            }
+            notifyProviderModelInventoryInvalidated(providerId);
+            set((state) => {
+              const providers = new Map(state.providers);
+              providers.set(providerId, { ...existing, fetchedAt: 0 });
+              persistModels(providers);
+              return { providers };
+            });
+            return;
+          }
           const configuredModels = existing?.configuredModels ?? [];
           const configuredModelsById = new Map(
             configuredModels.map((model) => [model.id, model]),


### PR DESCRIPTION
## Cache semantics

- Treat an empty discovered model list as a non-authoritative refresh result.
- Preserve the previous model payload while resetting `fetchedAt` to `0`, so stale and forced refreshes retry without waiting for the cache TTL.
- Treat persisted non-runtime entries with `models: []` as non-authoritative while preserving runtime-managed empty inventories.
- Retain the existing refresh generation fence before publishing the retryable cache state.

## Startup integration

- Require refreshed provider inventories to be both authoritative and error-free before using them for persona target migration.
- Preserve the existing behavior for runtime-managed provider inventories.

## Verification

- Added cache regression coverage for stale persisted entries, fresh forced refreshes, configured provisional models, absent caches, and legacy persisted empty entries.
- Added startup migration coverage for authoritative, provisional, and errored inventories.
- `pnpm vitest run src/features/providers/stores/providerModelCacheStore.test.ts src/app/lib/chatRuntimeStartup.test.ts`
- `just ci`

Closes #154
