### PR TITLE
perf(dev): share Cargo package cache across worktrees

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -2,4 +2,5 @@ manage-git = true
 
 env = {
   "CARGO_HOME": "${HOME}/.cache/berd/cargo-home",
+  "PATH": "${HOME}/.cache/berd/cargo-home/bin:${PATH}",
 }

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,1 +1,5 @@
 manage-git = true
+
+env = {
+  "CARGO_HOME": "${HOME}/.cache/berd/cargo-home",
+}

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -38,6 +38,15 @@ afterEach(async () => {
   );
 });
 
+describe("shared Cargo package cache", () => {
+  it("keeps Cargo dependency source paths stable across worktrees", async () => {
+    const hermitConfig = await readFile(join(repo, "bin/hermit.hcl"), "utf8");
+
+    expect(hermitConfig).toMatch(
+      /"CARGO_HOME": "\$\{HOME\}\/\.cache\/berd\/cargo-home"/,
+    );
+  });
+});
 describe("managed Goose build profile", () => {
   it("defaults development to debug and makes release selection profile-aware", async () => {
     const script = await readFile(

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -50,6 +50,7 @@ describe("shared Cargo package cache", () => {
     );
   });
 });
+
 describe("managed Goose build profile", () => {
   it("defaults development to debug and makes release selection profile-aware", async () => {
     const script = await readFile(

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -39,11 +39,14 @@ afterEach(async () => {
 });
 
 describe("shared Cargo package cache", () => {
-  it("keeps Cargo dependency source paths stable across worktrees", async () => {
+  it("keeps Cargo dependency and binary paths stable across worktrees", async () => {
     const hermitConfig = await readFile(join(repo, "bin/hermit.hcl"), "utf8");
 
     expect(hermitConfig).toMatch(
       /"CARGO_HOME": "\$\{HOME\}\/\.cache\/berd\/cargo-home"/,
+    );
+    expect(hermitConfig).toMatch(
+      /"PATH": "\$\{HOME\}\/\.cache\/berd\/cargo-home\/bin:\$\{PATH\}"/,
     );
   });
 });

--- a/scripts/release/tests/release-scripts.test.mjs
+++ b/scripts/release/tests/release-scripts.test.mjs
@@ -38,19 +38,6 @@ afterEach(async () => {
   );
 });
 
-describe("shared Cargo package cache", () => {
-  it("keeps Cargo dependency and binary paths stable across worktrees", async () => {
-    const hermitConfig = await readFile(join(repo, "bin/hermit.hcl"), "utf8");
-
-    expect(hermitConfig).toMatch(
-      /"CARGO_HOME": "\$\{HOME\}\/\.cache\/berd\/cargo-home"/,
-    );
-    expect(hermitConfig).toMatch(
-      /"PATH": "\$\{HOME\}\/\.cache\/berd\/cargo-home\/bin:\$\{PATH\}"/,
-    );
-  });
-});
-
 describe("managed Goose build profile", () => {
   it("defaults development to debug and makes release selection profile-aware", async () => {
     const script = await readFile(
@@ -138,6 +125,19 @@ describe("managed Goose build profile", () => {
     expect(windowsSetup).toContain('$GooseBuildProfile = "debug"');
     expect(windowsDev).toContain('$env:GOOSE_BUILD_PROFILE = "debug"');
     expect(windowsStage).toContain('$env:GOOSE_BUILD_PROFILE = "debug"');
+  });
+});
+
+describe("shared Cargo package cache", () => {
+  it("keeps Cargo dependency and binary paths stable across worktrees", async () => {
+    const hermitConfig = await readFile(join(repo, "bin/hermit.hcl"), "utf8");
+
+    expect(hermitConfig).toMatch(
+      /"CARGO_HOME": "\$\{HOME\}\/\.cache\/berd\/cargo-home"/,
+    );
+    expect(hermitConfig).toMatch(
+      /"PATH": "\$\{HOME\}\/\.cache\/berd\/cargo-home\/bin:\$\{PATH\}"/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Hermit currently gives each Berd worktree its own `CARGO_HOME`. That duplicates registry and Git dependency downloads and gives dependency sources checkout-specific absolute paths.

Use `${HOME}/.cache/berd/cargo-home` as Berd's stable Cargo package home and keep its `bin` directory on `PATH`. Cargo's package-cache locking supports concurrent access. Cargo target directories remain independently configured and are not shared by this change.

## Verification

Two fresh macOS worktrees activated Hermit against one initially empty shared Cargo home and built concurrently without package-cache errors. Both resolved the same `CARGO_HOME`; the second worktree reused all 59 dependencies in focused `cargo check` and `cargo test --no-run` runs with no downloads.
