### PR TITLE
fix(voice): resume false-positive interruptions

### DIFF
--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -892,8 +892,11 @@ pub fn start_pocket_voice_stream(
                     failure.delivery,
                 ),
             };
-            emit_pocket_stream_event(&app, &stream_id, event_state, error, delivery);
             finish_playback(&playback, &playback_active);
+            // A terminal event hands stream ownership back to the renderer,
+            // which may immediately start a replacement stream. Release the
+            // backend playback token before publishing that handoff.
+            emit_pocket_stream_event(&app, &stream_id, event_state, error, delivery);
         });
         Ok(())
     }

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -856,8 +856,11 @@ pub fn start_siri_voice_stream(
                     failure.delivery,
                 ),
             };
-            emit_stream_event(&app, &stream_id, event_state, error, delivery);
             finish_playback(&playback_state, &playback_active);
+            // A terminal event hands stream ownership back to the renderer,
+            // which may immediately start a replacement stream. Release the
+            // backend playback token before publishing that handoff.
+            emit_stream_event(&app, &stream_id, event_state, error, delivery);
         });
         Ok(())
     }

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -2041,6 +2041,109 @@ describe("native assistant speech stream", () => {
     }
   });
 
+  it("does not rewind across repeated false-positive interruptions", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore.getState().setMessages("session-1", [
+        assistant(
+          [
+            {
+              type: "text",
+              text: "First sentence. Second sentence. Third sentence.",
+            },
+          ],
+          "completed",
+          "assistant-repeated-resume",
+        ),
+      ]);
+      await vi.runAllTimersAsync();
+      const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: {
+          segments: [
+            {
+              text: "First sentence. ",
+              playedFrames: 1_000,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+            {
+              text: "Second sentence. ",
+              playedFrames: 500,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+          ],
+        },
+      });
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      const secondStreamId = mocks.start.mock.calls[1]?.[0] as string;
+      expect(mocks.append).toHaveBeenCalledWith(
+        secondStreamId,
+        "Second sentence. Third sentence.",
+      );
+      mocks.streamHandler?.({
+        streamId: secondStreamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.streamHandler?.({
+        streamId: secondStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: {
+          segments: [
+            {
+              text: "Second sentence. ",
+              playedFrames: 1_000,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+            {
+              text: "Third sentence.",
+              playedFrames: 500,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+          ],
+        },
+      });
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      const thirdStreamId = mocks.start.mock.calls[2]?.[0] as string;
+      expect(mocks.append).toHaveBeenCalledWith(
+        thirdStreamId,
+        "Third sentence.",
+      );
+      expect(mocks.append).not.toHaveBeenCalledWith(
+        thirdStreamId,
+        "First sentence. Second sentence. Third sentence.",
+      );
+      expect(mocks.append).not.toHaveBeenCalledWith(
+        thirdStreamId,
+        "Second sentence. Third sentence.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("restarts rewritten text from the beginning after a false interruption", async () => {
     vi.useFakeTimers();
     try {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -658,7 +658,7 @@ describe("native assistant speech stream", () => {
     expect(takeVoicePlaybackNotices("session-1")).toBeNull();
   });
 
-  it("finalizes an interruption before native playback starts", async () => {
+  it("waits for terminal ownership when interruption races native startup", async () => {
     let resolveStart: (() => void) | undefined;
     mocks.start.mockImplementationOnce(
       () =>
@@ -678,7 +678,20 @@ describe("native assistant speech stream", () => {
     useVoiceConversationStore.setState({ userSpeaking: true });
     await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
     finalizeVoiceTranscript("voice-after-queued-reply");
-
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).not.toMatchObject({ speech: { status: "interrupted" } });
+    const streamId = mocks.start.mock.calls[0]?.[0] as string;
+    resolveStart?.();
+    await vi.waitFor(() =>
+      expect(mocks.stop.mock.calls.length).toBeGreaterThan(1),
+    );
+    mocks.streamHandler?.({
+      streamId,
+      state: "interrupted",
+      error: null,
+      delivery: { segments: [] },
+    });
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
     ).toMatchObject({
@@ -689,8 +702,6 @@ describe("native assistant speech stream", () => {
       },
     });
     expect(takeVoicePlaybackNotices("session-1")).toContain('"spokenText":""');
-    resolveStart?.();
-    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalledTimes(2));
 
     useVoiceConversationStore.setState({ userSpeaking: false });
     useChatStore
@@ -709,6 +720,36 @@ describe("native assistant speech stream", () => {
         ),
       ]);
     await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(2));
+  });
+
+  it("resumes a false-positive interruption before native startup is invoked", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Queued false positive." }],
+            "completed",
+          ),
+        ]);
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      await vi.runAllTimersAsync();
+      expect(mocks.start).not.toHaveBeenCalled();
+
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[0]?.[0],
+        "Queued false positive.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ignores a late started event after interruption is requested", async () => {
@@ -1062,6 +1103,42 @@ describe("native assistant speech stream", () => {
     expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
     expect(notice).toContain("TTS delivery was interrupted");
     expect(notice).not.toContain("TTS delivery was blocked");
+  });
+
+  it("keeps a held suffix unspoken when completion wins the mute race", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Spoken prefix." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    emit("started");
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    useChatStore
+      .getState()
+      .appendStreamingText("session-1", "assistant-1", " Held suffix.");
+    useVoiceConversationStore.setState({
+      microphoneMuted: true,
+      status: {
+        ...useVoiceConversationStore.getState().status,
+        microphoneMuted: true,
+      },
+    });
+    emit("completed");
+
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({
+      speech: {
+        status: "interrupted",
+        spokenThrough: "Spoken prefix.".length,
+      },
+    });
+    const notice = takeVoicePlaybackNotices("session-1") ?? "";
+    expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
+    expect(notice).toContain('"unspokenText":" Held suffix."');
   });
 
   it("describes a hang-up as stopping the voice conversation", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -992,7 +992,53 @@ describe("native assistant speech stream", () => {
     ).toMatchObject({ speech: { status: "spoken" } });
   });
 
-  it("bounds a missing native terminal event and allows the next reply", async () => {
+  it("resumes after a missing terminal event releases native ownership", async () => {
+    mocks.stop
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "First reply." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+
+    vi.useFakeTimers();
+    try {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      await Promise.resolve();
+      expect(mocks.stop).toHaveBeenCalled();
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "First reply.",
+      );
+      expect(takeVoicePlaybackNotices("session-1")).toBeNull();
+
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: { segments: [] },
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(takeVoicePlaybackNotices("session-1")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not resume after a terminal timeout while playback remains active", async () => {
     startNativeAssistantSpeech("session-1", vi.fn());
     useChatStore
       .getState()
@@ -1004,9 +1050,11 @@ describe("native assistant speech stream", () => {
     vi.useFakeTimers();
     try {
       useVoiceConversationStore.setState({ userSpeaking: true });
-      await Promise.resolve();
-      expect(mocks.stop).toHaveBeenCalled();
+      useVoiceConversationStore.setState({ userSpeaking: false });
       await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(mocks.stop).toHaveBeenCalledTimes(3);
+      expect(mocks.start).toHaveBeenCalledTimes(1);
       expect(
         useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
       ).toMatchObject({
@@ -1015,31 +1063,6 @@ describe("native assistant speech stream", () => {
     } finally {
       vi.useRealTimers();
     }
-
-    useVoiceConversationStore.setState({ userSpeaking: false });
-    await new Promise((resolve) => window.setTimeout(resolve, 300));
-    expect(mocks.start).toHaveBeenCalledTimes(1);
-    useChatStore
-      .getState()
-      .setMessages("session-1", [
-        assistant(
-          [{ type: "text", text: "First reply." }],
-          "completed",
-          "assistant-1",
-        ),
-        assistant(
-          [{ type: "text", text: "Second reply." }],
-          "completed",
-          "assistant-2",
-        ),
-      ]);
-    await vi.waitFor(() => {
-      expect(mocks.start).toHaveBeenCalledTimes(2);
-      expect(mocks.append).toHaveBeenCalledWith(
-        mocks.start.mock.calls[1]?.[0],
-        "Second reply.",
-      );
-    });
   });
 
   it("finalizes only once when a terminal event races the fallback", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -156,6 +156,7 @@ describe("native assistant speech stream", () => {
       uiState: "listening",
       userSpeaking: false,
       assistantSpeaking: false,
+      microphoneMuted: false,
       latestFinalizedTranscriptKey: null,
     });
   });
@@ -523,7 +524,7 @@ describe("native assistant speech stream", () => {
     expect(content?.[2]).toMatchObject({ speech: { status: "spoken" } });
   });
 
-  it("replaces the interrupted tool-suffix notice when more text arrives", async () => {
+  it("resumes a tool suffix from its incomplete synthesis segment", async () => {
     startNativeAssistantSpeech("session-1", vi.fn());
     useChatStore.getState().setMessages("session-1", [
       assistant([
@@ -570,21 +571,17 @@ describe("native assistant speech stream", () => {
     useChatStore
       .getState()
       .appendStreamingText("session-1", "assistant-1", " More.");
-    await vi.waitFor(() => {
-      expect(
-        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[2],
-      ).toMatchObject({
-        text: "After the tool. More.",
-        speech: { status: "interrupted", spokenThrough: "After".length },
-      });
-    });
-    await new Promise((resolve) => window.setTimeout(resolve, 300));
-
-    const notice = takeVoicePlaybackNotices("session-1") ?? "";
-    expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
-    expect(notice).toContain('"spokenText":"After"');
-    expect(notice).toContain('"unspokenText":" the tool. More."');
-    expect(notice).not.toContain("Before the tool.");
+    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(2));
+    const resumedStreamId = mocks.start.mock.calls[1]?.[0] as string;
+    expect(mocks.append).toHaveBeenCalledWith(
+      resumedStreamId,
+      "After the tool. More.",
+    );
+    expect(mocks.append).not.toHaveBeenCalledWith(
+      resumedStreamId,
+      "Before the tool.",
+    );
+    expect(takeVoicePlaybackNotices("session-1")).toBeNull();
   });
 
   it("queues the next reply until the finishing stream completes", async () => {
@@ -651,6 +648,7 @@ describe("native assistant speech stream", () => {
     useVoiceConversationStore.setState({ userSpeaking: true });
     await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
     emit("interrupted");
+    finalizeVoiceTranscript("voice-genuine-interruption");
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
     ).toMatchObject({ speech: { status: "interrupted" } });
@@ -679,6 +677,7 @@ describe("native assistant speech stream", () => {
     mocks.stop.mockResolvedValueOnce(false).mockResolvedValue(true);
     useVoiceConversationStore.setState({ userSpeaking: true });
     await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    finalizeVoiceTranscript("voice-after-queued-reply");
 
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
@@ -702,6 +701,7 @@ describe("native assistant speech stream", () => {
           "completed",
           "assistant-1",
         ),
+        voiceUser("voice-after-queued-reply"),
         assistant(
           [{ type: "text", text: "Next reply." }],
           "completed",
@@ -1009,6 +1009,7 @@ describe("native assistant speech stream", () => {
           ],
         },
       });
+      finalizeVoiceTranscript("voice-terminal-race");
       await vi.advanceTimersByTimeAsync(1_000);
     } finally {
       vi.useRealTimers();
@@ -1260,6 +1261,7 @@ describe("native assistant speech stream", () => {
         confidence: "medium",
       },
     });
+    finalizeVoiceTranscript("voice-delivery-estimate");
     useVoiceConversationStore.setState({ userSpeaking: false });
     useChatStore
       .getState()
@@ -1321,6 +1323,7 @@ describe("native assistant speech stream", () => {
         confidence: "low",
       },
     });
+    finalizeVoiceTranscript("voice-incomplete-estimate");
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice).toContain('"spokenText":"One"');
     expect(notice).toContain('"unspokenText":". Two. Three."');
@@ -1359,6 +1362,7 @@ describe("native assistant speech stream", () => {
     ).toMatchObject({
       speech: { status: "interrupted", spokenThrough: 0, confidence: "low" },
     });
+    finalizeVoiceTranscript("voice-short-incomplete");
     expect(takeVoicePlaybackNotices("session-1")).toContain(
       '"unspokenText":"Yes"',
     );
@@ -1414,6 +1418,7 @@ describe("native assistant speech stream", () => {
     expect(content?.[1]).toMatchObject({
       speech: { status: "spoken", spokenThrough: "Beta. ".length },
     });
+    finalizeVoiceTranscript("voice-interleaved-estimate");
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice).toContain('"spokenText":"Alpha. Gamma"');
     expect(notice).toContain('"unspokenText":"."');
@@ -1448,6 +1453,7 @@ describe("native assistant speech stream", () => {
       },
     });
 
+    finalizeVoiceTranscript("voice-after-spoken-prefix");
     useVoiceConversationStore.setState({ userSpeaking: false });
     useChatStore
       .getState()
@@ -1495,6 +1501,7 @@ describe("native assistant speech stream", () => {
         ],
       },
     });
+    finalizeVoiceTranscript("voice-after-rewrite");
     useVoiceConversationStore.setState({ userSpeaking: false });
     useChatStore
       .getState()
@@ -1540,6 +1547,7 @@ describe("native assistant speech stream", () => {
       },
     });
 
+    finalizeVoiceTranscript("voice-bounded-notice");
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     const estimate = JSON.parse(
       notice.match(/Delivery estimate: (\{.*\})/)?.[1] ?? "{}",
@@ -1908,6 +1916,322 @@ describe("native assistant speech stream", () => {
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
     ).toMatchObject({ speech: { status: "interrupted" } });
+  });
+
+  it("resumes an interrupted reply at the first incomplete synthesis segment when no STT arrives", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "First sentence. Second sentence." }],
+            "completed",
+            "assistant-resume",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "started",
+        error: null,
+      });
+
+      const stopCallsBeforeInterruption = mocks.stop.mock.calls.length;
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      await Promise.resolve();
+      expect(mocks.stop).toHaveBeenCalledTimes(stopCallsBeforeInterruption + 1);
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: {
+          segments: [
+            {
+              text: "First sentence. ",
+              playedFrames: 1_000,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+            {
+              text: "Second sentence.",
+              playedFrames: 500,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+          ],
+        },
+      });
+      expect(takeVoicePlaybackNotices("session-1")).toBeNull();
+
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(249);
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      const resumedStreamId = mocks.start.mock.calls[1]?.[0] as string;
+      expect(mocks.append).toHaveBeenCalledWith(
+        resumedStreamId,
+        "Second sentence.",
+      );
+      expect(mocks.append).not.toHaveBeenCalledWith(
+        resumedStreamId,
+        "First sentence. ",
+      );
+      expect(mocks.finish).toHaveBeenCalledWith(resumedStreamId);
+
+      mocks.streamHandler?.({
+        streamId: resumedStreamId,
+        state: "completed",
+        error: null,
+      });
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).toMatchObject({ speech: { status: "spoken" } });
+      expect(takeVoicePlaybackNotices("session-1")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for a delayed native interruption event before resuming", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Delayed terminal." }],
+            "completed",
+            "assistant-delayed-resume",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "started",
+        error: null,
+      });
+
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: { segments: [] },
+      });
+      await vi.runAllTimersAsync();
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "Delayed terminal.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restarts rewritten text from the beginning after a false interruption", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Original reply." }],
+            "completed",
+            "assistant-rewritten-resume",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.streamHandler?.({
+        streamId: firstStreamId,
+        state: "interrupted",
+        error: null,
+        delivery: {
+          segments: [
+            {
+              text: "Original reply.",
+              playedFrames: 700,
+              totalFrames: 1_000,
+              synthesisComplete: true,
+            },
+          ],
+        },
+      });
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Replacement text." }],
+            "completed",
+            "assistant-rewritten-resume",
+          ),
+        ]);
+
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      const resumedStreamId = mocks.start.mock.calls[1]?.[0] as string;
+      expect(mocks.append).toHaveBeenCalledWith(
+        resumedStreamId,
+        "Replacement text.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards resumable speech when the microphone is explicitly muted", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Do not resume me." }],
+            "completed",
+            "assistant-muted",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const streamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.streamHandler?.({
+        streamId,
+        state: "interrupted",
+        error: null,
+        delivery: { segments: [] },
+      });
+
+      useVoiceConversationStore.setState({
+        userSpeaking: false,
+        microphoneMuted: true,
+        status: {
+          ...useVoiceConversationStore.getState().status,
+          microphoneMuted: true,
+        },
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(takeVoicePlaybackNotices("session-1")).toContain(
+        "Original text: Do not resume me.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards resumable speech when native assistant speech stops", async () => {
+    vi.useFakeTimers();
+    try {
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Stopped remainder." }],
+            "completed",
+            "assistant-stopped",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const streamId = mocks.start.mock.calls[0]?.[0] as string;
+      mocks.streamHandler?.({
+        streamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.streamHandler?.({
+        streamId,
+        state: "interrupted",
+        error: null,
+        delivery: { segments: [] },
+      });
+
+      stopNativeAssistantSpeech();
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.runAllTimersAsync();
+
+      expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(takeVoicePlaybackNotices("session-1")).toContain(
+        "Original text: Stopped remainder.",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("uses the same resumption path for Siri playback", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.backend = "siri";
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant(
+            [{ type: "text", text: "Siri resumes." }],
+            "completed",
+            "assistant-siri-resume",
+          ),
+        ]);
+      await vi.runAllTimersAsync();
+      const streamId = mocks.siriStart.mock.calls[0]?.[0] as string;
+      mocks.siriStreamHandler?.({
+        streamId,
+        state: "started",
+        error: null,
+      });
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      mocks.siriStreamHandler?.({
+        streamId,
+        state: "interrupted",
+        error: null,
+        delivery: { segments: [] },
+      });
+      useVoiceConversationStore.setState({ userSpeaking: false });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.runAllTimersAsync();
+
+      expect(mocks.siriStart).toHaveBeenCalledTimes(2);
+      expect(mocks.siriAppend).toHaveBeenCalledWith(
+        mocks.siriStart.mock.calls[1]?.[0],
+        "Siri resumes.",
+      );
+      expect(mocks.siriFinish).toHaveBeenCalledWith(
+        mocks.siriStart.mock.calls[1]?.[0],
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("fails closed when voice-origin metadata cannot establish ownership", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -901,41 +901,54 @@ describe("native assistant speech stream", () => {
   it.each([
     ["returns false", () => mocks.stop.mockResolvedValue(false)],
     ["rejects", () => mocks.stop.mockRejectedValue(new Error("stop failed"))],
-  ])("finalizes immediately when native stop %s", async (_label, setStop) => {
-    setStop();
-    startNativeAssistantSpeech("session-1", vi.fn());
-    useChatStore
-      .getState()
-      .setMessages("session-1", [
-        assistant([{ type: "text", text: "First reply." }]),
-      ]);
-    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+  ])("bounds a native stop that %s", async (_label, setStop) => {
+    vi.useFakeTimers();
+    try {
+      setStop();
+      startNativeAssistantSpeech("session-1", vi.fn());
+      useChatStore
+        .getState()
+        .setMessages("session-1", [
+          assistant([{ type: "text", text: "First reply." }]),
+        ]);
+      await vi.runAllTimersAsync();
 
-    useVoiceConversationStore.setState({ userSpeaking: true });
-    await vi.waitFor(() => {
+      useVoiceConversationStore.setState({ userSpeaking: true });
+      await Promise.resolve();
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+      ).not.toMatchObject({ speech: { status: "interrupted" } });
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(
         useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
       ).toMatchObject({
         speech: { status: "interrupted", spokenThrough: 0 },
       });
-    });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-    useVoiceConversationStore.setState({ userSpeaking: false });
+  it("accepts a completed event after native stop returns false", async () => {
+    mocks.stop.mockResolvedValue(false);
+    startNativeAssistantSpeech("session-1", vi.fn());
     useChatStore
       .getState()
       .setMessages("session-1", [
-        assistant(
-          [{ type: "text", text: "First reply." }],
-          "completed",
-          "assistant-1",
-        ),
-        assistant(
-          [{ type: "text", text: "Second reply." }],
-          "completed",
-          "assistant-2",
-        ),
+        assistant([{ type: "text", text: "Already completed." }], "completed"),
       ]);
-    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    emit("completed");
+    useVoiceConversationStore.setState({ userSpeaking: false });
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
+
+    expect(mocks.start).toHaveBeenCalledTimes(1);
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "spoken" } });
   });
 
   it("bounds a missing native terminal event and allows the next reply", async () => {
@@ -963,6 +976,8 @@ describe("native assistant speech stream", () => {
     }
 
     useVoiceConversationStore.setState({ userSpeaking: false });
+    await new Promise((resolve) => window.setTimeout(resolve, 300));
+    expect(mocks.start).toHaveBeenCalledTimes(1);
     useChatStore
       .getState()
       .setMessages("session-1", [
@@ -977,7 +992,13 @@ describe("native assistant speech stream", () => {
           "assistant-2",
         ),
       ]);
-    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => {
+      expect(mocks.start).toHaveBeenCalledTimes(2);
+      expect(mocks.append).toHaveBeenCalledWith(
+        mocks.start.mock.calls[1]?.[0],
+        "Second reply.",
+      );
+    });
   });
 
   it("finalizes only once when a terminal event races the fallback", async () => {
@@ -1018,6 +1039,29 @@ describe("native assistant speech stream", () => {
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
     expect(mocks.stop).toHaveBeenCalledTimes(stopCallsBeforeInterruption + 1);
+  });
+
+  it("records one notice when held text overlaps a resumable interruption", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "First reply." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    emit("started");
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    useChatStore
+      .getState()
+      .appendStreamingText("session-1", "assistant-1", " Later suffix.");
+    emit("interrupted");
+    stopNativeAssistantSpeech();
+
+    const notice = takeVoicePlaybackNotices("session-1") ?? "";
+    expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
+    expect(notice).toContain("TTS delivery was interrupted");
+    expect(notice).not.toContain("TTS delivery was blocked");
   });
 
   it("describes a hang-up as stopping the voice conversation", async () => {
@@ -2021,8 +2065,19 @@ describe("native assistant speech stream", () => {
 
       useVoiceConversationStore.setState({ userSpeaking: true });
       useVoiceConversationStore.setState({ userSpeaking: false });
+      useChatStore
+        .getState()
+        .appendStreamingText(
+          "session-1",
+          "assistant-delayed-resume",
+          " Later suffix.",
+        );
       await vi.advanceTimersByTimeAsync(250);
       expect(mocks.start).toHaveBeenCalledTimes(1);
+      expect(mocks.append).not.toHaveBeenCalledWith(
+        firstStreamId,
+        " Later suffix.",
+      );
 
       mocks.streamHandler?.({
         streamId: firstStreamId,
@@ -2034,7 +2089,7 @@ describe("native assistant speech stream", () => {
       expect(mocks.start).toHaveBeenCalledTimes(2);
       expect(mocks.append).toHaveBeenCalledWith(
         mocks.start.mock.calls[1]?.[0],
-        "Delayed terminal.",
+        "Delayed terminal. Later suffix.",
       );
     } finally {
       vi.useRealTimers();

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -1105,7 +1105,7 @@ describe("native assistant speech stream", () => {
     expect(notice).not.toContain("TTS delivery was blocked");
   });
 
-  it("keeps a held suffix unspoken when completion wins the mute race", async () => {
+  it("keeps a held suffix unspoken when mute wins the completion race", async () => {
     startNativeAssistantSpeech("session-1", vi.fn());
     useChatStore
       .getState()
@@ -1139,6 +1139,128 @@ describe("native assistant speech stream", () => {
     const notice = takeVoicePlaybackNotices("session-1") ?? "";
     expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
     expect(notice).toContain('"unspokenText":" Held suffix."');
+  });
+
+  it("preserves a spoken prefix when completion wins the mute race", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Spoken prefix." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    emit("started");
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    useChatStore
+      .getState()
+      .appendStreamingText("session-1", "assistant-1", " Held suffix.");
+    emit("completed");
+    useVoiceConversationStore.setState({
+      microphoneMuted: true,
+      status: {
+        ...useVoiceConversationStore.getState().status,
+        microphoneMuted: true,
+      },
+    });
+
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({
+      speech: {
+        status: "interrupted",
+        spokenThrough: "Spoken prefix.".length,
+      },
+    });
+    const notice = takeVoicePlaybackNotices("session-1") ?? "";
+    expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
+    expect(notice).toContain('"spokenText":"Spoken prefix."');
+    expect(notice).toContain('"unspokenText":" Held suffix."');
+  });
+
+  it("does not mark a held suffix spoken after an interrupted terminal", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Spoken prefix." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    const streamId = mocks.start.mock.calls[0]?.[0] as string;
+    emit("started");
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    useChatStore
+      .getState()
+      .appendStreamingText("session-1", "assistant-1", " Held suffix.");
+    useVoiceConversationStore.setState({
+      microphoneMuted: true,
+      status: {
+        ...useVoiceConversationStore.getState().status,
+        microphoneMuted: true,
+      },
+    });
+    mocks.streamHandler?.({
+      streamId,
+      state: "interrupted",
+      error: null,
+      delivery: {
+        segments: [
+          {
+            text: "Spoken prefix.",
+            playedFrames: 1_000,
+            totalFrames: 1_000,
+            synthesisComplete: true,
+          },
+        ],
+      },
+    });
+
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({
+      speech: {
+        status: "interrupted",
+        spokenThrough: "Spoken prefix.".length,
+      },
+    });
+    const notice = takeVoicePlaybackNotices("session-1") ?? "";
+    expect(notice.match(/\[voice: tts-delivery-failed\]/g)).toHaveLength(1);
+    expect(notice).toContain('"unspokenText":" Held suffix."');
+  });
+
+  it("does not apply a completed terminal to a held rewrite", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "Original reply." }]),
+      ]);
+    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
+    const streamId = mocks.start.mock.calls[0]?.[0] as string;
+    emit("started");
+
+    useVoiceConversationStore.setState({ userSpeaking: true });
+    useChatStore
+      .getState()
+      .setMessages("session-1", [assistant([{ type: "text", text: "New." }])]);
+    useVoiceConversationStore.setState({
+      microphoneMuted: true,
+      status: {
+        ...useVoiceConversationStore.getState().status,
+        microphoneMuted: true,
+      },
+    });
+    mocks.streamHandler?.({
+      streamId,
+      state: "completed",
+      error: null,
+      delivery: null,
+    });
+
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.[0]?.content[0],
+    ).toMatchObject({ speech: { status: "notSpoken" } });
   });
 
   it("describes a hang-up as stopping the voice conversation", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -50,7 +50,7 @@ type ActiveUtterance = {
   targetSpans: SpeechTargetSpan[];
   text: string;
   finishing: boolean;
-  nativeStreamStarted: boolean;
+  nativeStartInvoked: boolean;
   interruptionRequested: boolean;
   resumptionDiscarded: boolean;
   interruptionFallback: ReturnType<typeof setTimeout> | null;
@@ -183,7 +183,7 @@ function recordPlaybackNotice(
   estimate?: SpeechDeliveryEstimate,
   interruptionCause: InterruptionCause = "voiceStopped",
 ) {
-  const noticeKey = `${sessionId}\0${key}\0${status}`;
+  const noticeKey = `${sessionId}\0${key}`;
   const excerpt = text.length > 500 ? `${text.slice(0, 497).trimEnd()}…` : text;
   const outcome =
     status === "interrupted"
@@ -521,6 +521,34 @@ function setUtteranceStatus(utterance: ActiveUtterance, status: SpeechStatus) {
   }
 }
 
+function applyCompletedUtteranceStatus(utterance: ActiveUtterance): boolean {
+  let hasDiscardedSuffix = false;
+  for (const target of utterance.targets) {
+    const content = targetContent(utterance.sessionId, target);
+    const targetEnd = utterance.targetSpans
+      .filter((span) => targetKey(span) === targetKey(target))
+      .at(-1)?.targetEnd;
+    if (
+      utterance.resumptionDiscarded &&
+      content &&
+      targetEnd !== undefined &&
+      content.text.length > targetEnd
+    ) {
+      hasDiscardedSuffix = true;
+      setTargetSpeech(utterance.sessionId, target, {
+        status: "interrupted",
+        spokenThrough: targetEnd,
+        confidence: "medium",
+        interruptionCause: utterance.interruptionCause ?? "voiceStopped",
+      });
+      continue;
+    }
+    setTargetSpeech(utterance.sessionId, target, { status: "spoken" });
+  }
+  utterance.status = hasDiscardedSuffix ? "interrupted" : "spoken";
+  return hasDiscardedSuffix;
+}
+
 function failActiveUtterance(
   utteranceId: string,
   error: unknown,
@@ -625,7 +653,14 @@ function handleStreamEvent(
         clearTimeout(utterance.interruptionFallback);
         utterance.interruptionFallback = null;
       }
-      setUtteranceStatus(utterance, "spoken");
+      if (applyCompletedUtteranceStatus(utterance)) {
+        recordDeliveryNotices(
+          utterance,
+          estimateSpeechDelivery(utterance.text, utterance.latestDelivery),
+          "interrupted",
+          utterance.interruptionCause ?? "voiceStopped",
+        );
+      }
       restoreListeningIfConversationIsRunning(utterance);
       activeUtterance = null;
       reportAssistantActivity(
@@ -661,7 +696,7 @@ function interruptActiveUtterance(
 ): boolean {
   const utterance = activeUtterance;
   const terminalEventExpected =
-    awaitTerminalDelivery && utterance?.nativeStreamStarted === true;
+    awaitTerminalDelivery && utterance?.nativeStartInvoked === true;
   commandEpoch += 1;
   if (utterance && !utterance.interruptionRequested) {
     utterance.interruptionRequested = true;
@@ -671,6 +706,7 @@ function interruptActiveUtterance(
     finalizeInterruptedUtterance(
       utterance,
       utterance.interruptionCause ?? cause,
+      awaitTerminalDelivery && cause === "userSpeaking",
     );
   }
   if (utterance && terminalEventExpected) {
@@ -698,7 +734,7 @@ export function stopNativeAssistantSpeech(awaitTerminalDelivery = false): void {
   stopVoiceSubscription?.();
   stopVoiceSubscription = null;
   const shouldAwaitTerminal =
-    awaitTerminalDelivery && utterance?.nativeStreamStarted === true;
+    awaitTerminalDelivery && utterance?.nativeStartInvoked === true;
   if (utterance && shouldAwaitTerminal) {
     const onTerminal = utterance.onTerminal;
     utterance.onTerminal = () => {
@@ -984,27 +1020,16 @@ export function startNativeAssistantSpeech(
   };
 
   const discardHeldAndResumableSpeech = () => {
-    const activeTargetKeys = new Set(
-      activeUtterance?.targets.map((target) => targetKey(target)) ?? [],
-    );
-    const resumableTargetKeys = new Set(
-      resumableInterruption?.utterance.targets.map((target) =>
-        targetKey(target),
-      ) ?? [],
-    );
     if (activeUtterance) activeUtterance.resumptionDiscarded = true;
-    discardResumableInterruption();
     const held = heldSpeech;
     if (held) {
       for (const [slot, heldTarget] of held.targets) {
-        if (activeTargetKeys.has(slot) || resumableTargetKeys.has(slot)) {
-          continue;
-        }
         suppressTarget(slot, heldTarget.target, heldTarget.text);
       }
       heldSpeech = null;
       heldReleaseReady = false;
     }
+    discardResumableInterruption();
   };
 
   const ensureUtterance = (
@@ -1039,7 +1064,7 @@ export function startNativeAssistantSpeech(
       targetSpans: [],
       text: "",
       finishing: false,
-      nativeStreamStarted: false,
+      nativeStartInvoked: false,
       interruptionRequested: false,
       resumptionDiscarded: false,
       interruptionFallback: null,
@@ -1089,6 +1114,13 @@ export function startNativeAssistantSpeech(
       utterance,
       async () => {
         await streamListenerReady;
+        if (
+          utterance.interruptionRequested ||
+          activeUtterance?.id !== utterance.id
+        ) {
+          return;
+        }
+        utterance.nativeStartInvoked = true;
         await streamBackend.start(utterance.id);
         if (
           utterance.interruptionRequested ||
@@ -1097,7 +1129,6 @@ export function startNativeAssistantSpeech(
           await streamBackend.stop();
           return;
         }
-        utterance.nativeStreamStarted = true;
       },
       onFailure,
     );

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -29,7 +29,12 @@ import { useVoiceConversationStore } from "../stores/voiceConversationStore";
 
 type SpeechFailureHandler = (text: string, error: unknown) => void;
 type SpeechTarget = { messageId: string; textOrdinal: number };
-type SpeechTargetSpan = SpeechTarget & { start: number; end: number };
+type SpeechTargetSpan = SpeechTarget & {
+  start: number;
+  end: number;
+  targetStart: number;
+  targetEnd: number;
+};
 type SpeechDeliveryEstimate = {
   cutoff: number;
   spokenText: string;
@@ -381,17 +386,17 @@ function targetDeliveryCutoffs(utterance: ActiveUtterance, cutoff: number) {
     const spans = utterance.targetSpans.filter(
       (span) => targetKey(span) === targetKey(target),
     );
+    let localCutoff = 0;
+    for (const span of spans) {
+      if (cutoff < span.start) break;
+      localCutoff =
+        span.targetStart + Math.max(0, Math.min(span.end, cutoff) - span.start);
+      if (cutoff < span.end) break;
+    }
     return {
       target,
-      targetLength: spans.reduce(
-        (length, span) => length + (span.end - span.start),
-        0,
-      ),
-      localCutoff: spans.reduce(
-        (length, span) =>
-          length + Math.max(0, Math.min(span.end, cutoff) - span.start),
-        0,
-      ),
+      targetLength: spans.at(-1)?.targetEnd ?? 0,
+      localCutoff,
     };
   });
 }
@@ -1272,19 +1277,24 @@ export function startNativeAssistantSpeech(
         consumedTextBySlot.set(slot, content.text);
         if (utterance.finishing) continue;
         const spanStart = utterance.text.length;
+        const targetStart = appendOnly ? previous.length : 0;
         utterance.text += delta;
         const previousSpan = utterance.targetSpans.at(-1);
         if (
           previousSpan &&
           targetKey(previousSpan) === targetKey(target) &&
-          previousSpan.end === spanStart
+          previousSpan.end === spanStart &&
+          previousSpan.targetEnd === targetStart
         ) {
           previousSpan.end = utterance.text.length;
+          previousSpan.targetEnd = targetStart + delta.length;
         } else {
           utterance.targetSpans.push({
             ...target,
             start: spanStart,
             end: utterance.text.length,
+            targetStart,
+            targetEnd: targetStart + delta.length,
           });
         }
         queueStreamCommand(

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -742,13 +742,26 @@ function interruptActiveUtterance(
     );
   }
   if (utterance && terminalEventExpected) {
+    const stopVoice = stopActiveVoice;
     utterance.interruptionFallback = setTimeout(() => {
-      finalizeInterruptedUtterance(
-        utterance,
-        utterance.interruptionCause ?? cause,
-      );
+      if (activeUtterance?.id !== utterance.id) return;
+      utterance.interruptionFallback = null;
+      void stopVoice()
+        .then((playbackStillActive) => {
+          finalizeInterruptedUtterance(
+            utterance,
+            utterance.interruptionCause ?? cause,
+            cause === "userSpeaking" && !playbackStillActive,
+          );
+        })
+        .catch(() => {
+          finalizeInterruptedUtterance(
+            utterance,
+            utterance.interruptionCause ?? cause,
+          );
+        });
     }, INTERRUPTION_TERMINAL_TIMEOUT_MS);
-    void stopActiveVoice().catch(() => undefined);
+    void stopVoice().catch(() => undefined);
   } else {
     void stopActiveVoice().catch(() => undefined);
   }

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -353,7 +353,21 @@ function applyInterruptionEstimate(
     utterance,
     estimate.cutoff,
   )) {
+    const content = targetContent(utterance.sessionId, target);
+    if (!content || !targetRetainsUtteranceText(utterance, target, content)) {
+      setTargetSpeech(utterance.sessionId, target, { status: "notSpoken" });
+      continue;
+    }
     if (localCutoff >= targetLength && targetLength > 0) {
+      if (utterance.resumptionDiscarded && content.text.length > targetLength) {
+        setTargetSpeech(utterance.sessionId, target, {
+          status: "interrupted",
+          spokenThrough: targetLength,
+          confidence: estimate.confidence,
+          interruptionCause: utterance.interruptionCause ?? "voiceStopped",
+        });
+        continue;
+      }
       setTargetSpeech(utterance.sessionId, target, {
         status: "spoken",
         spokenThrough: targetLength,
@@ -455,6 +469,20 @@ function targetContent(
   return null;
 }
 
+function targetRetainsUtteranceText(
+  utterance: ActiveUtterance,
+  target: SpeechTarget,
+  content: TextContent,
+): boolean {
+  return utterance.targetSpans
+    .filter((span) => targetKey(span) === targetKey(target))
+    .every(
+      (span) =>
+        content.text.slice(span.targetStart, span.targetEnd) ===
+        utterance.text.slice(span.start, span.end),
+    );
+}
+
 function recordDeliveryNotices(
   utterance: ActiveUtterance,
   fallbackEstimate: SpeechDeliveryEstimate,
@@ -528,9 +556,13 @@ function applyCompletedUtteranceStatus(utterance: ActiveUtterance): boolean {
     const targetEnd = utterance.targetSpans
       .filter((span) => targetKey(span) === targetKey(target))
       .at(-1)?.targetEnd;
+    if (!content || !targetRetainsUtteranceText(utterance, target, content)) {
+      setTargetSpeech(utterance.sessionId, target, { status: "notSpoken" });
+      hasDiscardedSuffix = true;
+      continue;
+    }
     if (
       utterance.resumptionDiscarded &&
-      content &&
       targetEnd !== undefined &&
       content.text.length > targetEnd
     ) {
@@ -915,6 +947,40 @@ export function startNativeAssistantSpeech(
     recordPlaybackNotice(sessionId, slot, text, "notSpoken");
   };
 
+  const discardHeldTarget = (
+    slot: string,
+    target: SpeechTarget,
+    text: string,
+  ) => {
+    const consumedPrefix = consumedTextBySlot.get(slot) ?? "";
+    const content = targetContent(sessionId, target);
+    if (
+      consumedPrefix.length > 0 &&
+      text.startsWith(consumedPrefix) &&
+      content?.speech?.status === "spoken"
+    ) {
+      invalidatedMessages.add(target.messageId);
+      interruptedMessages.add(target.messageId);
+      interruptionCauseByMessage.set(target.messageId, "voiceStopped");
+      consumedTextBySlot.set(slot, text);
+      const estimate: SpeechDeliveryEstimate = {
+        cutoff: consumedPrefix.length,
+        spokenText: consumedPrefix,
+        unspokenText: text.slice(consumedPrefix.length),
+        confidence: "medium",
+      };
+      setTargetSpeech(sessionId, target, {
+        status: "interrupted",
+        spokenThrough: estimate.cutoff,
+        confidence: estimate.confidence,
+        interruptionCause: "voiceStopped",
+      });
+      recordPlaybackNotice(sessionId, slot, text, "interrupted", estimate);
+      return;
+    }
+    suppressTarget(slot, target, text);
+  };
+
   const holdAssistantChanges = (
     messages: ReturnType<
       typeof useChatStore.getState
@@ -961,7 +1027,7 @@ export function startNativeAssistantSpeech(
         held.targets.delete(slot);
         continue;
       }
-      suppressTarget(slot, heldTarget.target, heldTarget.text);
+      discardHeldTarget(slot, heldTarget.target, heldTarget.text);
       held.targets.delete(slot);
     }
     if (held.targets.size === 0) {
@@ -1024,7 +1090,7 @@ export function startNativeAssistantSpeech(
     const held = heldSpeech;
     if (held) {
       for (const [slot, heldTarget] of held.targets) {
-        suppressTarget(slot, heldTarget.target, heldTarget.text);
+        discardHeldTarget(slot, heldTarget.target, heldTarget.text);
       }
       heldSpeech = null;
       heldReleaseReady = false;

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -47,13 +47,17 @@ type ActiveUtterance = {
   finishing: boolean;
   nativeStreamStarted: boolean;
   interruptionRequested: boolean;
+  resumptionDiscarded: boolean;
   interruptionFallback: ReturnType<typeof setTimeout> | null;
   interruptionCause: InterruptionCause | null;
   latestDelivery: VoiceDeliveryProgress | null;
   causalTranscriptKey: string | null;
   status: SpeechStatus | null;
   onFailure: SpeechFailureHandler;
-  onInterrupted: () => void;
+  onInterrupted: (
+    estimate: SpeechDeliveryEstimate,
+    cause: InterruptionCause,
+  ) => boolean;
   onTerminal: () => void;
 };
 type HeldSpeech = {
@@ -61,6 +65,11 @@ type HeldSpeech = {
     string,
     { target: SpeechTarget; text: string; causalTranscriptKey: string | null }
   >;
+};
+type ResumableInterruption = {
+  utterance: ActiveUtterance;
+  estimate: SpeechDeliveryEstimate;
+  resumeCutoff: number;
 };
 type SpeechStatus =
   | "speaking"
@@ -304,6 +313,29 @@ function estimateSpeechDelivery(
   };
 }
 
+function safeResumeCutoff(
+  text: string,
+  delivery: VoiceDeliveryProgress | null,
+): number {
+  if (!delivery?.segments.length) return 0;
+
+  let searchFrom = 0;
+  let cutoff = 0;
+  for (const segment of delivery.segments) {
+    const segmentStart = text.indexOf(segment.text, searchFrom);
+    if (segmentStart === -1) return cutoff;
+    const segmentEnd = segmentStart + segment.text.length;
+    const fullyPlayed =
+      segment.synthesisComplete &&
+      segment.totalFrames > 0 &&
+      segment.playedFrames >= segment.totalFrames;
+    if (!fullyPlayed) return segmentStart;
+    cutoff = segmentEnd;
+    searchFrom = segmentEnd;
+  }
+  return cutoff;
+}
+
 function applyInterruptionEstimate(
   utterance: ActiveUtterance,
   estimate: SpeechDeliveryEstimate,
@@ -534,8 +566,10 @@ function finalizeInterruptedUtterance(
     utterance.latestDelivery,
   );
   applyInterruptionEstimate(utterance, estimate);
-  utterance.onInterrupted();
-  recordDeliveryNotices(utterance, estimate, "interrupted", cause);
+  const noticeDeferred = utterance.onInterrupted(estimate, cause);
+  if (!noticeDeferred) {
+    recordDeliveryNotices(utterance, estimate, "interrupted", cause);
+  }
   activeUtterance = null;
   restoreListeningIfConversationIsRunning(utterance);
   reportAssistantActivity(utterance.sessionId, utterance.voiceRevision, false);
@@ -624,7 +658,6 @@ function interruptActiveUtterance(
   if (utterance && !utterance.interruptionRequested) {
     utterance.interruptionRequested = true;
     utterance.interruptionCause = cause;
-    if (terminalEventExpected) utterance.onInterrupted();
   }
   if (utterance && !terminalEventExpected) {
     finalizeInterruptedUtterance(
@@ -816,7 +849,9 @@ export function startNativeAssistantSpeech(
   }
 
   let heldSpeech: HeldSpeech | null = null;
+  let resumableInterruption: ResumableInterruption | null = null;
   let heldReleaseReady = false;
+  let interruptionReleaseReady = false;
   let idleSettling = false;
   let heldReleaseTimer: number | null = null;
 
@@ -893,6 +928,10 @@ export function startNativeAssistantSpeech(
     if (!held) return;
     for (const [slot, heldTarget] of held.targets) {
       if (heldTarget.causalTranscriptKey === finalizedTranscriptKey) continue;
+      if (interruptedMessages.has(heldTarget.target.messageId)) {
+        held.targets.delete(slot);
+        continue;
+      }
       suppressTarget(slot, heldTarget.target, heldTarget.text);
       held.targets.delete(slot);
     }
@@ -900,6 +939,68 @@ export function startNativeAssistantSpeech(
       heldSpeech = null;
       heldReleaseReady = false;
     }
+  };
+
+  const discardResumableInterruption = () => {
+    const pending = resumableInterruption;
+    if (!pending) return;
+    for (const target of pending.utterance.targets) {
+      interruptedMessages.add(target.messageId);
+      interruptionCauseByMessage.set(target.messageId, "userSpeaking");
+    }
+    recordDeliveryNotices(
+      pending.utterance,
+      pending.estimate,
+      "interrupted",
+      "userSpeaking",
+    );
+    resumableInterruption = null;
+    interruptionReleaseReady = false;
+  };
+
+  const releaseResumableInterruption = () => {
+    const pending = resumableInterruption;
+    if (!pending || !interruptionReleaseReady) return;
+    const finalizedTranscriptKey =
+      useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
+    if (
+      pending.utterance.resumptionDiscarded ||
+      pending.utterance.causalTranscriptKey !== finalizedTranscriptKey
+    ) {
+      discardResumableInterruption();
+      return;
+    }
+    for (const { target, localCutoff } of targetDeliveryCutoffs(
+      pending.utterance,
+      pending.resumeCutoff,
+    )) {
+      const content = targetContent(sessionId, target);
+      if (!content) continue;
+      const priorText = consumedTextBySlot.get(targetKey(target)) ?? "";
+      const safeLocalCutoff = content.text.startsWith(priorText)
+        ? localCutoff
+        : 0;
+      consumedTextBySlot.set(
+        targetKey(target),
+        content.text.slice(0, safeLocalCutoff),
+      );
+      completedMessages.delete(target.messageId);
+    }
+    resumableInterruption = null;
+    interruptionReleaseReady = false;
+  };
+
+  const discardHeldAndResumableSpeech = () => {
+    const held = heldSpeech;
+    if (held) {
+      for (const [slot, heldTarget] of held.targets) {
+        suppressTarget(slot, heldTarget.target, heldTarget.text);
+      }
+      heldSpeech = null;
+      heldReleaseReady = false;
+    }
+    if (activeUtterance) activeUtterance.resumptionDiscarded = true;
+    discardResumableInterruption();
   };
 
   const ensureUtterance = (
@@ -936,6 +1037,7 @@ export function startNativeAssistantSpeech(
       finishing: false,
       nativeStreamStarted: false,
       interruptionRequested: false,
+      resumptionDiscarded: false,
       interruptionFallback: null,
       interruptionCause: null,
       latestDelivery: null,
@@ -947,7 +1049,25 @@ export function startNativeAssistantSpeech(
         }
         onFailure(text, error);
       },
-      onInterrupted: () => {
+      onInterrupted: (estimate, cause) => {
+        const finalizedTranscriptKey =
+          useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
+        if (
+          cause === "userSpeaking" &&
+          !utterance.resumptionDiscarded &&
+          utterance.causalTranscriptKey === finalizedTranscriptKey
+        ) {
+          resumableInterruption = {
+            utterance,
+            estimate,
+            resumeCutoff: safeResumeCutoff(
+              utterance.text,
+              utterance.latestDelivery,
+            ),
+          };
+          releaseResumableInterruption();
+          return true;
+        }
         for (const utteranceTarget of utterance.targets) {
           interruptedMessages.add(utteranceTarget.messageId);
           interruptionCauseByMessage.set(
@@ -955,6 +1075,7 @@ export function startNativeAssistantSpeech(
             utterance.interruptionCause ?? "voiceStopped",
           );
         }
+        return false;
       },
       onTerminal: () => queueMicrotask(inspect),
     };
@@ -994,16 +1115,26 @@ export function startNativeAssistantSpeech(
       holdAssistantChanges(messages);
     }
     const finalizedTranscriptKey = voice.latestFinalizedTranscriptKey;
+    if (
+      resumableInterruption &&
+      (resumableInterruption.utterance.resumptionDiscarded ||
+        resumableInterruption.utterance.causalTranscriptKey !==
+          finalizedTranscriptKey)
+    ) {
+      discardResumableInterruption();
+    }
     discardInvalidHeldSpeech(finalizedTranscriptKey);
     if (
       activeUtterance &&
       activeUtterance.causalTranscriptKey !== finalizedTranscriptKey
     ) {
+      activeUtterance.resumptionDiscarded = true;
       interruptActiveUtterance(true, "userSpeaking");
     }
 
     if (voice.userSpeaking || idleSettling) return;
     if (heldSpeech && !heldReleaseReady) return;
+    if (resumableInterruption) return;
 
     // The backend owns the current stream until its terminal playback event.
     // Leave later transcript changes entirely unconsumed so that terminal
@@ -1229,6 +1360,7 @@ export function startNativeAssistantSpeech(
     activeSpeechRevision = initialVoice.status.revision;
   }
   let wasUserSpeaking = initialVoice.userSpeaking;
+  let wasMicrophoneMuted = initialVoice.microphoneMuted;
   const unsubscribeVoice = useVoiceConversationStore.subscribe((voice) => {
     const runningForSession =
       voice.status.lifecycle === "running" &&
@@ -1248,13 +1380,25 @@ export function startNativeAssistantSpeech(
     activeSpeechRevision = voice.status.revision;
     const becameUserSpeaking = voice.userSpeaking && !wasUserSpeaking;
     const becameUserIdle = !voice.userSpeaking && wasUserSpeaking;
+    const becameMicrophoneMuted = voice.microphoneMuted && !wasMicrophoneMuted;
     wasUserSpeaking = voice.userSpeaking;
+    wasMicrophoneMuted = voice.microphoneMuted;
     if (activeGeneration !== generation) return;
+    if (becameMicrophoneMuted) {
+      if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
+      heldReleaseTimer = null;
+      idleSettling = false;
+      interruptionReleaseReady = false;
+      discardHeldAndResumableSpeech();
+      inspect();
+      return;
+    }
     if (becameUserSpeaking) {
       if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
       heldReleaseTimer = null;
       idleSettling = false;
       heldReleaseReady = false;
+      interruptionReleaseReady = false;
       interruptActiveUtterance(true, "userSpeaking");
       inspect();
       return;
@@ -1278,6 +1422,8 @@ export function startNativeAssistantSpeech(
         }
         idleSettling = false;
         heldReleaseReady = heldSpeech !== null;
+        interruptionReleaseReady = true;
+        releaseResumableInterruption();
         inspect();
       }, USER_IDLE_TRANSCRIPT_SETTLE_MS);
       return;
@@ -1287,6 +1433,7 @@ export function startNativeAssistantSpeech(
   stopVoiceSubscription = () => {
     if (heldReleaseTimer !== null) window.clearTimeout(heldReleaseTimer);
     heldReleaseTimer = null;
+    discardHeldAndResumableSpeech();
     unsubscribeVoice();
   };
   queueMicrotask(inspect);

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -62,6 +62,7 @@ type ActiveUtterance = {
   onInterrupted: (
     estimate: SpeechDeliveryEstimate,
     cause: InterruptionCause,
+    allowResume: boolean,
   ) => boolean;
   onTerminal: () => void;
 };
@@ -560,6 +561,7 @@ function failActiveUtterance(
 function finalizeInterruptedUtterance(
   utterance: ActiveUtterance,
   cause: InterruptionCause,
+  allowResume = false,
 ) {
   if (activeUtterance?.id !== utterance.id) return;
   if (utterance.interruptionFallback !== null) {
@@ -571,7 +573,7 @@ function finalizeInterruptedUtterance(
     utterance.latestDelivery,
   );
   applyInterruptionEstimate(utterance, estimate);
-  const noticeDeferred = utterance.onInterrupted(estimate, cause);
+  const noticeDeferred = utterance.onInterrupted(estimate, cause, allowResume);
   if (!noticeDeferred) {
     recordDeliveryNotices(utterance, estimate, "interrupted", cause);
   }
@@ -638,6 +640,7 @@ function handleStreamEvent(
       finalizeInterruptedUtterance(
         utterance,
         utterance.interruptionCause ?? "voiceStopped",
+        true,
       );
       break;
     }
@@ -677,22 +680,7 @@ function interruptActiveUtterance(
         utterance.interruptionCause ?? cause,
       );
     }, INTERRUPTION_TERMINAL_TIMEOUT_MS);
-    void stopActiveVoice().then(
-      (stopped) => {
-        if (!stopped) {
-          finalizeInterruptedUtterance(
-            utterance,
-            utterance.interruptionCause ?? cause,
-          );
-        }
-      },
-      () => {
-        finalizeInterruptedUtterance(
-          utterance,
-          utterance.interruptionCause ?? cause,
-        );
-      },
-    );
+    void stopActiveVoice().catch(() => undefined);
   } else {
     void stopActiveVoice().catch(() => undefined);
   }
@@ -996,16 +984,27 @@ export function startNativeAssistantSpeech(
   };
 
   const discardHeldAndResumableSpeech = () => {
+    const activeTargetKeys = new Set(
+      activeUtterance?.targets.map((target) => targetKey(target)) ?? [],
+    );
+    const resumableTargetKeys = new Set(
+      resumableInterruption?.utterance.targets.map((target) =>
+        targetKey(target),
+      ) ?? [],
+    );
+    if (activeUtterance) activeUtterance.resumptionDiscarded = true;
+    discardResumableInterruption();
     const held = heldSpeech;
     if (held) {
       for (const [slot, heldTarget] of held.targets) {
+        if (activeTargetKeys.has(slot) || resumableTargetKeys.has(slot)) {
+          continue;
+        }
         suppressTarget(slot, heldTarget.target, heldTarget.text);
       }
       heldSpeech = null;
       heldReleaseReady = false;
     }
-    if (activeUtterance) activeUtterance.resumptionDiscarded = true;
-    discardResumableInterruption();
   };
 
   const ensureUtterance = (
@@ -1054,11 +1053,12 @@ export function startNativeAssistantSpeech(
         }
         onFailure(text, error);
       },
-      onInterrupted: (estimate, cause) => {
+      onInterrupted: (estimate, cause, allowResume) => {
         const finalizedTranscriptKey =
           useVoiceConversationStore.getState().latestFinalizedTranscriptKey;
         if (
           cause === "userSpeaking" &&
+          allowResume &&
           !utterance.resumptionDiscarded &&
           utterance.causalTranscriptKey === finalizedTranscriptKey
         ) {
@@ -1140,6 +1140,7 @@ export function startNativeAssistantSpeech(
     if (voice.userSpeaking || idleSettling) return;
     if (heldSpeech && !heldReleaseReady) return;
     if (resumableInterruption) return;
+    if (activeUtterance?.interruptionRequested) return;
 
     // The backend owns the current stream until its terminal playback event.
     // Leave later transcript changes entirely unconsumed so that terminal


### PR DESCRIPTION
## Summary

This fixes assistant speech being permanently abandoned when Earshot reports a brief interruption but Apple speech recognition produces no newer finalized transcript. Berd holds the interrupted delivery through the existing transcript settle window and resumes from the first synthesis chunk not known to be complete.

Finalized speech, microphone mute, explicit stop, call or session ownership changes, and voice backend changes discard the remainder. Native playback ownership is released before a resumed stream starts, and resume positions remain absolute so repeated interruptions can replay the current chunk without rewinding into earlier completed chunks.

### Related issue

None found.

### Testing

On macOS, start a voice conversation with Pocket TTS and request a long response. Briefly interrupt it without producing finalized STT. The response resumes after the settle window. Interrupt the resumed response repeatedly: the current incomplete chunk may replay, but playback does not move back into earlier completed chunks and does not report that Pocket playback is already active.

Speak a real utterance that produces finalized STT, mute the microphone, or end the call while speech is held. The held remainder stays discarded rather than resuming.