### PR TITLE
feat(voice): default to Apple speech on macOS

### DIFF
--- a/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
@@ -53,6 +53,7 @@ describe("voice output preference", () => {
 
   it("keeps an explicit Pocket choice when local storage rejects the write", () => {
     setPlatform("Macintosh");
+    window.localStorage.setItem("goose:voice-output-backend", "siri");
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("storage unavailable");
     });

--- a/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
@@ -24,10 +24,10 @@ describe("voice output preference", () => {
     });
   });
 
-  it("defaults to Pocket on macOS", () => {
+  it("defaults to Siri on macOS", () => {
     setPlatform("Macintosh");
-    expect(getDefaultVoiceOutputBackend()).toBe("pocket");
-    expect(getVoiceOutputBackend()).toBe("pocket");
+    expect(getDefaultVoiceOutputBackend()).toBe("siri");
+    expect(getVoiceOutputBackend()).toBe("siri");
   });
 
   it("defaults to Pocket and rejects persisted Siri off macOS", () => {

--- a/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getDefaultVoiceOutputBackend,
   getVoiceOutputBackend,
+  setVoiceOutputBackend,
 } from "./voiceOutputPreference";
 
 const originalNavigator = globalThis.navigator;
@@ -18,6 +19,7 @@ describe("voice output preference", () => {
 
   afterEach(() => {
     window.localStorage.clear();
+    vi.restoreAllMocks();
     Object.defineProperty(globalThis, "navigator", {
       configurable: true,
       value: originalNavigator,
@@ -47,5 +49,16 @@ describe("voice output preference", () => {
     setPlatform("Macintosh");
     window.localStorage.setItem("goose:voice-output-backend", "siri");
     expect(getVoiceOutputBackend()).toBe("siri");
+  });
+
+  it("keeps an explicit Pocket choice when local storage rejects the write", () => {
+    setPlatform("Macintosh");
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+
+    setVoiceOutputBackend("pocket");
+
+    expect(getVoiceOutputBackend()).toBe("pocket");
   });
 });

--- a/src/features/voice-conversation/lib/voiceOutputPreference.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.ts
@@ -6,7 +6,7 @@ export type VoiceOutputBackend = "pocket" | "siri";
 const STORAGE_KEY = "goose:voice-output-backend";
 const CHANGED_EVENT = "goose:voice-output-backend-changed";
 export function getDefaultVoiceOutputBackend(): VoiceOutputBackend {
-  return "pocket";
+  return getPlatform() === "mac" ? "siri" : "pocket";
 }
 
 function normalize(value: unknown): VoiceOutputBackend {

--- a/src/features/voice-conversation/lib/voiceOutputPreference.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.ts
@@ -19,13 +19,12 @@ function normalize(value: unknown): VoiceOutputBackend {
 
 export function getVoiceOutputBackend(): VoiceOutputBackend {
   if (typeof window === "undefined") return getDefaultVoiceOutputBackend();
+  if (inMemoryBackend) return inMemoryBackend;
   try {
     const stored = window.localStorage.getItem(STORAGE_KEY);
-    return stored === null
-      ? (inMemoryBackend ?? getDefaultVoiceOutputBackend())
-      : normalize(stored);
+    return stored === null ? getDefaultVoiceOutputBackend() : normalize(stored);
   } catch {
-    return inMemoryBackend ?? getDefaultVoiceOutputBackend();
+    return getDefaultVoiceOutputBackend();
   }
 }
 

--- a/src/features/voice-conversation/lib/voiceOutputPreference.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.ts
@@ -5,6 +5,7 @@ export type VoiceOutputBackend = "pocket" | "siri";
 
 const STORAGE_KEY = "goose:voice-output-backend";
 const CHANGED_EVENT = "goose:voice-output-backend-changed";
+let inMemoryBackend: VoiceOutputBackend | null = null;
 export function getDefaultVoiceOutputBackend(): VoiceOutputBackend {
   return getPlatform() === "mac" ? "siri" : "pocket";
 }
@@ -19,9 +20,12 @@ function normalize(value: unknown): VoiceOutputBackend {
 export function getVoiceOutputBackend(): VoiceOutputBackend {
   if (typeof window === "undefined") return getDefaultVoiceOutputBackend();
   try {
-    return normalize(window.localStorage.getItem(STORAGE_KEY));
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === null
+      ? (inMemoryBackend ?? getDefaultVoiceOutputBackend())
+      : normalize(stored);
   } catch {
-    return getDefaultVoiceOutputBackend();
+    return inMemoryBackend ?? getDefaultVoiceOutputBackend();
   }
 }
 
@@ -37,7 +41,10 @@ function subscribe(listener: () => void) {
   listeners.add(listener);
   if (!removeWindowListeners) {
     const handleStorage = (event: StorageEvent) => {
-      if (event.key === STORAGE_KEY || event.key === null) notify();
+      if (event.key === STORAGE_KEY || event.key === null) {
+        inMemoryBackend = null;
+        notify();
+      }
     };
     window.addEventListener(CHANGED_EVENT, notify);
     window.addEventListener("storage", handleStorage);
@@ -60,8 +67,9 @@ export function setVoiceOutputBackend(backend: VoiceOutputBackend): void {
   const value = normalize(backend);
   try {
     window.localStorage.setItem(STORAGE_KEY, value);
+    inMemoryBackend = null;
   } catch {
-    // Keep the current in-memory renderer usable when storage is unavailable.
+    inMemoryBackend = value;
   }
   window.dispatchEvent(new CustomEvent(CHANGED_EVENT, { detail: { value } }));
 }


### PR DESCRIPTION
## Summary

New macOS users now start with Apple speech recognition and Siri voices. Existing explicit input and output choices remain unchanged, including when local storage temporarily rejects a write.

If no usable Siri voice is installed, Voice Conversation remains not ready and directs the user to Voice settings; it does not silently switch to Pocket TTS.

## Screenshot

<img width="1280" height="720" alt="Apple speech defaults on macOS" src="https://github.com/user-attachments/assets/cc1a2236-202c-4fd0-8dad-e0800ef172dc" />

## Reviewer-reproducible examples

1. On a Mac with no saved voice backend preferences, open Voice settings. Speech input shows Apple speech recognition and speech output shows Siri voices.
2. Choose Pocket TTS explicitly, then relaunch Berd. The saved Pocket choice remains selected.
3. With no installed Siri voice, start Voice Conversation. Berd opens the existing setup guidance for selecting or downloading a Siri voice.
