### PR TITLE
refactor(voice): compact backend settings

### DIFF
--- a/src/features/voice-conversation/ui/PocketVoiceSetupContent.test.tsx
+++ b/src/features/voice-conversation/ui/PocketVoiceSetupContent.test.tsx
@@ -174,8 +174,9 @@ describe("PocketVoiceSetupContent", () => {
       />,
     );
 
-    expect(screen.getByText("Pocket TTS")).toBeInTheDocument();
-    expect(screen.getByText("Parakeet STT")).toBeInTheDocument();
+    expect(screen.getByTestId("voice-model-pocket")).toBeInTheDocument();
+    expect(screen.getByTestId("voice-model-parakeet")).toBeInTheDocument();
+    expect(screen.getByText(/173.8 MB on disk/)).toBeInTheDocument();
     expect(screen.getByText(/131.7 MB on disk/)).toBeInTheDocument();
   });
 

--- a/src/features/voice-conversation/ui/PocketVoiceSetupContent.tsx
+++ b/src/features/voice-conversation/ui/PocketVoiceSetupContent.tsx
@@ -17,12 +17,10 @@ export function PocketVoiceSetupContent({
   setup,
   models: visibleModels,
   showPocketVoiceControls = true,
-  embedded = false,
 }: {
   setup: PocketVoiceSetup;
   models?: VoiceModelKind[];
   showPocketVoiceControls?: boolean;
-  embedded?: boolean;
 }) {
   const { t } = useTranslation("settings");
   const { status } = setup;
@@ -40,7 +38,6 @@ export function PocketVoiceSetupContent({
   const models = [
     {
       model: "pocket" as const,
-      label: "Pocket TTS",
       installed: pocketInstalled,
       diskBytes: status?.pocketSizeBytes ?? null,
       downloadBytes: status?.pocketDownloadBytes ?? 0,
@@ -54,7 +51,6 @@ export function PocketVoiceSetupContent({
     },
     {
       model: "parakeet" as const,
-      label: "Parakeet STT",
       installed: parakeetInstalled,
       diskBytes: status?.parakeetSizeBytes ?? null,
       downloadBytes: status?.parakeetDownloadBytes ?? 0,
@@ -74,7 +70,6 @@ export function PocketVoiceSetupContent({
         {models.map(
           ({
             model,
-            label,
             installed,
             diskBytes,
             downloadBytes,
@@ -86,29 +81,16 @@ export function PocketVoiceSetupContent({
               key={model}
               data-testid={`voice-model-${model}`}
               label={
-                embedded
-                  ? installed
-                    ? t("voice.modelInstalledSize", {
-                        size: formatBytes(diskBytes ?? 0),
-                      })
-                    : t("voice.modelMissingSize", {
-                        size: formatBytes(downloadBytes),
-                      })
-                  : label
+                installed
+                  ? t("voice.modelInstalledSize", {
+                      size: formatBytes(diskBytes ?? 0),
+                    })
+                  : t("voice.modelMissingSize", {
+                      size: formatBytes(downloadBytes),
+                    })
               }
-              description={
-                embedded
-                  ? undefined
-                  : installed
-                    ? t("voice.modelInstalledSize", {
-                        size: formatBytes(diskBytes ?? 0),
-                      })
-                    : t("voice.modelMissingSize", {
-                        size: formatBytes(downloadBytes),
-                      })
-              }
-              density={embedded ? "compact" : "default"}
-              className={embedded ? "rounded-md bg-muted/40 pl-3.5" : undefined}
+              density="compact"
+              className="rounded-md bg-muted/40 pl-3.5"
               action={
                 inProgress ? undefined : installed ? (
                   <Button

--- a/src/features/voice-conversation/ui/PocketVoiceSetupContent.tsx
+++ b/src/features/voice-conversation/ui/PocketVoiceSetupContent.tsx
@@ -17,10 +17,12 @@ export function PocketVoiceSetupContent({
   setup,
   models: visibleModels,
   showPocketVoiceControls = true,
+  embedded = false,
 }: {
   setup: PocketVoiceSetup;
   models?: VoiceModelKind[];
   showPocketVoiceControls?: boolean;
+  embedded?: boolean;
 }) {
   const { t } = useTranslation("settings");
   const { status } = setup;
@@ -83,16 +85,30 @@ export function PocketVoiceSetupContent({
             <SettingsRow
               key={model}
               data-testid={`voice-model-${model}`}
-              label={label}
-              description={
-                installed
-                  ? t("voice.modelInstalledSize", {
-                      size: formatBytes(diskBytes ?? 0),
-                    })
-                  : t("voice.modelMissingSize", {
-                      size: formatBytes(downloadBytes),
-                    })
+              label={
+                embedded
+                  ? installed
+                    ? t("voice.modelInstalledSize", {
+                        size: formatBytes(diskBytes ?? 0),
+                      })
+                    : t("voice.modelMissingSize", {
+                        size: formatBytes(downloadBytes),
+                      })
+                  : label
               }
+              description={
+                embedded
+                  ? undefined
+                  : installed
+                    ? t("voice.modelInstalledSize", {
+                        size: formatBytes(diskBytes ?? 0),
+                      })
+                    : t("voice.modelMissingSize", {
+                        size: formatBytes(downloadBytes),
+                      })
+              }
+              density={embedded ? "compact" : "default"}
+              className={embedded ? "rounded-md bg-muted/40 pl-3.5" : undefined}
               action={
                 inProgress ? undefined : installed ? (
                   <Button

--- a/src/features/voice-conversation/ui/VoiceSettings.test.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.test.tsx
@@ -187,7 +187,12 @@ describe("VoiceSettings", () => {
     const view = renderWithProviders(<VoiceSettings />);
 
     expect(
-      screen.getByRole("radiogroup", { name: "While Berd is speaking" }),
+      screen.getByRole("radiogroup", { name: "Interruptions" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Choose what happens when you speak while Berd is talking.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /^Automatic/ })).toBeChecked();
     expect(
@@ -237,7 +242,7 @@ describe("VoiceSettings", () => {
     renderWithProviders(<VoiceSettings />);
 
     expect(
-      screen.getByRole("radiogroup", { name: "While Berd is speaking" }),
+      screen.getByRole("radiogroup", { name: "Interruptions" }),
     ).toBeInTheDocument();
     const sensitivity = screen.getByRole("combobox", {
       name: "Interruption sensitivity",
@@ -292,8 +297,10 @@ describe("VoiceSettings", () => {
     expect(outputPicker).toHaveClass("w-full", "sm:w-auto");
     expect(
       screen.getByRole("heading", { name: "Speech output" }).parentElement
-        ?.parentElement,
+        ?.parentElement?.parentElement,
     ).toHaveClass("flex-col", "sm:flex-row");
+    expect(screen.getAllByText("Pocket TTS")).toHaveLength(1);
+    expect(screen.getAllByText("Parakeet STT")).toHaveLength(1);
   });
 
   it("keeps the Voice settings page open while Parakeet completes in place", () => {
@@ -336,12 +343,12 @@ describe("VoiceSettings", () => {
     expect(modelList).toHaveClass("divide-y", "divide-border");
     expect(modelList).not.toHaveClass("border", "rounded-md");
     expect(screen.getByTestId("voice-model-pocket")).toHaveClass(
-      "pr-4",
-      "py-4",
+      "py-2.5",
+      "pl-3.5",
+      "bg-muted/40",
     );
-    expect(screen.getByTestId("voice-model-pocket")).not.toHaveClass(
-      "pl-4",
-      "px-4",
+    expect(screen.getByTestId("voice-model-pocket")).not.toHaveTextContent(
+      "Pocket TTS",
     );
 
     setupState.current = setup({

--- a/src/features/voice-conversation/ui/VoiceSettings.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.tsx
@@ -6,6 +6,7 @@ import { getPlatform } from "@/shared/lib/platform";
 import { SettingsPage } from "@/shared/ui/SettingsPage";
 import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
 import { RadioGroup, RadioGroupItem } from "@/shared/ui/radio-group";
+import { SettingsRow } from "@/shared/ui/settings-row";
 import {
   Select,
   SelectContent,
@@ -135,19 +136,15 @@ export function VoiceSettings() {
         </Alert>
       ) : null}
       <section className="space-y-2 overflow-hidden">
-        <div className="flex min-w-0 flex-col gap-4 py-4 pr-4 sm:flex-row sm:items-center">
-          <div className="min-w-0 flex-1">
-            <h2 id={inputHeadingId} className="text-sm font-medium">
-              {t("voice.speechInput")}
-            </h2>
-            <p
-              id={inputDescriptionId}
-              className="mt-0.5 text-xs text-muted-foreground"
-            >
-              {t("voice.inputBackendDescription")}
-            </p>
-          </div>
-          <div className="w-full min-w-0 sm:w-auto sm:shrink-0">
+        <SettingsRow
+          label={
+            <h2 className="text-sm font-medium">{t("voice.speechInput")}</h2>
+          }
+          description={t("voice.inputBackendDescription")}
+          labelId={inputHeadingId}
+          descriptionId={inputDescriptionId}
+          layout="responsive"
+          action={({ labelId, descriptionId }) => (
             <Select
               value={input.backend ?? undefined}
               disabled={input.backend === null}
@@ -157,8 +154,8 @@ export function VoiceSettings() {
             >
               <SelectTrigger
                 className="w-full sm:w-auto"
-                aria-labelledby={inputHeadingId}
-                aria-describedby={inputDescriptionId}
+                aria-labelledby={labelId}
+                aria-describedby={descriptionId}
               >
                 <SelectValue placeholder={t("voice.macSpeechLoading")} />
               </SelectTrigger>
@@ -174,32 +171,31 @@ export function VoiceSettings() {
                 ) : null}
               </SelectContent>
             </Select>
-          </div>
-        </div>
-        {input.backend === "macos" ? (
-          <MacSpeechSettings setup={macSpeechSetup} />
-        ) : input.backend === "parakeet" ? (
-          <PocketVoiceSetupContent
-            setup={setup}
-            models={["parakeet"]}
-            showPocketVoiceControls={false}
-          />
-        ) : null}
+          )}
+          details={
+            input.backend === "macos" ? (
+              <MacSpeechSettings setup={macSpeechSetup} />
+            ) : input.backend === "parakeet" ? (
+              <PocketVoiceSetupContent
+                setup={setup}
+                models={["parakeet"]}
+                showPocketVoiceControls={false}
+                embedded
+              />
+            ) : null
+          }
+        />
       </section>
       <section className="space-y-2">
-        <div className="flex min-w-0 flex-col gap-4 py-4 pr-4 sm:flex-row sm:items-center">
-          <div className="min-w-0 flex-1">
-            <h2 id={outputHeadingId} className="text-sm font-medium">
-              {t("voice.speechOutput")}
-            </h2>
-            <p
-              id={outputDescriptionId}
-              className="mt-0.5 text-xs text-muted-foreground"
-            >
-              {t("voice.outputBackendDescription")}
-            </p>
-          </div>
-          <div className="w-full min-w-0 sm:w-auto sm:shrink-0">
+        <SettingsRow
+          label={
+            <h2 className="text-sm font-medium">{t("voice.speechOutput")}</h2>
+          }
+          description={t("voice.outputBackendDescription")}
+          labelId={outputHeadingId}
+          descriptionId={outputDescriptionId}
+          layout="responsive"
+          action={({ labelId, descriptionId }) => (
             <Select
               value={output.backend}
               onValueChange={(value) =>
@@ -208,8 +204,8 @@ export function VoiceSettings() {
             >
               <SelectTrigger
                 className="w-full sm:w-auto"
-                aria-labelledby={outputHeadingId}
-                aria-describedby={outputDescriptionId}
+                aria-labelledby={labelId}
+                aria-describedby={descriptionId}
               >
                 <SelectValue />
               </SelectTrigger>
@@ -222,18 +218,27 @@ export function VoiceSettings() {
                 ) : null}
               </SelectContent>
             </Select>
-          </div>
-        </div>
-        {output.backend === "siri" ? (
-          <SiriVoiceSettings setup={siriSetup} />
-        ) : (
-          <PocketVoiceSetupContent setup={setup} models={["pocket"]} />
-        )}
+          )}
+          details={
+            output.backend === "siri" ? (
+              <SiriVoiceSettings setup={siriSetup} />
+            ) : (
+              <PocketVoiceSetupContent
+                setup={setup}
+                models={["pocket"]}
+                embedded
+              />
+            )
+          }
+        />
       </section>
       <section className="space-y-4 py-4 pr-4">
         <h2 id={interruptionHeadingId} className="text-sm font-medium">
           {t("voice.interruptionMode")}
         </h2>
+        <p className="text-xs text-muted-foreground">
+          {t("voice.interruptionDescription")}
+        </p>
         <RadioGroup
           value={interruption.mode}
           onValueChange={(value) =>

--- a/src/features/voice-conversation/ui/VoiceSettings.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.tsx
@@ -82,6 +82,7 @@ export function VoiceSettings() {
   const outputHeadingId = useId();
   const outputDescriptionId = useId();
   const interruptionHeadingId = useId();
+  const interruptionDescriptionId = useId();
   const sensitivityHeadingId = useId();
   const sensitivityDescriptionId = useId();
   const inputReady =
@@ -180,7 +181,6 @@ export function VoiceSettings() {
                 setup={setup}
                 models={["parakeet"]}
                 showPocketVoiceControls={false}
-                embedded
               />
             ) : null
           }
@@ -223,11 +223,7 @@ export function VoiceSettings() {
             output.backend === "siri" ? (
               <SiriVoiceSettings setup={siriSetup} />
             ) : (
-              <PocketVoiceSetupContent
-                setup={setup}
-                models={["pocket"]}
-                embedded
-              />
+              <PocketVoiceSetupContent setup={setup} models={["pocket"]} />
             )
           }
         />
@@ -236,7 +232,10 @@ export function VoiceSettings() {
         <h2 id={interruptionHeadingId} className="text-sm font-medium">
           {t("voice.interruptionMode")}
         </h2>
-        <p className="text-xs text-muted-foreground">
+        <p
+          id={interruptionDescriptionId}
+          className="text-xs text-muted-foreground"
+        >
           {t("voice.interruptionDescription")}
         </p>
         <RadioGroup
@@ -245,6 +244,7 @@ export function VoiceSettings() {
             interruption.setMode(value as VoiceInterruptionMode)
           }
           aria-labelledby={interruptionHeadingId}
+          aria-describedby={interruptionDescriptionId}
           className="gap-2"
         >
           {INTERRUPTION_MODES.map((mode) => {

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -889,7 +889,8 @@
     "macSpeechModel": "On-device dictation",
     "macSpeechNotInstalled": "Not installed for {{locale}}",
     "macSpeechSystemLocale": "the system language",
-    "interruptionMode": "While Berd is speaking",
+    "interruptionDescription": "Choose what happens when you speak while Berd is talking.",
+    "interruptionMode": "Interruptions",
     "interruptionModeDescriptions": {
       "allowInterruptions": "Berd keeps listening on every audio device. You can interrupt, but speaker audio may be mistaken for your voice.",
       "automatic": "Allows interruptions on most audio devices. If the device name contains “speaker,” Berd pauses listening to prevent feedback.",

--- a/src/shared/i18n/locales/es/settings.json
+++ b/src/shared/i18n/locales/es/settings.json
@@ -892,7 +892,8 @@
     "macSpeechModel": "Dictado en el dispositivo",
     "macSpeechNotInstalled": "No instalado para {{locale}}",
     "macSpeechSystemLocale": "el idioma del sistema",
-    "interruptionMode": "Mientras Berd habla",
+    "interruptionDescription": "Elige qué ocurre cuando hablas mientras Berd habla.",
+    "interruptionMode": "Interrupciones",
     "interruptionModeDescriptions": {
       "allowInterruptions": "Berd sigue escuchando en todos los dispositivos de audio. Puedes interrumpirlo, pero el audio de los altavoces podría confundirse con tu voz.",
       "automatic": "Permite interrupciones en la mayoría de los dispositivos de audio. Si el nombre del dispositivo contiene «speaker», Berd deja de escuchar para evitar la retroalimentación.",

--- a/src/shared/ui/settings-row.tsx
+++ b/src/shared/ui/settings-row.tsx
@@ -16,7 +16,7 @@ interface SettingsRowProps
   children?: ReactNode;
   details?: ReactNode | ((context: SettingsRowSlotContext) => ReactNode);
   align?: "center" | "start";
-  layout?: "inline" | "stacked";
+  layout?: "inline" | "stacked" | "responsive";
   density?: "default" | "compact";
   labelId?: string;
   descriptionId?: string;
@@ -75,6 +75,8 @@ export function SettingsRow({
           "flex min-w-0 gap-4",
           align === "center" ? "items-center" : "items-start",
           layout === "stacked" && "flex-col items-stretch gap-3",
+          layout === "responsive" &&
+            "flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:gap-4",
         )}
       >
         {leading ? (
@@ -109,6 +111,7 @@ export function SettingsRow({
             className={cn(
               "min-w-0 shrink-0",
               layout === "stacked" && "w-full",
+              layout === "responsive" && "w-full sm:w-auto",
               actionClassName,
             )}
           >


### PR DESCRIPTION
## Summary

Voice settings now presents each speech backend and its model state as one compact settings row, so Pocket TTS and Parakeet STT are not repeated in adjacent rows. Download, removal, progress, playback, and voice controls remain available beneath the selected backend.

The speaking behavior section is labeled “Interruptions” with a short description associated with its controls.

## Screenshots

### Compact backend settings

<img width="1280" height="720" alt="Compact Voice settings showing one row per speech backend" src="https://github.com/user-attachments/assets/ca7b5746-9be4-402e-8676-414dc214eb20" />

### Interruptions

<img width="1280" height="720" alt="Voice settings Interruptions section" src="https://github.com/user-attachments/assets/7a1cca96-c278-488a-9fb6-cb5d74e1dfb9" />

## Reviewer-reproducible examples

1. Open Settings, then Voice. Select Parakeet STT for speech input and Pocket TTS for speech output. Each backend name appears once, with its installed or download state and action directly beneath the selector.
2. Scroll to Interruptions. Automatic, Allow interruptions, Prevent feedback, and interruption sensitivity remain available under the new heading.