### PR TITLE
fix(voice): prevent speaking over active user input

### DIFF
--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -21,6 +21,7 @@ import {
 import {
   confirmVoiceConversationForegroundSession,
   setVoiceConversationControlsSuppressed,
+  type PendingVoiceTranscript,
 } from "../api/voiceConversation";
 import type { VoiceInputBackend } from "../lib/voiceInputPreference";
 
@@ -304,6 +305,15 @@ export function hasDeliveredVoiceTranscript(
       message.metadata.voiceConversationLifecycleId === lifecycleId &&
       message.metadata.voiceUtteranceId === utteranceId &&
       message.metadata.voiceConversationRevision === revision,
+  );
+}
+
+function transcriptAlreadyInChat(transcript: PendingVoiceTranscript): boolean {
+  return hasDeliveredVoiceTranscript(
+    transcript.sessionId,
+    transcript.lifecycleId,
+    transcript.id,
+    transcript.revision,
   );
 }
 
@@ -666,7 +676,10 @@ export function useVoiceConversationController({
     if (routeMount.drainPending) {
       const routeSessionId = activeSendRoute?.sessionId;
       if (!routeSessionId) return;
-      void drainPendingTranscripts(routeSessionId).catch((drainError) => {
+      void drainPendingTranscripts(
+        routeSessionId,
+        transcriptAlreadyInChat,
+      ).catch((drainError) => {
         addErrorNotification(sessionId, errorText(drainError));
       });
     }
@@ -699,7 +712,7 @@ export function useVoiceConversationController({
     // that durable queue so a missed webview event is retried instead of
     // silently dropping a pause-bounded utterance.
     return startPendingTranscriptRecovery(
-      () => drainPendingTranscripts(sessionId),
+      () => drainPendingTranscripts(sessionId, transcriptAlreadyInChat),
       (drainError) =>
         console.warn("[native-voice] Retained transcript delivery failed", {
           sessionId,

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -87,6 +87,25 @@ function assistant(
   };
 }
 
+function voiceUser(
+  id: string,
+  metadata: Partial<NonNullable<Message["metadata"]>> = {},
+): Message {
+  return {
+    id: `user-${id}`,
+    role: "user",
+    created: 1,
+    content: [{ type: "text", text: `User ${id}` }],
+    metadata: {
+      origin: "voice_conversation",
+      voiceConversationLifecycleId: "lifecycle-1",
+      voiceConversationRevision: 1,
+      voiceUtteranceId: id,
+      ...metadata,
+    },
+  };
+}
+
 function finalizeVoiceTranscript(id = "voice-user-1") {
   useVoiceConversationStore.setState({
     latestFinalizedTranscriptKey: ["session-1", "lifecycle-1", "1", id].join(
@@ -1557,6 +1576,192 @@ describe("native assistant speech stream", () => {
       );
       expect(mocks.finish).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("plays a K1 continuation held while the same utterance remains active", async () => {
+    finalizeVoiceTranscript("voice-k1");
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        voiceUser("voice-k1"),
+        assistant(
+          [{ type: "text", text: "Continuation for K1." }],
+          "completed",
+          "assistant-k1",
+        ),
+      ]);
+
+    await Promise.resolve();
+    expect(mocks.start).not.toHaveBeenCalled();
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await vi.waitFor(() => {
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Continuation for K1.",
+      );
+    });
+  });
+
+  it("discards held K0 output while allowing a distinct K1 continuation", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const oldReply = assistant(
+      [{ type: "text", text: "Obsolete K0." }],
+      "completed",
+      "assistant-k0",
+    );
+    useChatStore.getState().setMessages("session-1", [oldReply]);
+
+    finalizeVoiceTranscript("voice-k1");
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        oldReply,
+        voiceUser("voice-k1"),
+        assistant(
+          [{ type: "text", text: "Current K1." }],
+          "completed",
+          "assistant-k1",
+        ),
+      ]);
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await vi.waitFor(() => {
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Current K1.",
+      );
+    });
+    expect(mocks.append).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "Obsolete K0.",
+    );
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "notSpoken" } });
+  });
+
+  it("keeps an invalidated K0 slot suppressed while a new K1 slot plays", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      const oldReply = assistant(
+        [{ type: "text", text: "Old" }],
+        "inProgress",
+        "assistant-k0",
+      );
+      useChatStore.getState().setMessages("session-1", [oldReply]);
+      finalizeVoiceTranscript("voice-k1");
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.runAllTimersAsync();
+
+      useChatStore
+        .getState()
+        .appendStreamingText("session-1", "assistant-k0", " suffix");
+      const withSuffix = useChatStore.getState().messagesBySession[
+        "session-1"
+      ]?.[0] as Message;
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          withSuffix,
+          voiceUser("voice-k1"),
+          assistant(
+            [{ type: "text", text: "Eligible K1." }],
+            "inProgress",
+            "assistant-k1",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+
+      expect(mocks.append).not.toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining("suffix"),
+      );
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Eligible K1.",
+      );
+      useChatStore
+        .getState()
+        .updateMessage("session-1", "assistant-k0", (message) => ({
+          ...message,
+          metadata: { ...message.metadata, completionStatus: "completed" },
+        }));
+      await vi.runAllTimersAsync();
+      expect(mocks.finish).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({
+        text: "Old suffix",
+        speech: { status: "notSpoken" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels active K0 playback and then speaks new K1 output", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const oldReply = assistant(
+      [{ type: "text", text: "Active K0." }],
+      "inProgress",
+      "assistant-k0",
+    );
+    useChatStore.getState().setMessages("session-1", [oldReply]);
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(1));
+    emit("started");
+
+    finalizeVoiceTranscript("voice-k1");
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        oldReply,
+        voiceUser("voice-k1"),
+        assistant(
+          [{ type: "text", text: "Fresh K1." }],
+          "completed",
+          "assistant-k1",
+        ),
+      ]);
+
+    await vi.waitFor(() => {
+      expect(mocks.stop).toHaveBeenCalled();
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "Fresh K1.",
+      );
+    });
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "interrupted" } });
+  });
+
+  it("fails closed when voice-origin metadata cannot establish ownership", async () => {
+    finalizeVoiceTranscript("voice-k1");
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        voiceUser("voice-k1", { voiceUtteranceId: undefined }),
+        assistant(
+          [{ type: "text", text: "Unowned output." }],
+          "completed",
+          "assistant-malformed",
+        ),
+      ]);
+
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.append).not.toHaveBeenCalled();
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[1]?.content[0],
+    ).toMatchObject({ speech: { status: "notSpoken" } });
   });
 
   it("plays each completed reply held during user speech in its own stream", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -578,6 +578,7 @@ describe("native assistant speech stream", () => {
         speech: { status: "interrupted", spokenThrough: "After".length },
       });
     });
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
 
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
@@ -1273,6 +1274,7 @@ describe("native assistant speech stream", () => {
         },
       });
     });
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
     expect(mocks.append).toHaveBeenCalledTimes(1);
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
@@ -1771,8 +1773,9 @@ describe("native assistant speech stream", () => {
         ),
       ]);
 
