### PR TITLE
make custom gloopies reusable across agents

### DIFF
--- a/src-tauri/src/commands/avatars.rs
+++ b/src-tauri/src/commands/avatars.rs
@@ -457,17 +457,13 @@ pub async fn import_user_avatar_data_url(
         .as_deref()
         .map(decode_imported_poster_data_url)
         .transpose()?;
-    let avatar_ref = write_user_avatar_with_poster(
+    write_user_avatar_with_poster(
         &app,
         &bytes,
         mime_type,
         alpha_mode.as_deref(),
         poster.as_deref().map(|bytes| (bytes, "image/png")),
-    )?;
-    if let Err(error) = app.emit(USER_AVATAR_LIBRARY_CHANGED_EVENT, ()) {
-        log::warn!("Failed to emit user avatar library change event: {error}");
-    }
-    Ok(avatar_ref)
+    )
 }
 
 fn decode_imported_avatar_data_url(data_url: &str) -> Result<(Vec<u8>, &'static str), String> {
@@ -1707,7 +1703,11 @@ pub(crate) fn write_user_avatar_with_poster(
 ) -> Result<String, String> {
     let id = format!("gloopie-{}", Uuid::new_v4());
     let paths = user_avatar_paths(app)?;
-    write_user_avatar_at(&paths, &id, bytes, mime_type, alpha_mode, poster)
+    let avatar_ref = write_user_avatar_at(&paths, &id, bytes, mime_type, alpha_mode, poster)?;
+    if let Err(error) = app.emit(USER_AVATAR_LIBRARY_CHANGED_EVENT, ()) {
+        log::warn!("Failed to emit user avatar library change event: {error}");
+    }
+    Ok(avatar_ref)
 }
 
 fn write_user_avatar_at(

--- a/src-tauri/src/commands/avatars.rs
+++ b/src-tauri/src/commands/avatars.rs
@@ -22,6 +22,7 @@ const USER_AVATAR_REF_PREFIX: &str = "user-avatar:";
 const USER_AVATAR_CATALOG_VERSION: &str = "user-generated";
 const USER_AVATAR_COLLECTION_ID: &str = "generated-gloopies";
 const AVATAR_CACHE_WARMED_EVENT: &str = "berd:avatar-cache-warmed";
+const USER_AVATAR_LIBRARY_CHANGED_EVENT: &str = "berd:user-avatar-library-changed";
 const LATEST_PATH: &str = "latest.json";
 const MANIFEST_FILE: &str = "manifest.json";
 const AVATAR_REFRESH_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
@@ -456,13 +457,17 @@ pub async fn import_user_avatar_data_url(
         .as_deref()
         .map(decode_imported_poster_data_url)
         .transpose()?;
-    write_user_avatar_with_poster(
+    let avatar_ref = write_user_avatar_with_poster(
         &app,
         &bytes,
         mime_type,
         alpha_mode.as_deref(),
         poster.as_deref().map(|bytes| (bytes, "image/png")),
-    )
+    )?;
+    if let Err(error) = app.emit(USER_AVATAR_LIBRARY_CHANGED_EVENT, ()) {
+        log::warn!("Failed to emit user avatar library change event: {error}");
+    }
+    Ok(avatar_ref)
 }
 
 fn decode_imported_avatar_data_url(data_url: &str) -> Result<(Vec<u8>, &'static str), String> {

--- a/src-tauri/src/commands/avatars.rs
+++ b/src-tauri/src/commands/avatars.rs
@@ -361,7 +361,14 @@ pub async fn get_avatar_library_snapshot(
 
     // Reading cached collections only inspects atomically-placed files, so it
     // does not need the catalog lock.
-    let cached_collections = cached_collections_for_catalog(&paths, &catalog)?;
+    let mut cached_collections = cached_collections_for_catalog(&paths, &catalog)?;
+    // User-generated gloopies are local library citizens: they ride the same
+    // snapshot so the picker and the collection gallery see one source of
+    // truth, stamped with the user catalog version instead of the published
+    // catalog's version.
+    if let Some(user_collection) = user_avatar_cached_collection(&app) {
+        cached_collections.push(user_collection);
+    }
     let (media_refreshing, media_refresh_completed, media_error_code) =
         avatar_refresh_status().lock().unwrap().snapshot();
     Ok(AvatarLibrarySnapshot {
@@ -1771,6 +1778,75 @@ fn rollback_user_avatar_files(paths: &[&Path]) {
     }
 }
 
+/// Enumerates every user-generated gloopie on this machine as a cached
+/// collection, so the avatar library snapshot can surface them alongside the
+/// bundled catalog. Enumeration is best-effort: a corrupt or half-written
+/// manifest skips that avatar instead of hiding the whole collection. A
+/// machine with no gloopies yields an empty collection; browsing surfaces omit
+/// it entirely.
+fn user_avatar_cached_collection(app: &AppHandle) -> Option<CachedAvatarCollection> {
+    let paths = user_avatar_paths(app).ok()?;
+    user_avatar_cached_collection_at(&paths)
+}
+
+fn user_avatar_cached_collection_at(paths: &UserAvatarPaths) -> Option<CachedAvatarCollection> {
+    let mut manifests: Vec<UserAvatarManifest> = Vec::new();
+    if paths.meta.exists() {
+        let entries = fs::read_dir(&paths.meta).ok()?;
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let Some(avatar_id) = file_name
+                .to_str()
+                .and_then(|name| name.strip_suffix(".json"))
+            else {
+                continue;
+            };
+            let Ok(manifest) = read_user_avatar_manifest(paths, avatar_id) else {
+                log::warn!("Skipping unreadable user avatar manifest: {avatar_id}");
+                continue;
+            };
+            let Ok(media_path) = user_avatar_media_path(paths, &manifest) else {
+                continue;
+            };
+            if media_path.exists() {
+                manifests.push(manifest);
+            }
+        }
+    }
+    // Newest first, so the collection reads as a timeline of what the user
+    // made most recently; the id tiebreak keeps the order deterministic.
+    manifests.sort_by(|left, right| {
+        right
+            .created_at_ms
+            .cmp(&left.created_at_ms)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let assets = manifests
+        .into_iter()
+        .map(|manifest| CachedAvatarAsset {
+            path: paths
+                .media
+                .join(&manifest.path)
+                .to_string_lossy()
+                .into_owned(),
+            poster_path: manifest
+                .poster_path
+                .as_deref()
+                .map(|poster| paths.media.join(poster).to_string_lossy().into_owned()),
+            id: manifest.id,
+            mime_type: manifest.mime_type,
+            alpha_mode: manifest.alpha_mode,
+        })
+        .collect();
+    Some(CachedAvatarCollection {
+        catalog_version: USER_AVATAR_CATALOG_VERSION.to_string(),
+        collection_id: USER_AVATAR_COLLECTION_ID.to_string(),
+        assets,
+        failed_asset_ids: Vec::new(),
+        error_code: None,
+    })
+}
+
 fn cached_user_avatar_for_id(
     app: &AppHandle,
     avatar_id: &str,
@@ -2651,6 +2727,78 @@ mod tests {
                 .unwrap_err()
                 .contains("5 MB or smaller")
         );
+    }
+
+    #[test]
+    fn user_avatar_collection_lists_gloopies_newest_first_and_skips_broken_entries() {
+        let (_dir, paths) = temp_user_avatar_paths();
+
+        // Older avatar.
+        seed_user_avatar(&paths, "gloopie-old");
+        // Newer avatar with a poster and stacked alpha.
+        let newer_media = paths.media.join("gloopie-new.webm");
+        fs::write(&newer_media, b"webm-bytes").unwrap();
+        let poster = paths.media.join("gloopie-new.poster.png");
+        fs::write(&poster, b"poster").unwrap();
+        let manifest = UserAvatarManifest {
+            id: "gloopie-new".to_string(),
+            path: "gloopie-new.webm".to_string(),
+            mime_type: "video/webm".to_string(),
+            alpha_mode: Some("stacked".to_string()),
+            poster_path: Some("gloopie-new.poster.png".to_string()),
+            byte_size: 10,
+            created_at_ms: 5,
+        };
+        fs::write(
+            paths.meta.join("gloopie-new.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        // Manifest without media on disk: excluded.
+        let manifest = UserAvatarManifest {
+            id: "gloopie-missing".to_string(),
+            path: "gloopie-missing.png".to_string(),
+            mime_type: "image/png".to_string(),
+            alpha_mode: None,
+            poster_path: None,
+            byte_size: 1,
+            created_at_ms: 9,
+        };
+        fs::write(
+            paths.meta.join("gloopie-missing.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+        // Corrupt manifest: skipped, does not fail the collection.
+        fs::write(paths.meta.join("gloopie-corrupt.json"), b"not json").unwrap();
+
+        let collection = user_avatar_cached_collection_at(&paths).unwrap();
+
+        assert_eq!(collection.collection_id, USER_AVATAR_COLLECTION_ID);
+        assert_eq!(collection.catalog_version, USER_AVATAR_CATALOG_VERSION);
+        assert!(collection.failed_asset_ids.is_empty());
+        let ids: Vec<&str> = collection
+            .assets
+            .iter()
+            .map(|asset| asset.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["gloopie-new", "gloopie-old"]);
+        let newest = &collection.assets[0];
+        assert_eq!(newest.mime_type, "video/webm");
+        assert_eq!(newest.alpha_mode.as_deref(), Some("stacked"));
+        assert!(newest
+            .poster_path
+            .as_deref()
+            .unwrap()
+            .ends_with("gloopie-new.poster.png"));
+    }
+
+    #[test]
+    fn user_avatar_collection_is_empty_when_no_gloopies_exist() {
+        let (_dir, paths) = temp_user_avatar_paths();
+        let collection = user_avatar_cached_collection_at(&paths).unwrap();
+        assert!(collection.assets.is_empty());
+        assert!(collection.failed_asset_ids.is_empty());
     }
 
     #[test]

--- a/src/features/agents/hooks/__tests__/useAvatarLibrary.test.tsx
+++ b/src/features/agents/hooks/__tests__/useAvatarLibrary.test.tsx
@@ -5,7 +5,8 @@ import type {
   CachedAvatarCollection,
 } from "@/shared/avatars/catalog";
 
-const listeners: Array<() => void> = [];
+const cacheWarmedListeners: Array<() => void> = [];
+const userLibraryChangedListeners: Array<() => void> = [];
 vi.mock("@/shared/api/avatars", async () => {
   const actual = await vi.importActual<typeof import("@/shared/api/avatars")>(
     "@/shared/api/avatars",
@@ -15,7 +16,11 @@ vi.mock("@/shared/api/avatars", async () => {
     getAvatarLibrarySnapshot: vi.fn(),
     refreshAvatarCache: vi.fn(),
     listenAvatarCacheWarmed: vi.fn(async (handler: () => void) => {
-      listeners.push(handler);
+      cacheWarmedListeners.push(handler);
+      return vi.fn();
+    }),
+    listenUserAvatarLibraryChanged: vi.fn(async (handler: () => void) => {
+      userLibraryChangedListeners.push(handler);
       return vi.fn();
     }),
     cachedAssetToMedia: (asset: { path: string; mimeType: string }) => ({
@@ -73,7 +78,8 @@ function cachedCollection(path: string): CachedAvatarCollection {
 
 describe("useAvatarLibrary", () => {
   beforeEach(() => {
-    listeners.length = 0;
+    cacheWarmedListeners.length = 0;
+    userLibraryChangedListeners.length = 0;
     vi.clearAllMocks();
     vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
       catalog,
@@ -182,12 +188,51 @@ describe("useAvatarLibrary", () => {
       mediaRefreshing: false,
       mediaRefreshCompleted: true,
     });
-    act(() => listeners[0]?.());
+    act(() => cacheWarmedListeners[0]?.());
 
     await waitFor(() =>
       expect(result.current.cachedAvatarMediaById["a-1"].media.src).toBe(
         "/cache/refreshed.webm",
       ),
     );
+  });
+
+  it("adds a newly created gloopie after the user library change event", async () => {
+    const { result } = renderHook(() => useAvatarLibrary(true));
+    await waitFor(() => expect(result.current.catalog).toEqual(catalog));
+
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
+      catalog,
+      cachedCollections: [
+        cachedCollection("/cache/a-1.webm"),
+        {
+          catalogVersion: "user-generated",
+          collectionId: "generated-gloopies",
+          assets: [
+            {
+              id: "gloopie-new",
+              path: "/user-avatars/gloopie-new.mp4",
+              mimeType: "video/mp4",
+              alphaMode: "stacked",
+            },
+          ],
+          failedAssetIds: [],
+        },
+      ],
+      mediaRefreshing: false,
+      mediaRefreshCompleted: true,
+    });
+    act(() => userLibraryChangedListeners[0]?.());
+
+    await waitFor(() =>
+      expect(result.current.userAvatarIds).toEqual(["gloopie-new"]),
+    );
+    expect(result.current.cachedAvatarMediaById["gloopie-new"]).toMatchObject({
+      catalogVersion: "user-generated",
+      media: {
+        src: "/user-avatars/gloopie-new.mp4",
+        mediaType: "video",
+      },
+    });
   });
 });

--- a/src/features/agents/hooks/__tests__/useAvatarLibrary.test.tsx
+++ b/src/features/agents/hooks/__tests__/useAvatarLibrary.test.tsx
@@ -34,6 +34,7 @@ vi.mock("@/shared/api/avatars", async () => {
 
 import {
   getAvatarLibrarySnapshot,
+  listenUserAvatarLibraryChanged,
   refreshAvatarCache,
 } from "@/shared/api/avatars";
 import { useAvatarLibrary } from "../useAvatarLibrary";
@@ -101,7 +102,7 @@ describe("useAvatarLibrary", () => {
   });
 
   it("keeps missing first-run media in progress while the initial refresh runs", async () => {
-    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValueOnce({
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
       catalog,
       cachedCollections: [],
       mediaRefreshing: true,
@@ -115,7 +116,7 @@ describe("useAvatarLibrary", () => {
   });
 
   it("surfaces missing media after a failed refresh and retries", async () => {
-    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValueOnce({
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
       catalog,
       cachedCollections: [],
       mediaRefreshing: false,
@@ -125,6 +126,12 @@ describe("useAvatarLibrary", () => {
     const { result } = renderHook(() => useAvatarLibrary(true));
 
     await waitFor(() => expect(result.current.mediaError).toBe(true));
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
+      catalog,
+      cachedCollections: [cachedCollection("/cache/a-1.webm")],
+      mediaRefreshing: false,
+      mediaRefreshCompleted: true,
+    });
     act(() => result.current.retryMedia());
 
     await waitFor(() => expect(refreshAvatarCache).toHaveBeenCalledOnce());
@@ -132,7 +139,7 @@ describe("useAvatarLibrary", () => {
   });
 
   it("surfaces an incomplete poster fallback after a failed refresh", async () => {
-    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValueOnce({
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
       catalog,
       cachedCollections: [
         {
@@ -157,7 +164,7 @@ describe("useAvatarLibrary", () => {
   });
 
   it("surfaces a failed manual media refresh", async () => {
-    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValueOnce({
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
       catalog,
       cachedCollections: [],
       mediaRefreshing: false,
@@ -197,6 +204,50 @@ describe("useAvatarLibrary", () => {
     );
   });
 
+  it("reconciles after delayed listener registration", async () => {
+    let finishRegistration!: () => void;
+    vi.mocked(listenUserAvatarLibraryChanged).mockImplementationOnce(
+      async (handler: () => void) => {
+        userLibraryChangedListeners.push(handler);
+        await new Promise<void>((resolve) => {
+          finishRegistration = resolve;
+        });
+        return () => {};
+      },
+    );
+    const { result } = renderHook(() => useAvatarLibrary(true));
+    await waitFor(() => expect(result.current.catalog).toEqual(catalog));
+
+    vi.mocked(getAvatarLibrarySnapshot).mockResolvedValue({
+      catalog,
+      cachedCollections: [
+        cachedCollection("/cache/a-1.webm"),
+        {
+          catalogVersion: "user-generated",
+          collectionId: "generated-gloopies",
+          assets: [
+            {
+              id: "gloopie-during-registration",
+              path: "/user-avatars/gloopie-during-registration.mp4",
+              mimeType: "video/mp4",
+              alphaMode: "stacked",
+            },
+          ],
+          failedAssetIds: [],
+        },
+      ],
+      mediaRefreshing: false,
+      mediaRefreshCompleted: true,
+    });
+    act(() => finishRegistration());
+
+    await waitFor(() =>
+      expect(result.current.userAvatarIds).toEqual([
+        "gloopie-during-registration",
+      ]),
+    );
+  });
+
   it("adds a newly created gloopie after the user library change event", async () => {
     const { result } = renderHook(() => useAvatarLibrary(true));
     await waitFor(() => expect(result.current.catalog).toEqual(catalog));
@@ -227,12 +278,10 @@ describe("useAvatarLibrary", () => {
     await waitFor(() =>
       expect(result.current.userAvatarIds).toEqual(["gloopie-new"]),
     );
-    expect(result.current.cachedAvatarMediaById["gloopie-new"]).toMatchObject({
-      catalogVersion: "user-generated",
-      media: {
-        src: "/user-avatars/gloopie-new.mp4",
-        mediaType: "video",
-      },
+    expect(result.current.userAvatarMediaById["gloopie-new"]).toMatchObject({
+      src: "/user-avatars/gloopie-new.mp4",
+      mediaType: "video",
     });
+    expect(result.current.cachedAvatarMediaById["gloopie-new"]).toBeUndefined();
   });
 });

--- a/src/features/agents/hooks/__tests__/usePersonas.test.ts
+++ b/src/features/agents/hooks/__tests__/usePersonas.test.ts
@@ -220,7 +220,7 @@ describe("usePersonas", () => {
       ).toBe("Updated");
     });
 
-    it("reclaims a replaced user avatar after the final reference changes", async () => {
+    it("preserves a replaced gloopie in the library after its final agent reference changes", async () => {
       const existing = makePersona({
         id: "test-id",
         avatar: "user-avatar:shared",
@@ -251,12 +251,10 @@ describe("usePersonas", () => {
       await act(async () => {
         await result.current.updatePersona(shared, { avatar: null });
       });
-      expect(avatarApiMocks.deleteUserAvatar).toHaveBeenCalledWith(
-        "user-avatar:shared",
-      );
+      expect(avatarApiMocks.deleteUserAvatar).not.toHaveBeenCalled();
     });
 
-    it("reclaims avatars displaced by overlapping updates", async () => {
+    it("preserves gloopies displaced by overlapping updates", async () => {
       const existing = makePersona({ id: "test-id", avatar: "user-avatar:a" });
       vi.mocked(api.listPersonas).mockResolvedValueOnce([existing]);
       const first = makePersona({ id: "test-id", avatar: "user-avatar:b" });
@@ -290,12 +288,7 @@ describe("usePersonas", () => {
         await updateTwo;
       });
 
-      expect(avatarApiMocks.deleteUserAvatar).toHaveBeenCalledWith(
-        "user-avatar:a",
-      );
-      expect(avatarApiMocks.deleteUserAvatar).toHaveBeenCalledWith(
-        "user-avatar:b",
-      );
+      expect(avatarApiMocks.deleteUserAvatar).not.toHaveBeenCalled();
     });
 
     it("deletePersona calls API and removes from store", async () => {
@@ -320,7 +313,7 @@ describe("usePersonas", () => {
       ).toBeUndefined();
     });
 
-    it("reclaims a deleted user avatar only after its final reference", async () => {
+    it("preserves a gloopie in the library after its final agent is deleted", async () => {
       const first = makePersona({
         id: "first",
         avatar: "user-avatar:shared",
@@ -341,9 +334,7 @@ describe("usePersonas", () => {
       await act(async () => {
         await result.current.deletePersona("second");
       });
-      expect(avatarApiMocks.deleteUserAvatar).toHaveBeenCalledWith(
-        "user-avatar:shared",
-      );
+      expect(avatarApiMocks.deleteUserAvatar).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/agents/hooks/useAvatarLibrary.ts
+++ b/src/features/agents/hooks/useAvatarLibrary.ts
@@ -26,10 +26,11 @@ export interface AvatarLibraryState {
   /**
    * Ids of the user's generated gloopies (newest first). They are local
    * library citizens prepended to the published Gloopies collection and
-   * persisted on agents as `user-avatar:<id>`. Their media lives in
-   * `cachedAvatarMediaById` under `USER_AVATAR_CATALOG_VERSION`.
+   * persisted on agents as `user-avatar:<id>`. Their media remains separate
+   * from the bundled cache so the two durable ref namespaces cannot collide.
    */
   userAvatarIds: string[];
+  userAvatarMediaById: Record<string, ResolvedAvatarMedia>;
   cachedAvatarMediaById: Record<string, CachedAvatarMediaEntry>;
   loading: boolean;
   cacheChecking: boolean;
@@ -47,11 +48,10 @@ function cachedMediaForCatalog(
 ): Record<string, CachedAvatarMediaEntry> {
   const mediaById: Record<string, CachedAvatarMediaEntry> = {};
   for (const collection of collections) {
-    const expectedVersion =
-      collection.collectionId === USER_AVATAR_COLLECTION_ID
-        ? USER_AVATAR_CATALOG_VERSION
-        : catalogVersion;
-    if (collection.catalogVersion !== expectedVersion) {
+    if (
+      collection.collectionId === USER_AVATAR_COLLECTION_ID ||
+      collection.catalogVersion !== catalogVersion
+    ) {
       continue;
     }
     for (const asset of collection.assets) {
@@ -60,6 +60,21 @@ function cachedMediaForCatalog(
         media: cachedAssetToMedia(asset),
       };
     }
+  }
+  return mediaById;
+}
+
+function userAvatarMediaForCollections(
+  collections: CachedAvatarCollection[],
+): Record<string, ResolvedAvatarMedia> {
+  const mediaById: Record<string, ResolvedAvatarMedia> = {};
+  const collection = collections.find(
+    (candidate) =>
+      candidate.collectionId === USER_AVATAR_COLLECTION_ID &&
+      candidate.catalogVersion === USER_AVATAR_CATALOG_VERSION,
+  );
+  for (const asset of collection?.assets ?? []) {
+    mediaById[asset.id] = cachedAssetToMedia(asset);
   }
   return mediaById;
 }
@@ -93,6 +108,9 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
     Record<string, CachedAvatarMediaEntry>
   >({});
   const [userAvatarIds, setUserAvatarIds] = useState<string[]>([]);
+  const [userAvatarMediaById, setUserAvatarMediaById] = useState<
+    Record<string, ResolvedAvatarMedia>
+  >({});
 
   useEffect(() => {
     if (!enabled) {
@@ -100,20 +118,40 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
     }
 
     let cancelled = false;
+    const unlisteners: Array<() => void> = [];
     const reload = () => {
       if (!cancelled) {
         setReloadToken((value) => value + 1);
       }
     };
-    const unlistenPromises = [
+
+    void Promise.allSettled([
       listenAvatarCacheWarmed(reload),
       listenUserAvatarLibraryChanged(reload),
-    ];
+    ]).then((registrations) => {
+      for (const registration of registrations) {
+        if (registration.status === "rejected") {
+          console.warn(
+            "Failed to subscribe to avatar library changes:",
+            registration.reason,
+          );
+          continue;
+        }
+        if (cancelled) {
+          registration.value();
+        } else {
+          unlisteners.push(registration.value);
+        }
+      }
+      // Close the snapshot/subscription gap: mutations emitted before listener
+      // registration completed are recovered by one post-subscribe read.
+      reload();
+    });
 
     return () => {
       cancelled = true;
-      for (const unlistenPromise of unlistenPromises) {
-        void unlistenPromise.then((unlisten) => unlisten());
+      for (const unlisten of unlisteners) {
+        unlisten();
       }
     };
   }, [enabled]);
@@ -140,6 +178,9 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
         setCachedAvatarMediaById(cachedMedia);
         setUserAvatarIds(
           userAvatarIdsForCollections(snapshot.cachedCollections),
+        );
+        setUserAvatarMediaById(
+          userAvatarMediaForCollections(snapshot.cachedCollections),
         );
         setBackendMediaRefreshing(snapshot.mediaRefreshing);
         const hasIncompleteMedia = snapshot.cachedCollections.some(
@@ -204,6 +245,7 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
   return {
     catalog,
     userAvatarIds,
+    userAvatarMediaById,
     cachedAvatarMediaById,
     loading,
     cacheChecking: loading || mediaRefreshing || backendMediaRefreshing,

--- a/src/features/agents/hooks/useAvatarLibrary.ts
+++ b/src/features/agents/hooks/useAvatarLibrary.ts
@@ -7,10 +7,12 @@ import {
   refreshAvatarCache,
   type AvatarLibraryErrorCode,
 } from "@/shared/api/avatars";
-import type {
-  AvatarCatalog,
-  CachedAvatarCollection,
-  ResolvedAvatarMedia,
+import {
+  USER_AVATAR_CATALOG_VERSION,
+  USER_AVATAR_COLLECTION_ID,
+  type AvatarCatalog,
+  type CachedAvatarCollection,
+  type ResolvedAvatarMedia,
 } from "@/shared/avatars/catalog";
 
 interface CachedAvatarMediaEntry {
@@ -20,6 +22,13 @@ interface CachedAvatarMediaEntry {
 
 export interface AvatarLibraryState {
   catalog: AvatarCatalog | null;
+  /**
+   * Ids of the user's generated gloopies (newest first). They form the
+   * "Your gloopies" collection: local library citizens outside the published
+   * catalog, persisted on agents as `user-avatar:<id>`. Their media lives in
+   * `cachedAvatarMediaById` under `USER_AVATAR_CATALOG_VERSION`.
+   */
+  userAvatarIds: string[];
   cachedAvatarMediaById: Record<string, CachedAvatarMediaEntry>;
   loading: boolean;
   cacheChecking: boolean;
@@ -37,17 +46,33 @@ function cachedMediaForCatalog(
 ): Record<string, CachedAvatarMediaEntry> {
   const mediaById: Record<string, CachedAvatarMediaEntry> = {};
   for (const collection of collections) {
-    if (collection.catalogVersion !== catalogVersion) {
+    const expectedVersion =
+      collection.collectionId === USER_AVATAR_COLLECTION_ID
+        ? USER_AVATAR_CATALOG_VERSION
+        : catalogVersion;
+    if (collection.catalogVersion !== expectedVersion) {
       continue;
     }
     for (const asset of collection.assets) {
       mediaById[asset.id] = {
-        catalogVersion,
+        catalogVersion: collection.catalogVersion,
         media: cachedAssetToMedia(asset),
       };
     }
   }
   return mediaById;
+}
+
+function userAvatarIdsForCollections(
+  collections: CachedAvatarCollection[],
+): string[] {
+  return (
+    collections
+      .find(
+        (collection) => collection.collectionId === USER_AVATAR_COLLECTION_ID,
+      )
+      ?.assets.map((asset) => asset.id) ?? []
+  );
 }
 
 export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
@@ -66,6 +91,7 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
   const [cachedAvatarMediaById, setCachedAvatarMediaById] = useState<
     Record<string, CachedAvatarMediaEntry>
   >({});
+  const [userAvatarIds, setUserAvatarIds] = useState<string[]>([]);
 
   useEffect(() => {
     if (!enabled) {
@@ -105,6 +131,9 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
         );
         setCatalog(snapshot.catalog);
         setCachedAvatarMediaById(cachedMedia);
+        setUserAvatarIds(
+          userAvatarIdsForCollections(snapshot.cachedCollections),
+        );
         setBackendMediaRefreshing(snapshot.mediaRefreshing);
         const hasIncompleteMedia = snapshot.cachedCollections.some(
           (collection) => collection.failedAssetIds.length > 0,
@@ -167,6 +196,7 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
 
   return {
     catalog,
+    userAvatarIds,
     cachedAvatarMediaById,
     loading,
     cacheChecking: loading || mediaRefreshing || backendMediaRefreshing,

--- a/src/features/agents/hooks/useAvatarLibrary.ts
+++ b/src/features/agents/hooks/useAvatarLibrary.ts
@@ -3,6 +3,7 @@ import {
   cachedAssetToMedia,
   getAvatarLibrarySnapshot,
   listenAvatarCacheWarmed,
+  listenUserAvatarLibraryChanged,
   normalizeAvatarLibraryError,
   refreshAvatarCache,
   type AvatarLibraryErrorCode,
@@ -23,9 +24,9 @@ interface CachedAvatarMediaEntry {
 export interface AvatarLibraryState {
   catalog: AvatarCatalog | null;
   /**
-   * Ids of the user's generated gloopies (newest first). They form the
-   * "Your gloopies" collection: local library citizens outside the published
-   * catalog, persisted on agents as `user-avatar:<id>`. Their media lives in
+   * Ids of the user's generated gloopies (newest first). They are local
+   * library citizens prepended to the published Gloopies collection and
+   * persisted on agents as `user-avatar:<id>`. Their media lives in
    * `cachedAvatarMediaById` under `USER_AVATAR_CATALOG_VERSION`.
    */
   userAvatarIds: string[];
@@ -99,15 +100,21 @@ export function useAvatarLibrary(enabled: boolean): AvatarLibraryState {
     }
 
     let cancelled = false;
-    const unlistenPromise = listenAvatarCacheWarmed(() => {
+    const reload = () => {
       if (!cancelled) {
         setReloadToken((value) => value + 1);
       }
-    });
+    };
+    const unlistenPromises = [
+      listenAvatarCacheWarmed(reload),
+      listenUserAvatarLibraryChanged(reload),
+    ];
 
     return () => {
       cancelled = true;
-      void unlistenPromise.then((unlisten) => unlisten());
+      for (const unlistenPromise of unlistenPromises) {
+        void unlistenPromise.then((unlisten) => unlisten());
+      }
     };
   }, [enabled]);
 

--- a/src/features/agents/hooks/usePersonas.ts
+++ b/src/features/agents/hooks/usePersonas.ts
@@ -10,22 +10,8 @@ import type {
   Persona,
 } from "@/shared/types/agents";
 import * as api from "@/shared/api/agents";
-import { deleteUserAvatar } from "@/shared/api/avatars";
-import { isUserAvatarRef } from "@/shared/avatars/catalog";
 
 const REFRESH_INTERVAL_MS = 60_000;
-
-function deleteUnreferencedUserAvatar(avatar: string | null | undefined) {
-  if (!avatar || !isUserAvatarRef(avatar)) return;
-  const stillReferenced = useAgentStore
-    .getState()
-    .personas.some((persona) => persona.avatar === avatar);
-  if (!stillReferenced) {
-    void deleteUserAvatar(avatar).catch((error) => {
-      console.warn("Failed to clean up unreferenced agent avatar:", error);
-    });
-  }
-}
 
 export function usePersonas() {
   const personas = useAgentStore(selectPersonas);
@@ -130,18 +116,17 @@ export function usePersonas() {
     [addPersona, trackMutation],
   );
 
+  // Custom gloopies are library citizens, not per-agent attachments: a
+  // displaced or orphaned `user-avatar:<id>` stays in "Your gloopies" so any
+  // agent can wear it again. Library-level delete is a deliberate later
+  // feature (alongside export), so no reference-count garbage collection
+  // happens here.
   const updatePersona = useCallback(
     async (existing: Persona, req: UpdatePersonaRequest) => {
       const persona = await trackMutation(() =>
         api.updatePersona(existing, req),
       );
-      const displacedAvatar = useAgentStore
-        .getState()
-        .personas.find((candidate) => candidate.id === existing.id)?.avatar;
       updatePersonaInStore(existing.id, persona);
-      if (displacedAvatar !== persona.avatar) {
-        deleteUnreferencedUserAvatar(displacedAvatar);
-      }
       return persona;
     },
     [trackMutation, updatePersonaInStore],
@@ -149,12 +134,8 @@ export function usePersonas() {
 
   const deletePersona = useCallback(
     async (id: string) => {
-      const deletedAvatar = useAgentStore
-        .getState()
-        .personas.find((persona) => persona.id === id)?.avatar;
       await trackMutation(() => api.deletePersona(id));
       removePersona(id);
-      deleteUnreferencedUserAvatar(deletedAvatar);
     },
     [removePersona, trackMutation],
   );

--- a/src/features/agents/hooks/usePersonas.ts
+++ b/src/features/agents/hooks/usePersonas.ts
@@ -117,8 +117,8 @@ export function usePersonas() {
   );
 
   // Custom gloopies are library citizens, not per-agent attachments: a
-  // displaced or orphaned `user-avatar:<id>` stays in "Your gloopies" so any
-  // agent can wear it again. Library-level delete is a deliberate later
+  // displaced or orphaned `user-avatar:<id>` stays in the Gloopies collection
+  // so any agent can wear it again. Library-level delete is a deliberate later
   // feature (alongside export), so no reference-count garbage collection
   // happens here.
   const updatePersona = useCallback(

--- a/src/features/agents/lib/avatarLibraryView.test.ts
+++ b/src/features/agents/lib/avatarLibraryView.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AvatarLibraryState } from "@/features/agents/hooks/useAvatarLibrary";
+import type { AvatarCatalog } from "@/shared/avatars/catalog";
+import { buildAvatarDisplayCollections } from "./avatarLibraryView";
+
+const catalog: AvatarCatalog = {
+  schemaVersion: 1,
+  catalogVersion: "v1",
+  collections: [
+    {
+      id: "gloopies",
+      label: "Gloopies",
+      coverAvatarId: "bundled-cover",
+      avatarIds: ["shared-id", "bundled-cover"],
+    },
+    {
+      id: "pollies",
+      label: "Pollies",
+      coverAvatarId: "pollie-cover",
+      avatarIds: ["pollie-first", "pollie-cover"],
+    },
+  ],
+  assets: [
+    ["shared-id", "gloopies"],
+    ["bundled-cover", "gloopies"],
+    ["pollie-first", "pollies"],
+    ["pollie-cover", "pollies"],
+  ].map(([id, collectionId]) => ({
+    id,
+    label: id,
+    collectionId,
+    variants: {
+      webm: {
+        path: `${id}.webm`,
+        mimeType: "video/webm",
+        byteSize: 1,
+        sha256: id,
+      },
+      hevc: {
+        path: `${id}.mov`,
+        mimeType: "video/quicktime",
+        byteSize: 1,
+        sha256: id,
+      },
+    },
+  })),
+};
+
+function library(
+  overrides: Partial<AvatarLibraryState> = {},
+): AvatarLibraryState {
+  return {
+    catalog,
+    userAvatarIds: [],
+    userAvatarMediaById: {},
+    cachedAvatarMediaById: Object.fromEntries(
+      catalog.assets.map((asset) => [
+        asset.id,
+        {
+          catalogVersion: "v1",
+          media: { src: `bundled:${asset.id}`, mediaType: "video" as const },
+        },
+      ]),
+    ),
+    loading: false,
+    cacheChecking: false,
+    error: false,
+    errorCode: null,
+    mediaError: false,
+    mediaErrorCode: null,
+    retryCatalog: vi.fn(),
+    retryMedia: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("buildAvatarDisplayCollections", () => {
+  it("preserves a catalog-authored cover independently of tile order", () => {
+    const pollies = buildAvatarDisplayCollections(library()).find(
+      (collection) => collection.id === "pollies",
+    );
+
+    expect(pollies?.entries.map((entry) => entry.ref)).toEqual([
+      "app-avatar:pollie-first",
+      "app-avatar:pollie-cover",
+    ]);
+    expect(pollies?.cover?.ref).toBe("app-avatar:pollie-cover");
+  });
+
+  it("uses the newest custom gloopie as cover without collapsing ref namespaces", () => {
+    const gloopies = buildAvatarDisplayCollections(
+      library({
+        userAvatarIds: ["shared-id"],
+        userAvatarMediaById: {
+          "shared-id": { src: "custom:shared-id", mediaType: "video" },
+        },
+      }),
+    ).find((collection) => collection.id === "gloopies");
+
+    expect(gloopies?.cover?.ref).toBe("user-avatar:shared-id");
+    expect(gloopies?.entries.slice(0, 2).map((entry) => entry.ref)).toEqual([
+      "user-avatar:shared-id",
+      "app-avatar:shared-id",
+    ]);
+    expect(
+      gloopies?.entries.slice(0, 2).map((entry) => entry.media?.src),
+    ).toEqual(["custom:shared-id", "bundled:shared-id"]);
+  });
+});

--- a/src/features/agents/lib/avatarLibraryView.ts
+++ b/src/features/agents/lib/avatarLibraryView.ts
@@ -1,6 +1,5 @@
 import type { AvatarLibraryState } from "@/features/agents/hooks/useAvatarLibrary";
 import {
-  USER_AVATAR_CATALOG_VERSION,
   avatarRef,
   getAvatarCatalogEntry,
   mediaTypeFromMimeType,
@@ -16,6 +15,7 @@ const GLOOPIES_COLLECTION_ID = "gloopies";
 /** One selectable avatar in a browsing surface. */
 export interface AvatarDisplayEntry {
   id: string;
+  /** Full persisted ref; also the stable identity across avatar namespaces. */
   ref: string;
   label?: string;
   media?: ResolvedAvatarMedia;
@@ -29,25 +29,42 @@ export interface AvatarDisplayEntry {
 export interface AvatarDisplayCollection {
   id: string;
   label?: string;
+  /** Cover presentation is independent from the ordered collection entries. */
+  cover?: AvatarDisplayEntry;
   entries: AvatarDisplayEntry[];
 }
 
-function cachedMedia(
+function bundledEntry(
   library: AvatarLibraryState,
-  expectedCatalogVersion: string | undefined,
   avatarId: string,
-): ResolvedAvatarMedia | undefined {
-  const entry = library.cachedAvatarMediaById[avatarId];
-  return entry?.catalogVersion === expectedCatalogVersion
-    ? entry.media
-    : undefined;
+): AvatarDisplayEntry | undefined {
+  const entry = getAvatarCatalogEntry(library.catalog, avatarId);
+  if (!entry) {
+    return undefined;
+  }
+  const cachedMedia = library.cachedAvatarMediaById[avatarId];
+  const catalogVersion = library.catalog?.catalogVersion;
+  const fallbackVariant = entry.variants.webm ?? entry.variants.hevc;
+  return {
+    id: entry.id,
+    ref: avatarRef(entry.id),
+    label: entry.label,
+    media:
+      cachedMedia?.catalogVersion === catalogVersion
+        ? cachedMedia.media
+        : undefined,
+    fallbackMediaType: fallbackVariant
+      ? mediaTypeFromMimeType(fallbackVariant.mimeType)
+      : "image",
+    isUserAvatar: false,
+  };
 }
 
 function userGloopieEntries(library: AvatarLibraryState): AvatarDisplayEntry[] {
   return library.userAvatarIds.map((avatarId) => ({
     id: avatarId,
     ref: userAvatarRef(avatarId),
-    media: cachedMedia(library, USER_AVATAR_CATALOG_VERSION, avatarId),
+    media: library.userAvatarMediaById[avatarId],
     fallbackMediaType: "video",
     isUserAvatar: true,
   }));
@@ -56,43 +73,29 @@ function userGloopieEntries(library: AvatarLibraryState): AvatarDisplayEntry[] {
 /**
  * Builds the single browsing model shared by the inline picker and full-screen
  * gallery. Custom gloopies are prepended to the existing Gloopies collection;
- * they remain a separate local storage source and are never written into the
- * published catalog.
+ * the newest custom gloopie also becomes that collection's cover. Other
+ * collections retain their catalog-authored cover independently of tile order.
  */
 export function buildAvatarDisplayCollections(
   library: AvatarLibraryState,
 ): AvatarDisplayCollection[] {
-  const catalogVersion = library.catalog?.catalogVersion;
   const customGloopies = userGloopieEntries(library);
 
   return (library.catalog?.collections ?? []).map((collection) => {
     const bundledEntries = collection.avatarIds.flatMap((avatarId) => {
-      const entry = getAvatarCatalogEntry(library.catalog, avatarId);
-      if (!entry) {
-        return [];
-      }
-      const fallbackVariant = entry.variants.webm ?? entry.variants.hevc;
-      return [
-        {
-          id: entry.id,
-          ref: avatarRef(entry.id),
-          label: entry.label,
-          media: cachedMedia(library, catalogVersion, entry.id),
-          fallbackMediaType: fallbackVariant
-            ? mediaTypeFromMimeType(fallbackVariant.mimeType)
-            : "image",
-          isUserAvatar: false,
-        },
-      ];
+      const entry = bundledEntry(library, avatarId);
+      return entry ? [entry] : [];
     });
+    const catalogCover = bundledEntry(library, collection.coverAvatarId);
+    const isGloopies = collection.id === GLOOPIES_COLLECTION_ID;
 
     return {
       id: collection.id,
       label: collection.label,
-      entries:
-        collection.id === GLOOPIES_COLLECTION_ID
-          ? [...customGloopies, ...bundledEntries]
-          : bundledEntries,
+      cover: isGloopies ? (customGloopies[0] ?? catalogCover) : catalogCover,
+      entries: isGloopies
+        ? [...customGloopies, ...bundledEntries]
+        : bundledEntries,
     };
   });
 }

--- a/src/features/agents/lib/avatarLibraryView.ts
+++ b/src/features/agents/lib/avatarLibraryView.ts
@@ -1,0 +1,98 @@
+import type { AvatarLibraryState } from "@/features/agents/hooks/useAvatarLibrary";
+import {
+  USER_AVATAR_CATALOG_VERSION,
+  avatarRef,
+  getAvatarCatalogEntry,
+  mediaTypeFromMimeType,
+  userAvatarRef,
+} from "@/shared/avatars/catalog";
+import type {
+  AvatarMediaType,
+  ResolvedAvatarMedia,
+} from "@/shared/avatars/catalog";
+
+const GLOOPIES_COLLECTION_ID = "gloopies";
+
+/** One selectable avatar in a browsing surface. */
+export interface AvatarDisplayEntry {
+  id: string;
+  ref: string;
+  label?: string;
+  media?: ResolvedAvatarMedia;
+  /** Media type of the source asset even when the media is not cached yet. */
+  fallbackMediaType: AvatarMediaType;
+  /** Custom gloopies have no catalog-authored label. */
+  isUserAvatar: boolean;
+}
+
+/** One collection in a browsing surface. */
+export interface AvatarDisplayCollection {
+  id: string;
+  label?: string;
+  entries: AvatarDisplayEntry[];
+}
+
+function cachedMedia(
+  library: AvatarLibraryState,
+  expectedCatalogVersion: string | undefined,
+  avatarId: string,
+): ResolvedAvatarMedia | undefined {
+  const entry = library.cachedAvatarMediaById[avatarId];
+  return entry?.catalogVersion === expectedCatalogVersion
+    ? entry.media
+    : undefined;
+}
+
+function userGloopieEntries(library: AvatarLibraryState): AvatarDisplayEntry[] {
+  return library.userAvatarIds.map((avatarId) => ({
+    id: avatarId,
+    ref: userAvatarRef(avatarId),
+    media: cachedMedia(library, USER_AVATAR_CATALOG_VERSION, avatarId),
+    fallbackMediaType: "video",
+    isUserAvatar: true,
+  }));
+}
+
+/**
+ * Builds the single browsing model shared by the inline picker and full-screen
+ * gallery. Custom gloopies are prepended to the existing Gloopies collection;
+ * they remain a separate local storage source and are never written into the
+ * published catalog.
+ */
+export function buildAvatarDisplayCollections(
+  library: AvatarLibraryState,
+): AvatarDisplayCollection[] {
+  const catalogVersion = library.catalog?.catalogVersion;
+  const customGloopies = userGloopieEntries(library);
+
+  return (library.catalog?.collections ?? []).map((collection) => {
+    const bundledEntries = collection.avatarIds.flatMap((avatarId) => {
+      const entry = getAvatarCatalogEntry(library.catalog, avatarId);
+      if (!entry) {
+        return [];
+      }
+      const fallbackVariant = entry.variants.webm ?? entry.variants.hevc;
+      return [
+        {
+          id: entry.id,
+          ref: avatarRef(entry.id),
+          label: entry.label,
+          media: cachedMedia(library, catalogVersion, entry.id),
+          fallbackMediaType: fallbackVariant
+            ? mediaTypeFromMimeType(fallbackVariant.mimeType)
+            : "image",
+          isUserAvatar: false,
+        },
+      ];
+    });
+
+    return {
+      id: collection.id,
+      label: collection.label,
+      entries:
+        collection.id === GLOOPIES_COLLECTION_ID
+          ? [...customGloopies, ...bundledEntries]
+          : bundledEntries,
+    };
+  });
+}

--- a/src/features/agents/ui/AgentBuilderRail.tsx
+++ b/src/features/agents/ui/AgentBuilderRail.tsx
@@ -14,7 +14,7 @@ import {
   IconSparkles,
   IconX,
 } from "@tabler/icons-react";
-import { avatarRef, parseAvatarRef } from "@/shared/avatars/catalog";
+import { avatarRef, isLibraryAvatarRef } from "@/shared/avatars/catalog";
 import { normalizeAvatarUrl } from "@/shared/lib/avatarUrl";
 import { cn } from "@/shared/lib/cn";
 import type { AgentSourceEntry } from "@/shared/api/agents";
@@ -200,13 +200,16 @@ export function AgentBuilderRail({
   const [selectedCollectionId, setSelectedCollectionId] = useState<
     string | null
   >(null);
-  const selectedCollection = useMemo(
-    () =>
+  const selectedCollectionLabel = useMemo(() => {
+    if (!selectedCollectionId) {
+      return null;
+    }
+    return (
       avatarLibrary.catalog?.collections.find(
         (collection) => collection.id === selectedCollectionId,
-      ) ?? null,
-    [avatarLibrary.catalog, selectedCollectionId],
-  );
+      )?.label ?? null
+    );
+  }, [avatarLibrary.catalog, selectedCollectionId]);
 
   const provider = (data?.properties?.provider as string | undefined) ?? "";
   const modelProviderId =
@@ -228,8 +231,8 @@ export function AgentBuilderRail({
   );
 
   const onSelectAvatar = useCallback(
-    (avatarId: string) => {
-      writeProperty("avatar", avatarRef(avatarId));
+    (selectedAvatarRef: string) => {
+      writeProperty("avatar", selectedAvatarRef);
       setSelectedCollectionId(null);
       setAvatarPanel("closed");
     },
@@ -258,11 +261,10 @@ export function AgentBuilderRail({
       : null;
   const effectiveAvatar =
     normalizedAvatar ?? (defaultAvatarId ? avatarRef(defaultAvatarId) : null);
-  const selectedAvatarRefValue = effectiveAvatar
-    ? parseAvatarRef(effectiveAvatar)
+  const selectedAvatarRefValue =
+    effectiveAvatar && isLibraryAvatarRef(effectiveAvatar)
       ? effectiveAvatar
-      : null
-    : null;
+      : null;
   const selectedAvatarMediaState = useAvatarMediaState(effectiveAvatar);
 
   const onChangeProvider = useCallback(
@@ -564,9 +566,7 @@ export function AgentBuilderRail({
         <IconArrowLeft className="size-4" aria-hidden="true" />
       </Button>
       <h2 className="truncate text-sm font-normal text-foreground">
-        {selectedCollection
-          ? selectedCollection.label
-          : t("builderRail.chooseAvatarTitle")}
+        {selectedCollectionLabel ?? t("builderRail.chooseAvatarTitle")}
       </h2>
     </div>
   );
@@ -845,9 +845,7 @@ export function AgentBuilderRail({
             <IconArrowLeft className="size-4" aria-hidden="true" />
           </Button>
           <h3 className="truncate text-sm font-normal text-foreground">
-            {selectedCollection
-              ? selectedCollection.label
-              : t("builderRail.chooseAvatarTitle")}
+            {selectedCollectionLabel ?? t("builderRail.chooseAvatarTitle")}
           </h3>
         </div>
         {avatarLibraryPickerNode}

--- a/src/features/agents/ui/AgentDetailPage.tsx
+++ b/src/features/agents/ui/AgentDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { usePinToHomeWidget } from "@/features/home/hooks/usePinToHomeWidget";
-import { avatarRef, isBundledAvatarRef } from "@/shared/avatars/catalog";
+import { isLibraryAvatarRef } from "@/shared/avatars/catalog";
 import { MessageResponse } from "@/shared/ui/ai-elements/message";
 import { AvatarMedia } from "@/shared/ui/avatar-media";
 import { Badge } from "@/shared/ui/badge";
@@ -136,7 +136,7 @@ export function AgentDetailPage({
   const avatarLibrary = useAvatarLibrary(isEditable);
   const trimmedAvatarValue = avatarValue.trim();
   const normalizedAvatarValue = normalizeAvatarUrl(trimmedAvatarValue);
-  const customAvatarUrlValue = isBundledAvatarRef(trimmedAvatarValue)
+  const customAvatarUrlValue = isLibraryAvatarRef(trimmedAvatarValue)
     ? ""
     : avatarValue;
   const avatarUrlError =
@@ -144,13 +144,13 @@ export function AgentDetailPage({
       ? t("editor.avatarUrlInvalid")
       : null;
   const avatarMedia = useAvatarMedia(normalizedAvatarValue ?? null);
-  const selectedBundledAvatarRef =
-    normalizedAvatarValue && isBundledAvatarRef(normalizedAvatarValue)
+  const selectedLibraryAvatarRef =
+    normalizedAvatarValue && isLibraryAvatarRef(normalizedAvatarValue)
       ? normalizedAvatarValue
       : null;
   const canSaveCustomAvatar =
     Boolean(normalizedAvatarValue) &&
-    !isBundledAvatarRef(normalizedAvatarValue ?? "") &&
+    !isLibraryAvatarRef(normalizedAvatarValue ?? "") &&
     normalizedAvatarValue !== personaAvatarValue &&
     !avatarSavePending;
   const descriptionValue = getRealPersonaDescription(persona);
@@ -257,19 +257,18 @@ export function AgentDetailPage({
   }, [avatarUrlError, commitAvatar, normalizedAvatarValue]);
 
   const handleSelectAvatar = useCallback(
-    (avatarId: string) => {
-      const nextAvatar = avatarRef(avatarId);
-      setAvatarValue(nextAvatar);
+    (nextAvatarRef: string) => {
+      setAvatarValue(nextAvatarRef);
       setAvatarPreviewFailed(false);
-      void commitAvatar(nextAvatar);
+      void commitAvatar(nextAvatarRef);
     },
     [commitAvatar],
   );
 
   const handleSelectOverlayAvatar = useCallback(
-    (avatarId: string) => {
+    (nextAvatarRef: string) => {
       setShowAvatarOverlay(false);
-      handleSelectAvatar(avatarId);
+      handleSelectAvatar(nextAvatarRef);
     },
     [handleSelectAvatar],
   );
@@ -502,7 +501,7 @@ export function AgentDetailPage({
             onPreviewError={() => setAvatarPreviewFailed(true)}
             onSaveCustomAvatar={handleSaveCustomAvatar}
             onSelectAvatar={handleSelectAvatar}
-            selectedAvatarRef={selectedBundledAvatarRef}
+            selectedAvatarRef={selectedLibraryAvatarRef}
             showClearAvatar={trimmedAvatarValue.length > 0}
             title={t("editor.customizeAvatar")}
           />

--- a/src/features/agents/ui/AgentImageImportDialog.tsx
+++ b/src/features/agents/ui/AgentImageImportDialog.tsx
@@ -16,10 +16,7 @@ import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
 import { Textarea } from "@/shared/ui/textarea";
 import type { SnapshotV1 } from "@/features/agents/agent-snapshot";
-import {
-  deleteUserAvatar,
-  importUserAvatarDataUrl,
-} from "@/shared/api/avatars";
+import { importUserAvatarDataUrl } from "@/shared/api/avatars";
 import { decodeAvatarAnimation } from "@/features/agents/agent-snapshot";
 import { isSafePngAvatarDataUrl } from "@/shared/lib/avatarUrl";
 import { snapshotToCreatePersonaRequest } from "@/features/agents/agent-snapshot";
@@ -219,12 +216,9 @@ export function AgentImageImportDialog({
             snapshotToCreatePersonaRequest(snapshot).avatar,
         });
       } catch {
-        if (importedAnimationAvatar) {
-          void deleteUserAvatar(importedAnimationAvatar).catch(() => {
-            // Agent creation is the primary error; cleanup is best effort.
-          });
-        }
-        // The parent owns user-facing error reporting; keep this click handler
+        // The imported gloopie is now a durable library asset, independent of
+        // whether this agent can be created. The parent owns user-facing error
+        // reporting; keep this click handler
         // settled so a failed create does not become an unhandled rejection.
       }
     } finally {

--- a/src/features/agents/ui/AvatarCollectionOverlay.tsx
+++ b/src/features/agents/ui/AvatarCollectionOverlay.tsx
@@ -177,8 +177,8 @@ export function AvatarCollectionOverlay({
   const [collectionId, setCollectionId] = useState<string | null>(
     initialCollectionId,
   );
-  const [pendingAvatarId, setPendingAvatarId] = useState<string | null>(null);
-  const [hoveredAvatarId, setHoveredAvatarId] = useState<string | null>(null);
+  const [pendingAvatarRef, setPendingAvatarRef] = useState<string | null>(null);
+  const [hoveredAvatarRef, setHoveredAvatarRef] = useState<string | null>(null);
   const [closing, setClosing] = useState(false);
   // Where the funnel exit collapses to (viewport px); null = plain fade.
   const [exitTarget, setExitTarget] = useState<{
@@ -269,7 +269,7 @@ export function AvatarCollectionOverlay({
       return;
     }
     if (collection && hasCollectionsLevel) {
-      setPendingAvatarId(null);
+      setPendingAvatarRef(null);
       setCollectionId(null);
       return;
     }
@@ -330,7 +330,7 @@ export function AvatarCollectionOverlay({
     // runs straight across the wordmark like the reference (the wordmark
     // renders *behind* the avatars; hover brings a tile further forward).
     return buildCollectionLayout(
-      collection.entries.map((entry) => entry.id),
+      collection.entries.map((entry) => entry.ref),
       tileSize.width + panMargin * 2,
       tileSize.height + panMargin * 2,
       {
@@ -387,7 +387,7 @@ export function AvatarCollectionOverlay({
         // highlight — everything fades back up. Deliberately not a dismiss:
         // mis-clicking near an avatar must not throw the user out of the
         // picker.
-        setPendingAvatarId(null);
+        setPendingAvatarRef(null);
         return;
       }
       // On the collections level, empty-canvas clicks light-dismiss the
@@ -398,11 +398,11 @@ export function AvatarCollectionOverlay({
   );
 
   const onConfirmSelect = useCallback(() => {
-    if (!pendingAvatarId || closing) {
+    if (!pendingAvatarRef || closing) {
       return;
     }
     const pendingRef = collection?.entries.find(
-      (entry) => entry.id === pendingAvatarId,
+      (entry) => entry.ref === pendingAvatarRef,
     )?.ref;
     if (!pendingRef) {
       return;
@@ -414,24 +414,26 @@ export function AvatarCollectionOverlay({
     closeWithAnimation,
     collection,
     onSelectAvatar,
-    pendingAvatarId,
+    pendingAvatarRef,
   ]);
 
   const hoverHandlers = useCallback(
-    (id: string) => ({
-      onPointerEnter: () => setHoveredAvatarId(id),
+    (avatarRef: string) => ({
+      onPointerEnter: () => setHoveredAvatarRef(avatarRef),
       onPointerLeave: () =>
-        setHoveredAvatarId((current) => (current === id ? null : current)),
+        setHoveredAvatarRef((current) =>
+          current === avatarRef ? null : current,
+        ),
     }),
     [],
   );
 
   const renderAvatarItem = useCallback(
     (entry: AvatarDisplayEntry, item: ScatterItemLayout) => {
-      const pending = pendingAvatarId === entry.id;
+      const pending = pendingAvatarRef === entry.ref;
       // Highlighting an avatar fades everything else back instead of drawing
       // a ring; the highlighted one stays at full strength (and animates).
-      const dimmed = pendingAvatarId !== null && !pending;
+      const dimmed = pendingAvatarRef !== null && !pending;
       const cachedMedia = entry.media;
       const label = entry.label ?? t("editor.userGloopieLabel");
       return (
@@ -445,10 +447,10 @@ export function AvatarCollectionOverlay({
             pending && "z-10",
             // Hold the entrance (paused at opacity 0) until the media has
             // painted, so tiles never pop in empty and fill in later.
-            cachedMedia && !readyIds.has(entry.id) && "avatar-scatter-waiting",
+            cachedMedia && !readyIds.has(entry.ref) && "avatar-scatter-waiting",
           )}
           style={scatterItemStyle(item)}
-          ref={registerTileNode(entry.id)}
+          ref={registerTileNode(entry.ref)}
         >
           <button
             type="button"
@@ -462,10 +464,10 @@ export function AvatarCollectionOverlay({
             aria-label={label}
             aria-pressed={pending}
             disabled={!cachedMedia || closing}
-            {...hoverHandlers(entry.id)}
+            {...hoverHandlers(entry.ref)}
             onClick={() =>
-              setPendingAvatarId((current) =>
-                current === entry.id ? null : entry.id,
+              setPendingAvatarRef((current) =>
+                current === entry.ref ? null : entry.ref,
               )
             }
           >
@@ -481,10 +483,10 @@ export function AvatarCollectionOverlay({
                 loadingStrategy="eager"
                 // Calm by default: only the hovered or highlighted avatar
                 // plays; everything else sits on its first frame.
-                paused={hoveredAvatarId !== entry.id && !pending}
+                paused={hoveredAvatarRef !== entry.ref && !pending}
                 className="avatar-scatter-media h-full w-full object-contain"
                 onError={() => {}}
-                onReady={() => markReady(entry.id)}
+                onReady={() => markReady(entry.ref)}
               />
             ) : (
               <span className="max-w-full truncate px-2 text-xs text-muted-foreground">
@@ -513,11 +515,11 @@ export function AvatarCollectionOverlay({
     },
     [
       closing,
-      hoveredAvatarId,
+      hoveredAvatarRef,
       hoverHandlers,
       markReady,
       onConfirmSelect,
-      pendingAvatarId,
+      pendingAvatarRef,
       readyIds,
       registerTileNode,
       t,
@@ -526,7 +528,7 @@ export function AvatarCollectionOverlay({
 
   const renderCollectionRowItem = useCallback(
     (entry: AvatarDisplayCollection, index: number) => {
-      const cachedMedia = entry.entries[0]?.media;
+      const cachedMedia = entry.cover?.media;
       const label = collectionDisplayLabel(entry);
       return (
         <button
@@ -655,7 +657,7 @@ export function AvatarCollectionOverlay({
             >
               {layout.map((item) => {
                 const entry = collection.entries.find(
-                  (candidate) => candidate.id === item.id,
+                  (candidate) => candidate.ref === item.id,
                 );
                 return entry ? (
                   <div key={item.id} className="contents">

--- a/src/features/agents/ui/AvatarCollectionOverlay.tsx
+++ b/src/features/agents/ui/AvatarCollectionOverlay.tsx
@@ -12,11 +12,6 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
-import type {
-  AvatarCatalogEntry,
-  AvatarCollection,
-} from "@/shared/avatars/catalog";
-import { getAvatarCatalogEntry } from "@/shared/avatars/catalog";
 import { cn } from "@/shared/lib/cn";
 import { AvatarMedia } from "@/shared/ui/avatar-media";
 import { Button } from "@/shared/ui/button";
@@ -28,7 +23,11 @@ import {
   type ScatterItemLayout,
 } from "@/features/agents/lib/avatarScatter";
 import { useAvatarScatterPan } from "@/features/agents/hooks/useAvatarScatterPan";
-import { getCachedAvatarMedia } from "@/features/agents/ui/AvatarLibraryPicker";
+import {
+  buildAvatarDisplayCollections,
+  type AvatarDisplayCollection,
+  type AvatarDisplayEntry,
+} from "@/features/agents/lib/avatarLibraryView";
 
 /** Exit animation length; keep in sync with .avatar-overlay-exit. */
 const OVERLAY_EXIT_MS = 260;
@@ -114,7 +113,9 @@ function rowItemStyle(index: number): CSSProperties {
 const WORDMARK_CLASS =
   "avatar-collection-wordmark text-center font-light leading-[0.96] tracking-[-0.05em] text-foreground/90 text-[clamp(3.25rem,8vw,9.5rem)]";
 
-/** Presentation order for public avatar collections. */
+/**
+ * Presentation order for avatar collections.
+ */
 const COLLECTION_DISPLAY_ORDER = ["gloopies", "pollies", "fuzzies"];
 
 function collectionRank(id: string): number {
@@ -137,7 +138,8 @@ interface AvatarCollectionOverlayProps {
   library: AvatarLibraryState;
   /** Collection to open with; null starts at the collections level. */
   initialCollectionId?: string | null;
-  onSelectAvatar: (avatarId: string) => void;
+  /** Receives the full persisted ref (`app-avatar:<id>` or `user-avatar:<id>`). */
+  onSelectAvatar: (avatarRef: string) => void;
   onClose: () => void;
 }
 
@@ -206,10 +208,10 @@ export function AvatarCollectionOverlay({
 
   const collections = useMemo(
     () =>
-      [...(library.catalog?.collections ?? [])].sort(
+      buildAvatarDisplayCollections(library).sort(
         (a, b) => collectionRank(a.id) - collectionRank(b.id),
       ),
-    [library.catalog],
+    [library],
   );
   // A single-collection catalog skips the collections level entirely — the
   // takeover opens straight onto that collection and back closes rather than
@@ -219,7 +221,10 @@ export function AvatarCollectionOverlay({
   const collection =
     collections.find((entry) => entry.id === effectiveCollectionId) ?? null;
   const hasCollectionsLevel = collections.length > 1;
-  const catalogVersion = library.catalog?.catalogVersion;
+  const collectionDisplayLabel = useCallback(
+    (entry: AvatarDisplayCollection) => entry.label ?? entry.id,
+    [],
+  );
 
   useEffect(
     () => () => {
@@ -325,7 +330,7 @@ export function AvatarCollectionOverlay({
     // runs straight across the wordmark like the reference (the wordmark
     // renders *behind* the avatars; hover brings a tile further forward).
     return buildCollectionLayout(
-      collection.avatarIds,
+      collection.entries.map((entry) => entry.id),
       tileSize.width + panMargin * 2,
       tileSize.height + panMargin * 2,
       {
@@ -396,10 +401,21 @@ export function AvatarCollectionOverlay({
     if (!pendingAvatarId || closing) {
       return;
     }
-    const avatarId = pendingAvatarId;
+    const pendingRef = collection?.entries.find(
+      (entry) => entry.id === pendingAvatarId,
+    )?.ref;
+    if (!pendingRef) {
+      return;
+    }
     // The chosen avatar lands on the rail's preview; funnel toward it.
-    closeWithAnimation(() => onSelectAvatar(avatarId), "funnel");
-  }, [closing, closeWithAnimation, onSelectAvatar, pendingAvatarId]);
+    closeWithAnimation(() => onSelectAvatar(pendingRef), "funnel");
+  }, [
+    closing,
+    closeWithAnimation,
+    collection,
+    onSelectAvatar,
+    pendingAvatarId,
+  ]);
 
   const hoverHandlers = useCallback(
     (id: string) => ({
@@ -411,16 +427,13 @@ export function AvatarCollectionOverlay({
   );
 
   const renderAvatarItem = useCallback(
-    (entry: AvatarCatalogEntry, item: ScatterItemLayout) => {
+    (entry: AvatarDisplayEntry, item: ScatterItemLayout) => {
       const pending = pendingAvatarId === entry.id;
       // Highlighting an avatar fades everything else back instead of drawing
       // a ring; the highlighted one stays at full strength (and animates).
       const dimmed = pendingAvatarId !== null && !pending;
-      const cachedMedia = getCachedAvatarMedia(
-        library.cachedAvatarMediaById,
-        catalogVersion,
-        entry.id,
-      );
+      const cachedMedia = entry.media;
+      const label = entry.label ?? t("editor.userGloopieLabel");
       return (
         <div
           className={cn(
@@ -446,7 +459,7 @@ export function AvatarCollectionOverlay({
               dimmed && "opacity-25 hover:opacity-60",
               !cachedMedia && "cursor-default",
             )}
-            aria-label={entry.label}
+            aria-label={label}
             aria-pressed={pending}
             disabled={!cachedMedia || closing}
             {...hoverHandlers(entry.id)}
@@ -475,7 +488,7 @@ export function AvatarCollectionOverlay({
               />
             ) : (
               <span className="max-w-full truncate px-2 text-xs text-muted-foreground">
-                {entry.label}
+                {label}
               </span>
             )}
           </button>
@@ -499,11 +512,9 @@ export function AvatarCollectionOverlay({
       );
     },
     [
-      catalogVersion,
       closing,
       hoveredAvatarId,
       hoverHandlers,
-      library.cachedAvatarMediaById,
       markReady,
       onConfirmSelect,
       pendingAvatarId,
@@ -514,15 +525,9 @@ export function AvatarCollectionOverlay({
   );
 
   const renderCollectionRowItem = useCallback(
-    (entry: AvatarCollection, index: number) => {
-      const cover = getAvatarCatalogEntry(library.catalog, entry.coverAvatarId);
-      const cachedMedia = cover
-        ? getCachedAvatarMedia(
-            library.cachedAvatarMediaById,
-            catalogVersion,
-            cover.id,
-          )
-        : undefined;
+    (entry: AvatarDisplayCollection, index: number) => {
+      const cachedMedia = entry.entries[0]?.media;
+      const label = collectionDisplayLabel(entry);
       return (
         <button
           key={entry.id}
@@ -533,7 +538,7 @@ export function AvatarCollectionOverlay({
           )}
           style={rowItemStyle(index)}
           aria-label={t("collectionPage.openCollection", {
-            label: entry.label,
+            label,
           })}
           disabled={closing}
           onClick={() => setCollectionId(entry.id)}
@@ -562,23 +567,17 @@ export function AvatarCollectionOverlay({
               <Spinner className="size-5 text-muted-foreground" />
             )}
           </span>
-          <span className={COLLECTION_CARD_LABEL_CLASS}>{entry.label}</span>
+          <span className={COLLECTION_CARD_LABEL_CLASS}>{label}</span>
         </button>
       );
     },
-    [
-      catalogVersion,
-      closing,
-      library.cachedAvatarMediaById,
-      library.catalog,
-      markReady,
-      readyIds,
-      t,
-    ],
+    [closing, collectionDisplayLabel, markReady, readyIds, t],
   );
 
   const heading = collection
-    ? t("collectionPage.collectionHeading", { label: collection.label })
+    ? t("collectionPage.collectionHeading", {
+        label: collectionDisplayLabel(collection),
+      })
     : t("collectionPage.collectionsHeading");
 
   const backLabel =
@@ -655,7 +654,9 @@ export function AvatarCollectionOverlay({
               }}
             >
               {layout.map((item) => {
-                const entry = getAvatarCatalogEntry(library.catalog, item.id);
+                const entry = collection.entries.find(
+                  (candidate) => candidate.id === item.id,
+                );
                 return entry ? (
                   <div key={item.id} className="contents">
                     {renderAvatarItem(entry, item)}

--- a/src/features/agents/ui/AvatarLibraryPicker.tsx
+++ b/src/features/agents/ui/AvatarLibraryPicker.tsx
@@ -92,7 +92,7 @@ export function AvatarLibraryPicker({
 
       return (
         <button
-          key={entry.id}
+          key={entry.ref}
           type="button"
           className={cn(
             "relative flex aspect-square min-h-24 items-center justify-center overflow-hidden rounded-sm bg-popover p-2",
@@ -141,7 +141,7 @@ export function AvatarLibraryPicker({
 
   const renderCollectionButton = useCallback(
     (collection: AvatarDisplayCollection) => {
-      const cover = collection.entries[0];
+      const cover = collection.cover;
       if (!cover) {
         return null;
       }

--- a/src/features/agents/ui/AvatarLibraryPicker.tsx
+++ b/src/features/agents/ui/AvatarLibraryPicker.tsx
@@ -1,25 +1,22 @@
 import { ArrowLeft, Check, RefreshCw } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  avatarRef,
-  getAvatarCatalogEntry,
-  mediaTypeFromMimeType,
-} from "@/shared/avatars/catalog";
-import type {
-  AvatarCatalogEntry,
-  AvatarCollection,
-} from "@/shared/avatars/catalog";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { AvatarMedia } from "@/shared/ui/avatar-media";
 import { Spinner } from "@/shared/ui/spinner";
 import type { AvatarLibraryState } from "@/features/agents/hooks/useAvatarLibrary";
+import {
+  buildAvatarDisplayCollections,
+  type AvatarDisplayCollection,
+  type AvatarDisplayEntry,
+} from "@/features/agents/lib/avatarLibraryView";
 
 interface AvatarLibraryPickerProps {
   library: AvatarLibraryState;
   selectedAvatarRef: string | null;
-  onSelectAvatar: (avatarId: string) => void;
+  /** Receives the full persisted ref (`app-avatar:<id>` or `user-avatar:<id>`). */
+  onSelectAvatar: (avatarRef: string) => void;
   onPreviewError: () => void;
   disabled?: boolean;
   /**
@@ -70,7 +67,10 @@ export function AvatarLibraryPicker({
     [isControlled, onSelectCollection],
   );
 
-  const avatarCollections = library.catalog?.collections ?? [];
+  const avatarCollections = useMemo(
+    () => buildAvatarDisplayCollections(library),
+    [library],
+  );
   const selectedCollection = avatarCollections.find(
     (collection) => collection.id === selectedCollectionId,
   );
@@ -78,23 +78,17 @@ export function AvatarLibraryPicker({
     library.errorCode === "networkAccess"
       ? t("editor.avatarCatalogNetworkAccess")
       : t("editor.avatarCatalogUnavailable");
-  const catalogVersion = library.catalog?.catalogVersion;
-  const { cachedAvatarMediaById } = library;
+
+  const collectionLabel = useCallback(
+    (collection: AvatarDisplayCollection) => collection.label ?? collection.id,
+    [],
+  );
 
   const renderAvatarTile = useCallback(
-    (entry: AvatarCatalogEntry) => {
-      const ref = avatarRef(entry.id);
-      const selected = selectedAvatarRef === ref;
-      const cachedMedia = getCachedAvatarMedia(
-        cachedAvatarMediaById,
-        catalogVersion,
-        entry.id,
-      );
-      const fallbackVariant = entry.variants.webm ?? entry.variants.hevc;
-      const fallbackMediaType = fallbackVariant
-        ? mediaTypeFromMimeType(fallbackVariant.mimeType)
-        : "image";
-      const selectable = Boolean(cachedMedia) && !disabled;
+    (entry: AvatarDisplayEntry) => {
+      const selected = selectedAvatarRef === entry.ref;
+      const label = entry.label ?? t("editor.userGloopieLabel");
+      const selectable = Boolean(entry.media) && !disabled;
 
       return (
         <button
@@ -108,15 +102,15 @@ export function AvatarLibraryPicker({
               "cursor-not-allowed opacity-60 hover:border-border/80",
             selected && "border-ring ring-2 ring-ring/25",
           )}
-          aria-label={entry.label}
+          aria-label={label}
           aria-pressed={selected}
           aria-disabled={!selectable}
           disabled={!selectable}
-          onClick={() => onSelectAvatar(entry.id)}
+          onClick={() => onSelectAvatar(entry.ref)}
         >
-          {cachedMedia ? (
+          {entry.media ? (
             <AvatarMedia
-              media={cachedMedia}
+              media={entry.media}
               alt=""
               lazy
               loadingStrategy="visible-video"
@@ -127,10 +121,11 @@ export function AvatarLibraryPicker({
             <span
               className={cn(
                 "text-center text-xs text-muted-foreground",
-                fallbackMediaType === "video" && "italic",
+                (entry.fallbackMediaType === "video" || entry.isUserAvatar) &&
+                  "italic",
               )}
             >
-              {entry.label}
+              {label}
             </span>
           )}
           {selected ? (
@@ -141,30 +136,17 @@ export function AvatarLibraryPicker({
         </button>
       );
     },
-    [
-      cachedAvatarMediaById,
-      catalogVersion,
-      disabled,
-      onPreviewError,
-      onSelectAvatar,
-      selectedAvatarRef,
-    ],
+    [disabled, onPreviewError, onSelectAvatar, selectedAvatarRef, t],
   );
 
   const renderCollectionButton = useCallback(
-    (collection: AvatarCollection) => {
-      const cover = getAvatarCatalogEntry(
-        library.catalog,
-        collection.coverAvatarId,
-      );
+    (collection: AvatarDisplayCollection) => {
+      const cover = collection.entries[0];
       if (!cover) {
         return null;
       }
-      const cachedCoverMedia = getCachedAvatarMedia(
-        cachedAvatarMediaById,
-        catalogVersion,
-        cover.id,
-      );
+      const label = collectionLabel(collection);
+      const coverReady = Boolean(cover.media);
 
       return (
         <button
@@ -180,25 +162,21 @@ export function AvatarLibraryPicker({
           onClick={() => setSelectedCollectionId(collection.id)}
         >
           <span className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-border bg-muted/40">
-            {cachedCoverMedia ? (
+            {cover.media ? (
               <AvatarMedia
-                media={cachedCoverMedia}
+                media={cover.media}
                 alt=""
                 loadingStrategy="visible-video"
                 className="h-full w-full object-contain p-1"
                 onError={onPreviewError}
               />
             ) : (
-              <span className="text-xs text-muted-foreground">
-                {collection.label}
-              </span>
+              <span className="text-xs text-muted-foreground">{label}</span>
             )}
           </span>
           <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
-            <span className="truncate text-base text-foreground">
-              {collection.label}
-            </span>
-            {cachedCoverMedia ? (
+            <span className="truncate text-base text-foreground">{label}</span>
+            {coverReady ? (
               <Check className="size-4 shrink-0 text-muted-foreground" />
             ) : library.mediaError ? (
               <RefreshCw className="size-4 shrink-0 text-muted-foreground" />
@@ -210,10 +188,9 @@ export function AvatarLibraryPicker({
       );
     },
     [
-      cachedAvatarMediaById,
-      catalogVersion,
+      collectionLabel,
       disabled,
-      library,
+      library.mediaError,
       onPreviewError,
       setSelectedCollectionId,
     ],
@@ -232,6 +209,8 @@ export function AvatarLibraryPicker({
       </span>
     </div>
   );
+
+  const hasCollections = avatarCollections.length > 0;
 
   return (
     <div
@@ -282,20 +261,17 @@ export function AvatarLibraryPicker({
                 <ArrowLeft className="size-3.5" />
               </Button>
               <p className="text-xs text-foreground">
-                {selectedCollection.label}
+                {collectionLabel(selectedCollection)}
               </p>
             </div>
           )}
           <div className="grid min-h-0 flex-1 grid-cols-3 gap-2 overflow-y-auto pr-1">
-            {selectedCollection.avatarIds.map((avatarId) => {
-              const entry = getAvatarCatalogEntry(library.catalog, avatarId);
-              return entry ? renderAvatarTile(entry) : null;
-            })}
+            {selectedCollection.entries.map((entry) => renderAvatarTile(entry))}
           </div>
         </div>
       ) : (
         <div className="flex flex-col gap-3">
-          {library.loading && avatarCollections.length === 0
+          {library.loading && !hasCollections
             ? [0, 1, 2].map(renderCollectionSkeleton)
             : avatarCollections.map(renderCollectionButton)}
         </div>

--- a/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/features/agents/lib/agentBuilderSession", () => ({
 vi.mock("@/features/agents/hooks/useAvatarLibrary", () => ({
   useAvatarLibrary: vi.fn(() => ({
     catalog: null,
+    userAvatarIds: [],
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -134,6 +135,7 @@ describe("AgentBuilderRail", () => {
     agentTelemetryMocks.trackAgentDeleteCompleted.mockReset();
     vi.mocked(useAvatarLibrary).mockReturnValue({
       catalog: null,
+      userAvatarIds: [],
       cachedAvatarMediaById: {},
       loading: false,
       cacheChecking: false,
@@ -365,6 +367,7 @@ describe("AgentBuilderRail", () => {
           },
         ],
       },
+      userAvatarIds: [],
       cachedAvatarMediaById: {
         "gloopy-1": {
           catalogVersion: "v1",

--- a/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/features/agents/hooks/useAvatarLibrary", () => ({
   useAvatarLibrary: vi.fn(() => ({
     catalog: null,
     userAvatarIds: [],
+    userAvatarMediaById: {},
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -136,6 +137,7 @@ describe("AgentBuilderRail", () => {
     vi.mocked(useAvatarLibrary).mockReturnValue({
       catalog: null,
       userAvatarIds: [],
+      userAvatarMediaById: {},
       cachedAvatarMediaById: {},
       loading: false,
       cacheChecking: false,
@@ -368,6 +370,7 @@ describe("AgentBuilderRail", () => {
         ],
       },
       userAvatarIds: [],
+      userAvatarMediaById: {},
       cachedAvatarMediaById: {
         "gloopy-1": {
           catalogVersion: "v1",

--- a/src/features/agents/ui/__tests__/AgentImageImportDialog.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentImageImportDialog.test.tsx
@@ -179,7 +179,7 @@ describe("AgentImageImportDialog", () => {
     await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
   });
 
-  it("cleans up an imported animation when agent creation fails", async () => {
+  it("preserves an imported library gloopie when agent creation fails", async () => {
     snapshotMocks.decodeAvatarAnimation.mockReturnValue({
       bytes: new Uint8Array([1, 2, 3]),
       mimeType: "video/mp4",
@@ -201,11 +201,8 @@ describe("AgentImageImportDialog", () => {
       screen.getByRole("button", { name: "imageImport.add" }),
     );
 
-    await waitFor(() =>
-      expect(avatarApiMocks.deleteUserAvatar).toHaveBeenCalledWith(
-        "user-avatar:temporary",
-      ),
-    );
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledOnce());
+    expect(avatarApiMocks.deleteUserAvatar).not.toHaveBeenCalled();
   });
 
   it("does not claim memory is present when the field is omitted", () => {

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -160,6 +160,7 @@ vi.mock("@/features/agents/hooks/useAvatarLibrary", () => ({
 
 const EMPTY_AVATAR_LIBRARY: AvatarLibraryState = {
   catalog: null,
+  userAvatarIds: [],
   cachedAvatarMediaById: {},
   loading: false,
   cacheChecking: false,

--- a/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentsView.entry.test.tsx
@@ -161,6 +161,7 @@ vi.mock("@/features/agents/hooks/useAvatarLibrary", () => ({
 const EMPTY_AVATAR_LIBRARY: AvatarLibraryState = {
   catalog: null,
   userAvatarIds: [],
+  userAvatarMediaById: {},
   cachedAvatarMediaById: {},
   loading: false,
   cacheChecking: false,

--- a/src/features/agents/ui/__tests__/AvatarCollectionOverlay.test.tsx
+++ b/src/features/agents/ui/__tests__/AvatarCollectionOverlay.test.tsx
@@ -57,6 +57,7 @@ function libraryWith(
   return {
     catalog,
     userAvatarIds: [],
+    userAvatarMediaById: {},
     cachedAvatarMediaById,
     loading: false,
     cacheChecking: false,

--- a/src/features/agents/ui/__tests__/AvatarCollectionOverlay.test.tsx
+++ b/src/features/agents/ui/__tests__/AvatarCollectionOverlay.test.tsx
@@ -56,6 +56,7 @@ function libraryWith(
   }
   return {
     catalog,
+    userAvatarIds: [],
     cachedAvatarMediaById,
     loading: false,
     cacheChecking: false,
@@ -150,7 +151,7 @@ describe("AvatarCollectionOverlay", () => {
     fireEvent.click(overlay().getByRole("button", { name: /^select$/i }));
     expect(onSelectAvatar).not.toHaveBeenCalled();
     finishExitAnimation();
-    expect(onSelectAvatar).toHaveBeenCalledWith("g-1");
+    expect(onSelectAvatar).toHaveBeenCalledWith("app-avatar:g-1");
   });
 
   it("toggles the highlight off when the same avatar is clicked again", () => {

--- a/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
+++ b/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
@@ -9,6 +9,7 @@ function libraryWithError(
 ): AvatarLibraryState {
   return {
     catalog: null,
+    userAvatarIds: [],
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -57,6 +58,7 @@ function libraryWithMediaError(): AvatarLibraryState {
         },
       ],
     },
+    userAvatarIds: [],
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -69,12 +71,12 @@ function libraryWithMediaError(): AvatarLibraryState {
   };
 }
 
-function picker(library: AvatarLibraryState) {
+function picker(library: AvatarLibraryState, onSelectAvatar = vi.fn()) {
   return (
     <AvatarLibraryPicker
       library={library}
       selectedAvatarRef={null}
-      onSelectAvatar={vi.fn()}
+      onSelectAvatar={onSelectAvatar}
       onPreviewError={vi.fn()}
     />
   );
@@ -100,6 +102,48 @@ describe("AvatarLibraryPicker", () => {
     expect(
       screen.queryByText(/Custom URLs still work/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("leaves the Gloopies collection unchanged when the user has none", () => {
+    renderWithProviders(picker(libraryWithMediaError()));
+
+    expect(
+      screen.getByRole("button", { name: /Gloopies/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Custom gloopie" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("prepends and selects a reusable custom gloopie in Gloopies", () => {
+    const library = libraryWithMediaError();
+    library.userAvatarIds = ["gloopie-custom"];
+    library.cachedAvatarMediaById["gloopie-custom"] = {
+      catalogVersion: "user-generated",
+      media: {
+        src: "asset://gloopie-custom.webm",
+        mediaType: "video",
+        alphaMode: "stacked",
+        posterSrc: "asset://gloopie-custom.poster.png",
+      },
+    };
+    const onSelectAvatar = vi.fn();
+    renderWithProviders(picker(library, onSelectAvatar));
+
+    fireEvent.click(screen.getByRole("button", { name: "Gloopies" }));
+    const avatarButtons = screen
+      .getAllByRole("button")
+      .filter((button) =>
+        ["Custom gloopie", "Gloopie One"].includes(
+          button.getAttribute("aria-label") ?? "",
+        ),
+      );
+    expect(
+      avatarButtons.map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Custom gloopie", "Gloopie One"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Custom gloopie" }));
+    expect(onSelectAvatar).toHaveBeenCalledWith("user-avatar:gloopie-custom");
   });
 
   it("shows missing-media feedback with a manual retry", () => {

--- a/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
+++ b/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
@@ -130,7 +130,13 @@ describe("AvatarLibraryPicker", () => {
     const onSelectAvatar = vi.fn();
     renderWithProviders(picker(library, onSelectAvatar));
 
-    fireEvent.click(screen.getByRole("button", { name: "Gloopies" }));
+    const collectionButton = screen.getByRole("button", { name: "Gloopies" });
+    expect(collectionButton.querySelector("video")).toHaveAttribute(
+      "src",
+      "asset://gloopie-custom.webm",
+    );
+
+    fireEvent.click(collectionButton);
     const avatarButtons = screen
       .getAllByRole("button")
       .filter((button) =>

--- a/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
+++ b/src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx
@@ -10,6 +10,7 @@ function libraryWithError(
   return {
     catalog: null,
     userAvatarIds: [],
+    userAvatarMediaById: {},
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -59,6 +60,7 @@ function libraryWithMediaError(): AvatarLibraryState {
       ],
     },
     userAvatarIds: [],
+    userAvatarMediaById: {},
     cachedAvatarMediaById: {},
     loading: false,
     cacheChecking: false,
@@ -118,14 +120,11 @@ describe("AvatarLibraryPicker", () => {
   it("prepends and selects a reusable custom gloopie in Gloopies", () => {
     const library = libraryWithMediaError();
     library.userAvatarIds = ["gloopie-custom"];
-    library.cachedAvatarMediaById["gloopie-custom"] = {
-      catalogVersion: "user-generated",
-      media: {
-        src: "asset://gloopie-custom.webm",
-        mediaType: "video",
-        alphaMode: "stacked",
-        posterSrc: "asset://gloopie-custom.poster.png",
-      },
+    library.userAvatarMediaById["gloopie-custom"] = {
+      src: "asset://gloopie-custom.webm",
+      mediaType: "video",
+      alphaMode: "stacked",
+      posterSrc: "asset://gloopie-custom.poster.png",
     };
     const onSelectAvatar = vi.fn();
     renderWithProviders(picker(library, onSelectAvatar));

--- a/src/shared/api/avatars.ts
+++ b/src/shared/api/avatars.ts
@@ -258,6 +258,8 @@ export function cachedAssetToMedia(asset: {
 }
 
 export const AVATAR_CACHE_WARMED_EVENT = "berd:avatar-cache-warmed";
+export const USER_AVATAR_LIBRARY_CHANGED_EVENT =
+  "berd:user-avatar-library-changed";
 export const AVATAR_CACHED_REF_QUERY_KEY_PREFIX = [
   "avatars",
   "cached-ref",
@@ -281,4 +283,12 @@ export function listenAvatarCacheWarmed(
   return listen<AvatarCacheWarmedPayload>(AVATAR_CACHE_WARMED_EVENT, (event) =>
     handler(event.payload),
   );
+}
+
+export function listenUserAvatarLibraryChanged(handler: () => void) {
+  if (!window.__TAURI_INTERNALS__) {
+    return Promise.resolve(() => {});
+  }
+
+  return listen(USER_AVATAR_LIBRARY_CHANGED_EVENT, handler);
 }

--- a/src/shared/avatars/catalog.ts
+++ b/src/shared/avatars/catalog.ts
@@ -1,6 +1,16 @@
 export const APP_AVATAR_REF_PREFIX = "app-avatar:" as const;
 export const USER_AVATAR_REF_PREFIX = "user-avatar:" as const;
 
+/**
+ * Collection id and catalog version the backend assigns to user-generated
+ * gloopies (`src-tauri/src/commands/avatars.rs` mirrors these constants).
+ * User gloopies live outside the published catalog, so their media entries
+ * are stamped with `USER_AVATAR_CATALOG_VERSION` instead of the catalog's
+ * version string.
+ */
+export const USER_AVATAR_COLLECTION_ID = "generated-gloopies" as const;
+export const USER_AVATAR_CATALOG_VERSION = "user-generated" as const;
+
 export type AvatarMediaType = "image" | "video";
 export type AvatarAlphaMode = "stacked";
 export type AvatarAssetFormat = "webm" | "hevc";
@@ -102,6 +112,15 @@ export function parseUserAvatarRef(value: string): string | undefined {
 
 export function isUserAvatarRef(value: string): boolean {
   return parseUserAvatarRef(value) !== undefined;
+}
+
+/**
+ * Whether the value references an avatar the library owns — bundled catalog
+ * (`app-avatar:`) or user-generated (`user-avatar:`) — as opposed to a custom
+ * URL or data URL.
+ */
+export function isLibraryAvatarRef(value: string): boolean {
+  return isAppAvatarRef(value) || isUserAvatarRef(value);
 }
 
 export function mediaTypeFromMimeType(mimeType: string): AvatarMediaType {

--- a/src/shared/i18n/locales/en/agents.json
+++ b/src/shared/i18n/locales/en/agents.json
@@ -94,6 +94,7 @@
     "avatarDownloading": "Downloading",
     "avatarLibrary": "Avatar library",
     "avatarLoading": "Loading",
+    "userGloopieLabel": "Custom gloopie",
     "avatarRetry": "Retry",
     "avatarBackToProfile": "Back to profile",
     "changeAvatar": "Change avatar",

--- a/src/shared/i18n/locales/es/agents.json
+++ b/src/shared/i18n/locales/es/agents.json
@@ -94,6 +94,7 @@
     "avatarDownloading": "Descargando",
     "avatarLibrary": "Biblioteca de avatares",
     "avatarLoading": "Cargando",
+    "userGloopieLabel": "Gloopie personalizado",
     "avatarRetry": "Reintentar",
     "avatarBackToProfile": "Volver al perfil",
     "changeAvatar": "Cambiar avatar",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Custom gloopies now appear first in the Gloopies collection and can be reused across agents.
**Problem:** Custom animated gloopies were stored as attachments to individual agents, so they disappeared from reach after avatar changes and could not be selected for another agent.
**Solution:** Treat generated gloopies as durable local avatar-library assets, merge them into the existing Gloopies collection, and keep their lifecycle and identity independent from any one agent.

<details>
<summary>File changes</summary>

**src-tauri/src/commands/avatars.rs**
Enumerates valid local gloopie manifests into avatar-library snapshots, preserves newest-first ordering, and emits a library-change event after successful writes.

**src/features/agents/hooks/__tests__/useAvatarLibrary.test.tsx**
Covers startup loading, live invalidation, post-subscription reconciliation, and separation of custom media from bundled media.

**src/features/agents/hooks/__tests__/usePersonas.test.ts**
Updates lifecycle expectations so changing or deleting an agent preserves its gloopie in the library.

**src/features/agents/hooks/useAvatarLibrary.ts**
Loads custom gloopie IDs and media into a separate namespace and subscribes to both catalog and user-library invalidations.

**src/features/agents/hooks/usePersonas.ts**
Removes agent-owned garbage collection because custom gloopies are durable library assets.

**src/features/agents/lib/avatarLibraryView.test.ts**
Protects explicit collection-cover behavior and verifies equal bare IDs remain distinct across custom and bundled namespaces.

**src/features/agents/lib/avatarLibraryView.ts**
Builds the shared picker/gallery model, prepending custom gloopies and selecting the newest custom gloopie as the Gloopies cover.

**src/features/agents/ui/AgentBuilderRail.tsx**
Accepts full avatar references from the picker so agent creation can persist either bundled or custom avatars.

**src/features/agents/ui/AgentDetailPage.tsx**
Treats both bundled and custom refs as library selections and persists the full selected reference during editing.

**src/features/agents/ui/AgentImageImportDialog.tsx**
Preserves successfully imported gloopies even when subsequent agent creation fails.

**src/features/agents/ui/AvatarCollectionOverlay.tsx**
Renders the merged collection model and uses full refs for layout, hover, readiness, and selection identity.

**src/features/agents/ui/AvatarLibraryPicker.tsx**
Shows custom gloopies first in the existing collection and returns complete persisted refs when selected.

**src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx**
Updates avatar-library fixtures for the separated custom-media state.

**src/features/agents/ui/__tests__/AgentImageImportDialog.test.tsx**
Verifies a failed agent import does not delete the committed gloopie.

**src/features/agents/ui/__tests__/AgentsView.entry.test.tsx**
Updates shared avatar-library fixtures for the new state contract.

**src/features/agents/ui/__tests__/AvatarCollectionOverlay.test.tsx**
Verifies overlay selection emits complete persisted references.

**src/features/agents/ui/__tests__/AvatarLibraryPicker.test.tsx**
Covers no-custom behavior, custom-first ordering, custom cover presentation, and custom selection.

**src/shared/api/avatars.ts**
Adds the renderer subscription for user-avatar-library changes.

**src/shared/avatars/catalog.ts**
Defines user-library constants and helpers for identifying library-owned avatar refs.

**src/shared/i18n/locales/en/agents.json**
Adds the English accessible label for custom gloopies.

**src/shared/i18n/locales/es/agents.json**
Adds the Spanish accessible label for custom gloopies.

</details>

## Validation

- `just check`
- `just tauri-check`
- 123 focused Vitest tests across avatar APIs, library state, picker/gallery surfaces, imports, and persona lifecycle
