### PR TITLE
fix(voice): prevent starts after leaving settings

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -3179,6 +3179,25 @@ describe("AppShell global navigation", () => {
     expect(
       await screen.findByPlaceholderText("Start a conversation"),
     ).toHaveValue("keep this voice draft");
+    expect(
+      screen.getByPlaceholderText("Start a conversation"),
+    ).not.toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: "Back" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
+    });
+    await user.keyboard("{Meta>}n{/Meta}");
+    const restoredTextbox = await screen.findByPlaceholderText(
+      "Start a conversation",
+    );
+    await waitFor(() => {
+      expect(restoredTextbox.closest("[data-placement]")).toHaveAttribute(
+        "data-placement",
+        "centered",
+      );
+    });
+    expect(restoredTextbox).toHaveValue("keep this voice draft");
   });
 
   it("queues a ready global voice start for the created chat", async () => {

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -93,7 +93,10 @@ const mockAcpCreateSession = vi.hoisted(() => vi.fn());
 const mockAcpPrepareSession = vi.hoisted(() => vi.fn());
 const mockAcpSetSessionConfigOption = vi.hoisted(() => vi.fn());
 const mockAcpListSessionsPage = vi.hoisted(() => vi.fn());
-const mockBuildFeatures = vi.hoisted(() => ({ byoKeyProviders: false }));
+const mockBuildFeatures = vi.hoisted(() => ({
+  byoKeyProviders: false,
+  voiceConversation: false,
+}));
 const mockAcpArchiveSession = vi.hoisted(() => vi.fn());
 const mockAcpGetSessionInfo = vi.hoisted(() => vi.fn());
 const mockAcpLoadSession = vi.hoisted(() => vi.fn());
@@ -935,6 +938,7 @@ describe("AppShell global navigation", () => {
     window.history.replaceState(null, "", "/");
     window.localStorage.clear();
     mockBuildFeatures.byoKeyProviders = false;
+    mockBuildFeatures.voiceConversation = false;
     mockGetPlatform.mockReturnValue("mac");
     mockDesignSystemExplorerEnabled.mockReturnValue(false);
     mockAfterNextPaint.callbacks = [];
@@ -3148,6 +3152,56 @@ describe("AppShell global navigation", () => {
       "centered",
     );
     expect(mockAcpCreateSession).not.toHaveBeenCalled();
+  });
+
+  it("opens Voice settings without creating a chat when global voice is unready", async () => {
+    mockBuildFeatures.voiceConversation = true;
+    renderAppShell();
+
+    const { textbox, user } = await openCenteredComposerFromChat();
+    mockAcpCreateSession.mockClear();
+    await user.type(textbox, "keep this voice draft");
+    await user.click(
+      screen.getByRole("button", { name: "Start voice conversation" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
+    });
+    await act(async () => {
+      flushAfterNextPaintCallbacks();
+    });
+    expect(screen.getByTestId("settings-section")).toHaveTextContent("voice");
+    expect(mockAcpCreateSession).not.toHaveBeenCalled();
+    expect(
+      useVoiceConversationStore.getState().requestedStartSessionId,
+    ).toBeNull();
+    expect(
+      await screen.findByPlaceholderText("Start a conversation"),
+    ).toHaveValue("keep this voice draft");
+  });
+
+  it("queues a ready global voice start for the created chat", async () => {
+    mockBuildFeatures.voiceConversation = true;
+    mockVoiceSetupReadiness.ready = true;
+    renderAppShell();
+
+    const { textbox, user } = await openCenteredComposerFromChat();
+    mockAcpCreateSession.mockClear();
+    mockAcpCreateSession.mockResolvedValueOnce({ sessionId: "voice-session" });
+    await user.type(textbox, "start this voice chat");
+    await user.click(
+      screen.getByRole("button", { name: "Start voice conversation" }),
+    );
+
+    await waitFor(() => {
+      expect(useChatSessionStore.getState().activeSessionId).toBe(
+        "voice-session",
+      );
+    });
+    expect(useVoiceConversationStore.getState().requestedStartSessionId).toBe(
+      "voice-session",
+    );
   });
 
   it("dismisses the centered global composer from the backdrop and global Escape", async () => {

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -4479,6 +4479,9 @@ describe("AppShell global navigation", () => {
     await waitFor(() => {
       expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
     });
+    expect(
+      useVoiceConversationStore.getState().requestedStartSessionId,
+    ).toBeNull();
     await user.click(screen.getByRole("button", { name: "Back" }));
 
     await waitFor(() => {

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -132,8 +132,6 @@ const mockSessionWindowSupport = vi.hoisted(() => ({ supported: false }));
 const mockFocusSessionWindow = vi.hoisted(() => vi.fn());
 const mockVoiceSetupReadiness = vi.hoisted(() => ({
   ready: false,
-  authoritativeReady: false,
-  refreshPromise: null as Promise<boolean> | null,
 }));
 const mockVoiceSettingsEnabled = vi.hoisted(() => ({ enabled: false }));
 
@@ -156,9 +154,6 @@ vi.mock("@/features/settings/ui/settingsSections", async (importOriginal) => {
 
 vi.mock("@/features/voice-conversation/lib/voiceSetupReadiness", () => ({
   isVoiceSetupReady: () => mockVoiceSetupReadiness.ready,
-  refreshStableVoiceSetupReadiness: () =>
-    mockVoiceSetupReadiness.refreshPromise ??
-    Promise.resolve(mockVoiceSetupReadiness.authoritativeReady),
 }));
 
 function deferred<T>() {
@@ -948,8 +943,6 @@ describe("AppShell global navigation", () => {
     document.documentElement.removeAttribute("data-global-composer-visible");
     mockSessionWindowSupport.supported = false;
     mockVoiceSetupReadiness.ready = false;
-    mockVoiceSetupReadiness.authoritativeReady = false;
-    mockVoiceSetupReadiness.refreshPromise = null;
     mockVoiceSettingsEnabled.enabled = false;
     mockFocusSessionWindow.mockReset();
     useSessionWindowStore.getState().setSnapshot([]);
@@ -4577,7 +4570,7 @@ describe("AppShell global navigation", () => {
     ).toBeNull();
   });
 
-  it("preserves a voice start when authoritative readiness leads the AppShell snapshot", async () => {
+  it("cancels a voice start when setup becomes ready before returning", async () => {
     const user = userEvent.setup();
     const session = useChatSessionStore.getState().createDraftSession({
       title: "Voice setup target",
@@ -4604,7 +4597,7 @@ describe("AppShell global navigation", () => {
       expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
     });
 
-    mockVoiceSetupReadiness.authoritativeReady = true;
+    mockVoiceSetupReadiness.ready = true;
     view.rerender(appShellWithTheme());
     await user.click(screen.getByRole("button", { name: "Back" }));
 
@@ -4612,59 +4605,9 @@ describe("AppShell global navigation", () => {
       expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
     });
     expect(useChatSessionStore.getState().activeSessionId).toBe(session.id);
-    expect(useVoiceConversationStore.getState().requestedStartSessionId).toBe(
-      session.id,
-    );
-  });
-
-  it("lets a reopened Voice target return while its previous readiness refresh is pending", async () => {
-    const user = userEvent.setup();
-    const session = useChatSessionStore.getState().createDraftSession({
-      title: "Voice target",
-      workingDir: "/tmp/voice-target",
-    });
-    const firstRefresh = deferred<boolean>();
-    const secondRefresh = deferred<boolean>();
-    mockVoiceSettingsEnabled.enabled = true;
-    renderAppShell();
-
-    const openVoiceSetup = (sessionId: string) => {
-      useVoiceConversationStore.getState().requestStart(sessionId);
-      window.dispatchEvent(
-        new CustomEvent(OPEN_SETTINGS_EVENT, {
-          detail: {
-            section: "voice",
-            returnTarget: { type: "voice-setup", sessionId },
-          },
-        }),
-      );
-    };
-
-    act(() => openVoiceSetup(session.id));
-    await waitFor(() => {
-      expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
-    });
-    mockVoiceSetupReadiness.refreshPromise = firstRefresh.promise;
-    await user.click(screen.getByRole("button", { name: "Back" }));
-
-    act(() => openVoiceSetup(session.id));
-    mockVoiceSetupReadiness.refreshPromise = secondRefresh.promise;
-    await user.click(screen.getByRole("button", { name: "Back" }));
-
-    firstRefresh.resolve(false);
-    await act(async () => {
-      await firstRefresh.promise;
-    });
-    expect(screen.getByTestId("active-view")).toHaveTextContent("settings");
-
-    secondRefresh.resolve(true);
-    await waitFor(() => {
-      expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
-    });
-    expect(useChatSessionStore.getState().activeSessionId).toBe(session.id);
-    expect(useVoiceConversationStore.getState().requestedStartSessionId).toBe(
-      session.id,
-    );
+    expect(
+      useVoiceConversationStore.getState().requestedStartSessionId,
+    ).toBeNull();
   });
 
   it("guards Voice setup navigation from a dirty agent draft", async () => {

--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -3187,6 +3187,11 @@ describe("AppShell global navigation", () => {
     await waitFor(() => {
       expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
     });
+    expect(
+      screen
+        .getByPlaceholderText("Start a conversation")
+        .closest("[data-placement]"),
+    ).toHaveStyle({ display: "none" });
     await user.keyboard("{Meta>}n{/Meta}");
     const restoredTextbox = await screen.findByPlaceholderText(
       "Start a conversation",
@@ -3198,6 +3203,9 @@ describe("AppShell global navigation", () => {
       );
     });
     expect(restoredTextbox).toHaveValue("keep this voice draft");
+    expect(restoredTextbox.closest("[data-placement]")).not.toHaveStyle({
+      display: "none",
+    });
   });
 
   it("queues a ready global voice start for the created chat", async () => {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -258,7 +258,6 @@ import type {
 } from "./types/appNavigation";
 import type { TopBarBreadcrumb } from "./ui/TopBar";
 import { STARTUP_LOADING_MIN_DISPLAY_MS } from "./lib/startupLoading";
-import { scheduleAfterNextPaint } from "./lib/scheduleAfterNextPaint";
 import { StartupLoadingView } from "./ui/StartupLoadingView";
 import { deriveStarterTaskCompletion } from "@/features/home/onboarding/starterTaskCompletion";
 import {
@@ -885,6 +884,8 @@ export function AppShell({
     useState<GlobalComposerPlacement>("docked");
   const [globalComposerStarterRequest, setGlobalComposerStarterRequest] =
     useState<GlobalComposerStarterRequest | null>(null);
+  const [retainGlobalComposerDraft, setRetainGlobalComposerDraft] =
+    useState(false);
   const globalComposerStarterRequestIdRef = useRef(0);
   const [chatComposerHandoffRequest, setChatComposerHandoffRequest] =
     useState(0);
@@ -3239,19 +3240,9 @@ export function AppShell({
         return new Promise<boolean>((resolve) => {
           guardAppNavigation(
             () => {
+              setRetainGlobalComposerDraft(true);
               requestOpenSettings("voice");
               resetGlobalComposerTransition();
-              scheduleAfterNextPaint(() => {
-                globalComposerStarterRequestIdRef.current += 1;
-                setGlobalComposerStarterRequest({
-                  id: globalComposerStarterRequestIdRef.current,
-                  text: payload.text,
-                  selectedSkills: payload.selectedSkills,
-                  attachments: payload.options?.attachments,
-                  personaId: payload.options?.personaId,
-                  projectId: payload.options?.projectId,
-                });
-              });
               resolve(false);
             },
             () => resolve(false),
@@ -4577,8 +4568,19 @@ export function AppShell({
   const showGlobalComposer =
     canShowGlobalComposer &&
     (globalComposerPlacement !== "docked" || renderedLocation.view !== "chat");
+  const mountGlobalComposer = showGlobalComposer || retainGlobalComposerDraft;
   const showGlobalComposerShim =
     canShowGlobalComposer && globalComposerPlacement !== "docked";
+
+  useEffect(() => {
+    if (
+      retainGlobalComposerDraft &&
+      showGlobalComposer &&
+      globalComposerPlacement === "centered"
+    ) {
+      setRetainGlobalComposerDraft(false);
+    }
+  }, [globalComposerPlacement, retainGlobalComposerDraft, showGlobalComposer]);
 
   useEffect(() => {
     if (
@@ -5502,8 +5504,9 @@ export function AppShell({
                 onClick={dismissCenteredGlobalComposer}
               />
             ) : null}
-            {showGlobalComposer ? (
+            {mountGlobalComposer ? (
               <GlobalComposerPill
+                hidden={!showGlobalComposer}
                 elevated={renderedLocation.view === "settings"}
                 focusRequest={globalComposerFocusRequest}
                 onSend={handleGlobalCompose}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -3288,7 +3288,6 @@ export function AppShell({
         chatState.setDraft(sessionId, payload.text);
         chatState.setSkillDrafts(sessionId, payload.selectedSkills);
         chatState.setDraftAttachments(sessionId, options?.attachments ?? []);
-        requestVoiceConversationStart(sessionId);
         if (!globalVoiceReady) {
           requestOpenSettings("voice", {
             returnTarget: { type: "voice-setup", sessionId },
@@ -3296,6 +3295,7 @@ export function AppShell({
           resetGlobalComposerTransition();
           return true;
         }
+        requestVoiceConversationStart(sessionId);
         handleNavigateToSession(sessionId);
         resetGlobalComposerTransition();
         return true;
@@ -3623,6 +3623,11 @@ export function AppShell({
           useVoiceConversationStore
             .getState()
             .clearRequestedStart(currentVoiceTarget.sessionId);
+        }
+        if (nextVoiceTarget) {
+          useVoiceConversationStore
+            .getState()
+            .clearRequestedStart(nextVoiceTarget.sessionId);
         }
         voiceSettingsReturnTargetRef.current = nextVoiceTarget;
         setVoiceSettingsReturnTarget(nextVoiceTarget);

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -258,6 +258,7 @@ import type {
 } from "./types/appNavigation";
 import type { TopBarBreadcrumb } from "./ui/TopBar";
 import { STARTUP_LOADING_MIN_DISPLAY_MS } from "./lib/startupLoading";
+import { scheduleAfterNextPaint } from "./lib/scheduleAfterNextPaint";
 import { StartupLoadingView } from "./ui/StartupLoadingView";
 import { deriveStarterTaskCompletion } from "@/features/home/onboarding/starterTaskCompletion";
 import {
@@ -3234,6 +3235,29 @@ export function AppShell({
   const handleGlobalVoiceConversationStart = useCallback(
     (payload: GlobalComposerExpandPayload): Promise<boolean> => {
       if (!capabilities.voiceConversation) return Promise.resolve(false);
+      if (!globalVoiceReady) {
+        return new Promise<boolean>((resolve) => {
+          guardAppNavigation(
+            () => {
+              requestOpenSettings("voice");
+              resetGlobalComposerTransition();
+              scheduleAfterNextPaint(() => {
+                globalComposerStarterRequestIdRef.current += 1;
+                setGlobalComposerStarterRequest({
+                  id: globalComposerStarterRequestIdRef.current,
+                  text: payload.text,
+                  selectedSkills: payload.selectedSkills,
+                  attachments: payload.options?.attachments,
+                  personaId: payload.options?.personaId,
+                  projectId: payload.options?.projectId,
+                });
+              });
+              resolve(false);
+            },
+            () => resolve(false),
+          );
+        });
+      }
       const options = payload.options;
       const project = options?.projectId
         ? projects.find((candidate) => candidate.id === options.projectId)
@@ -3288,13 +3312,6 @@ export function AppShell({
         chatState.setDraft(sessionId, payload.text);
         chatState.setSkillDrafts(sessionId, payload.selectedSkills);
         chatState.setDraftAttachments(sessionId, options?.attachments ?? []);
-        if (!globalVoiceReady) {
-          requestOpenSettings("voice", {
-            returnTarget: { type: "voice-setup", sessionId },
-          });
-          resetGlobalComposerTransition();
-          return true;
-        }
         requestVoiceConversationStart(sessionId);
         handleNavigateToSession(sessionId);
         resetGlobalComposerTransition();

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -241,10 +241,7 @@ import {
   useVoiceInputPreference,
 } from "@/features/voice-conversation/lib/voiceInputPreference";
 import { useVoiceOutputPreference } from "@/features/voice-conversation/lib/voiceOutputPreference";
-import {
-  isVoiceSetupReady,
-  refreshStableVoiceSetupReadiness,
-} from "@/features/voice-conversation/lib/voiceSetupReadiness";
+import { isVoiceSetupReady } from "@/features/voice-conversation/lib/voiceSetupReadiness";
 import { useProfileCapabilities } from "@/shared/profile/capabilities";
 import { getOptimisticArtifactCwd } from "@/shared/artifacts/sessionArtifactLocation";
 import {
@@ -748,27 +745,6 @@ export function AppShell({
   const globalSiriVoiceSetup = useSiriVoiceSetup(
     capabilities.voiceConversation && globalVoiceOutput.backend === "siri",
   );
-  const globalVoiceSetupSelectionRef = useRef({
-    inputBackend: globalVoiceInput.backend,
-    outputBackend: globalVoiceOutput.backend,
-    siriLanguage: globalSiriVoiceSetup.language,
-    revision: 0,
-  });
-  if (
-    globalVoiceSetupSelectionRef.current.inputBackend !==
-      globalVoiceInput.backend ||
-    globalVoiceSetupSelectionRef.current.outputBackend !==
-      globalVoiceOutput.backend ||
-    globalVoiceSetupSelectionRef.current.siriLanguage !==
-      globalSiriVoiceSetup.language
-  ) {
-    globalVoiceSetupSelectionRef.current = {
-      inputBackend: globalVoiceInput.backend,
-      outputBackend: globalVoiceOutput.backend,
-      siriLanguage: globalSiriVoiceSetup.language,
-      revision: globalVoiceSetupSelectionRef.current.revision + 1,
-    };
-  }
   const globalVoiceReady = isVoiceSetupReady(
     globalPocketVoiceSetup.status,
     globalMacSpeechSetup.status,
@@ -942,8 +918,6 @@ export function AppShell({
   const [voiceSettingsReturnTarget, setVoiceSettingsReturnTarget] =
     useState<VoiceSetupReturnTarget | null>(null);
   const voiceSettingsReturnTargetRef = useRef(voiceSettingsReturnTarget);
-  const voiceSettingsReturnInFlightRef = useRef<string | null>(null);
-  const voiceSettingsReturnGenerationRef = useRef(0);
   voiceSettingsReturnTargetRef.current = voiceSettingsReturnTarget;
   const [homeSessionId, setHomeSessionId] = useState<string | null>(() =>
     loadStoredHomeSessionId(),
@@ -3501,14 +3475,8 @@ export function AppShell({
       return false;
     }
 
-    if (voiceSettingsReturnInFlightRef.current === target.sessionId) {
-      return true;
-    }
-
     const session = useChatSessionStore.getState().getSession(target.sessionId);
     if (!session || session.archivedAt) {
-      voiceSettingsReturnGenerationRef.current += 1;
-      voiceSettingsReturnInFlightRef.current = null;
       voiceSettingsReturnTargetRef.current = null;
       setVoiceSettingsReturnTarget(null);
       useVoiceConversationStore
@@ -3517,59 +3485,32 @@ export function AppShell({
       return false;
     }
 
-    voiceSettingsReturnInFlightRef.current = target.sessionId;
-    const returnGeneration = ++voiceSettingsReturnGenerationRef.current;
-    void refreshStableVoiceSetupReadiness(
-      () => globalVoiceSetupSelectionRef.current,
-    )
-      .then((ready) => {
-        if (
-          !ready &&
-          voiceSettingsReturnGenerationRef.current === returnGeneration
-        ) {
-          useVoiceConversationStore
-            .getState()
-            .clearRequestedStart(target.sessionId);
-        }
-      })
-      .catch(() => {
-        // Preserve the requested start when readiness cannot be confirmed.
-        // The session controller will consume it only after its live status is ready.
-      })
-      .finally(() => {
-        if (
-          voiceSettingsReturnGenerationRef.current !== returnGeneration ||
-          voiceSettingsReturnTargetRef.current?.sessionId !== target.sessionId
-        ) {
-          return;
-        }
-        voiceSettingsReturnInFlightRef.current = null;
-        voiceSettingsReturnTargetRef.current = null;
-        setVoiceSettingsReturnTarget(null);
+    useVoiceConversationStore.getState().clearRequestedStart(target.sessionId);
+    voiceSettingsReturnTargetRef.current = null;
+    setVoiceSettingsReturnTarget(null);
 
-        const history = navigationHistoryRef.current;
-        const previousLocation =
-          history.index > 0 ? history.entries[history.index - 1] : null;
-        if (
-          previousLocation?.view === "chat" &&
-          previousLocation.sessionId === target.sessionId
-        ) {
-          history.index -= 1;
-        } else {
-          history.entries.splice(history.index, 0, {
-            view: "chat",
-            sessionId: target.sessionId,
-          });
-        }
-
-        clearSettingsSectionUrl();
-        setActiveSession(target.sessionId);
-        setActiveView("chat");
-        setChatActiveSession(target.sessionId);
-        useChatStore.getState().markSessionRead(target.sessionId);
-        void loadSessionMessagesAndPrepare(target.sessionId);
-        updateNavigationAvailability();
+    const history = navigationHistoryRef.current;
+    const previousLocation =
+      history.index > 0 ? history.entries[history.index - 1] : null;
+    if (
+      previousLocation?.view === "chat" &&
+      previousLocation.sessionId === target.sessionId
+    ) {
+      history.index -= 1;
+    } else {
+      history.entries.splice(history.index, 0, {
+        view: "chat",
+        sessionId: target.sessionId,
       });
+    }
+
+    clearSettingsSectionUrl();
+    setActiveSession(target.sessionId);
+    setActiveView("chat");
+    setChatActiveSession(target.sessionId);
+    useChatStore.getState().markSessionRead(target.sessionId);
+    void loadSessionMessagesAndPrepare(target.sessionId);
+    updateNavigationAvailability();
     return true;
   }, [
     setActiveSession,
@@ -3588,8 +3529,6 @@ export function AppShell({
     useVoiceConversationStore
       .getState()
       .clearRequestedStart(voiceSettingsReturnTarget.sessionId);
-    voiceSettingsReturnGenerationRef.current += 1;
-    voiceSettingsReturnInFlightRef.current = null;
     voiceSettingsReturnTargetRef.current = null;
     setVoiceSettingsReturnTarget(null);
   }, [activeSettingsSection, activeView, voiceSettingsReturnTarget]);
@@ -3684,10 +3623,6 @@ export function AppShell({
           useVoiceConversationStore
             .getState()
             .clearRequestedStart(currentVoiceTarget.sessionId);
-        }
-        if (voiceSettingsReturnInFlightRef.current !== null) {
-          voiceSettingsReturnGenerationRef.current += 1;
-          voiceSettingsReturnInFlightRef.current = null;
         }
         voiceSettingsReturnTargetRef.current = nextVoiceTarget;
         setVoiceSettingsReturnTarget(nextVoiceTarget);

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -73,7 +73,6 @@ import { useVoiceOutputPreference } from "@/features/voice-conversation/lib/voic
 import { isVoiceSetupReady } from "@/features/voice-conversation/lib/voiceSetupReadiness";
 import { useProfileCapabilities } from "@/shared/profile/capabilities";
 import { requestOpenSettings } from "@/features/settings/lib/settingsEvents";
-import { useVoiceConversationStore } from "@/features/voice-conversation/stores/voiceConversationStore";
 import {
   SecurityConfirmationPanel,
   useRegisterSecurityConfirmationSurface,
@@ -241,9 +240,6 @@ export function ChatView({
     voiceInput.backend,
     voiceOutput.backend,
   );
-  const requestVoiceConversationStart = useVoiceConversationStore(
-    (state) => state.requestStart,
-  );
   const voiceConversation = useVoiceConversationController({
     sessionId,
     // Voice delivery only needs to wait for admission. Holding its per-session
@@ -255,7 +251,6 @@ export function ChatView({
     pocketReady: voiceReady,
     inputBackend: voiceInput.backend,
     onPocketSetupRequired: () => {
-      requestVoiceConversationStart(sessionId);
       requestOpenSettings("voice", {
         returnTarget: { type: "voice-setup", sessionId },
       });

--- a/src/features/voice-conversation/lib/voiceSetupReadiness.test.ts
+++ b/src/features/voice-conversation/lib/voiceSetupReadiness.test.ts
@@ -1,26 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { PocketVoiceStatus } from "../api/pocketVoice";
 import type { MacSpeechStatus } from "../api/macSpeech";
 import type { SiriVoiceStatus } from "../api/siriVoice";
-import {
-  isVoiceSetupReady,
-  refreshStableVoiceSetupReadiness,
-  refreshVoiceSetupReadiness,
-} from "./voiceSetupReadiness";
-
-const mockGetPocketVoiceStatus = vi.hoisted(() => vi.fn());
-const mockGetMacSpeechStatus = vi.hoisted(() => vi.fn());
-const mockGetSiriVoiceStatus = vi.hoisted(() => vi.fn());
-
-vi.mock("../api/pocketVoice", () => ({
-  getPocketVoiceStatus: mockGetPocketVoiceStatus,
-}));
-vi.mock("../api/macSpeech", () => ({
-  getMacSpeechStatus: mockGetMacSpeechStatus,
-}));
-vi.mock("../api/siriVoice", () => ({
-  getSiriVoiceStatus: mockGetSiriVoiceStatus,
-}));
+import { isVoiceSetupReady } from "./voiceSetupReadiness";
 
 const pocket = {
   installed: true,
@@ -41,12 +23,6 @@ const macSpeech = {
 } as MacSpeechStatus;
 
 describe("voice setup readiness", () => {
-  beforeEach(() => {
-    mockGetPocketVoiceStatus.mockReset();
-    mockGetMacSpeechStatus.mockReset();
-    mockGetSiriVoiceStatus.mockReset();
-  });
-
   it("requires Parakeet and Pocket for the Pocket backend", () => {
     expect(isVoiceSetupReady(pocket, null, null, "parakeet", "pocket")).toBe(
       true,
@@ -77,95 +53,15 @@ describe("voice setup readiness", () => {
     ).toBe(false);
   });
 
-  it("refreshes Pocket readiness without querying Siri", async () => {
-    mockGetPocketVoiceStatus.mockResolvedValue(pocket);
-
-    await expect(
-      refreshVoiceSetupReadiness("parakeet", "pocket", "en-US"),
-    ).resolves.toBe(true);
-    expect(mockGetPocketVoiceStatus).toHaveBeenCalledOnce();
-    expect(mockGetSiriVoiceStatus).not.toHaveBeenCalled();
-  });
-
-  it("refreshes Siri readiness for the selected language", async () => {
-    mockGetPocketVoiceStatus.mockResolvedValue(pocket);
-    mockGetSiriVoiceStatus.mockResolvedValue(siri);
-
-    await expect(
-      refreshVoiceSetupReadiness("parakeet", "siri", "en-AU"),
-    ).resolves.toBe(true);
-    expect(mockGetPocketVoiceStatus).toHaveBeenCalledOnce();
-    expect(mockGetSiriVoiceStatus).toHaveBeenCalledWith("en-AU");
-  });
-
-  it("uses native macOS speech readiness instead of Parakeet when selected", async () => {
-    mockGetPocketVoiceStatus.mockResolvedValue({
-      ...pocket,
-      parakeetInstalled: false,
-    });
-    mockGetMacSpeechStatus.mockResolvedValue(macSpeech);
-
-    await expect(
-      refreshVoiceSetupReadiness("macos", "pocket", "en-US"),
-    ).resolves.toBe(true);
-    expect(mockGetMacSpeechStatus).toHaveBeenCalledOnce();
-  });
-
-  it("rechecks readiness when the selected backend changes during refresh", async () => {
-    let resolvePocket!: (status: PocketVoiceStatus) => void;
-    const firstPocket = new Promise<PocketVoiceStatus>((resolve) => {
-      resolvePocket = resolve;
-    });
-    mockGetPocketVoiceStatus
-      .mockReturnValueOnce(firstPocket)
-      .mockResolvedValueOnce(pocket);
-    mockGetSiriVoiceStatus.mockResolvedValue(siri);
-    let selection: {
-      inputBackend: "parakeet" | "macos";
-      outputBackend: "pocket" | "siri";
-      siriLanguage: string;
-      revision: number;
-    } = {
-      inputBackend: "parakeet",
-      outputBackend: "pocket",
-      siriLanguage: "en-US",
-      revision: 0,
-    };
-
-    const readiness = refreshStableVoiceSetupReadiness(() => selection);
-    selection = {
-      inputBackend: "parakeet",
-      outputBackend: "siri",
-      siriLanguage: "en-AU",
-      revision: 1,
-    };
-    resolvePocket({ ...pocket, pocketInstalled: false });
-
-    await expect(readiness).resolves.toBe(true);
-    expect(mockGetPocketVoiceStatus).toHaveBeenCalledTimes(2);
-    expect(mockGetSiriVoiceStatus).toHaveBeenCalledWith("en-AU");
-  });
-
-  it("rechecks readiness after an A-to-B-to-A selection change", async () => {
-    let resolveFirst!: (status: PocketVoiceStatus) => void;
-    const firstPocket = new Promise<PocketVoiceStatus>((resolve) => {
-      resolveFirst = resolve;
-    });
-    mockGetPocketVoiceStatus
-      .mockReturnValueOnce(firstPocket)
-      .mockResolvedValueOnce(pocket);
-    let selection = {
-      inputBackend: "parakeet" as const,
-      outputBackend: "pocket" as const,
-      siriLanguage: "en-US",
-      revision: 0,
-    };
-
-    const readiness = refreshStableVoiceSetupReadiness(() => selection);
-    selection = { ...selection, revision: 2 };
-    resolveFirst({ ...pocket, pocketInstalled: false });
-
-    await expect(readiness).resolves.toBe(true);
-    expect(mockGetPocketVoiceStatus).toHaveBeenCalledTimes(2);
+  it("uses native macOS speech readiness instead of Parakeet when selected", () => {
+    expect(
+      isVoiceSetupReady(
+        { ...pocket, parakeetInstalled: false },
+        macSpeech,
+        null,
+        "macos",
+        "pocket",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/features/voice-conversation/lib/voiceSetupReadiness.ts
+++ b/src/features/voice-conversation/lib/voiceSetupReadiness.ts
@@ -1,9 +1,6 @@
-import {
-  getPocketVoiceStatus,
-  type PocketVoiceStatus,
-} from "../api/pocketVoice";
-import { getSiriVoiceStatus, type SiriVoiceStatus } from "../api/siriVoice";
-import { getMacSpeechStatus, type MacSpeechStatus } from "../api/macSpeech";
+import type { PocketVoiceStatus } from "../api/pocketVoice";
+import type { SiriVoiceStatus } from "../api/siriVoice";
+import type { MacSpeechStatus } from "../api/macSpeech";
 import type { VoiceInputBackend } from "./voiceInputPreference";
 import type { VoiceOutputBackend } from "./voiceOutputPreference";
 
@@ -28,53 +25,4 @@ export function isVoiceSetupReady(
   return Boolean(
     siri?.supported && siri.selectedVoice && siri.selectedVoiceInstalled,
   );
-}
-
-export async function refreshVoiceSetupReadiness(
-  inputBackend: VoiceInputBackend | null,
-  outputBackend: VoiceOutputBackend,
-  siriLanguage: string,
-): Promise<boolean> {
-  if (inputBackend === null) return false;
-  const [pocket, macSpeech, siri] = await Promise.all([
-    getPocketVoiceStatus(),
-    inputBackend === "macos" ? getMacSpeechStatus() : null,
-    outputBackend === "siri" ? getSiriVoiceStatus(siriLanguage) : null,
-  ]);
-  return isVoiceSetupReady(
-    pocket,
-    macSpeech,
-    siri,
-    inputBackend,
-    outputBackend,
-  );
-}
-
-export interface VoiceSetupSelection {
-  inputBackend: VoiceInputBackend | null;
-  outputBackend: VoiceOutputBackend;
-  siriLanguage: string;
-  revision: number;
-}
-
-export async function refreshStableVoiceSetupReadiness(
-  getSelection: () => VoiceSetupSelection,
-): Promise<boolean> {
-  for (;;) {
-    const selection = getSelection();
-    const ready = await refreshVoiceSetupReadiness(
-      selection.inputBackend,
-      selection.outputBackend,
-      selection.siriLanguage,
-    );
-    const current = getSelection();
-    if (
-      current.inputBackend === selection.inputBackend &&
-      current.outputBackend === selection.outputBackend &&
-      current.siriLanguage === selection.siriLanguage &&
-      current.revision === selection.revision
-    ) {
-      return ready;
-    }
-  }
 }

--- a/src/shared/ui/GlobalComposerPill.test.tsx
+++ b/src/shared/ui/GlobalComposerPill.test.tsx
@@ -1013,6 +1013,33 @@ describe("GlobalComposerPill", () => {
     expect(screen.getByRole("textbox")).toHaveFocus();
   });
 
+  it("restores a complete starter draft", async () => {
+    renderGlobalComposer(vi.fn(), {
+      starterRequest: {
+        id: 1,
+        text: "keep this voice draft",
+        selectedSkills: [
+          {
+            id: "skill-1",
+            name: "code-review",
+          },
+        ],
+        attachments: [
+          {
+            id: "attachment-1",
+            kind: "file",
+            name: "brief.md",
+            path: "/Users/test/brief.md",
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByRole("textbox")).toHaveValue("keep this voice draft");
+    expect(await screen.findByText("code-review")).toBeInTheDocument();
+    expect(screen.getByText("brief.md")).toBeInTheDocument();
+  });
+
   it("uses the selected provider for skill discovery and instruction prompts", async () => {
     const user = userEvent.setup();
     const skill = {

--- a/src/shared/ui/GlobalComposerPill.test.tsx
+++ b/src/shared/ui/GlobalComposerPill.test.tsx
@@ -1013,33 +1013,6 @@ describe("GlobalComposerPill", () => {
     expect(screen.getByRole("textbox")).toHaveFocus();
   });
 
-  it("restores a complete starter draft", async () => {
-    renderGlobalComposer(vi.fn(), {
-      starterRequest: {
-        id: 1,
-        text: "keep this voice draft",
-        selectedSkills: [
-          {
-            id: "skill-1",
-            name: "code-review",
-          },
-        ],
-        attachments: [
-          {
-            id: "attachment-1",
-            kind: "file",
-            name: "brief.md",
-            path: "/Users/test/brief.md",
-          },
-        ],
-      },
-    });
-
-    expect(screen.getByRole("textbox")).toHaveValue("keep this voice draft");
-    expect(await screen.findByText("code-review")).toBeInTheDocument();
-    expect(screen.getByText("brief.md")).toBeInTheDocument();
-  });
-
   it("uses the selected provider for skill discovery and instruction prompts", async () => {
     const user = userEvent.setup();
     const skill = {

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -1235,7 +1235,10 @@ export function GlobalComposerPill({
           setFocused(false);
         }
       }}
-      style={composerStyle}
+      style={{
+        ...composerStyle,
+        display: hidden ? "none" : undefined,
+      }}
       className={cn(
         "global-composer-pill group relative fixed z-40 isolate flex flex-col rounded-composer bg-card-glass py-2 pl-4 pr-2.5 [backdrop-filter:var(--backdrop-panel)] [-webkit-backdrop-filter:var(--backdrop-panel)] transition-[box-shadow,opacity,transform] duration-300 ease-out hover:shadow-global-composer-pill-hover",
         placementClassName,

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -88,15 +88,13 @@ export interface GlobalComposerHandoffRect {
 
 export interface GlobalComposerStarterRequest {
   id: number;
-  text?: string;
   personaId?: string | null;
   projectId?: string | null;
   skill?: ChatSkillDraft;
-  selectedSkills?: ChatSkillDraft[];
-  attachments?: ChatAttachmentDraft[];
 }
 
 interface GlobalComposerPillProps {
+  hidden?: boolean;
   focusRequest?: number;
   elevated?: boolean;
   onSend: (text: string, options?: GlobalComposeOptions) => void;
@@ -210,6 +208,7 @@ function getPreferredModel(
 }
 
 export function GlobalComposerPill({
+  hidden = false,
   focusRequest = 0,
   elevated = false,
   onSend,
@@ -284,7 +283,6 @@ export function GlobalComposerPill({
     addBrowserFiles,
     addPathAttachments,
     removeAttachment,
-    replaceAttachments,
     clearAttachments,
   } = useChatInputAttachments();
   const attachmentWorkPending = attachmentWorkCount > 0;
@@ -381,9 +379,6 @@ export function GlobalComposerPill({
     }
 
     lastStarterRequestIdRef.current = starterRequest.id;
-    if (starterRequest.text !== undefined) {
-      setText(starterRequest.text);
-    }
     if (starterRequest.personaId !== undefined) {
       setSelectedPersonaId(starterRequest.personaId);
       personaSelectionSourceRef.current = starterRequest.personaId
@@ -403,15 +398,9 @@ export function GlobalComposerPill({
           : [...current, skill],
       );
     }
-    if (starterRequest.selectedSkills !== undefined) {
-      setSelectedSkills([...starterRequest.selectedSkills]);
-    }
-    if (starterRequest.attachments !== undefined) {
-      replaceAttachments(starterRequest.attachments);
-    }
     textareaRef.current?.focus();
     onStarterRequestConsumed?.(starterRequest.id);
-  }, [onStarterRequestConsumed, replaceAttachments, starterRequest]);
+  }, [onStarterRequestConsumed, starterRequest]);
 
   const handleRemoveSelectedSkill = useCallback((skillId: string) => {
     setSelectedSkills((current) =>
@@ -1230,6 +1219,7 @@ export function GlobalComposerPill({
 
   return (
     <div
+      hidden={hidden}
       ref={handleContainerRef}
       role="region"
       aria-label={t("globalPill.ariaLabel")}

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -88,9 +88,12 @@ export interface GlobalComposerHandoffRect {
 
 export interface GlobalComposerStarterRequest {
   id: number;
+  text?: string;
   personaId?: string | null;
   projectId?: string | null;
   skill?: ChatSkillDraft;
+  selectedSkills?: ChatSkillDraft[];
+  attachments?: ChatAttachmentDraft[];
 }
 
 interface GlobalComposerPillProps {
@@ -281,6 +284,7 @@ export function GlobalComposerPill({
     addBrowserFiles,
     addPathAttachments,
     removeAttachment,
+    replaceAttachments,
     clearAttachments,
   } = useChatInputAttachments();
   const attachmentWorkPending = attachmentWorkCount > 0;
@@ -377,6 +381,9 @@ export function GlobalComposerPill({
     }
 
     lastStarterRequestIdRef.current = starterRequest.id;
+    if (starterRequest.text !== undefined) {
+      setText(starterRequest.text);
+    }
     if (starterRequest.personaId !== undefined) {
       setSelectedPersonaId(starterRequest.personaId);
       personaSelectionSourceRef.current = starterRequest.personaId
@@ -396,9 +403,15 @@ export function GlobalComposerPill({
           : [...current, skill],
       );
     }
+    if (starterRequest.selectedSkills !== undefined) {
+      setSelectedSkills([...starterRequest.selectedSkills]);
+    }
+    if (starterRequest.attachments !== undefined) {
+      replaceAttachments(starterRequest.attachments);
+    }
     textareaRef.current?.focus();
     onStarterRequestConsumed?.(starterRequest.id);
-  }, [onStarterRequestConsumed, starterRequest]);
+  }, [onStarterRequestConsumed, replaceAttachments, starterRequest]);
 
   const handleRemoveSelectedSkill = useCallback((skillId: string) => {
     setSelectedSkills((current) =>


### PR DESCRIPTION
## Summary

This bug fix prevents Voice settings from authorizing a future call. When Voice Conversation is not ready, Call now opens Voice settings without creating a chat or queuing a pending start. Returning from settings leaves voice stopped, and a global-composer draft remains available. A ready global-composer call still creates a chat and starts after navigation.

## Reviewer-reproducible examples

1. Configure Voice Conversation so setup is still required. In an existing chat, click Call, then press Back from Voice settings. Confirm the chat returns without Voice Conversation starting.
2. Open the global composer, enter a draft, and click Call while voice is unready. Confirm Voice settings opens without creating a chat. Press Back, reopen the global composer, and confirm the draft is intact and no call starts.
3. Configure Voice Conversation so it is ready, then click Call from the global composer. Confirm a new chat opens and Voice Conversation starts there.

## Verification

John manually verified the no-auto-start return flow in a separate macOS development build.

The global-composer regression case fails without the fix because session creation is called once before setup opens. It passes with this branch, alongside coverage for the preserved ready handoff.
