### PR TITLE
perf(dev): skip current setup during just dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -64,8 +64,12 @@ sync-schema:
 # Install dependencies and build workspace packages.
 [unix]
 _setup-dev-deps:
-    pnpm install
-    cd sdk && pnpm build
+    ./scripts/ensure-dev-deps.sh --force
+
+# Repair only stale development dependencies and workspace package outputs.
+[unix]
+_ensure-dev-deps:
+    ./scripts/ensure-dev-deps.sh
 
 [unix]
 _install-lefthook:
@@ -469,10 +473,11 @@ dev:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    if [[ -n "${GOOSE_BIN:-}" ]]; then
-        just _setup-no-goose
-    else
-        GOOSE_BUILD_PROFILE=debug just setup
+    just _ensure-dev-deps
+
+    if [[ -z "${GOOSE_BIN:-}" ]]; then
+        LOCAL_GOOSE_BIN="$(GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=debug ./scripts/ensure-local-goose.sh --print-bin)"
+        export GOOSE_BIN="$LOCAL_GOOSE_BIN"
     fi
 
     VITE_PORT="$(python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)")"
@@ -507,20 +512,7 @@ dev:
         ./scripts/prepare-bb-cli-resource.sh
     fi
 
-    if [[ -n "${GOOSE_BIN:-}" ]]; then
-        echo "Using explicitly set GOOSE_BIN: ${GOOSE_BIN}"
-    else
-        LOCAL_GOOSE_BIN="$(GOOSE_BUILD_PROFILE=debug ./scripts/ensure-local-goose.sh --check-bin)" || {
-            rc=$?
-            if [[ $rc -eq 2 ]]; then
-                echo "❌ Local goose binary is not ready. Run 'just setup' first." >&2
-                exit 1
-            fi
-            exit $rc
-        }
-        export GOOSE_BIN="$LOCAL_GOOSE_BIN"
-        echo "Using local goose binary: ${GOOSE_BIN}"
-    fi
+    echo "Using Goose binary: ${GOOSE_BIN}"
 
     DISTRO_DIR="$(pwd)/distro"
     if [[ -z "${GOOSE_DISTRO_DIR:-}" && -d "$DISTRO_DIR" ]]; then

--- a/scripts/ensure-dev-deps.sh
+++ b/scripts/ensure-dev-deps.sh
@@ -86,6 +86,7 @@ if [[ "$force" == "1" ]] \
   || [[ ! -f "$installed_lock" ]] \
   || ! cmp -s "$repo_root/pnpm-lock.yaml" "$installed_lock"; then
   echo "Preparing pnpm dependencies."
+  rm -f "$dependency_stamp"
   (cd "$repo_root" && "$pnpm_bin" install)
   dependency_inputs="$(dependency_inputs_hash)"
   write_stamp "$dependency_stamp" "$dependency_inputs"

