### PR TITLE
fix(dev): isolate Cargo targets per worktree

### DIFF
--- a/justfile
+++ b/justfile
@@ -333,7 +333,7 @@ _bundle-unix:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    TAURI_CARGO_TARGET_DIR="$(bash ./scripts/resolve-tauri-cargo-target-dir.sh)"
+    TAURI_CARGO_TARGET_DIR="$(bash ./scripts/resolve-tauri-cargo-target-dir.sh bundle)"
     if [[ -z "${GOOSE_BIN:-}" ]]; then
       GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=release ./scripts/ensure-local-goose.sh
     fi
@@ -412,7 +412,7 @@ _bundle-debug-unix:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    TAURI_CARGO_TARGET_DIR="$(bash ./scripts/resolve-tauri-cargo-target-dir.sh)"
+    TAURI_CARGO_TARGET_DIR="$(bash ./scripts/resolve-tauri-cargo-target-dir.sh bundle)"
     if [[ -z "${GOOSE_BIN:-}" ]]; then
       GOOSE_DEV_MODE=required GOOSE_BUILD_PROFILE=debug ./scripts/ensure-local-goose.sh
     fi

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -38,6 +38,28 @@ afterEach(async () => {
   );
 });
 
+describe("Tauri Cargo target isolation", () => {
+  it("defaults to the current checkout's ignored Cargo target", () => {
+    const result = run("bash", ["scripts/resolve-tauri-cargo-target-dir.sh"], {
+      BERD_TAURI_CARGO_TARGET_DIR: "",
+      XDG_CACHE_HOME: join(tmpdir(), "unrelated-xdg-cache"),
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(join(repo, "src-tauri/target"));
+  });
+
+  it("preserves the explicit target directory override", async () => {
+    const override = join(await tempDir(), "cargo-target");
+    const result = run("bash", ["scripts/resolve-tauri-cargo-target-dir.sh"], {
+      BERD_TAURI_CARGO_TARGET_DIR: override,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(override);
+  });
+});
+
 describe("managed Goose build profile", () => {
   it("defaults development to debug and makes release selection profile-aware", async () => {
     const script = await readFile(

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -79,10 +79,10 @@ describe("Tauri Cargo target isolation", () => {
         : join(home, ".cache/berd-tauri/cargo-target"),
     );
     expect(justfile).toMatch(
-      /_bundle-unix:[\s\S]*resolve-tauri-cargo-target-dir\.sh bundle/,
+      /^_bundle-unix:\n(?:(?: {4}.*)?\n)* {4}TAURI_CARGO_TARGET_DIR=.*resolve-tauri-cargo-target-dir\.sh bundle/m,
     );
     expect(justfile).toMatch(
-      /_bundle-debug-unix:[\s\S]*resolve-tauri-cargo-target-dir\.sh bundle/,
+      /^_bundle-debug-unix:\n(?:(?: {4}.*)?\n)* {4}TAURI_CARGO_TARGET_DIR=.*resolve-tauri-cargo-target-dir\.sh bundle/m,
     );
   });
 });

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -58,6 +58,33 @@ describe("Tauri Cargo target isolation", () => {
     expect(result.status).toBe(0);
     expect(result.stdout.trim()).toBe(override);
   });
+
+  it("preserves the shared Unix bundle target contract", async () => {
+    const home = join(await tempDir(), "home");
+    const justfile = await readFile(join(repo, "justfile"), "utf8");
+    const result = run(
+      "bash",
+      ["scripts/resolve-tauri-cargo-target-dir.sh", "bundle"],
+      {
+        BERD_TAURI_CARGO_TARGET_DIR: "",
+        HOME: home,
+        XDG_CACHE_HOME: "",
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(
+      process.platform === "darwin"
+        ? join(home, "Library/Caches/berd-tauri/cargo-target")
+        : join(home, ".cache/berd-tauri/cargo-target"),
+    );
+    expect(justfile).toMatch(
+      /_bundle-unix:[\s\S]*resolve-tauri-cargo-target-dir\.sh bundle/,
+    );
+    expect(justfile).toMatch(
+      /_bundle-debug-unix:[\s\S]*resolve-tauri-cargo-target-dir\.sh bundle/,
+    );
+  });
 });
 
 describe("managed Goose build profile", () => {

--- a/scripts/resolve-tauri-cargo-target-dir.sh
+++ b/scripts/resolve-tauri-cargo-target-dir.sh
@@ -1,8 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+scope="${1:-development}"
+case "$scope" in
+  development|bundle) ;;
+  *)
+    printf 'Usage: %s [development|bundle]\n' "$0" >&2
+    exit 2
+    ;;
+esac
+
 if [[ -n "${BERD_TAURI_CARGO_TARGET_DIR:-}" ]]; then
   printf '%s\n' "$BERD_TAURI_CARGO_TARGET_DIR"
+elif [[ "$scope" == "bundle" && -n "${XDG_CACHE_HOME:-}" ]]; then
+  printf '%s/berd-tauri/cargo-target\n' "$XDG_CACHE_HOME"
+elif [[ "$scope" == "bundle" && "$(uname -s)" = "Darwin" ]]; then
+  printf '%s/Library/Caches/berd-tauri/cargo-target\n' "$HOME"
+elif [[ "$scope" == "bundle" ]]; then
+  printf '%s/.cache/berd-tauri/cargo-target\n' "$HOME"
 else
   # Cargo coordinates writers inside one target directory. Keep the default
   # checkout-local so concurrent worktrees can build without blocking.

--- a/scripts/resolve-tauri-cargo-target-dir.sh
+++ b/scripts/resolve-tauri-cargo-target-dir.sh
@@ -3,10 +3,9 @@ set -euo pipefail
 
 if [[ -n "${BERD_TAURI_CARGO_TARGET_DIR:-}" ]]; then
   printf '%s\n' "$BERD_TAURI_CARGO_TARGET_DIR"
-elif [[ -n "${XDG_CACHE_HOME:-}" ]]; then
-  printf '%s/berd-tauri/cargo-target\n' "$XDG_CACHE_HOME"
-elif [[ "$(uname -s)" = "Darwin" ]]; then
-  printf '%s/Library/Caches/berd-tauri/cargo-target\n' "$HOME"
 else
-  printf '%s/.cache/berd-tauri/cargo-target\n' "$HOME"
+  # Cargo coordinates writers inside one target directory. Keep the default
+  # checkout-local so concurrent worktrees can build without blocking.
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s/src-tauri/target\n' "$(dirname "$script_dir")"
 fi

--- a/scripts/windows/Test-WindowsDev.ps1
+++ b/scripts/windows/Test-WindowsDev.ps1
@@ -41,6 +41,7 @@ $oldGooseRepo = $env:GOOSE_DEV_REPO
 $oldGooseTarget = $env:GOOSE_DEV_CARGO_TARGET_DIR
 $oldGooseStamp = $env:GOOSE_DEV_STAMP_FILE
 $oldGooseBuildProfile = $env:GOOSE_BUILD_PROFILE
+$oldBerdTauriCargoTargetDir = $env:BERD_TAURI_CARGO_TARGET_DIR
 $oldLocalAppData = $env:LOCALAPPDATA
 $oldUserProfile = $env:USERPROFILE
 $oldAppData = $env:APPDATA
@@ -680,6 +681,13 @@ try {
     $env:APPDATA = Join-Path $temp "Roaming"
     $env:FNM_DIR = ""
 
+    $env:BERD_TAURI_CARGO_TARGET_DIR = ""
+    Assert-Equal "Tauri cargo target defaults to this checkout" `
+        (Get-TauriCargoTargetDir) (Join-Path (Get-BerdRepoRoot) "src-tauri\target")
+    $env:BERD_TAURI_CARGO_TARGET_DIR = Join-Path $temp "explicit-tauri-target"
+    Assert-Equal "Tauri cargo target honors explicit override" `
+        (Get-TauriCargoTargetDir) $env:BERD_TAURI_CARGO_TARGET_DIR
+
     # Cleanup honors the same env overrides setup/dev use.
     $env:BERD_TAURI_CARGO_TARGET_DIR = Join-Path $temp "override-target"
     $overriddenPaths = Resolve-WindowsCleanupPaths
@@ -690,7 +698,7 @@ try {
 
     $cleanupPaths = Resolve-WindowsCleanupPaths
     Assert-Equal "cleanup Berd dev root" $cleanupPaths.BerdDevRoot (Join-Path $env:LOCALAPPDATA "berd-dev")
-    Assert-Equal "cleanup Tauri root" $cleanupPaths.BerdTauriRoot (Join-Path $env:LOCALAPPDATA "berd-tauri")
+    Assert-Equal "cleanup Tauri root" $cleanupPaths.BerdTauriRoot (Join-Path (Get-BerdRepoRoot) "src-tauri\target")
     Assert-Equal "Block npm cert file" $cleanupPaths.BlockCertFile (Join-Path $env:USERPROFILE ".block-certs\root-certs.pem")
     Assert-Equal "cleanup Corepack pnpm dir" $cleanupPaths.CorepackPnpmVersionDir (Join-Path $env:LOCALAPPDATA "node\corepack\v1\pnpm\$(Get-RequiredPnpmVersion)")
     Assert-Equal "cleanup fnm Node dir" $cleanupPaths.FnmNodeVersionDir (Join-Path $env:APPDATA "fnm\node-versions\v$(Get-RequiredNodeVersion)")
@@ -719,6 +727,7 @@ try {
     $env:GOOSE_DEV_CARGO_TARGET_DIR = $oldGooseTarget
     $env:GOOSE_DEV_STAMP_FILE = $oldGooseStamp
     $env:GOOSE_BUILD_PROFILE = $oldGooseBuildProfile
+    $env:BERD_TAURI_CARGO_TARGET_DIR = $oldBerdTauriCargoTargetDir
     $env:LOCALAPPDATA = $oldLocalAppData
     $env:USERPROFILE = $oldUserProfile
     $env:APPDATA = $oldAppData

--- a/scripts/windows/WindowsDev.psm1
+++ b/scripts/windows/WindowsDev.psm1
@@ -607,7 +607,7 @@ function Resolve-WindowsCleanupPaths {
     # the state that setup/dev actually created. A BERD_TAURI_CARGO_TARGET_DIR
     # override points directly at a cargo target dir; only that dir is
     # Berd-owned, not its parent.
-    $berdTauriRoot = Join-Path $localAppData "berd-tauri"
+    $berdTauriRoot = Join-Path $repoRoot "src-tauri\target"
     if (-not [string]::IsNullOrWhiteSpace($env:BERD_TAURI_CARGO_TARGET_DIR)) {
         $berdTauriRoot = $env:BERD_TAURI_CARGO_TARGET_DIR
     }
@@ -674,7 +674,8 @@ function Get-TauriCargoTargetDir {
     if (-not [string]::IsNullOrWhiteSpace($env:BERD_TAURI_CARGO_TARGET_DIR)) {
         return $env:BERD_TAURI_CARGO_TARGET_DIR
     }
-    return (Join-Path (Get-LocalAppDataRoot) "berd-tauri\cargo-target")
+    # Isolate Cargo's writer lock and incremental state to this checkout.
+    return (Join-Path (Get-BerdRepoRoot) "src-tauri\target")
 }
 
 function Read-JsonFile {


### PR DESCRIPTION
## Summary

Berd currently directs interactive Cargo commands from every checkout on a machine to one target directory. Concurrent just dev, test, check, and Clippy processes then serialize on the Cargo artifact lock.

Default development Cargo output to each checkout's ignored src-tauri/target directory on Unix and Windows, while preserving BERD_TAURI_CARGO_TARGET_DIR as an explicit override. Unix just bundle and just bundle-debug retain the shared bundle target expected by existing packaging consumers.

## Reviewer-reproducible examples

Resolve development and bundle targets separately:

    bash scripts/resolve-tauri-cargo-target-dir.sh
    bash scripts/resolve-tauri-cargo-target-dir.sh bundle

The first prints the checkout's src-tauri/target. On macOS, the second prints ~/Library/Caches/berd-tauri/cargo-target.

An explicit override remains unchanged in either scope:

    BERD_TAURI_CARGO_TARGET_DIR=/tmp/berd-target bash scripts/resolve-tauri-cargo-target-dir.sh
    BERD_TAURI_CARGO_TARGET_DIR=/tmp/berd-target bash scripts/resolve-tauri-cargo-target-dir.sh bundle
