### PR TITLE
fix(voice): start new calls on first click

### DIFF
--- a/src/shared/ui/GlobalComposerPill.test.tsx
+++ b/src/shared/ui/GlobalComposerPill.test.tsx
@@ -559,6 +559,35 @@ describe("GlobalComposerPill", () => {
     await waitFor(() => expect(input).toHaveValue(""));
   });
 
+  it("keeps an empty centered composer stable and starts voice on its first click", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn().mockResolvedValue(true);
+    renderGlobalComposer(vi.fn(), {
+      placement: "centered",
+      voiceConversation: { enabled: true, ready: true, onStart },
+    });
+
+    await user.click(screen.getByRole("textbox"));
+    expect(
+      screen.getByRole("button", { name: /choose agent and model/i }),
+    ).toHaveAttribute("tabindex", "0");
+
+    const button = screen.getByRole("button", {
+      name: "Start voice conversation",
+    });
+    const mouseDown = createEvent.mouseDown(button, {
+      button: 0,
+      cancelable: true,
+    });
+    fireEvent(button, mouseDown);
+
+    expect(mouseDown.defaultPrevented).toBe(true);
+
+    await user.click(button);
+
+    expect(onStart).toHaveBeenCalledOnce();
+  });
+
   it("blocks Voice Conversation while dictation owns the microphone", async () => {
     const user = userEvent.setup();
     const onStart = vi.fn().mockResolvedValue(true);

--- a/src/shared/ui/GlobalComposerPill.tsx
+++ b/src/shared/ui/GlobalComposerPill.tsx
@@ -1547,6 +1547,11 @@ export function GlobalComposerPill({
                 attachmentWorkPending ||
                 dictationOwnsMicrophone
               }
+              onMouseDown={(event) => {
+                if (voiceConversation.ready) {
+                  event.preventDefault();
+                }
+              }}
               onClick={() => void handleStartVoiceConversation()}
               size="icon-pill-sm"
               aria-label={t("globalPill.startVoiceConversation")}


### PR DESCRIPTION
## Summary

Fixes the new-chat voice action requiring two clicks. When Voice Conversation is ready, the Call button keeps the focused empty composer stable through mouse-down so the first click opens the new chat and starts the call. The not-ready path still releases focus and opens Voice settings.

## Reviewer-reproducible examples

1. Open an existing chat and press Cmd-N.
2. Click Call once in the empty centered composer.
3. Confirm a new chat opens and Voice Conversation starts without a second click.
4. With Voice Conversation setup still required, repeat the flow and confirm Voice settings opens instead.

## Verification

John manually verified the Cmd-N first-click flow in a macOS development build.

The regression test fails without the mouse-down safeguard because the event is not cancelled. It passes with this branch, alongside the existing unready Voice settings coverage.