--- a/scripts/ensure-dev-deps.sh
+++ b/scripts/ensure-dev-deps.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+force=0
+
+if [[ "${1:-}" == "--force" ]]; then
+  force=1
+  shift
+fi
+
+if [[ $# -ne 0 ]]; then
+  echo "Usage: scripts/ensure-dev-deps.sh [--force]" >&2
+  exit 2
+fi
+
+pnpm_bin="${PNPM_BIN:-pnpm}"
+dependency_stamp="$repo_root/node_modules/.berd-dev-dependency-inputs.sha256"
+installed_lock="$repo_root/node_modules/.pnpm/lock.yaml"
+sdk_stamp="$repo_root/sdk/dist/.berd-dev-build-inputs.sha256"
+
+hash_files() {
+  local path
+  for path in "$@"; do
+    if [[ -d "$path" ]]; then
+      find "$path" -type f -print
+    elif [[ -f "$path" ]]; then
+      printf '%s\n' "$path"
+    fi
+  done \
+    | LC_ALL=C sort -u \
+    | while IFS= read -r path; do
+        shasum -a 256 "$path"
+      done \
+    | shasum -a 256 \
+    | awk '{print $1}'
+}
+
+stamp_matches() {
+  local stamp="$1"
+  local expected="$2"
+  [[ -f "$stamp" ]] && [[ "$(<"$stamp")" == "$expected" ]]
+}
+
+write_stamp() {
+  local stamp="$1"
+  local value="$2"
+  local temp_stamp
+  mkdir -p "$(dirname "$stamp")"
+  temp_stamp="$(mktemp "${stamp}.XXXXXX")"
+  printf '%s\n' "$value" >"$temp_stamp"
+  mv "$temp_stamp" "$stamp"
+}
+
+dependency_inputs_hash() {
+  hash_files \
+    "$repo_root/package.json" \
+    "$repo_root/pnpm-lock.yaml" \
+    "$repo_root/pnpm-workspace.yaml" \
+    "$repo_root/sdk/package.json"
+}
+
+sdk_inputs_hash() {
+  hash_files \
+    "$repo_root/pnpm-lock.yaml" \
+    "$repo_root/pnpm-workspace.yaml" \
+    "$repo_root/sdk/package.json" \
+    "$repo_root/sdk/tsconfig.json" \
+    "$repo_root/sdk/generate-schema.ts" \
+    "$repo_root/sdk/schema" \
+    "$repo_root/sdk/src"
+}
+
+dependency_inputs="$(dependency_inputs_hash)"
+
+if [[ "$force" == "1" ]] \
+  || ! stamp_matches "$dependency_stamp" "$dependency_inputs" \
+  || [[ ! -f "$installed_lock" ]] \
+  || ! cmp -s "$repo_root/pnpm-lock.yaml" "$installed_lock"; then
+  echo "Preparing pnpm dependencies."
+  (cd "$repo_root" && "$pnpm_bin" install)
+  dependency_inputs="$(dependency_inputs_hash)"
+  write_stamp "$dependency_stamp" "$dependency_inputs"
+else
+  echo "pnpm dependencies are current; skipping install."
+fi
+
+sdk_inputs="$(sdk_inputs_hash)"
+
+if [[ "$force" == "1" ]] \
+  || ! stamp_matches "$sdk_stamp" "$sdk_inputs" \
+  || [[ ! -f "$repo_root/sdk/dist/index.js" ]] \
+  || [[ ! -f "$repo_root/sdk/dist/index.d.ts" ]]; then
+  echo "Building @aaif/goose-sdk."
+  (cd "$repo_root/sdk" && "$pnpm_bin" build)
+  # Schema generation is part of the SDK build and may update derived source
+  # files, so record the inputs after the successful build.
+  sdk_inputs="$(sdk_inputs_hash)"
+  write_stamp "$sdk_stamp" "$sdk_inputs"
+else
+  echo "@aaif/goose-sdk is current; skipping build."
+fi

--- a/scripts/ensure-dev-deps.sh
+++ b/scripts/ensure-dev-deps.sh
@@ -72,6 +72,13 @@ sdk_inputs_hash() {
     "$repo_root/sdk/src"
 }
 
+sdk_outputs_current() {
+  local output
+  for output in index.js index.d.ts resolve-binary.js resolve-binary.d.ts; do
+    [[ -f "$repo_root/sdk/dist/$output" ]] || return 1
+  done
+}
+
 dependency_inputs="$(dependency_inputs_hash)"
 
 if [[ "$force" == "1" ]] \
@@ -90,9 +97,9 @@ sdk_inputs="$(sdk_inputs_hash)"
 
 if [[ "$force" == "1" ]] \
   || ! stamp_matches "$sdk_stamp" "$sdk_inputs" \
-  || [[ ! -f "$repo_root/sdk/dist/index.js" ]] \
-  || [[ ! -f "$repo_root/sdk/dist/index.d.ts" ]]; then
+  || ! sdk_outputs_current; then
   echo "Building @aaif/goose-sdk."
+  rm -f "$sdk_stamp"
   (cd "$repo_root/sdk" && "$pnpm_bin" build)
   # Schema generation is part of the SDK build and may update derived source
   # files, so record the inputs after the successful build.

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -118,7 +118,7 @@ describe("managed Goose build profile", () => {
       /_bundle-debug-unix:[\s\S]*if \[\[ -z "\$\{GOOSE_BIN:-\}" \]\]; then[\s\S]*GOOSE_BUILD_PROFILE=debug \.\/scripts\/ensure-local-goose\.sh/,
     );
     expect(justfile).toMatch(
-      /dev:[\s\S]*GOOSE_BUILD_PROFILE=debug just setup[\s\S]*GOOSE_BUILD_PROFILE=debug \.\/scripts\/ensure-local-goose\.sh --check-bin/,
+      /dev:[\s\S]*just _ensure-dev-deps[\s\S]*GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=debug \.\/scripts\/ensure-local-goose\.sh --print-bin/,
     );
     expect(devE2e).toContain("GOOSE_BUILD_PROFILE=debug just setup");
     expect(schema).toContain("GOOSE_BUILD_PROFILE=debug");

--- a/scripts/release/tests/setup-tooling.test.mjs
+++ b/scripts/release/tests/setup-tooling.test.mjs
@@ -116,6 +116,10 @@ if [[ "\${1:-}" == "install" ]]; then
 elif [[ "\${1:-}" == "build" ]]; then
   mkdir -p dist
   touch dist/index.js dist/index.d.ts
+  if [[ "\${PNPM_BUILD_FAIL:-0}" == "1" ]]; then
+    exit 42
+  fi
+  touch dist/resolve-binary.js dist/resolve-binary.d.ts
 fi
 `,
     ),
@@ -229,6 +233,41 @@ describe("setup tooling regressions", () => {
     expect(forced.status, `${forced.stdout}\n${forced.stderr}`).toBe(0);
     expect(await callsFor(fixture.calls)).toBe(
       `${fixture.root}:install\n${join(fixture.root, "sdk")}:build\n`,
+    );
+  });
+
+  it("rebuilds when a package-exported SDK artifact is missing", async () => {
+    const fixture = await devDepsFixture();
+
+    const initial = fixture.run();
+    expect(initial.status, `${initial.stdout}\n${initial.stderr}`).toBe(0);
+
+    await Promise.all([
+      writeFile(fixture.calls, ""),
+      rm(join(fixture.root, "sdk/dist/resolve-binary.js")),
+    ]);
+    const repaired = fixture.run();
+    expect(repaired.status, `${repaired.stdout}\n${repaired.stderr}`).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(
+      `${join(fixture.root, "sdk")}:build\n`,
+    );
+  });
+
+  it("retries an SDK build after an interrupted repair", async () => {
+    const fixture = await devDepsFixture();
+
+    const initial = fixture.run();
+    expect(initial.status, `${initial.stdout}\n${initial.stderr}`).toBe(0);
+
+    await writeFile(fixture.calls, "");
+    const failed = fixture.run(["--force"], { PNPM_BUILD_FAIL: "1" });
+    expect(failed.status).toBe(42);
+
+    await writeFile(fixture.calls, "");
+    const retried = fixture.run();
+    expect(retried.status, `${retried.stdout}\n${retried.stderr}`).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(
+      `${join(fixture.root, "sdk")}:build\n`,
     );
   });
 

--- a/scripts/release/tests/setup-tooling.test.mjs
+++ b/scripts/release/tests/setup-tooling.test.mjs
@@ -76,6 +76,65 @@ async function callsFor(path) {
   return readFile(path, "utf8").catch(() => "");
 }
 
+async function devDepsFixture() {
+  const root = await mkdtemp(join(tmpdir(), "berd-dev-deps-"));
+  tempDirs.push(root);
+  const scriptDir = join(root, "scripts");
+  const sdkDir = join(root, "sdk");
+  const fakePnpm = join(root, "fake-pnpm");
+  const calls = join(root, "pnpm-calls");
+
+  await Promise.all([
+    mkdir(scriptDir),
+    mkdir(join(sdkDir, "schema"), { recursive: true }),
+    mkdir(join(sdkDir, "src"), { recursive: true }),
+  ]);
+  await Promise.all([
+    copyFile(
+      join(repo, "scripts/ensure-dev-deps.sh"),
+      join(scriptDir, "ensure-dev-deps.sh"),
+    ),
+    writeFile(join(root, "package.json"), '{"name":"fixture"}\n'),
+    writeFile(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n"),
+    writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['.', 'sdk']\n"),
+    writeFile(join(sdkDir, "package.json"), '{"name":"sdk"}\n'),
+    writeFile(join(sdkDir, "tsconfig.json"), "{}\n"),
+    writeFile(join(sdkDir, "generate-schema.ts"), "export {};\n"),
+    writeFile(join(sdkDir, "schema/schema.json"), "{}\n"),
+    writeFile(join(sdkDir, "src/index.ts"), "export {};\n"),
+    writeFile(
+      fakePnpm,
+      `#!/bin/bash
+set -euo pipefail
+printf '%s:%s\\n' "$PWD" "$*" >> "${calls}"
+if [[ "\${1:-}" == "install" ]]; then
+  if [[ "\${PNPM_REWRITE_LOCK:-0}" == "1" ]] && ! grep -q autoInstallPeers pnpm-lock.yaml; then
+    printf 'settings:\n  autoInstallPeers: true\n' >> pnpm-lock.yaml
+  fi
+  mkdir -p node_modules/.pnpm
+  cp pnpm-lock.yaml node_modules/.pnpm/lock.yaml
+elif [[ "\${1:-}" == "build" ]]; then
+  mkdir -p dist
+  touch dist/index.js dist/index.d.ts
+fi
+`,
+    ),
+  ]);
+  await Promise.all([
+    chmod(join(scriptDir, "ensure-dev-deps.sh"), 0o755),
+    chmod(fakePnpm, 0o755),
+  ]);
+
+  const run = (args = [], env = {}) =>
+    spawnSync(join(scriptDir, "ensure-dev-deps.sh"), args, {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PNPM_BIN: fakePnpm, ...env },
+    });
+
+  return { root, calls, run };
+}
+
 afterEach(async () => {
   await Promise.all(
     tempDirs
@@ -85,20 +144,91 @@ afterEach(async () => {
 });
 
 describe("setup tooling regressions", () => {
-  it("uses the SDK's direct build commands through the pnpm setup recipe", async () => {
-    const [sdkPackage, justfile] = await Promise.all([
+  it("routes full setup and incremental dev preparation through the dependency guard", async () => {
+    const [sdkPackage, justfile, ensureDevDeps] = await Promise.all([
       readFile(join(repo, "sdk/package.json"), "utf8"),
       readFile(justfilePath, "utf8"),
+      readFile(join(repo, "scripts/ensure-dev-deps.sh"), "utf8"),
     ]);
 
     expect(JSON.parse(sdkPackage).scripts.build).toBe(
       "tsx generate-schema.ts && tsc",
     );
     expect(justfile).toMatch(
-      /_setup-dev-deps:\n {4}pnpm install\n {4}cd sdk && pnpm build\n/,
+      /_setup-dev-deps:\n {4}\.\/scripts\/ensure-dev-deps\.sh --force\n/,
+    );
+    expect(justfile).toMatch(
+      /_ensure-dev-deps:\n {4}\.\/scripts\/ensure-dev-deps\.sh\n/,
     );
     expect(justfile).toMatch(
       /_install-lefthook:\n {4}\.\/scripts\/install-lefthook\.sh\n/,
+    );
+    expect(ensureDevDeps).toContain('"$pnpm_bin" install');
+    expect(ensureDevDeps).toContain('"$pnpm_bin" build');
+  });
+
+  it("records dependency inputs after pnpm updates the lockfile", async () => {
+    const fixture = await devDepsFixture();
+
+    const initial = fixture.run([], { PNPM_REWRITE_LOCK: "1" });
+    expect(initial.status, `${initial.stdout}\n${initial.stderr}`).toBe(0);
+
+    await writeFile(fixture.calls, "");
+    const warm = fixture.run();
+    expect(warm.status, `${warm.stdout}\n${warm.stderr}`).toBe(0);
+    expect(warm.stdout).toContain("skipping install");
+    expect(warm.stdout).toContain("skipping build");
+    expect(await callsFor(fixture.calls)).toBe("");
+  });
+
+  it("skips current dependencies and rebuilds only stale SDK inputs", async () => {
+    const fixture = await devDepsFixture();
+
+    const first = fixture.run();
+    expect(first.status, `${first.stdout}\n${first.stderr}`).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(
+      `${fixture.root}:install\n${join(fixture.root, "sdk")}:build\n`,
+    );
+
+    await writeFile(fixture.calls, "");
+    const warm = fixture.run();
+    expect(warm.status, `${warm.stdout}\n${warm.stderr}`).toBe(0);
+    expect(warm.stdout).toContain("skipping install");
+    expect(warm.stdout).toContain("skipping build");
+    expect(await callsFor(fixture.calls)).toBe("");
+
+    await writeFile(fixture.calls, "");
+    await writeFile(
+      join(fixture.root, "pnpm-lock.yaml"),
+      "lockfileVersion: '9.0'\nsettings:\n  autoInstallPeers: true\n",
+    );
+    const dependencyChange = fixture.run();
+    expect(
+      dependencyChange.status,
+      `${dependencyChange.stdout}\n${dependencyChange.stderr}`,
+    ).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(
+      `${fixture.root}:install\n${join(fixture.root, "sdk")}:build\n`,
+    );
+
+    await writeFile(fixture.calls, "");
+    await writeFile(
+      join(fixture.root, "sdk/src/index.ts"),
+      "export const changed = true;\n",
+    );
+    const sdkChange = fixture.run();
+    expect(sdkChange.status, `${sdkChange.stdout}\n${sdkChange.stderr}`).toBe(
+      0,
+    );
+    expect(await callsFor(fixture.calls)).toBe(
+      `${join(fixture.root, "sdk")}:build\n`,
+    );
+
+    await writeFile(fixture.calls, "");
+    const forced = fixture.run(["--force"]);
+    expect(forced.status, `${forced.stdout}\n${forced.stderr}`).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(
+      `${fixture.root}:install\n${join(fixture.root, "sdk")}:build\n`,
     );
   });
 

--- a/scripts/release/tests/setup-tooling.test.mjs
+++ b/scripts/release/tests/setup-tooling.test.mjs
@@ -113,6 +113,9 @@ if [[ "\${1:-}" == "install" ]]; then
   fi
   mkdir -p node_modules/.pnpm
   cp pnpm-lock.yaml node_modules/.pnpm/lock.yaml
+  if [[ "\${PNPM_INSTALL_FAIL:-0}" == "1" ]]; then
+    exit 43
+  fi
 elif [[ "\${1:-}" == "build" ]]; then
   mkdir -p dist
   touch dist/index.js dist/index.d.ts
@@ -251,6 +254,22 @@ describe("setup tooling regressions", () => {
     expect(await callsFor(fixture.calls)).toBe(
       `${join(fixture.root, "sdk")}:build\n`,
     );
+  });
+
+  it("retries dependency installation after an interrupted repair", async () => {
+    const fixture = await devDepsFixture();
+
+    const initial = fixture.run();
+    expect(initial.status, `${initial.stdout}\n${initial.stderr}`).toBe(0);
+
+    await writeFile(fixture.calls, "");
+    const failed = fixture.run(["--force"], { PNPM_INSTALL_FAIL: "1" });
+    expect(failed.status).toBe(43);
+
+    await writeFile(fixture.calls, "");
+    const retried = fixture.run();
+    expect(retried.status, `${retried.stdout}\n${retried.stderr}`).toBe(0);
+    expect(await callsFor(fixture.calls)).toBe(`${fixture.root}:install\n`);
   });
 
   it("retries an SDK build after an interrupted repair", async () => {


### PR DESCRIPTION
## Summary

`just dev` currently reruns dependency installation, SDK compilation, hook setup, and managed Goose setup before every launch. It now verifies pnpm and SDK inputs with worktree-local success stamps, rebuilds only stale outputs, and delegates managed Goose freshness to its existing stamped ensure path. Dependency installs and SDK rebuilds invalidate their prior success stamps before work begins and publish replacements only after success, so interrupted repairs retry on the next launch. SDK freshness also requires every package-exported output. Explicit `just setup` continues to force the complete setup workflow.

## Reviewer-reproducible examples

From a prepared checkout, force the setup path and then exercise the warm development path:

```bash
just _setup-dev-deps
just _ensure-dev-deps
```

The second command reports:

```text
pnpm dependencies are current; skipping install.
@aaif/goose-sdk is current; skipping build.
```

Changing a workspace manifest, lockfile, SDK schema, generator, configuration, or source invalidates the corresponding output on the next run. A failed dependency install, missing package-exported SDK output, or failed SDK rebuild also leaves that prerequisite stale for automatic repair.
