### PR TITLE
refactor(voice): hide ready Apple speech details

### DIFF
--- a/src/features/voice-conversation/ui/MacSpeechSettings.tsx
+++ b/src/features/voice-conversation/ui/MacSpeechSettings.tsx
@@ -18,6 +18,9 @@ export function MacSpeechSettings({ setup }: { setup: MacSpeechSetup }) {
   if (!status?.supported) {
     return null;
   }
+  if (status.modelInstalled) {
+    return null;
+  }
 
   const locale = status.locale ?? t("voice.macSpeechSystemLocale");
   const error = setup.error ?? status.error;
@@ -25,13 +28,9 @@ export function MacSpeechSettings({ setup }: { setup: MacSpeechSetup }) {
     <div className="space-y-3 overflow-hidden">
       <SettingsRow
         label={t("voice.macSpeechModel")}
-        description={
-          status.modelInstalled
-            ? t("voice.macSpeechInstalled", { locale })
-            : t("voice.macSpeechNotInstalled", { locale })
-        }
+        description={t("voice.macSpeechNotInstalled", { locale })}
         action={
-          status.modelInstalled || status.installing ? undefined : (
+          status.installing ? undefined : (
             <Button
               type="button"
               variant="outline"

--- a/src/features/voice-conversation/ui/VoiceSettings.test.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.test.tsx
@@ -491,4 +491,31 @@ describe("VoiceSettings", () => {
       screen.getByRole("button", { name: "Download model" }),
     ).toBeEnabled();
   });
+
+  it("hides Apple speech model details when speech recognition is ready", () => {
+    inputState.backend = "macos";
+    setupState.current = setup(pocketStatus({ pocketInstalled: true }));
+    macSpeechSetupState.current = {
+      status: {
+        supported: true,
+        unavailableReason: null,
+        locale: "en-CA",
+        localeSupported: true,
+        modelInstalled: true,
+        installing: false,
+        progress: null,
+        error: null,
+        revision: 1,
+      },
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      install: vi.fn(),
+    };
+
+    renderWithProviders(<VoiceSettings />);
+
+    expect(screen.queryByText("On-device dictation")).not.toBeInTheDocument();
+    expect(screen.queryByText("Installed for en-CA")).not.toBeInTheDocument();
+  });
 });

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -883,7 +883,6 @@
     "downloadProgress": "{{downloaded}} of {{total}}",
     "inputBackendDescription": "Choose how Berd transcribes your speech.",
     "macSpeechDownloading": "Downloading dictation model… {{progress}}%",
-    "macSpeechInstalled": "Installed for {{locale}}",
     "macSpeechLoading": "Checking macOS speech recognition…",
     "macSpeechLocaleUnsupported": "Apple speech recognition does not support {{locale}}.",
     "macSpeechModel": "On-device dictation",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -886,7 +886,6 @@
     "downloadProgress": "{{downloaded}} de {{total}}",
     "inputBackendDescription": "Elige cómo Berd transcribe tu voz.",
     "macSpeechDownloading": "Descargando el modelo de dictado… {{progress}} %",
-    "macSpeechInstalled": "Instalado para {{locale}}",
     "macSpeechLoading": "Comprobando el reconocimiento de voz de macOS…",
     "macSpeechLocaleUnsupported": "El reconocimiento de voz de Apple no admite {{locale}}.",
     "macSpeechModel": "Dictado en el dispositivo",


### PR DESCRIPTION
## Summary

Keeps Apple speech recognition setup quiet when it is already ready. Voice settings only show the on-device dictation row when the selected locale needs a model download, is downloading, is unsupported, or has an actionable error.

## Reviewer-reproducible examples

- Select Apple speech recognition on a Mac where it is ready, then open Voice settings. The redundant “On-device dictation / Installed for …” row is absent.
- On a Mac where the selected locale needs speech assets, open Voice settings. The download action, progress, retry, and error states remain available.

## Testing

Manually verified the simplified ready state in the separate macOS dev build.