+    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    emit("interrupted");
     await vi.waitFor(() => {
-      expect(mocks.stop).toHaveBeenCalled();
       expect(mocks.start).toHaveBeenCalledTimes(2);
       expect(mocks.append).toHaveBeenCalledWith(
         mocks.start.mock.calls[1]?.[0],
@@ -2092,6 +2095,7 @@ describe("native assistant speech stream", () => {
     finalizeVoiceTranscript("voice-user-late");
 
     await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    emit("interrupted");
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
     ).toMatchObject({ speech: { status: "interrupted" } });

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -87,6 +87,14 @@ function assistant(
   };
 }
 
+function finalizeVoiceTranscript(id = "voice-user-1") {
+  useVoiceConversationStore.setState({
+    latestFinalizedTranscriptKey: ["session-1", "lifecycle-1", "1", id].join(
+      "\0",
+    ),
+  });
+}
+
 function emit(
   state: PocketVoiceStreamEvent["state"],
   error: string | null = null,
@@ -129,6 +137,7 @@ describe("native assistant speech stream", () => {
       uiState: "listening",
       userSpeaking: false,
       assistantSpeaking: false,
+      latestFinalizedTranscriptKey: null,
     });
   });
 
@@ -1523,5 +1532,270 @@ describe("native assistant speech stream", () => {
     expect(estimate.unspokenText.length).toBeLessThanOrEqual(250);
     expect(estimate.spokenTextTruncated).toBe(true);
     expect(estimate.unspokenTextTruncated).toBe(true);
+  });
+
+  it("plays a reply held during user speech after idle when no transcript arrives", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Held reply." }], "completed"),
+      ]);
+
+    await Promise.resolve();
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.append).not.toHaveBeenCalled();
+
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await vi.waitFor(() => {
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Held reply.",
+      );
+      expect(mocks.finish).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("plays each completed reply held during user speech in its own stream", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant(
+          [{ type: "text", text: "First held reply." }],
+          "completed",
+          "assistant-1",
+        ),
+        assistant(
+          [{ type: "text", text: "Second held reply." }],
+          "completed",
+          "assistant-2",
+        ),
+      ]);
+
+    useVoiceConversationStore.setState({ userSpeaking: false });
+    await vi.waitFor(() => {
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "First held reply.",
+      );
+      expect(mocks.finish).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.append).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "Second held reply.",
+    );
+
+    mocks.streamHandler?.({
+      streamId: mocks.start.mock.calls[0]?.[0] as string,
+      state: "completed",
+      error: null,
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "Second held reply.",
+      );
+      expect(mocks.finish).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("discards every pending held reply when a transcript interrupts the first", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const first = assistant(
+      [{ type: "text", text: "First obsolete reply." }],
+      "completed",
+      "assistant-held-first",
+    );
+    const second = assistant(
+      [{ type: "text", text: "Second obsolete reply." }],
+      "completed",
+      "assistant-held-second",
+    );
+    useChatStore.getState().setMessages("session-1", [first, second]);
+
+    useVoiceConversationStore.setState({ userSpeaking: false });
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(1));
+    emit("started");
+    finalizeVoiceTranscript("voice-after-first");
+
+    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+    expect(mocks.start).toHaveBeenCalledTimes(1);
+    expect(mocks.append).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "Second obsolete reply.",
+    );
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[1]?.content[0],
+    ).toMatchObject({ speech: { status: "notSpoken" } });
+  });
+
+  it("does not release held speech when user speech resumes before the idle timer", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Still held." }], "completed"),
+      ]);
+
+    useVoiceConversationStore.setState({ userSpeaking: false });
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+    expect(mocks.start).not.toHaveBeenCalled();
+
+    useVoiceConversationStore.setState({ userSpeaking: false });
+    await vi.waitFor(() => {
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Still held.",
+      );
+    });
+  });
+
+  it("never starts a held reply when a newer finalized voice transcript arrives", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const heldReply = assistant(
+      [{ type: "text", text: "Obsolete held reply." }],
+      "completed",
+    );
+    useChatStore.getState().setMessages("session-1", [heldReply]);
+    await Promise.resolve();
+
+    finalizeVoiceTranscript();
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 10));
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.append).not.toHaveBeenCalled();
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "notSpoken" } });
+    expect(takeVoicePlaybackNotices("session-1")).toContain(
+      "Original text: Obsolete held reply.",
+    );
+  });
+
+  it("discards text appended during idle settling when a voice transcript arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Hello" }],
+            "completed",
+            "assistant-idle-suffix",
+          ),
+        ]);
+
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      useChatStore
+        .getState()
+        .appendStreamingText("session-1", "assistant-idle-suffix", " world");
+      finalizeVoiceTranscript();
+
+      await vi.runAllTimersAsync();
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({
+        text: "Hello world",
+        speech: { status: "notSpoken" },
+      });
+      expect(takeVoicePlaybackNotices("session-1")).toContain(
+        "Original text: Hello world",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("holds assistant text first arriving during the idle settling task", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useVoiceConversationStore.setState({ userSpeaking: false });
+
+      const lateReply = assistant(
+        [{ type: "text", text: "Late obsolete reply." }],
+        "completed",
+        "assistant-after-idle",
+      );
+      useChatStore.getState().setMessages("session-1", [lateReply]);
+      finalizeVoiceTranscript("voice-during-idle-settlement");
+
+      await vi.runAllTimersAsync();
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({ speech: { status: "notSpoken" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards stale assistant text that arrives after finalized STT during the hold", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      finalizeVoiceTranscript("voice-before-stale-reply");
+
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Stale reply after final STT." }],
+            "completed",
+            "assistant-after-final-stt",
+          ),
+        ]);
+      useVoiceConversationStore.setState({ userSpeaking: false });
+
+      await vi.runAllTimersAsync();
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({ speech: { status: "notSpoken" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("cancels held playback when the finalized voice transcript lands after playback starts", async () => {
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const heldReply = assistant(
+      [{ type: "text", text: "Reply released after idle." }],
+      "completed",
+    );
+    useChatStore.getState().setMessages("session-1", [heldReply]);
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(1));
+    emit("started");
+    finalizeVoiceTranscript("voice-user-late");
+
+    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "interrupted" } });
   });
 });

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -1554,28 +1554,63 @@ describe("native assistant speech stream", () => {
   });
 
   it("plays a reply held during user speech after idle when no transcript arrives", async () => {
-    useVoiceConversationStore.setState({ userSpeaking: true });
-    startNativeAssistantSpeech("session-1", vi.fn());
-    useChatStore
-      .getState()
-      .setMessages("session-1", [
-        assistant([{ type: "text", text: "Held reply." }], "completed"),
-      ]);
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant([{ type: "text", text: "Held reply." }], "completed"),
+        ]);
 
-    await Promise.resolve();
-    expect(mocks.start).not.toHaveBeenCalled();
-    expect(mocks.append).not.toHaveBeenCalled();
+      await Promise.resolve();
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
 
-    useVoiceConversationStore.setState({ userSpeaking: false });
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(249);
+      expect(mocks.start).not.toHaveBeenCalled();
 
-    await vi.waitFor(() => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTimersAsync();
       expect(mocks.start).toHaveBeenCalledTimes(1);
       expect(mocks.append).toHaveBeenCalledWith(
         mocks.start.mock.calls[0]?.[0],
         "Held reply.",
       );
       expect(mocks.finish).toHaveBeenCalledTimes(1);
-    });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not release held speech when final STT follows VAD idle", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant([{ type: "text", text: "Obsolete reply." }], "completed"),
+        ]);
+
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(50);
+      expect(mocks.start).not.toHaveBeenCalled();
+
+      finalizeVoiceTranscript("voice-k1");
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({ speech: { status: "notSpoken" } });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("plays a K1 continuation held while the same utterance remains active", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -1764,6 +1764,57 @@ describe("native assistant speech stream", () => {
     ).toMatchObject({ speech: { status: "notSpoken" } });
   });
 
+  it("speaks a typed turn after finalized voice input", async () => {
+    finalizeVoiceTranscript("voice-k1");
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore.getState().setMessages("session-1", [
+      voiceUser("voice-k1"),
+      {
+        id: "typed-user",
+        role: "user",
+        created: 2,
+        content: [{ type: "text", text: "Typed follow-up" }],
+      },
+      assistant(
+        [{ type: "text", text: "Typed-turn reply." }],
+        "completed",
+        "assistant-typed",
+      ),
+    ]);
+
+    await vi.waitFor(() =>
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Typed-turn reply.",
+      ),
+    );
+  });
+
+  it("hydrates causal ownership from an existing voice transcript", async () => {
+    useChatStore.getState().setMessages("session-1", [voiceUser("voice-k1")]);
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        voiceUser("voice-k1"),
+        assistant(
+          [{ type: "text", text: "Recovered-turn reply." }],
+          "completed",
+          "assistant-recovered",
+        ),
+      ]);
+
+    await vi.waitFor(() =>
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Recovered-turn reply.",
+      ),
+    );
+    expect(
+      useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(["session-1", "lifecycle-1", "1", "voice-k1"].join("\0"));
+  });
+
   it("plays each completed reply held during user speech in its own stream", async () => {
     useVoiceConversationStore.setState({ userSpeaking: true });
     startNativeAssistantSpeech("session-1", vi.fn());

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -1749,6 +1749,129 @@ describe("native assistant speech stream", () => {
     }
   });
 
+  it("keeps every later block of an invalidated response suppressed after causal rollback", async () => {
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      startNativeAssistantSpeech("session-1", vi.fn());
+      const oldReply = assistant(
+        [{ type: "text", text: "Old block." }],
+        "inProgress",
+        "assistant-k0",
+      );
+      useChatStore.getState().setMessages("session-1", [oldReply]);
+
+      finalizeVoiceTranscript("voice-k1");
+      useVoiceConversationStore.setState({
+        latestFinalizedTranscriptKey: null,
+      });
+      useChatStore.getState().setMessages("session-1", [
+        {
+          ...oldReply,
+          content: [
+            ...oldReply.content,
+            { type: "text", text: "New block after rollback." },
+          ],
+        },
+      ]);
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).not.toHaveBeenCalled();
+      expect(mocks.append).not.toHaveBeenCalled();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[1],
+      ).toMatchObject({ speech: { status: "notSpoken" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains completion until a replacement response can own a stream", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    const oldReply = assistant(
+      [{ type: "text", text: "Interrupted K0." }],
+      "inProgress",
+      "assistant-k0",
+    );
+    useChatStore.getState().setMessages("session-1", [oldReply]);
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(1));
+    emit("started");
+
+    finalizeVoiceTranscript("voice-k1");
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        oldReply,
+        voiceUser("voice-k1"),
+        assistant(
+          [{ type: "text", text: "Completed K1." }],
+          "completed",
+          "assistant-k1",
+        ),
+      ]);
+    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    expect(mocks.finish).not.toHaveBeenCalled();
+
+    emit("interrupted");
+    await vi.waitFor(() => {
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "Completed K1.",
+      );
+      expect(mocks.finish).toHaveBeenCalledWith(mocks.start.mock.calls[1]?.[0]);
+    });
+  });
+
+  it("preserves partial interruption status for suffixes arriving during speech", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant(
+          [{ type: "text", text: "Partially spoken." }],
+          "inProgress",
+          "assistant-k0",
+        ),
+      ]);
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(1));
+    emit("started");
+    const streamId = mocks.start.mock.calls[0]?.[0] as string;
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    mocks.streamHandler?.({
+      streamId,
+      state: "interrupted",
+      error: null,
+      delivery: {
+        segments: [
+          {
+            text: "Partially spoken.",
+            playedFrames: 500,
+            totalFrames: 1_000,
+            synthesisComplete: true,
+          },
+        ],
+      },
+    });
+    useChatStore
+      .getState()
+      .appendStreamingText("session-1", "assistant-k0", " Later suffix.");
+    finalizeVoiceTranscript("voice-k1");
+    useVoiceConversationStore.setState({ userSpeaking: false });
+
+    await vi.waitFor(() => {
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({ speech: { status: "interrupted" } });
+    });
+    expect(mocks.append).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining("Later suffix"),
+    );
+  });
+
   it("cancels active K0 playback and then speaks new K1 output", async () => {
     startNativeAssistantSpeech("session-1", vi.fn());
     const oldReply = assistant(

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -1593,7 +1593,11 @@ describe("native assistant speech stream", () => {
       useChatStore
         .getState()
         .setMessages("session-1", [
-          assistant([{ type: "text", text: "Obsolete reply." }], "completed"),
+          assistant(
+            [{ type: "text", text: "Obsolete reply." }],
+            "completed",
+            "assistant-delayed-final",
+          ),
         ]);
 
       useVoiceConversationStore.setState({ userSpeaking: false });
@@ -1608,6 +1612,9 @@ describe("native assistant speech stream", () => {
       expect(
         useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
       ).toMatchObject({ speech: { status: "notSpoken" } });
+      expect(takeVoicePlaybackNotices("session-1")).toContain(
+        "Original text: Obsolete reply.",
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -108,6 +108,7 @@ function boundedDeliveryText(
       };
 }
 const MALFORMED_VOICE_TRANSCRIPT_KEY = "\0malformed-voice-transcript";
+const USER_IDLE_TRANSCRIPT_SETTLE_MS = 250;
 
 function voiceTranscriptKeyForMessage(
   sessionId: string,
@@ -1253,9 +1254,9 @@ export function startNativeAssistantSpeech(
     if (becameUserIdle) {
       if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
       idleSettling = true;
-      // Wait one task turn for an adjacent finalized-transcript event before
-      // releasing held speech. Keep this gate even when no assistant text
-      // exists yet, since model output can race that event.
+      // VAD can report silence shortly before the recognizer commits its final
+      // transcript. Give that transcript a bounded opportunity to invalidate
+      // causally stale speech before releasing the held reply.
       heldReleaseTimer = window.setTimeout(() => {
         heldReleaseTimer = null;
         const current = useVoiceConversationStore.getState();
@@ -1270,7 +1271,7 @@ export function startNativeAssistantSpeech(
         idleSettling = false;
         heldReleaseReady = heldSpeech !== null;
         inspect();
-      }, 0);
+      }, USER_IDLE_TRANSCRIPT_SETTLE_MS);
       return;
     }
     inspect();

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -50,10 +50,15 @@ type ActiveUtterance = {
   interruptionFallback: ReturnType<typeof setTimeout> | null;
   interruptionCause: InterruptionCause | null;
   latestDelivery: VoiceDeliveryProgress | null;
+  finalizedTranscriptKeyAtCreation: string | null;
   status: SpeechStatus | null;
   onFailure: SpeechFailureHandler;
   onInterrupted: () => void;
   onTerminal: () => void;
+};
+type HeldSpeech = {
+  finalizedTranscriptKeyAtCreation: string | null;
+  targets: Map<string, { target: SpeechTarget; text: string }>;
 };
 type SpeechStatus =
   | "speaking"
@@ -730,6 +735,7 @@ export function startNativeAssistantSpeech(
       stopStreamSubscription = unlisten;
     });
 
+  const initialVoice = useVoiceConversationStore.getState();
   const toolCountByMessage = new Map<string, number>();
   const consumedTextBySlot = new Map<string, string>();
   const completedMessages = new Set<string>();
@@ -755,6 +761,59 @@ export function startNativeAssistantSpeech(
       textOrdinal += 1;
     }
   }
+
+  let heldSpeech: HeldSpeech | null = null;
+  let heldReleaseReady = false;
+  let idleSettling = false;
+  let heldReleaseTimer: number | null = null;
+  let speechGateTranscriptKey: string | null | undefined =
+    initialVoice.userSpeaking
+      ? initialVoice.latestFinalizedTranscriptKey
+      : undefined;
+
+  const holdAssistantChanges = (
+    messages: ReturnType<
+      typeof useChatStore.getState
+    >["messagesBySession"][string],
+  ) => {
+    for (const message of messages ?? []) {
+      if (
+        message.role !== "assistant" ||
+        message.metadata?.userVisible === false
+      ) {
+        continue;
+      }
+      let textOrdinal = 0;
+      for (const content of message.content) {
+        if (content.type !== "text") continue;
+        const target = { messageId: message.id, textOrdinal };
+        const slot = targetKey(target);
+        textOrdinal += 1;
+        if (content.text === (consumedTextBySlot.get(slot) ?? "")) continue;
+        heldSpeech ??= {
+          finalizedTranscriptKeyAtCreation:
+            speechGateTranscriptKey !== undefined
+              ? speechGateTranscriptKey
+              : useVoiceConversationStore.getState()
+                  .latestFinalizedTranscriptKey,
+          targets: new Map(),
+        };
+        heldSpeech.targets.set(slot, { target, text: content.text });
+      }
+    }
+  };
+
+  const discardHeldSpeech = () => {
+    const held = heldSpeech;
+    heldSpeech = null;
+    heldReleaseReady = false;
+    if (!held) return;
+    for (const [slot, { target, text }] of held.targets) {
+      consumedTextBySlot.set(slot, text);
+      setTargetStatus(sessionId, target, "notSpoken");
+      recordPlaybackNotice(sessionId, slot, text, "notSpoken");
+    }
+  };
 
   const ensureUtterance = (target: SpeechTarget): ActiveUtterance => {
     if (activeUtterance) {
@@ -787,6 +846,8 @@ export function startNativeAssistantSpeech(
       interruptionFallback: null,
       interruptionCause: null,
       latestDelivery: null,
+      finalizedTranscriptKeyAtCreation:
+        useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
       status: null,
       onFailure: (text, error) => {
         for (const utteranceTarget of utterance.targets) {
@@ -834,13 +895,40 @@ export function startNativeAssistantSpeech(
     ) {
       return;
     }
+    const messages = useChatStore.getState().messagesBySession[sessionId] ?? [];
+    if (heldSpeech || voice.userSpeaking || idleSettling) {
+      // Text can keep streaming during the idle settling turn. Refresh the
+      // held snapshot before a finalized voice message can invalidate it.
+      holdAssistantChanges(messages);
+    }
+    const finalizedTranscriptKey = voice.latestFinalizedTranscriptKey;
+    if (
+      heldSpeech &&
+      heldSpeech.finalizedTranscriptKeyAtCreation !== finalizedTranscriptKey
+    ) {
+      discardHeldSpeech();
+    }
+    if (
+      activeUtterance &&
+      activeUtterance.finalizedTranscriptKeyAtCreation !==
+        finalizedTranscriptKey
+    ) {
+      interruptActiveUtterance(true, "userSpeaking");
+    }
+
+    if (voice.userSpeaking || idleSettling) return;
+    if (heldSpeech && !heldReleaseReady) return;
+
     // The backend owns the current stream until its terminal playback event.
     // Leave later transcript changes entirely unconsumed so that terminal
     // handling can inspect them into a distinct utterance.
     if (activeUtterance?.finishing) return;
 
-    const messages = useChatStore.getState().messagesBySession[sessionId] ?? [];
     for (const message of messages) {
+      // Completing one message hands its stream to the backend. Do not
+      // advance any later message's cursors until that terminal event lets a
+      // fresh utterance inspect it.
+      if (activeUtterance?.finishing) break;
       if (
         message.role !== "assistant" ||
         message.metadata?.userVisible === false
@@ -952,12 +1040,8 @@ export function startNativeAssistantSpeech(
           continue;
         }
 
-        if (voice.userSpeaking) {
-          setTargetSpeech(sessionId, target, { status: "notSpoken" });
-          recordPlaybackNotice(sessionId, slot, content.text, "notSpoken");
-          continue;
-        }
-
+        const targetWasHeld =
+          heldReleaseReady && (heldSpeech?.targets.has(slot) ?? false);
         const utterance = ensureUtterance(target);
         if (utterance.finishing) continue;
         const spanStart = utterance.text.length;
@@ -981,6 +1065,13 @@ export function startNativeAssistantSpeech(
           () => streamBackend.append(utterance.id, delta),
           onFailure,
         );
+        if (targetWasHeld) {
+          heldSpeech?.targets.delete(slot);
+          if (heldSpeech?.targets.size === 0) {
+            heldSpeech = null;
+            heldReleaseReady = false;
+          }
+        }
       }
 
       const utterance = activeUtterance;
@@ -1014,7 +1105,6 @@ export function startNativeAssistantSpeech(
   };
 
   stopSubscription = useChatStore.subscribe(inspect);
-  const initialVoice = useVoiceConversationStore.getState();
   let reachedRunning =
     initialVoice.status.lifecycle === "running" &&
     initialVoice.status.sessionId === sessionId;
@@ -1022,7 +1112,7 @@ export function startNativeAssistantSpeech(
     activeSpeechRevision = initialVoice.status.revision;
   }
   let wasUserSpeaking = initialVoice.userSpeaking;
-  stopVoiceSubscription = useVoiceConversationStore.subscribe((voice) => {
+  const unsubscribeVoice = useVoiceConversationStore.subscribe((voice) => {
     const runningForSession =
       voice.status.lifecycle === "running" &&
       voice.status.sessionId === sessionId;
@@ -1039,11 +1129,50 @@ export function startNativeAssistantSpeech(
     }
     reachedRunning = true;
     activeSpeechRevision = voice.status.revision;
-    inspect();
     const becameUserSpeaking = voice.userSpeaking && !wasUserSpeaking;
+    const becameUserIdle = !voice.userSpeaking && wasUserSpeaking;
     wasUserSpeaking = voice.userSpeaking;
-    if (!becameUserSpeaking || activeGeneration !== generation) return;
-    interruptActiveUtterance(true, "userSpeaking");
+    if (activeGeneration !== generation) return;
+    if (becameUserSpeaking) {
+      speechGateTranscriptKey = voice.latestFinalizedTranscriptKey;
+      if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
+      heldReleaseTimer = null;
+      idleSettling = false;
+      heldReleaseReady = false;
+      interruptActiveUtterance(true, "userSpeaking");
+      inspect();
+      return;
+    }
+    if (becameUserIdle) {
+      if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
+      idleSettling = true;
+      // Wait one task turn for an adjacent finalized-transcript event before
+      // releasing held speech. Keep this gate even when no assistant text
+      // exists yet, since model output can race that event.
+      heldReleaseTimer = window.setTimeout(() => {
+        heldReleaseTimer = null;
+        const current = useVoiceConversationStore.getState();
+        if (
+          activeGeneration !== generation ||
+          current.userSpeaking ||
+          current.status.lifecycle !== "running" ||
+          current.status.sessionId !== sessionId
+        ) {
+          return;
+        }
+        idleSettling = false;
+        heldReleaseReady = heldSpeech !== null;
+        speechGateTranscriptKey = undefined;
+        inspect();
+      }, 0);
+      return;
+    }
+    inspect();
   });
+  stopVoiceSubscription = () => {
+    if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
+    heldReleaseTimer = null;
+    unsubscribeVoice();
+  };
   queueMicrotask(inspect);
 }

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -50,15 +50,17 @@ type ActiveUtterance = {
   interruptionFallback: ReturnType<typeof setTimeout> | null;
   interruptionCause: InterruptionCause | null;
   latestDelivery: VoiceDeliveryProgress | null;
-  finalizedTranscriptKeyAtCreation: string | null;
+  causalTranscriptKey: string | null;
   status: SpeechStatus | null;
   onFailure: SpeechFailureHandler;
   onInterrupted: () => void;
   onTerminal: () => void;
 };
 type HeldSpeech = {
-  finalizedTranscriptKeyAtCreation: string | null;
-  targets: Map<string, { target: SpeechTarget; text: string }>;
+  targets: Map<
+    string,
+    { target: SpeechTarget; text: string; causalTranscriptKey: string | null }
+  >;
 };
 type SpeechStatus =
   | "speaking"
@@ -104,6 +106,33 @@ function boundedDeliveryText(
         text: `…${text.slice(-(DELIVERY_NOTICE_TEXT_LIMIT - 1))}`,
         truncated: true,
       };
+}
+const MALFORMED_VOICE_TRANSCRIPT_KEY = "\0malformed-voice-transcript";
+
+function voiceTranscriptKeyForMessage(
+  sessionId: string,
+  message: ReturnType<
+    typeof useChatStore.getState
+  >["messagesBySession"][string][number],
+): string | null {
+  const metadata = message.metadata;
+  if (metadata?.origin !== "voice_conversation") return null;
+  if (
+    typeof metadata.voiceConversationLifecycleId !== "string" ||
+    metadata.voiceConversationLifecycleId.length === 0 ||
+    typeof metadata.voiceConversationRevision !== "number" ||
+    !Number.isInteger(metadata.voiceConversationRevision) ||
+    typeof metadata.voiceUtteranceId !== "string" ||
+    metadata.voiceUtteranceId.length === 0
+  ) {
+    return MALFORMED_VOICE_TRANSCRIPT_KEY;
+  }
+  return [
+    sessionId,
+    metadata.voiceConversationLifecycleId,
+    metadata.voiceConversationRevision,
+    metadata.voiceUtteranceId,
+  ].join("\0");
 }
 
 function reportAssistantActivity(
@@ -738,11 +767,19 @@ export function startNativeAssistantSpeech(
   const initialVoice = useVoiceConversationStore.getState();
   const toolCountByMessage = new Map<string, number>();
   const consumedTextBySlot = new Map<string, string>();
+  const causalTranscriptKeyByMessage = new Map<string, string | null>();
+  const invalidatedSlots = new Set<string>();
   const completedMessages = new Set<string>();
   const interruptedMessages = new Set<string>();
   const failedMessages = new Set<string>();
   const interruptionCauseByMessage = new Map<string, InterruptionCause>();
+  let precedingTranscriptKey: string | null = null;
   for (const message of initialMessages) {
+    if (message.role === "user") {
+      precedingTranscriptKey = voiceTranscriptKeyForMessage(sessionId, message);
+    } else if (message.role === "assistant") {
+      causalTranscriptKeyByMessage.set(message.id, precedingTranscriptKey);
+    }
     toolCountByMessage.set(
       message.id,
       message.content.filter((content) => content.type === "toolRequest")
@@ -766,16 +803,38 @@ export function startNativeAssistantSpeech(
   let heldReleaseReady = false;
   let idleSettling = false;
   let heldReleaseTimer: number | null = null;
-  let speechGateTranscriptKey: string | null | undefined =
-    initialVoice.userSpeaking
-      ? initialVoice.latestFinalizedTranscriptKey
-      : undefined;
+
+  const cacheCausalTranscriptKeys = (
+    messages: ReturnType<
+      typeof useChatStore.getState
+    >["messagesBySession"][string],
+  ) => {
+    let causalTranscriptKey: string | null = null;
+    for (const message of messages ?? []) {
+      if (message.role === "user") {
+        causalTranscriptKey = voiceTranscriptKeyForMessage(sessionId, message);
+      } else if (
+        message.role === "assistant" &&
+        !causalTranscriptKeyByMessage.has(message.id)
+      ) {
+        causalTranscriptKeyByMessage.set(message.id, causalTranscriptKey);
+      }
+    }
+  };
+
+  const suppressTarget = (slot: string, target: SpeechTarget, text: string) => {
+    invalidatedSlots.add(slot);
+    consumedTextBySlot.set(slot, text);
+    setTargetStatus(sessionId, target, "notSpoken");
+    recordPlaybackNotice(sessionId, slot, text, "notSpoken");
+  };
 
   const holdAssistantChanges = (
     messages: ReturnType<
       typeof useChatStore.getState
     >["messagesBySession"][string],
   ) => {
+    cacheCausalTranscriptKeys(messages);
     for (const message of messages ?? []) {
       if (
         message.role !== "assistant" ||
@@ -790,33 +849,43 @@ export function startNativeAssistantSpeech(
         const slot = targetKey(target);
         textOrdinal += 1;
         if (content.text === (consumedTextBySlot.get(slot) ?? "")) continue;
-        heldSpeech ??= {
-          finalizedTranscriptKeyAtCreation:
-            speechGateTranscriptKey !== undefined
-              ? speechGateTranscriptKey
-              : useVoiceConversationStore.getState()
-                  .latestFinalizedTranscriptKey,
-          targets: new Map(),
-        };
-        heldSpeech.targets.set(slot, { target, text: content.text });
+        if (invalidatedSlots.has(slot)) {
+          suppressTarget(slot, target, content.text);
+          continue;
+        }
+        heldSpeech ??= { targets: new Map() };
+        heldSpeech.targets.set(slot, {
+          target,
+          text: content.text,
+          causalTranscriptKey:
+            causalTranscriptKeyByMessage.get(message.id) ?? null,
+        });
       }
     }
   };
 
-  const discardHeldSpeech = () => {
+  const discardInvalidHeldSpeech = (finalizedTranscriptKey: string | null) => {
     const held = heldSpeech;
-    heldSpeech = null;
-    heldReleaseReady = false;
     if (!held) return;
-    for (const [slot, { target, text }] of held.targets) {
-      consumedTextBySlot.set(slot, text);
-      setTargetStatus(sessionId, target, "notSpoken");
-      recordPlaybackNotice(sessionId, slot, text, "notSpoken");
+    for (const [slot, heldTarget] of held.targets) {
+      if (heldTarget.causalTranscriptKey === finalizedTranscriptKey) continue;
+      suppressTarget(slot, heldTarget.target, heldTarget.text);
+      held.targets.delete(slot);
+    }
+    if (held.targets.size === 0) {
+      heldSpeech = null;
+      heldReleaseReady = false;
     }
   };
 
-  const ensureUtterance = (target: SpeechTarget): ActiveUtterance => {
+  const ensureUtterance = (
+    target: SpeechTarget,
+    causalTranscriptKey: string | null,
+  ): ActiveUtterance | null => {
     if (activeUtterance) {
+      if (activeUtterance.causalTranscriptKey !== causalTranscriptKey) {
+        return null;
+      }
       if (
         !activeUtterance.targets.some(
           (candidate) => targetKey(candidate) === targetKey(target),
@@ -846,8 +915,7 @@ export function startNativeAssistantSpeech(
       interruptionFallback: null,
       interruptionCause: null,
       latestDelivery: null,
-      finalizedTranscriptKeyAtCreation:
-        useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+      causalTranscriptKey,
       status: null,
       onFailure: (text, error) => {
         for (const utteranceTarget of utterance.targets) {
@@ -902,16 +970,10 @@ export function startNativeAssistantSpeech(
       holdAssistantChanges(messages);
     }
     const finalizedTranscriptKey = voice.latestFinalizedTranscriptKey;
-    if (
-      heldSpeech &&
-      heldSpeech.finalizedTranscriptKeyAtCreation !== finalizedTranscriptKey
-    ) {
-      discardHeldSpeech();
-    }
+    discardInvalidHeldSpeech(finalizedTranscriptKey);
     if (
       activeUtterance &&
-      activeUtterance.finalizedTranscriptKeyAtCreation !==
-        finalizedTranscriptKey
+      activeUtterance.causalTranscriptKey !== finalizedTranscriptKey
     ) {
       interruptActiveUtterance(true, "userSpeaking");
     }
@@ -923,6 +985,8 @@ export function startNativeAssistantSpeech(
     // Leave later transcript changes entirely unconsumed so that terminal
     // handling can inspect them into a distinct utterance.
     if (activeUtterance?.finishing) return;
+
+    cacheCausalTranscriptKeys(messages);
 
     for (const message of messages) {
       // Completing one message hands its stream to the backend. Do not
@@ -955,10 +1019,18 @@ export function startNativeAssistantSpeech(
         const previous = consumedTextBySlot.get(slot) ?? "";
         if (content.text === previous) continue;
         const appendOnly = content.text.startsWith(previous);
+        const causalTranscriptKey =
+          causalTranscriptKeyByMessage.get(message.id) ?? null;
+        if (
+          invalidatedSlots.has(slot) ||
+          causalTranscriptKey !== finalizedTranscriptKey
+        ) {
+          suppressTarget(slot, target, content.text);
+          continue;
+        }
         const delta = appendOnly
           ? content.text.slice(previous.length)
           : content.text;
-        consumedTextBySlot.set(slot, content.text);
         if (!delta) continue;
 
         if (failedMessages.has(message.id)) {
@@ -1042,7 +1114,9 @@ export function startNativeAssistantSpeech(
 
         const targetWasHeld =
           heldReleaseReady && (heldSpeech?.targets.has(slot) ?? false);
-        const utterance = ensureUtterance(target);
+        const utterance = ensureUtterance(target, causalTranscriptKey);
+        if (!utterance) break;
+        consumedTextBySlot.set(slot, content.text);
         if (utterance.finishing) continue;
         const spanStart = utterance.text.length;
         utterance.text += delta;
@@ -1075,14 +1149,27 @@ export function startNativeAssistantSpeech(
       }
 
       const utterance = activeUtterance;
-      if (crossedToolBoundary && utterance && !utterance.finishing) {
+      const utteranceOwnsMessage = utterance?.targets.some(
+        (target) => target.messageId === message.id,
+      );
+      if (
+        crossedToolBoundary &&
+        utterance &&
+        utteranceOwnsMessage &&
+        !utterance.finishing
+      ) {
         queueStreamCommand(
           utterance,
           () => streamBackend.flush(utterance.id),
           onFailure,
         );
       }
-      if (completed && utterance && !utterance.finishing) {
+      if (
+        completed &&
+        utterance &&
+        utteranceOwnsMessage &&
+        !utterance.finishing
+      ) {
         utterance.finishing = true;
         queueStreamCommand(
           utterance,
@@ -1134,7 +1221,6 @@ export function startNativeAssistantSpeech(
     wasUserSpeaking = voice.userSpeaking;
     if (activeGeneration !== generation) return;
     if (becameUserSpeaking) {
-      speechGateTranscriptKey = voice.latestFinalizedTranscriptKey;
       if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
       heldReleaseTimer = null;
       idleSettling = false;
@@ -1162,7 +1248,6 @@ export function startNativeAssistantSpeech(
         }
         idleSettling = false;
         heldReleaseReady = heldSpeech !== null;
-        speechGateTranscriptKey = undefined;
         inspect();
       }, 0);
       return;

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -776,7 +776,13 @@ export function startNativeAssistantSpeech(
   let precedingTranscriptKey: string | null = null;
   for (const message of initialMessages) {
     if (message.role === "user") {
-      precedingTranscriptKey = voiceTranscriptKeyForMessage(sessionId, message);
+      const voiceTranscriptKey = voiceTranscriptKeyForMessage(
+        sessionId,
+        message,
+      );
+      if (voiceTranscriptKey !== null) {
+        precedingTranscriptKey = voiceTranscriptKey;
+      }
     } else if (message.role === "assistant") {
       causalTranscriptKeyByMessage.set(message.id, precedingTranscriptKey);
     }
@@ -798,6 +804,15 @@ export function startNativeAssistantSpeech(
       textOrdinal += 1;
     }
   }
+  if (
+    initialVoice.latestFinalizedTranscriptKey === null &&
+    precedingTranscriptKey !== null &&
+    precedingTranscriptKey !== MALFORMED_VOICE_TRANSCRIPT_KEY
+  ) {
+    useVoiceConversationStore.setState({
+      latestFinalizedTranscriptKey: precedingTranscriptKey,
+    });
+  }
 
   let heldSpeech: HeldSpeech | null = null;
   let heldReleaseReady = false;
@@ -812,7 +827,13 @@ export function startNativeAssistantSpeech(
     let causalTranscriptKey: string | null = null;
     for (const message of messages ?? []) {
       if (message.role === "user") {
-        causalTranscriptKey = voiceTranscriptKeyForMessage(sessionId, message);
+        const voiceTranscriptKey = voiceTranscriptKeyForMessage(
+          sessionId,
+          message,
+        );
+        if (voiceTranscriptKey !== null) {
+          causalTranscriptKey = voiceTranscriptKey;
+        }
       } else if (
         message.role === "assistant" &&
         !causalTranscriptKeyByMessage.has(message.id)

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -769,7 +769,7 @@ export function startNativeAssistantSpeech(
   const toolCountByMessage = new Map<string, number>();
   const consumedTextBySlot = new Map<string, string>();
   const causalTranscriptKeyByMessage = new Map<string, string | null>();
-  const invalidatedSlots = new Set<string>();
+  const invalidatedMessages = new Set<string>();
   const completedMessages = new Set<string>();
   const interruptedMessages = new Set<string>();
   const failedMessages = new Set<string>();
@@ -845,7 +845,7 @@ export function startNativeAssistantSpeech(
   };
 
   const suppressTarget = (slot: string, target: SpeechTarget, text: string) => {
-    invalidatedSlots.add(slot);
+    invalidatedMessages.add(target.messageId);
     consumedTextBySlot.set(slot, text);
     setTargetSpeech(sessionId, target, { status: "notSpoken" });
     recordPlaybackNotice(sessionId, slot, text, "notSpoken");
@@ -860,7 +860,9 @@ export function startNativeAssistantSpeech(
     for (const message of messages ?? []) {
       if (
         message.role !== "assistant" ||
-        message.metadata?.userVisible === false
+        message.metadata?.userVisible === false ||
+        interruptedMessages.has(message.id) ||
+        failedMessages.has(message.id)
       ) {
         continue;
       }
@@ -871,7 +873,7 @@ export function startNativeAssistantSpeech(
         const slot = targetKey(target);
         textOrdinal += 1;
         if (content.text === (consumedTextBySlot.get(slot) ?? "")) continue;
-        if (invalidatedSlots.has(slot)) {
+        if (invalidatedMessages.has(message.id)) {
           suppressTarget(slot, target, content.text);
           continue;
         }
@@ -1029,9 +1031,6 @@ export function startNativeAssistantSpeech(
       const completed =
         message.metadata?.completionStatus === "completed" &&
         !completedMessages.has(message.id);
-      toolCountByMessage.set(message.id, toolCount);
-      if (completed) completedMessages.add(message.id);
-
       let textOrdinal = 0;
       for (const content of message.content) {
         if (content.type !== "text") continue;
@@ -1128,7 +1127,7 @@ export function startNativeAssistantSpeech(
         }
 
         if (
-          invalidatedSlots.has(slot) ||
+          invalidatedMessages.has(message.id) ||
           causalTranscriptKey !== finalizedTranscriptKey
         ) {
           suppressTarget(slot, target, content.text);
@@ -1175,6 +1174,14 @@ export function startNativeAssistantSpeech(
       const utteranceOwnsMessage = utterance?.targets.some(
         (target) => target.messageId === message.id,
       );
+      const messageCannotSpeak =
+        failedMessages.has(message.id) ||
+        interruptedMessages.has(message.id) ||
+        invalidatedMessages.has(message.id);
+      if (utteranceOwnsMessage || messageCannotSpeak) {
+        toolCountByMessage.set(message.id, toolCount);
+        if (completed) completedMessages.add(message.id);
+      }
       if (
         crossedToolBoundary &&
         utterance &&

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -847,7 +847,7 @@ export function startNativeAssistantSpeech(
   const suppressTarget = (slot: string, target: SpeechTarget, text: string) => {
     invalidatedSlots.add(slot);
     consumedTextBySlot.set(slot, text);
-    setTargetStatus(sessionId, target, "notSpoken");
+    setTargetSpeech(sessionId, target, { status: "notSpoken" });
     recordPlaybackNotice(sessionId, slot, text, "notSpoken");
   };
 
@@ -1043,13 +1043,6 @@ export function startNativeAssistantSpeech(
         const appendOnly = content.text.startsWith(previous);
         const causalTranscriptKey =
           causalTranscriptKeyByMessage.get(message.id) ?? null;
-        if (
-          invalidatedSlots.has(slot) ||
-          causalTranscriptKey !== finalizedTranscriptKey
-        ) {
-          suppressTarget(slot, target, content.text);
-          continue;
-        }
         const delta = appendOnly
           ? content.text.slice(previous.length)
           : content.text;
@@ -1131,6 +1124,14 @@ export function startNativeAssistantSpeech(
             },
             interruptionCause,
           );
+          continue;
+        }
+
+        if (
+          invalidatedSlots.has(slot) ||
+          causalTranscriptKey !== finalizedTranscriptKey
+        ) {
+          suppressTarget(slot, target, content.text);
           continue;
         }
 

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -220,6 +220,50 @@ describe("voice conversation store lifecycle ordering", () => {
     unsubscribe();
   });
 
+  it("removes terminally rejected transcripts from pending rollback chains", async () => {
+    mocks.reject.mockResolvedValue({ attempts: 3, terminal: true });
+    const firstDelivery = deferred<void>();
+    const secondDelivery = deferred<void>();
+    const module = await import("./voiceConversationStore");
+    const unsubscribe = module.subscribeToVoiceConversationEvents((event) =>
+      event.type === "user" && event.id === "first-rejection"
+        ? firstDelivery.promise
+        : secondDelivery.promise,
+    );
+    await module.useVoiceConversationStore.getState().init();
+    module.useVoiceConversationStore.setState({
+      latestFinalizedTranscriptKey: "prior-transcript",
+    });
+
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "first-rejection",
+      text: "First failure",
+      revision: 1,
+      deliveryAttempts: 2,
+    });
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "second-rejection",
+      text: "Second failure",
+      revision: 2,
+      deliveryAttempts: 2,
+    });
+
+    firstDelivery.reject(new Error("chat unavailable"));
+    await vi.waitFor(() => expect(mocks.reject).toHaveBeenCalledOnce());
+    secondDelivery.reject(new Error("chat unavailable"));
+    await vi.waitFor(() => expect(mocks.reject).toHaveBeenCalledTimes(2));
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe("prior-transcript");
+    unsubscribe();
+  });
+
   it("records a recovered transcript before its subscriber settles", async () => {
     const delivery = deferred<void>();
     const transcript = {

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -192,6 +192,78 @@ describe("voice conversation store lifecycle ordering", () => {
     unsubscribe();
   });
 
+  it("records a recovered transcript before its subscriber settles", async () => {
+    const delivery = deferred<void>();
+    const transcript = {
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "recovered-k1",
+      text: "Recovered",
+      revision: 1,
+      deliveryAttempts: 1,
+    };
+    mocks.drain.mockResolvedValueOnce([transcript]);
+    const module = await import("./voiceConversationStore");
+    module.subscribeToVoiceConversationEvents(() => delivery.promise);
+    await module.useVoiceConversationStore.getState().init();
+
+    const draining = module.useVoiceConversationStore
+      .getState()
+      .drainPendingTranscripts("session-1");
+    await vi.waitFor(() => {
+      expect(
+        module.useVoiceConversationStore.getState()
+          .latestFinalizedTranscriptKey,
+      ).toBe(["session-1", "lifecycle-1", "1", "recovered-k1"].join("\0"));
+    });
+    expect(mocks.acknowledge).not.toHaveBeenCalled();
+
+    delivery.resolve();
+    await draining;
+  });
+
+  it("does not let an old retained transcript roll back a newer key", async () => {
+    mocks.acknowledge
+      .mockRejectedValueOnce(new Error("ack unavailable"))
+      .mockResolvedValue(undefined);
+    const module = await import("./voiceConversationStore");
+    module.subscribeToVoiceConversationEvents(() => Promise.resolve());
+    await module.useVoiceConversationStore.getState().init();
+    const oldTranscript = {
+      type: "user" as const,
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "old-k0",
+      text: "Old",
+      revision: 1,
+      deliveryAttempts: 0,
+    };
+    emit(oldTranscript);
+    await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledOnce());
+
+    emit({
+      ...oldTranscript,
+      id: "new-k1",
+      text: "New",
+    });
+    await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledTimes(2));
+    const newerKey = ["session-1", "lifecycle-1", "1", "new-k1"].join("\0");
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(newerKey);
+
+    mocks.drain.mockResolvedValueOnce([
+      { ...oldTranscript, deliveryAttempts: 1 },
+    ]);
+    await module.useVoiceConversationStore
+      .getState()
+      .drainPendingTranscripts("session-1");
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(newerKey);
+  });
+
   it("clears finalized STT at lifecycle boundaries", async () => {
     const store = await loadStore();
     emit({

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -337,6 +337,34 @@ describe("voice conversation store lifecycle ordering", () => {
     ).toBe(["session-1", "lifecycle-1", "1", "retry-k1"].join("\0"));
   });
 
+  it("does not rewind for a retained duplicate found in chat after reload", async () => {
+    const module = await import("./voiceConversationStore");
+    module.subscribeToVoiceConversationEvents(() => Promise.resolve());
+    await module.useVoiceConversationStore.getState().init();
+    const currentKey = ["session-1", "lifecycle-1", "1", "live-k1"].join("\0");
+    module.useVoiceConversationStore.setState({
+      latestFinalizedTranscriptKey: currentKey,
+    });
+    mocks.drain.mockResolvedValueOnce([
+      {
+        sessionId: "session-1",
+        lifecycleId: "lifecycle-1",
+        id: "retained-k0",
+        text: "Already in chat",
+        revision: 1,
+        deliveryAttempts: 1,
+      },
+    ]);
+
+    await module.useVoiceConversationStore
+      .getState()
+      .drainPendingTranscripts("session-1", () => true);
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(currentKey);
+  });
+
   it("clears finalized STT at lifecycle boundaries", async () => {
     const store = await loadStore();
     emit({

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -264,6 +264,41 @@ describe("voice conversation store lifecycle ordering", () => {
     ).toBe(newerKey);
   });
 
+  it("does not let an unseen retained transcript roll back a live key", async () => {
+    const module = await import("./voiceConversationStore");
+    module.subscribeToVoiceConversationEvents(() => Promise.resolve());
+    await module.useVoiceConversationStore.getState().init();
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "live-k1",
+      text: "Live",
+      revision: 1,
+      deliveryAttempts: 0,
+    });
+    await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledOnce());
+    const liveKey = ["session-1", "lifecycle-1", "1", "live-k1"].join("\0");
+
+    mocks.drain.mockResolvedValueOnce([
+      {
+        sessionId: "session-1",
+        lifecycleId: "lifecycle-1",
+        id: "unseen-retained-k0",
+        text: "Retained",
+        revision: 1,
+        deliveryAttempts: 1,
+      },
+    ]);
+    await module.useVoiceConversationStore
+      .getState()
+      .drainPendingTranscripts("session-1");
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(liveKey);
+  });
+
   it("clears finalized STT at lifecycle boundaries", async () => {
     const store = await loadStore();
     emit({

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -264,7 +264,7 @@ describe("voice conversation store lifecycle ordering", () => {
     ).toBe(newerKey);
   });
 
-  it("does not let an unseen retained transcript roll back a live key", async () => {
+  it("advances to an unseen retained transcript delivered after a live key", async () => {
     const module = await import("./voiceConversationStore");
     module.subscribeToVoiceConversationEvents(() => Promise.resolve());
     await module.useVoiceConversationStore.getState().init();
@@ -278,8 +278,6 @@ describe("voice conversation store lifecycle ordering", () => {
       deliveryAttempts: 0,
     });
     await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledOnce());
-    const liveKey = ["session-1", "lifecycle-1", "1", "live-k1"].join("\0");
-
     mocks.drain.mockResolvedValueOnce([
       {
         sessionId: "session-1",
@@ -296,7 +294,47 @@ describe("voice conversation store lifecycle ordering", () => {
 
     expect(
       module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
-    ).toBe(liveKey);
+    ).toBe(["session-1", "lifecycle-1", "1", "unseen-retained-k0"].join("\0"));
+  });
+
+  it("restores a retried transcript after lifecycle state clears", async () => {
+    mocks.acknowledge
+      .mockRejectedValueOnce(new Error("ack unavailable"))
+      .mockResolvedValue(undefined);
+    const module = await import("./voiceConversationStore");
+    module.subscribeToVoiceConversationEvents(() => Promise.resolve());
+    await module.useVoiceConversationStore.getState().init();
+    const transcript = {
+      type: "user" as const,
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "retry-k1",
+      text: "Retry",
+      revision: 1,
+      deliveryAttempts: 0,
+    };
+    emit(transcript);
+    await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledOnce());
+
+    emit({
+      type: "startup",
+      sessionId: "session-1",
+      ownerWindowLabel: "main",
+      line: "started",
+      revision: 2,
+    });
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBeNull();
+    mocks.drain.mockResolvedValueOnce([{ ...transcript, deliveryAttempts: 1 }]);
+
+    await module.useVoiceConversationStore
+      .getState()
+      .drainPendingTranscripts("session-1");
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(["session-1", "lifecycle-1", "1", "retry-k1"].join("\0"));
   });
 
   it("clears finalized STT at lifecycle boundaries", async () => {

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -192,6 +192,34 @@ describe("voice conversation store lifecycle ordering", () => {
     unsubscribe();
   });
 
+  it("restores prior causal state after terminal transcript rejection", async () => {
+    mocks.reject.mockResolvedValueOnce({ attempts: 3, terminal: true });
+    const module = await import("./voiceConversationStore");
+    const unsubscribe = module.subscribeToVoiceConversationEvents(() =>
+      Promise.reject(new Error("chat unavailable")),
+    );
+    await module.useVoiceConversationStore.getState().init();
+    module.useVoiceConversationStore.setState({
+      latestFinalizedTranscriptKey: "prior-transcript",
+    });
+
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "terminal-rejection",
+      text: "Cannot deliver",
+      revision: 1,
+      deliveryAttempts: 2,
+    });
+
+    await vi.waitFor(() => expect(mocks.reject).toHaveBeenCalledOnce());
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe("prior-transcript");
+    unsubscribe();
+  });
+
   it("records a recovered transcript before its subscriber settles", async () => {
     const delivery = deferred<void>();
     const transcript = {

--- a/src/features/voice-conversation/stores/voiceConversationStore.test.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.test.ts
@@ -135,6 +135,90 @@ describe("voice conversation store lifecycle ordering", () => {
     await Promise.all([first, second]);
   });
 
+  it("records finalized STT before transcript delivery settles", async () => {
+    const delivery = deferred<void>();
+    const module = await import("./voiceConversationStore");
+    const unsubscribe = module.subscribeToVoiceConversationEvents(
+      () => delivery.promise,
+    );
+    await module.useVoiceConversationStore.getState().init();
+
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "utterance-1",
+      text: "Hello",
+      revision: 1,
+      deliveryAttempts: 0,
+    });
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(["session-1", "lifecycle-1", "1", "utterance-1"].join("\0"));
+    expect(mocks.acknowledge).not.toHaveBeenCalled();
+    expect(mocks.reject).not.toHaveBeenCalled();
+
+    delivery.resolve();
+    await vi.waitFor(() => expect(mocks.acknowledge).toHaveBeenCalledOnce());
+    unsubscribe();
+  });
+
+  it("retains finalized STT when transcript delivery rejects", async () => {
+    const module = await import("./voiceConversationStore");
+    const unsubscribe = module.subscribeToVoiceConversationEvents(() =>
+      Promise.reject(new Error("chat unavailable")),
+    );
+    await module.useVoiceConversationStore.getState().init();
+
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "utterance-2",
+      text: "Hello again",
+      revision: 1,
+      deliveryAttempts: 0,
+    });
+
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toBe(["session-1", "lifecycle-1", "1", "utterance-2"].join("\0"));
+    await vi.waitFor(() => expect(mocks.reject).toHaveBeenCalledOnce());
+    expect(mocks.acknowledge).not.toHaveBeenCalled();
+    expect(
+      module.useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    ).toContain("utterance-2");
+    unsubscribe();
+  });
+
+  it("clears finalized STT at lifecycle boundaries", async () => {
+    const store = await loadStore();
+    emit({
+      type: "user",
+      sessionId: "session-1",
+      lifecycleId: "lifecycle-1",
+      id: "utterance-1",
+      text: "Hello",
+      revision: 1,
+      deliveryAttempts: 0,
+    });
+    expect(store.getState().latestFinalizedTranscriptKey).not.toBeNull();
+
+    emit({
+      type: "startup",
+      sessionId: "session-2",
+      ownerWindowLabel: "main",
+      line: "started",
+      revision: 2,
+    });
+    expect(store.getState().latestFinalizedTranscriptKey).toBeNull();
+
+    store.setState({ latestFinalizedTranscriptKey: "stale" });
+    emit({ type: "cleanShutdown", sessionId: "session-2", revision: 3 });
+    expect(store.getState().latestFinalizedTranscriptKey).toBeNull();
+  });
+
   it("blocks new starts until an archive transition releases its lease", async () => {
     const { blockVoiceConversationStarts, useVoiceConversationStore } =
       await import("./voiceConversationStore");

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -92,12 +92,15 @@ const observedFinalizedTranscriptOrder: string[] = [];
 
 function observeFinalizedTranscript(transcript: PendingVoiceTranscript): void {
   const key = finalizedTranscriptKey(transcript);
-  if (observedFinalizedTranscripts.has(key)) return;
-  observedFinalizedTranscripts.add(key);
-  observedFinalizedTranscriptOrder.push(key);
-  if (observedFinalizedTranscriptOrder.length > MAX_DELIVERED_TRANSCRIPT_KEYS) {
-    const expired = observedFinalizedTranscriptOrder.shift();
-    if (expired) observedFinalizedTranscripts.delete(expired);
+  if (!observedFinalizedTranscripts.has(key)) {
+    observedFinalizedTranscripts.add(key);
+    observedFinalizedTranscriptOrder.push(key);
+    if (
+      observedFinalizedTranscriptOrder.length > MAX_DELIVERED_TRANSCRIPT_KEYS
+    ) {
+      const expired = observedFinalizedTranscriptOrder.shift();
+      if (expired) observedFinalizedTranscripts.delete(expired);
+    }
   }
   useVoiceConversationStore.setState({ latestFinalizedTranscriptKey: key });
 }
@@ -935,18 +938,15 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
           count: pendingTranscripts.length,
         });
       }
-      let recoveredCursor: string | null = null;
       for (const transcript of pendingTranscripts) {
         const key = finalizedTranscriptKey(transcript);
         const current =
           useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
-        if (
-          current === null ||
-          current === key ||
-          (recoveredCursor !== null && current === recoveredCursor)
-        ) {
+        const alreadyDelivered = deliveredTranscripts.has(
+          transcriptKey(transcript),
+        );
+        if (!alreadyDelivered || current === null || current === key) {
           observeFinalizedTranscript(transcript);
-          recoveredCursor = key;
         }
         if (!(await deliverTranscriptOnce(transcript))) {
           throw new Error("Voice transcript delivery was rejected.");

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -66,7 +66,10 @@ interface VoiceConversationStore {
   ) => Promise<VoiceConversationStatus>;
   setMicrophoneMuted: (muted: boolean) => Promise<void>;
   setUiState: (state: VoiceConversationUiState, error?: string) => void;
-  drainPendingTranscripts: (sessionId: string) => Promise<void>;
+  drainPendingTranscripts: (
+    sessionId: string,
+    transcriptAlreadyInChat?: (transcript: PendingVoiceTranscript) => boolean,
+  ) => Promise<void>;
 }
 
 function finalizedTranscriptKey(event: PendingVoiceTranscript): string {
@@ -930,7 +933,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
       });
     },
 
-    drainPendingTranscripts: async (sessionId) => {
+    drainPendingTranscripts: async (sessionId, transcriptAlreadyInChat) => {
       const pendingTranscripts =
         await drainVoiceConversationTranscripts(sessionId);
       if (pendingTranscripts.length > 0) {
@@ -942,9 +945,9 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
         const key = finalizedTranscriptKey(transcript);
         const current =
           useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
-        const alreadyDelivered = deliveredTranscripts.has(
-          transcriptKey(transcript),
-        );
+        const alreadyDelivered =
+          deliveredTranscripts.has(transcriptKey(transcript)) ||
+          transcriptAlreadyInChat?.(transcript) === true;
         if (!alreadyDelivered || current === null || current === key) {
           observeFinalizedTranscript(transcript);
         }

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -90,21 +90,9 @@ const transcriptDeliveries = new Map<string, Promise<boolean>>();
 const deliveredTranscripts = new Set<string>();
 const deliveredTranscriptOrder: string[] = [];
 const MAX_DELIVERED_TRANSCRIPT_KEYS = 256;
-const observedFinalizedTranscripts = new Set<string>();
-const observedFinalizedTranscriptOrder: string[] = [];
 
 function observeFinalizedTranscript(transcript: PendingVoiceTranscript): void {
   const key = finalizedTranscriptKey(transcript);
-  if (!observedFinalizedTranscripts.has(key)) {
-    observedFinalizedTranscripts.add(key);
-    observedFinalizedTranscriptOrder.push(key);
-    if (
-      observedFinalizedTranscriptOrder.length > MAX_DELIVERED_TRANSCRIPT_KEYS
-    ) {
-      const expired = observedFinalizedTranscriptOrder.shift();
-      if (expired) observedFinalizedTranscripts.delete(expired);
-    }
-  }
   useVoiceConversationStore.setState({ latestFinalizedTranscriptKey: key });
 }
 

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -87,6 +87,20 @@ const transcriptDeliveries = new Map<string, Promise<boolean>>();
 const deliveredTranscripts = new Set<string>();
 const deliveredTranscriptOrder: string[] = [];
 const MAX_DELIVERED_TRANSCRIPT_KEYS = 256;
+const observedFinalizedTranscripts = new Set<string>();
+const observedFinalizedTranscriptOrder: string[] = [];
+
+function observeFinalizedTranscript(transcript: PendingVoiceTranscript): void {
+  const key = finalizedTranscriptKey(transcript);
+  if (observedFinalizedTranscripts.has(key)) return;
+  observedFinalizedTranscripts.add(key);
+  observedFinalizedTranscriptOrder.push(key);
+  if (observedFinalizedTranscriptOrder.length > MAX_DELIVERED_TRANSCRIPT_KEYS) {
+    const expired = observedFinalizedTranscriptOrder.shift();
+    if (expired) observedFinalizedTranscripts.delete(expired);
+  }
+  useVoiceConversationStore.setState({ latestFinalizedTranscriptKey: key });
+}
 
 export function subscribeToVoiceConversationEvents(
   subscriber: (event: VoiceConversationEvent) => void | Promise<void>,
@@ -320,6 +334,8 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
         await listenToVoiceConversation((event) => {
           if (!shouldApplyEventRevision(get().status, event.revision)) return;
 
+          if (event.type === "user") observeFinalizedTranscript(event);
+
           if (event.type === "microphoneMute") {
             microphoneMuteIntent += 1;
             microphoneMuteStateVersion += 1;
@@ -373,7 +389,6 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
               case "user":
                 return {
                   ...state,
-                  latestFinalizedTranscriptKey: finalizedTranscriptKey(event),
                   status: {
                     ...state.status,
                     lifecycle: "running",
@@ -921,6 +936,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
         });
       }
       for (const transcript of pendingTranscripts) {
+        observeFinalizedTranscript(transcript);
         if (!(await deliverTranscriptOnce(transcript))) {
           throw new Error("Voice transcript delivery was rejected.");
         }

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -189,6 +189,14 @@ async function deliverTranscriptOnce(
       if (rejection.terminal) {
         const priorKey = priorFinalizedTranscriptKeys.get(key) ?? null;
         priorFinalizedTranscriptKeys.delete(key);
+        for (const [
+          pendingKey,
+          pendingPriorKey,
+        ] of priorFinalizedTranscriptKeys) {
+          if (pendingPriorKey === finalizedKey) {
+            priorFinalizedTranscriptKeys.set(pendingKey, priorKey);
+          }
+        }
         useVoiceConversationStore.setState((state) =>
           state.latestFinalizedTranscriptKey === finalizedKey
             ? { latestFinalizedTranscriptKey: priorKey }

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -935,8 +935,19 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
           count: pendingTranscripts.length,
         });
       }
+      let recoveredCursor: string | null = null;
       for (const transcript of pendingTranscripts) {
-        observeFinalizedTranscript(transcript);
+        const key = finalizedTranscriptKey(transcript);
+        const current =
+          useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
+        if (
+          current === null ||
+          current === key ||
+          (recoveredCursor !== null && current === recoveredCursor)
+        ) {
+          observeFinalizedTranscript(transcript);
+          recoveredCursor = key;
+        }
         if (!(await deliverTranscriptOnce(transcript))) {
           throw new Error("Voice transcript delivery was rejected.");
         }

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -90,9 +90,17 @@ const transcriptDeliveries = new Map<string, Promise<boolean>>();
 const deliveredTranscripts = new Set<string>();
 const deliveredTranscriptOrder: string[] = [];
 const MAX_DELIVERED_TRANSCRIPT_KEYS = 256;
+const priorFinalizedTranscriptKeys = new Map<string, string | null>();
 
 function observeFinalizedTranscript(transcript: PendingVoiceTranscript): void {
+  const deliveryKey = transcriptKey(transcript);
   const key = finalizedTranscriptKey(transcript);
+  if (!priorFinalizedTranscriptKeys.has(deliveryKey)) {
+    priorFinalizedTranscriptKeys.set(
+      deliveryKey,
+      useVoiceConversationStore.getState().latestFinalizedTranscriptKey,
+    );
+  }
   useVoiceConversationStore.setState({ latestFinalizedTranscriptKey: key });
 }
 
@@ -156,6 +164,7 @@ async function deliverTranscriptOnce(
   const key = transcriptKey(transcript);
   if (deliveredTranscripts.has(key)) {
     await acknowledgeVoiceConversationTranscript(transcript);
+    priorFinalizedTranscriptKeys.delete(key);
     return true;
   }
 
@@ -163,6 +172,7 @@ async function deliverTranscriptOnce(
   if (existing) return existing;
 
   const event = { type: "user" as const, ...transcript };
+  const finalizedKey = finalizedTranscriptKey(transcript);
   const subscribers = [...eventSubscribers];
   if (subscribers.length === 0) return false;
   const delivery = (async () => {
@@ -173,8 +183,18 @@ async function deliverTranscriptOnce(
     if (accepted) {
       rememberDeliveredTranscript(key);
       await acknowledgeVoiceConversationTranscript(transcript);
+      priorFinalizedTranscriptKeys.delete(key);
     } else {
-      await rejectVoiceConversationTranscript(transcript);
+      const rejection = await rejectVoiceConversationTranscript(transcript);
+      if (rejection.terminal) {
+        const priorKey = priorFinalizedTranscriptKeys.get(key) ?? null;
+        priorFinalizedTranscriptKeys.delete(key);
+        useVoiceConversationStore.setState((state) =>
+          state.latestFinalizedTranscriptKey === finalizedKey
+            ? { latestFinalizedTranscriptKey: priorKey }
+            : state,
+        );
+      }
     }
     return accepted;
   })().finally(() => transcriptDeliveries.delete(key));
@@ -342,6 +362,15 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
           ) {
             microphoneMuteIntent += 1;
             microphoneMuteStateVersion += 1;
+          }
+
+          if (
+            event.type === "startup" ||
+            event.type === "cleanShutdown" ||
+            event.type === "controlsDismissed" ||
+            (event.type === "error" && event.terminal)
+          ) {
+            priorFinalizedTranscriptKeys.clear();
           }
 
           set((state) => {

--- a/src/features/voice-conversation/stores/voiceConversationStore.ts
+++ b/src/features/voice-conversation/stores/voiceConversationStore.ts
@@ -49,6 +49,7 @@ interface VoiceConversationStore {
   error: string | null;
   hydrated: boolean;
   requestedStartSessionId: string | null;
+  latestFinalizedTranscriptKey: string | null;
   init: () => Promise<void>;
   refreshStatus: () => Promise<VoiceConversationStatus>;
   requestStart: (sessionId: string) => void;
@@ -66,6 +67,10 @@ interface VoiceConversationStore {
   setMicrophoneMuted: (muted: boolean) => Promise<void>;
   setUiState: (state: VoiceConversationUiState, error?: string) => void;
   drainPendingTranscripts: (sessionId: string) => Promise<void>;
+}
+
+function finalizedTranscriptKey(event: PendingVoiceTranscript): string {
+  return `${event.sessionId}\0${event.lifecycleId}\0${event.revision}\0${event.id}`;
 }
 
 let initialized = false;
@@ -233,6 +238,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
     error: null,
     hydrated: false,
     requestedStartSessionId: null,
+    latestFinalizedTranscriptKey: null,
 
     requestStart: (sessionId) => set({ requestedStartSessionId: sessionId }),
     clearRequestedStart: (sessionId) =>
@@ -343,6 +349,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
                   },
                   uiState: "listening",
                   microphoneMuted: false,
+                  latestFinalizedTranscriptKey: null,
                   error: null,
                 };
               case "microphoneMute": {
@@ -366,6 +373,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
               case "user":
                 return {
                   ...state,
+                  latestFinalizedTranscriptKey: finalizedTranscriptKey(event),
                   status: {
                     ...state.status,
                     lifecycle: "running",
@@ -427,6 +435,7 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
                   assistantSpeaking: false,
                   microphoneMuted: false,
                   activityFallbackState: "listening",
+                  latestFinalizedTranscriptKey: null,
                   error: preservesTerminalError ? state.error : null,
                 };
               }
@@ -451,6 +460,9 @@ export const useVoiceConversationStore = create<VoiceConversationStore>(
                   microphoneMuted: event.terminal
                     ? false
                     : state.microphoneMuted,
+                  latestFinalizedTranscriptKey: event.terminal
+                    ? null
+                    : state.latestFinalizedTranscriptKey,
                   error: event.message,
                 };
             }


### PR DESCRIPTION
## Summary

Fixes voice turn-taking when speech recognition finalization and voice activity do not arrive together. Assistant speech that becomes ready while the user is still speaking waits for silence, then plays only if no newer finalized utterance invalidated that response.

Barge-in invalidates the entire causal assistant response. Any later text streamed by that interrupted response remains unspoken, while the response to the newer user utterance can play normally.

## Reviewer-reproducible examples

- In a voice conversation, speak a multi-sentence prompt without pausing after the first clause. The assistant waits for you to finish instead of beginning after an earlier finalized transcript.
- Ask for a long response, then interrupt while the response is still streaming. The current audio stops, its later streamed tail does not play after you finish speaking, and the response to your new utterance can play.

## Testing

Manually confirmed continued speech and barge-in with Apple speech recognition. The assistant waited through continued speech, stopped on interruption, and spoke the replacement response without replaying the old tail.