### PR TITLE
Fall back when the selected Siri voice is unavailable

### DIFF
--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -716,6 +716,7 @@ fn resolve_voice_selection(
     })
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn resolve_stream_voice(
     selection: &SiriVoiceSelection,
     load_all_voices: impl FnOnce() -> Result<Vec<SiriVoice>, String>,

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -37,8 +37,15 @@ pub struct SiriVoiceState {
 struct SiriVoiceRuntime {
     active: Option<Arc<AtomicBool>>,
     owner_window: Option<String>,
+    resolved_voice: Option<ResolvedSiriVoice>,
     #[cfg(target_os = "macos")]
     stream: Option<ActiveSiriStream>,
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedSiriVoice {
+    configured: Option<SiriVoiceSelection>,
+    effective: Option<SiriVoiceSelection>,
 }
 
 #[cfg(target_os = "macos")]
@@ -709,22 +716,65 @@ fn resolve_voice_selection(
         }
     }
 
-    let fallback =
-        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices));
+    let fallback = if selected_voice.is_some() {
+        first_installed_voice(&all_voices)
+    } else {
+        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices))
+    };
     Ok(match fallback {
         Some(selection) => (Some(selection), true),
         None => (selected_voice.cloned(), false),
     })
 }
 
-fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
+fn voice_for_playback(
+    configured: Option<&SiriVoiceSelection>,
+    resolved: Option<&ResolvedSiriVoice>,
+) -> Option<SiriVoiceSelection> {
+    match resolved.filter(|resolved| resolved.configured.as_ref() == configured) {
+        Some(resolved) => resolved.effective.clone(),
+        None => configured.cloned(),
+    }
+}
+
+fn status(
+    app: &AppHandle,
+    state: &SiriVoiceState,
+    language_prefix: &str,
+) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
-    let settings = read_settings(&settings_path(app)?);
-    let (resolved_selection, resolved_selection_installed) =
+    let path = settings_path(app)?;
+    let mut settings = read_settings(&path);
+    let (mut resolved_selection, mut resolved_selection_installed) =
         resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || {
             discover_voices("")
         })?;
+    if settings.selected_voice.is_none() && resolved_selection_installed {
+        let automatic_selection = resolved_selection.clone();
+        settings = update_settings(&path, |settings| {
+            if settings.selected_voice.is_none() {
+                settings.selected_voice = automatic_selection;
+                true
+            } else {
+                false
+            }
+        })?;
+        if settings.selected_voice != resolved_selection {
+            resolved_selection = settings.selected_voice.clone();
+            resolved_selection_installed = resolved_selection.is_some();
+        }
+    }
+    state
+        .runtime
+        .lock()
+        .map_err(|_| "Siri voice state lock was poisoned".to_string())?
+        .resolved_voice = Some(ResolvedSiriVoice {
+        configured: settings.selected_voice.clone(),
+        effective: resolved_selection_installed
+            .then(|| resolved_selection.clone())
+            .flatten(),
+    });
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
@@ -740,16 +790,22 @@ fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, Str
 #[tauri::command]
 pub async fn get_siri_voice_status(
     app: AppHandle,
+    state: tauri::State<'_, SiriVoiceState>,
     language_prefix: Option<String>,
 ) -> Result<SiriVoiceStatus, String> {
     let prefix = language_prefix.unwrap_or_default();
-    tauri::async_runtime::spawn_blocking(move || status(&app, prefix.trim()))
+    let state = state.inner().clone();
+    tauri::async_runtime::spawn_blocking(move || status(&app, &state, prefix.trim()))
         .await
         .map_err(|error| format!("Siri voice catalog task failed: {error}"))?
 }
 
 #[tauri::command]
-pub async fn select_siri_voice(app: AppHandle, voice: SiriVoiceSelection) -> Result<(), String> {
+pub async fn select_siri_voice(
+    app: AppHandle,
+    state: tauri::State<'_, SiriVoiceState>,
+    voice: SiriVoiceSelection,
+) -> Result<(), String> {
     let prefix = voice.language.clone();
     let candidate = voice.clone();
     let installed = tauri::async_runtime::spawn_blocking(move || {
@@ -765,10 +821,18 @@ pub async fn select_siri_voice(app: AppHandle, voice: SiriVoiceSelection) -> Res
         ));
     }
     update_settings(&settings_path(&app)?, |settings| {
-        settings.selected_voice = Some(voice);
+        settings.selected_voice = Some(voice.clone());
         true
-    })
-    .map(|_| ())
+    })?;
+    state
+        .runtime
+        .lock()
+        .map_err(|_| "Siri voice state lock was poisoned".to_string())?
+        .resolved_voice = Some(ResolvedSiriVoice {
+        configured: Some(voice.clone()),
+        effective: Some(voice),
+    });
+    Ok(())
 }
 
 #[tauri::command]
@@ -1063,10 +1127,16 @@ pub fn start_siri_voice_stream(
             return Err("Siri voice stream id cannot be empty".to_string());
         }
         let settings = read_settings(&settings_path(&app)?);
-        let voices = discover_voices("")?;
-        let (selection, selection_installed) =
-            resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || Ok(Vec::new()))?;
-        let selection = selection.filter(|_| selection_installed).ok_or_else(|| {
+        let selection = voice_for_playback(
+            settings.selected_voice.as_ref(),
+            state
+                .runtime
+                .lock()
+                .map_err(|_| "Siri voice state lock was poisoned".to_string())?
+                .resolved_voice
+                .as_ref(),
+        )
+        .ok_or_else(|| {
             "Select an installed Siri voice in Voice settings before using Siri TTS".to_string()
         })?;
         let active = begin_playback(&state, webview_window.label())?;
@@ -1494,6 +1564,40 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_selection_uses_the_same_global_fallback_for_every_filter() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let preferred_voices = vec![SiriVoice {
+            name: "Samantha".to_string(),
+            language: "en-US".to_string(),
+            size_bytes: 10,
+            installed: true,
+        }];
+        let all_voices = vec![
+            SiriVoice {
+                name: "Catherine".to_string(),
+                language: "en-AU".to_string(),
+                size_bytes: 10,
+                installed: true,
+            },
+            preferred_voices[0].clone(),
+        ];
+
+        assert_eq!(
+            resolve_voice_selection(&preferred_voices, Some(&selected), || Ok(all_voices)),
+            Ok((
+                Some(SiriVoiceSelection {
+                    name: "Catherine".to_string(),
+                    language: "en-AU".to_string(),
+                }),
+                true,
+            ))
+        );
+    }
+
+    #[test]
     fn unavailable_selection_is_preserved_when_no_siri_voice_is_installed() {
         let selected = SiriVoiceSelection {
             name: "Aaron".to_string(),
@@ -1509,6 +1613,45 @@ mod tests {
         assert_eq!(
             resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
             Ok((Some(selected), false))
+        );
+    }
+
+    #[test]
+    fn playback_uses_only_a_fallback_resolved_for_the_current_preference() {
+        let configured = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let fallback = SiriVoiceSelection {
+            name: "Samantha".to_string(),
+            language: "en-US".to_string(),
+        };
+        let resolved = ResolvedSiriVoice {
+            configured: Some(configured.clone()),
+            effective: Some(fallback.clone()),
+        };
+
+        assert_eq!(
+            voice_for_playback(Some(&configured), Some(&resolved)),
+            Some(fallback)
+        );
+
+        let newer_preference = SiriVoiceSelection {
+            name: "Nora".to_string(),
+            language: "en-US".to_string(),
+        };
+        assert_eq!(
+            voice_for_playback(Some(&newer_preference), Some(&resolved)),
+            Some(newer_preference)
+        );
+
+        let unavailable = ResolvedSiriVoice {
+            configured: Some(configured.clone()),
+            effective: None,
+        };
+        assert_eq!(
+            voice_for_playback(Some(&configured), Some(&unavailable)),
+            None
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -702,9 +702,6 @@ fn resolve_voice_selection(
         return Ok((Some(selection), true));
     }
 
-    // A successful unfiltered discovery is a complete snapshot of the local
-    // Siri catalog. Discovery errors return above, before a fallback can be
-    // selected or persisted.
     let all_voices = load_all_voices()?;
     if let Some(selection) = selected_voice {
         if find_voice(&all_voices, selection).is_some_and(|voice| voice.installed) {
@@ -728,7 +725,8 @@ fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, Str
     let (resolved_selection, resolved_selection_installed) =
         resolve_voice_selection(&voices, previous_selection.as_ref(), || discover_voices(""))?;
     let settings = update_settings(&path, |settings| {
-        if resolved_selection_installed
+        if previous_selection.is_none()
+            && resolved_selection_installed
             && settings.selected_voice == previous_selection
             && settings.selected_voice != resolved_selection
         {
@@ -738,21 +736,23 @@ fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, Str
             false
         }
     })?;
-    let selected_voice_installed = if settings.selected_voice == resolved_selection {
-        resolved_selection_installed
-    } else {
-        settings.selected_voice.as_ref().is_some_and(|selection| {
-            find_voice(&voices, selection).is_some_and(|voice| voice.installed)
-                || discover_voices(&selection.language)
-                    .ok()
-                    .and_then(|selected| find_voice(&selected, selection).cloned())
-                    .is_some_and(|voice| voice.installed)
-        })
-    };
+    let (selected_voice, selected_voice_installed) =
+        if settings.selected_voice == previous_selection {
+            (resolved_selection, resolved_selection_installed)
+        } else {
+            let installed = settings.selected_voice.as_ref().is_some_and(|selection| {
+                find_voice(&voices, selection).is_some_and(|voice| voice.installed)
+                    || discover_voices(&selection.language)
+                        .ok()
+                        .and_then(|selected| find_voice(&selected, selection).cloned())
+                        .is_some_and(|voice| voice.installed)
+            });
+            (settings.selected_voice.clone(), installed)
+        };
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
-        selected_voice: settings.selected_voice,
+        selected_voice,
         selected_voice_installed,
         playback_speed: settings
             .playback_speed
@@ -1064,6 +1064,7 @@ pub fn start_siri_voice_stream(
     state: tauri::State<'_, SiriVoiceState>,
     native_voice: tauri::State<'_, NativeVoiceState>,
     stream_id: String,
+    voice: SiriVoiceSelection,
     interruption_mode: VoiceInterruptionMode,
     interruption_sensitivity: InterruptionSensitivity,
 ) -> Result<(), String> {
@@ -1075,6 +1076,7 @@ pub fn start_siri_voice_stream(
             state,
             native_voice,
             stream_id,
+            voice,
             interruption_mode,
             interruption_sensitivity,
         );
@@ -1087,9 +1089,6 @@ pub fn start_siri_voice_stream(
             return Err("Siri voice stream id cannot be empty".to_string());
         }
         let settings = read_settings(&settings_path(&app)?);
-        let selection = settings.selected_voice.ok_or_else(|| {
-            "Select an installed Siri voice in Voice settings before using Siri TTS".to_string()
-        })?;
         let active = begin_playback(&state, webview_window.label())?;
         let effective_output_device = effective_output_device_name(None);
         let suppress_capture =
@@ -1114,7 +1113,7 @@ pub fn start_siri_voice_stream(
             let result = run_siri_stream(
                 app.clone(),
                 stream_id.clone(),
-                selection,
+                voice,
                 settings
                     .playback_speed
                     .clamp(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED),
@@ -1530,27 +1529,6 @@ mod tests {
         assert_eq!(
             resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
             Ok((Some(selected), false))
-        );
-    }
-
-    #[test]
-    fn unavailable_selection_does_not_fallback_when_catalog_discovery_fails() {
-        let selected = SiriVoiceSelection {
-            name: "Aaron".to_string(),
-            language: "en-US".to_string(),
-        };
-        let filtered_voices = vec![SiriVoice {
-            name: "Samantha".to_string(),
-            language: "en-US".to_string(),
-            size_bytes: 10,
-            installed: true,
-        }];
-
-        assert_eq!(
-            resolve_voice_selection(&filtered_voices, Some(&selected), || {
-                Err("catalog unavailable".to_string())
-            }),
-            Err("catalog unavailable".to_string())
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -716,6 +716,20 @@ fn resolve_voice_selection(
     })
 }
 
+fn resolve_stream_voice(
+    selection: &SiriVoiceSelection,
+    load_all_voices: impl FnOnce() -> Result<Vec<SiriVoice>, String>,
+) -> Result<SiriVoiceSelection, String> {
+    let voices = load_all_voices()?;
+    if find_voice(&voices, selection).is_some_and(|voice| voice.installed) {
+        return Ok(selection.clone());
+    }
+
+    first_installed_voice(&voices).ok_or_else(|| {
+        "No installed Siri voice is available. Open Voice settings to download one.".to_string()
+    })
+}
+
 fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
@@ -1088,6 +1102,7 @@ pub fn start_siri_voice_stream(
         if stream_id.trim().is_empty() {
             return Err("Siri voice stream id cannot be empty".to_string());
         }
+        let voice = resolve_stream_voice(&voice, || discover_voices(""))?;
         let settings = read_settings(&settings_path(&app)?);
         let active = begin_playback(&state, webview_window.label())?;
         let effective_output_device = effective_output_device_name(None);
@@ -1537,6 +1552,65 @@ mod tests {
         assert_eq!(
             resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
             Ok((Some(selected), false))
+        );
+    }
+
+    #[test]
+    fn stream_voice_ingress_re_resolves_a_voice_removed_after_status() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let status_catalog = vec![SiriVoice {
+            name: selected.name.clone(),
+            language: selected.language.clone(),
+            size_bytes: 10,
+            installed: true,
+        }];
+        assert!(find_voice(&status_catalog, &selected).is_some_and(|voice| voice.installed));
+
+        let current_catalog = vec![
+            SiriVoice {
+                installed: false,
+                ..status_catalog[0].clone()
+            },
+            SiriVoice {
+                name: "Catherine".to_string(),
+                language: "en-AU".to_string(),
+                size_bytes: 10,
+                installed: true,
+            },
+        ];
+
+        assert_eq!(
+            resolve_stream_voice(&selected, || Ok(current_catalog)),
+            Ok(SiriVoiceSelection {
+                name: "Catherine".to_string(),
+                language: "en-AU".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn stream_voice_ingress_rejects_when_no_siri_voice_is_installed() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+
+        assert_eq!(
+            resolve_stream_voice(&selected, || {
+                Ok(vec![SiriVoice {
+                    name: selected.name.clone(),
+                    language: selected.language.clone(),
+                    size_bytes: 10,
+                    installed: false,
+                }])
+            }),
+            Err(
+                "No installed Siri voice is available. Open Voice settings to download one."
+                    .to_string()
+            )
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -1057,6 +1057,7 @@ fn run_siri_stream(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri injects four runtime dependencies beside the stream payload.
 pub fn start_siri_voice_stream(
     app: AppHandle,
     webview_window: tauri::WebviewWindow,

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -689,41 +689,63 @@ fn first_installed_voice(voices: &[SiriVoice]) -> Option<SiriVoiceSelection> {
         })
 }
 
-fn choose_installed_voice(
+fn resolve_voice_selection(
     preferred_voices: &[SiriVoice],
+    selected_voice: Option<&SiriVoiceSelection>,
     load_all_voices: impl FnOnce() -> Result<Vec<SiriVoice>, String>,
-) -> Result<Option<SiriVoiceSelection>, String> {
-    if let Some(selection) = first_installed_voice(preferred_voices) {
-        return Ok(Some(selection));
+) -> Result<(Option<SiriVoiceSelection>, bool), String> {
+    if let Some(selection) = selected_voice {
+        if find_voice(preferred_voices, selection).is_some_and(|voice| voice.installed) {
+            return Ok((Some(selection.clone()), true));
+        }
+    } else if let Some(selection) = first_installed_voice(preferred_voices) {
+        return Ok((Some(selection), true));
     }
 
-    Ok(first_installed_voice(&load_all_voices()?))
+    let all_voices = load_all_voices()?;
+    if let Some(selection) = selected_voice {
+        if find_voice(&all_voices, selection).is_some_and(|voice| voice.installed) {
+            return Ok((Some(selection.clone()), true));
+        }
+    }
+
+    let fallback =
+        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices));
+    Ok(match fallback {
+        Some(selection) => (Some(selection), true),
+        None => (selected_voice.cloned(), false),
+    })
 }
 
 fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
     let path = settings_path(app)?;
-    let automatic_selection = if read_settings(&path).selected_voice.is_none() {
-        choose_installed_voice(&voices, || discover_voices(""))?
-    } else {
-        None
-    };
+    let previous_selection = read_settings(&path).selected_voice;
+    let (resolved_selection, resolved_selection_installed) =
+        resolve_voice_selection(&voices, previous_selection.as_ref(), || discover_voices(""))?;
     let settings = update_settings(&path, |settings| {
-        if settings.selected_voice.is_none() && automatic_selection.is_some() {
-            settings.selected_voice = automatic_selection;
+        if resolved_selection_installed
+            && settings.selected_voice == previous_selection
+            && settings.selected_voice != resolved_selection
+        {
+            settings.selected_voice = resolved_selection.clone();
             true
         } else {
             false
         }
     })?;
-    let selected_voice_installed = settings.selected_voice.as_ref().is_some_and(|selection| {
-        find_voice(&voices, selection).is_some_and(|voice| voice.installed)
-            || discover_voices(&selection.language)
-                .ok()
-                .and_then(|selected| find_voice(&selected, selection).cloned())
-                .is_some_and(|voice| voice.installed)
-    });
+    let selected_voice_installed = if settings.selected_voice == resolved_selection {
+        resolved_selection_installed
+    } else {
+        settings.selected_voice.as_ref().is_some_and(|selection| {
+            find_voice(&voices, selection).is_some_and(|voice| voice.installed)
+                || discover_voices(&selection.language)
+                    .ok()
+                    .and_then(|selected| find_voice(&selected, selection).cloned())
+                    .is_some_and(|voice| voice.installed)
+        })
+    };
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
@@ -1415,11 +1437,14 @@ mod tests {
         ];
 
         assert_eq!(
-            first_installed_voice(&voices),
-            Some(SiriVoiceSelection {
-                name: "Aaron".to_string(),
-                language: "en-US".to_string(),
-            })
+            resolve_voice_selection(&voices, None, || Ok(Vec::new())),
+            Ok((
+                Some(SiriVoiceSelection {
+                    name: "Aaron".to_string(),
+                    language: "en-US".to_string(),
+                }),
+                true,
+            ))
         );
     }
 
@@ -1433,7 +1458,7 @@ mod tests {
         }];
 
         assert_eq!(
-            choose_installed_voice(&filtered_voices, || {
+            resolve_voice_selection(&filtered_voices, None, || {
                 Ok(vec![SiriVoice {
                     name: "Catherine".to_string(),
                     language: "en-AU".to_string(),
@@ -1441,10 +1466,67 @@ mod tests {
                     installed: true,
                 }])
             }),
-            Ok(Some(SiriVoiceSelection {
-                name: "Catherine".to_string(),
-                language: "en-AU".to_string(),
-            }))
+            Ok((
+                Some(SiriVoiceSelection {
+                    name: "Catherine".to_string(),
+                    language: "en-AU".to_string(),
+                }),
+                true,
+            ))
+        );
+    }
+
+    #[test]
+    fn unavailable_selection_falls_back_to_an_installed_siri_voice() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let preferred_voices = vec![
+            SiriVoice {
+                name: "Aaron".to_string(),
+                language: "en-US".to_string(),
+                size_bytes: 10,
+                installed: false,
+            },
+            SiriVoice {
+                name: "Samantha".to_string(),
+                language: "en-US".to_string(),
+                size_bytes: 10,
+                installed: true,
+            },
+        ];
+
+        assert_eq!(
+            resolve_voice_selection(&preferred_voices, Some(&selected), || {
+                Ok(preferred_voices.clone())
+            }),
+            Ok((
+                Some(SiriVoiceSelection {
+                    name: "Samantha".to_string(),
+                    language: "en-US".to_string(),
+                }),
+                true,
+            ))
+        );
+    }
+
+    #[test]
+    fn unavailable_selection_is_preserved_when_no_siri_voice_is_installed() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let voices = vec![SiriVoice {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+            size_bytes: 10,
+            installed: false,
+        }];
+
+        assert_eq!(
+            resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
+            Ok((Some(selected), false))
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -709,8 +709,7 @@ fn resolve_voice_selection(
         }
     }
 
-    let fallback =
-        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices));
+    let fallback = first_installed_voice(&all_voices);
     Ok(match fallback {
         Some(selection) => (Some(selection), true),
         None => (selected_voice.cloned(), false),
@@ -1501,12 +1500,20 @@ mod tests {
 
         assert_eq!(
             resolve_voice_selection(&preferred_voices, Some(&selected), || {
-                Ok(preferred_voices.clone())
+                Ok(vec![
+                    SiriVoice {
+                        name: "Catherine".to_string(),
+                        language: "en-AU".to_string(),
+                        size_bytes: 10,
+                        installed: true,
+                    },
+                    preferred_voices[1].clone(),
+                ])
             }),
             Ok((
                 Some(SiriVoiceSelection {
-                    name: "Samantha".to_string(),
-                    language: "en-US".to_string(),
+                    name: "Catherine".to_string(),
+                    language: "en-AU".to_string(),
                 }),
                 true,
             ))

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -37,15 +37,8 @@ pub struct SiriVoiceState {
 struct SiriVoiceRuntime {
     active: Option<Arc<AtomicBool>>,
     owner_window: Option<String>,
-    resolved_voice: Option<ResolvedSiriVoice>,
     #[cfg(target_os = "macos")]
     stream: Option<ActiveSiriStream>,
-}
-
-#[derive(Clone, Debug)]
-struct ResolvedSiriVoice {
-    configured: Option<SiriVoiceSelection>,
-    effective: Option<SiriVoiceSelection>,
 }
 
 #[cfg(target_os = "macos")]
@@ -716,65 +709,22 @@ fn resolve_voice_selection(
         }
     }
 
-    let fallback = if selected_voice.is_some() {
-        first_installed_voice(&all_voices)
-    } else {
-        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices))
-    };
+    let fallback =
+        first_installed_voice(preferred_voices).or_else(|| first_installed_voice(&all_voices));
     Ok(match fallback {
         Some(selection) => (Some(selection), true),
         None => (selected_voice.cloned(), false),
     })
 }
 
-fn voice_for_playback(
-    configured: Option<&SiriVoiceSelection>,
-    resolved: Option<&ResolvedSiriVoice>,
-) -> Option<SiriVoiceSelection> {
-    match resolved.filter(|resolved| resolved.configured.as_ref() == configured) {
-        Some(resolved) => resolved.effective.clone(),
-        None => configured.cloned(),
-    }
-}
-
-fn status(
-    app: &AppHandle,
-    state: &SiriVoiceState,
-    language_prefix: &str,
-) -> Result<SiriVoiceStatus, String> {
+fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
-    let path = settings_path(app)?;
-    let mut settings = read_settings(&path);
-    let (mut resolved_selection, mut resolved_selection_installed) =
+    let settings = read_settings(&settings_path(app)?);
+    let (resolved_selection, resolved_selection_installed) =
         resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || {
             discover_voices("")
         })?;
-    if settings.selected_voice.is_none() && resolved_selection_installed {
-        let automatic_selection = resolved_selection.clone();
-        settings = update_settings(&path, |settings| {
-            if settings.selected_voice.is_none() {
-                settings.selected_voice = automatic_selection;
-                true
-            } else {
-                false
-            }
-        })?;
-        if settings.selected_voice != resolved_selection {
-            resolved_selection = settings.selected_voice.clone();
-            resolved_selection_installed = resolved_selection.is_some();
-        }
-    }
-    state
-        .runtime
-        .lock()
-        .map_err(|_| "Siri voice state lock was poisoned".to_string())?
-        .resolved_voice = Some(ResolvedSiriVoice {
-        configured: settings.selected_voice.clone(),
-        effective: resolved_selection_installed
-            .then(|| resolved_selection.clone())
-            .flatten(),
-    });
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
@@ -790,22 +740,16 @@ fn status(
 #[tauri::command]
 pub async fn get_siri_voice_status(
     app: AppHandle,
-    state: tauri::State<'_, SiriVoiceState>,
     language_prefix: Option<String>,
 ) -> Result<SiriVoiceStatus, String> {
     let prefix = language_prefix.unwrap_or_default();
-    let state = state.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || status(&app, &state, prefix.trim()))
+    tauri::async_runtime::spawn_blocking(move || status(&app, prefix.trim()))
         .await
         .map_err(|error| format!("Siri voice catalog task failed: {error}"))?
 }
 
 #[tauri::command]
-pub async fn select_siri_voice(
-    app: AppHandle,
-    state: tauri::State<'_, SiriVoiceState>,
-    voice: SiriVoiceSelection,
-) -> Result<(), String> {
+pub async fn select_siri_voice(app: AppHandle, voice: SiriVoiceSelection) -> Result<(), String> {
     let prefix = voice.language.clone();
     let candidate = voice.clone();
     let installed = tauri::async_runtime::spawn_blocking(move || {
@@ -821,18 +765,10 @@ pub async fn select_siri_voice(
         ));
     }
     update_settings(&settings_path(&app)?, |settings| {
-        settings.selected_voice = Some(voice.clone());
+        settings.selected_voice = Some(voice);
         true
-    })?;
-    state
-        .runtime
-        .lock()
-        .map_err(|_| "Siri voice state lock was poisoned".to_string())?
-        .resolved_voice = Some(ResolvedSiriVoice {
-        configured: Some(voice.clone()),
-        effective: Some(voice),
-    });
-    Ok(())
+    })
+    .map(|_| ())
 }
 
 #[tauri::command]
@@ -1127,16 +1063,10 @@ pub fn start_siri_voice_stream(
             return Err("Siri voice stream id cannot be empty".to_string());
         }
         let settings = read_settings(&settings_path(&app)?);
-        let selection = voice_for_playback(
-            settings.selected_voice.as_ref(),
-            state
-                .runtime
-                .lock()
-                .map_err(|_| "Siri voice state lock was poisoned".to_string())?
-                .resolved_voice
-                .as_ref(),
-        )
-        .ok_or_else(|| {
+        let voices = discover_voices("")?;
+        let (selection, selection_installed) =
+            resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || Ok(Vec::new()))?;
+        let selection = selection.filter(|_| selection_installed).ok_or_else(|| {
             "Select an installed Siri voice in Voice settings before using Siri TTS".to_string()
         })?;
         let active = begin_playback(&state, webview_window.label())?;
@@ -1564,40 +1494,6 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_selection_uses_the_same_global_fallback_for_every_filter() {
-        let selected = SiriVoiceSelection {
-            name: "Aaron".to_string(),
-            language: "en-US".to_string(),
-        };
-        let preferred_voices = vec![SiriVoice {
-            name: "Samantha".to_string(),
-            language: "en-US".to_string(),
-            size_bytes: 10,
-            installed: true,
-        }];
-        let all_voices = vec![
-            SiriVoice {
-                name: "Catherine".to_string(),
-                language: "en-AU".to_string(),
-                size_bytes: 10,
-                installed: true,
-            },
-            preferred_voices[0].clone(),
-        ];
-
-        assert_eq!(
-            resolve_voice_selection(&preferred_voices, Some(&selected), || Ok(all_voices)),
-            Ok((
-                Some(SiriVoiceSelection {
-                    name: "Catherine".to_string(),
-                    language: "en-AU".to_string(),
-                }),
-                true,
-            ))
-        );
-    }
-
-    #[test]
     fn unavailable_selection_is_preserved_when_no_siri_voice_is_installed() {
         let selected = SiriVoiceSelection {
             name: "Aaron".to_string(),
@@ -1613,45 +1509,6 @@ mod tests {
         assert_eq!(
             resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
             Ok((Some(selected), false))
-        );
-    }
-
-    #[test]
-    fn playback_uses_only_a_fallback_resolved_for_the_current_preference() {
-        let configured = SiriVoiceSelection {
-            name: "Aaron".to_string(),
-            language: "en-US".to_string(),
-        };
-        let fallback = SiriVoiceSelection {
-            name: "Samantha".to_string(),
-            language: "en-US".to_string(),
-        };
-        let resolved = ResolvedSiriVoice {
-            configured: Some(configured.clone()),
-            effective: Some(fallback.clone()),
-        };
-
-        assert_eq!(
-            voice_for_playback(Some(&configured), Some(&resolved)),
-            Some(fallback)
-        );
-
-        let newer_preference = SiriVoiceSelection {
-            name: "Nora".to_string(),
-            language: "en-US".to_string(),
-        };
-        assert_eq!(
-            voice_for_playback(Some(&newer_preference), Some(&resolved)),
-            Some(newer_preference)
-        );
-
-        let unavailable = ResolvedSiriVoice {
-            configured: Some(configured.clone()),
-            effective: None,
-        };
-        assert_eq!(
-            voice_for_playback(Some(&configured), Some(&unavailable)),
-            None
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -702,6 +702,9 @@ fn resolve_voice_selection(
         return Ok((Some(selection), true));
     }
 
+    // A successful unfiltered discovery is a complete snapshot of the local
+    // Siri catalog. Discovery errors return above, before a fallback can be
+    // selected or persisted.
     let all_voices = load_all_voices()?;
     if let Some(selection) = selected_voice {
         if find_voice(&all_voices, selection).is_some_and(|voice| voice.installed) {
@@ -1527,6 +1530,27 @@ mod tests {
         assert_eq!(
             resolve_voice_selection(&voices, Some(&selected), || Ok(voices.clone())),
             Ok((Some(selected), false))
+        );
+    }
+
+    #[test]
+    fn unavailable_selection_does_not_fallback_when_catalog_discovery_fails() {
+        let selected = SiriVoiceSelection {
+            name: "Aaron".to_string(),
+            language: "en-US".to_string(),
+        };
+        let filtered_voices = vec![SiriVoice {
+            name: "Samantha".to_string(),
+            language: "en-US".to_string(),
+            size_bytes: 10,
+            installed: true,
+        }];
+
+        assert_eq!(
+            resolve_voice_selection(&filtered_voices, Some(&selected), || {
+                Err("catalog unavailable".to_string())
+            }),
+            Err("catalog unavailable".to_string())
         );
     }
 

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -720,16 +720,37 @@ fn resolve_voice_selection(
 fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
-    let settings = read_settings(&settings_path(app)?);
+    let path = settings_path(app)?;
+    let previous_selection = read_settings(&path).selected_voice;
     let (resolved_selection, resolved_selection_installed) =
-        resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || {
-            discover_voices("")
-        })?;
+        resolve_voice_selection(&voices, previous_selection.as_ref(), || discover_voices(""))?;
+    let settings = update_settings(&path, |settings| {
+        if resolved_selection_installed
+            && settings.selected_voice == previous_selection
+            && settings.selected_voice != resolved_selection
+        {
+            settings.selected_voice = resolved_selection.clone();
+            true
+        } else {
+            false
+        }
+    })?;
+    let selected_voice_installed = if settings.selected_voice == resolved_selection {
+        resolved_selection_installed
+    } else {
+        settings.selected_voice.as_ref().is_some_and(|selection| {
+            find_voice(&voices, selection).is_some_and(|voice| voice.installed)
+                || discover_voices(&selection.language)
+                    .ok()
+                    .and_then(|selected| find_voice(&selected, selection).cloned())
+                    .is_some_and(|voice| voice.installed)
+        })
+    };
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
-        selected_voice: resolved_selection,
-        selected_voice_installed: resolved_selection_installed,
+        selected_voice: settings.selected_voice,
+        selected_voice_installed,
         playback_speed: settings
             .playback_speed
             .clamp(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED),
@@ -1063,10 +1084,7 @@ pub fn start_siri_voice_stream(
             return Err("Siri voice stream id cannot be empty".to_string());
         }
         let settings = read_settings(&settings_path(&app)?);
-        let voices = discover_voices("")?;
-        let (selection, selection_installed) =
-            resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || Ok(Vec::new()))?;
-        let selection = selection.filter(|_| selection_installed).ok_or_else(|| {
+        let selection = settings.selected_voice.ok_or_else(|| {
             "Select an installed Siri voice in Voice settings before using Siri TTS".to_string()
         })?;
         let active = begin_playback(&state, webview_window.label())?;

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -720,37 +720,16 @@ fn resolve_voice_selection(
 fn status(app: &AppHandle, language_prefix: &str) -> Result<SiriVoiceStatus, String> {
     let voices = discover_voices(language_prefix)?;
     let available_languages = discover_languages()?;
-    let path = settings_path(app)?;
-    let previous_selection = read_settings(&path).selected_voice;
+    let settings = read_settings(&settings_path(app)?);
     let (resolved_selection, resolved_selection_installed) =
-        resolve_voice_selection(&voices, previous_selection.as_ref(), || discover_voices(""))?;
-    let settings = update_settings(&path, |settings| {
-        if resolved_selection_installed
-            && settings.selected_voice == previous_selection
-            && settings.selected_voice != resolved_selection
-        {
-            settings.selected_voice = resolved_selection.clone();
-            true
-        } else {
-            false
-        }
-    })?;
-    let selected_voice_installed = if settings.selected_voice == resolved_selection {
-        resolved_selection_installed
-    } else {
-        settings.selected_voice.as_ref().is_some_and(|selection| {
-            find_voice(&voices, selection).is_some_and(|voice| voice.installed)
-                || discover_voices(&selection.language)
-                    .ok()
-                    .and_then(|selected| find_voice(&selected, selection).cloned())
-                    .is_some_and(|voice| voice.installed)
-        })
-    };
+        resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || {
+            discover_voices("")
+        })?;
     Ok(SiriVoiceStatus {
         supported: cfg!(target_os = "macos"),
         available_languages,
-        selected_voice: settings.selected_voice,
-        selected_voice_installed,
+        selected_voice: resolved_selection,
+        selected_voice_installed: resolved_selection_installed,
         playback_speed: settings
             .playback_speed
             .clamp(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED),
@@ -1084,7 +1063,10 @@ pub fn start_siri_voice_stream(
             return Err("Siri voice stream id cannot be empty".to_string());
         }
         let settings = read_settings(&settings_path(&app)?);
-        let selection = settings.selected_voice.ok_or_else(|| {
+        let voices = discover_voices("")?;
+        let (selection, selection_installed) =
+            resolve_voice_selection(&voices, settings.selected_voice.as_ref(), || Ok(Vec::new()))?;
+        let selection = selection.filter(|_| selection_installed).ok_or_else(|| {
             "Select an installed Siri voice in Voice settings before using Siri TTS".to_string()
         })?;
         let active = begin_playback(&state, webview_window.label())?;

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -250,6 +250,10 @@ export function ChatView({
     isGooseSession: controller.selectedProvider === "goose",
     pocketReady: voiceReady,
     inputBackend: voiceInput.backend,
+    siriVoice:
+      siriVoiceSetup.status?.selectedVoiceInstalled === true
+        ? siriVoiceSetup.status.selectedVoice
+        : null,
     onPocketSetupRequired: () => {
       requestOpenSettings("voice", {
         returnTarget: { type: "voice-setup", sessionId },

--- a/src/features/voice-conversation/api/siriVoice.test.ts
+++ b/src/features/voice-conversation/api/siriVoice.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
 
-import { getSiriVoiceStatus } from "./siriVoice";
+import { getSiriVoiceStatus, startSiriVoiceStream } from "./siriVoice";
 
 describe("Siri voice API", () => {
   beforeEach(() => {
@@ -41,5 +41,24 @@ describe("Siri voice API", () => {
     expect(mocks.invoke).toHaveBeenCalledTimes(2);
     resolveRequest?.({ supported: true, voices: [] });
     await Promise.all([first, joined, separate]);
+  });
+
+  it("passes the resolved voice to stream playback", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+    const voice = { name: "Samantha", language: "en-US" };
+
+    await startSiriVoiceStream(
+      "stream-1",
+      voice,
+      "allowInterruptions",
+      "balanced",
+    );
+
+    expect(mocks.invoke).toHaveBeenCalledWith("start_siri_voice_stream", {
+      streamId: "stream-1",
+      voice,
+      interruptionMode: "allowInterruptions",
+      interruptionSensitivity: "balanced",
+    });
   });
 });

--- a/src/features/voice-conversation/api/siriVoice.ts
+++ b/src/features/voice-conversation/api/siriVoice.ts
@@ -70,11 +70,13 @@ export interface SiriVoiceStreamEvent {
 
 export function startSiriVoiceStream(
   streamId: string,
+  voice: SiriVoiceSelection,
   interruptionMode: VoiceInterruptionMode,
   interruptionSensitivity: VoiceInterruptionSensitivity,
 ): Promise<void> {
   return invoke("start_siri_voice_stream", {
     streamId,
+    voice,
     interruptionMode,
     interruptionSensitivity,
   });

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -607,6 +607,8 @@ export function useVoiceConversationController({
   disabled = false,
 }: UseVoiceConversationControllerOptions): ChatInputVoiceConversation {
   const { t } = useTranslation("chat");
+  const siriVoiceRef = useRef(siriVoice);
+  siriVoiceRef.current = siriVoice;
   const status = useVoiceConversationStore((state) => state.status);
   const uiState = useVoiceConversationStore((state) => state.uiState);
   const error = useVoiceConversationStore((state) => state.error);
@@ -736,6 +738,7 @@ export function useVoiceConversationController({
   const startAssistantSpeech = useCallback(
     (
       initialMessages?: ReturnType<typeof captureNativeAssistantSpeechHistory>,
+      resolvedSiriVoice = siriVoiceRef.current,
     ) => {
       const onFailure = (text: string, playbackError: unknown) => {
         addErrorNotification(
@@ -750,18 +753,18 @@ export function useVoiceConversationController({
           error: playbackError,
         });
       };
-      if (siriVoice) {
+      if (resolvedSiriVoice) {
         startNativeAssistantSpeech(
           sessionId,
           onFailure,
           initialMessages,
-          siriVoice,
+          resolvedSiriVoice,
         );
       } else {
         startNativeAssistantSpeech(sessionId, onFailure, initialMessages);
       }
     },
-    [sessionId, siriVoice],
+    [sessionId],
   );
 
   const startCurrentConversation = useCallback(async () => {
@@ -843,9 +846,10 @@ export function useVoiceConversationController({
     // The initiating operation captured the pre-start history boundary and
     // activates speech after native startup succeeds.
     if (operationInFlightBySession.has(sessionId)) return;
-    startAssistantSpeech();
+    startAssistantSpeech(undefined, siriVoice);
   }, [
     sessionId,
+    siriVoice,
     startAssistantSpeech,
     status.lifecycle,
     status.ownerWindowLabel,

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -607,6 +607,8 @@ export function useVoiceConversationController({
   disabled = false,
 }: UseVoiceConversationControllerOptions): ChatInputVoiceConversation {
   const { t } = useTranslation("chat");
+  const siriVoiceRef = useRef(siriVoice);
+  siriVoiceRef.current = siriVoice;
   const status = useVoiceConversationStore((state) => state.status);
   const uiState = useVoiceConversationStore((state) => state.uiState);
   const error = useVoiceConversationStore((state) => state.error);
@@ -755,7 +757,7 @@ export function useVoiceConversationController({
           sessionId,
           onFailure,
           initialMessages,
-          siriVoice,
+          () => siriVoiceRef.current,
         );
       } else {
         startNativeAssistantSpeech(sessionId, onFailure, initialMessages);

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -24,6 +24,7 @@ import {
   type PendingVoiceTranscript,
 } from "../api/voiceConversation";
 import type { VoiceInputBackend } from "../lib/voiceInputPreference";
+import type { SiriVoiceSelection } from "../api/siriVoice";
 
 interface VoiceSendRoute {
   sessionId: string;
@@ -587,6 +588,7 @@ export interface UseVoiceConversationControllerOptions {
   isGooseSession: boolean;
   pocketReady: boolean;
   inputBackend?: VoiceInputBackend | null;
+  siriVoice?: SiriVoiceSelection | null;
   onPocketSetupRequired: () => void;
   readOnly?: boolean;
   disabled?: boolean;
@@ -599,6 +601,7 @@ export function useVoiceConversationController({
   isGooseSession,
   pocketReady,
   inputBackend = "parakeet",
+  siriVoice = null,
   onPocketSetupRequired,
   readOnly = false,
   disabled = false,
@@ -734,25 +737,31 @@ export function useVoiceConversationController({
     (
       initialMessages?: ReturnType<typeof captureNativeAssistantSpeechHistory>,
     ) => {
-      startNativeAssistantSpeech(
-        sessionId,
-        (text, playbackError) => {
-          addErrorNotification(
-            sessionId,
-            `Pocket TTS could not speak the assistant response: ${errorText(
-              playbackError,
-            )}`,
-          );
-          console.error("Native Pocket playback failed", {
-            sessionId,
-            textLength: text.length,
-            error: playbackError,
-          });
-        },
-        initialMessages,
-      );
+      const onFailure = (text: string, playbackError: unknown) => {
+        addErrorNotification(
+          sessionId,
+          `Pocket TTS could not speak the assistant response: ${errorText(
+            playbackError,
+          )}`,
+        );
+        console.error("Native Pocket playback failed", {
+          sessionId,
+          textLength: text.length,
+          error: playbackError,
+        });
+      };
+      if (siriVoice) {
+        startNativeAssistantSpeech(
+          sessionId,
+          onFailure,
+          initialMessages,
+          siriVoice,
+        );
+      } else {
+        startNativeAssistantSpeech(sessionId, onFailure, initialMessages);
+      }
     },
-    [sessionId],
+    [sessionId, siriVoice],
   );
 
   const startCurrentConversation = useCallback(async () => {

--- a/src/features/voice-conversation/hooks/useVoiceConversationController.ts
+++ b/src/features/voice-conversation/hooks/useVoiceConversationController.ts
@@ -607,8 +607,6 @@ export function useVoiceConversationController({
   disabled = false,
 }: UseVoiceConversationControllerOptions): ChatInputVoiceConversation {
   const { t } = useTranslation("chat");
-  const siriVoiceRef = useRef(siriVoice);
-  siriVoiceRef.current = siriVoice;
   const status = useVoiceConversationStore((state) => state.status);
   const uiState = useVoiceConversationStore((state) => state.uiState);
   const error = useVoiceConversationStore((state) => state.error);
@@ -757,7 +755,7 @@ export function useVoiceConversationController({
           sessionId,
           onFailure,
           initialMessages,
-          () => siriVoiceRef.current,
+          siriVoice,
         );
       } else {
         startNativeAssistantSpeech(sessionId, onFailure, initialMessages);

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -246,7 +246,12 @@ describe("native assistant speech stream", () => {
     mocks.backend = "siri";
     mocks.interruptionMode = "allowInterruptions";
     const siriVoice = { name: "Samantha", language: "en-US" };
-    startNativeAssistantSpeech("session-1", vi.fn(), undefined, siriVoice);
+    startNativeAssistantSpeech(
+      "session-1",
+      vi.fn(),
+      undefined,
+      () => siriVoice,
+    );
     useChatStore
       .getState()
       .setMessages("session-1", [
@@ -280,7 +285,9 @@ describe("native assistant speech stream", () => {
       "session-1",
       onFailure,
       undefined,
-      backend === "siri" ? { name: "Samantha", language: "en-US" } : undefined,
+      backend === "siri"
+        ? () => ({ name: "Samantha", language: "en-US" })
+        : undefined,
     );
     useChatStore
       .getState()
@@ -783,10 +790,7 @@ describe("native assistant speech stream", () => {
   it("resumes a false-positive interruption before native startup is invoked", async () => {
     vi.useFakeTimers();
     try {
-      startNativeAssistantSpeech("session-1", vi.fn(), undefined, {
-        name: "Samantha",
-        language: "en-US",
-      });
+      startNativeAssistantSpeech("session-1", vi.fn());
       useChatStore
         .getState()
         .setMessages("session-1", [
@@ -2634,10 +2638,16 @@ describe("native assistant speech stream", () => {
     vi.useFakeTimers();
     try {
       mocks.backend = "siri";
-      startNativeAssistantSpeech("session-1", vi.fn(), undefined, {
+      let siriVoice = {
         name: "Samantha",
         language: "en-US",
-      });
+      };
+      startNativeAssistantSpeech(
+        "session-1",
+        vi.fn(),
+        undefined,
+        () => siriVoice,
+      );
       useChatStore
         .getState()
         .setMessages("session-1", [
@@ -2661,11 +2671,13 @@ describe("native assistant speech stream", () => {
         error: null,
         delivery: { segments: [] },
       });
+      siriVoice = { name: "Eddy", language: "en-GB" };
       useVoiceConversationStore.setState({ userSpeaking: false });
       await vi.advanceTimersByTimeAsync(250);
       await vi.runAllTimersAsync();
 
       expect(mocks.siriStart).toHaveBeenCalledTimes(2);
+      expect(mocks.siriStart.mock.calls[1]?.[1]).toEqual(siriVoice);
       expect(mocks.siriAppend).toHaveBeenCalledWith(
         mocks.siriStart.mock.calls[1]?.[0],
         "Siri resumes.",

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -246,12 +246,7 @@ describe("native assistant speech stream", () => {
     mocks.backend = "siri";
     mocks.interruptionMode = "allowInterruptions";
     const siriVoice = { name: "Samantha", language: "en-US" };
-    startNativeAssistantSpeech(
-      "session-1",
-      vi.fn(),
-      undefined,
-      () => siriVoice,
-    );
+    startNativeAssistantSpeech("session-1", vi.fn(), undefined, siriVoice);
     useChatStore
       .getState()
       .setMessages("session-1", [
@@ -285,9 +280,7 @@ describe("native assistant speech stream", () => {
       "session-1",
       onFailure,
       undefined,
-      backend === "siri"
-        ? () => ({ name: "Samantha", language: "en-US" })
-        : undefined,
+      backend === "siri" ? { name: "Samantha", language: "en-US" } : undefined,
     );
     useChatStore
       .getState()
@@ -884,14 +877,17 @@ describe("native assistant speech stream", () => {
   });
 
   it("preserves terminal delivery before activating a replacement session", async () => {
-    startNativeAssistantSpeech("session-1", vi.fn());
+    mocks.backend = "siri";
+    const initialVoice = { name: "Samantha", language: "en-US" };
+    const replacementVoice = { name: "Eddy", language: "en-GB" };
+    startNativeAssistantSpeech("session-1", vi.fn(), undefined, initialVoice);
     useChatStore
       .getState()
       .setMessages("session-1", [
         assistant([{ type: "text", text: "One. Two. Three." }]),
       ]);
-    await vi.waitFor(() => expect(mocks.append).toHaveBeenCalled());
-    const firstStreamId = mocks.start.mock.calls[0]?.[0] as string;
+    await vi.waitFor(() => expect(mocks.siriAppend).toHaveBeenCalled());
+    const firstStreamId = mocks.siriStart.mock.calls[0]?.[0] as string;
 
     useVoiceConversationStore.setState((voice) => ({
       status: {
@@ -901,12 +897,17 @@ describe("native assistant speech stream", () => {
         revision: voice.status.revision + 1,
       },
     }));
-    await vi.waitFor(() => expect(mocks.stop).toHaveBeenCalled());
+    await vi.waitFor(() => expect(mocks.siriStop).toHaveBeenCalled());
 
-    startNativeAssistantSpeech("session-2", vi.fn());
-    expect(mocks.start).toHaveBeenCalledTimes(1);
+    startNativeAssistantSpeech(
+      "session-2",
+      vi.fn(),
+      undefined,
+      replacementVoice,
+    );
+    expect(mocks.siriStart).toHaveBeenCalledTimes(1);
 
-    mocks.streamHandler?.({
+    mocks.siriStreamHandler?.({
       streamId: firstStreamId,
       state: "interrupted",
       error: null,
@@ -941,7 +942,8 @@ describe("native assistant speech stream", () => {
           "assistant-2",
         ),
       ]);
-    await vi.waitFor(() => expect(mocks.start).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(mocks.siriStart).toHaveBeenCalledTimes(2));
+    expect(mocks.siriStart.mock.calls[1]?.[1]).toEqual(replacementVoice);
   });
 
   it("cancels a deferred replacement when its voice lifecycle stops", async () => {
@@ -2646,7 +2648,7 @@ describe("native assistant speech stream", () => {
         "session-1",
         vi.fn(),
         undefined,
-        () => initialSiriVoice,
+        initialSiriVoice,
       );
       useChatStore
         .getState()
@@ -2676,7 +2678,7 @@ describe("native assistant speech stream", () => {
         "session-1",
         vi.fn(),
         undefined,
-        () => refreshedSiriVoice,
+        refreshedSiriVoice,
       );
       useVoiceConversationStore.setState({ userSpeaking: false });
       await vi.advanceTimersByTimeAsync(250);

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
     vi.fn<
       (
         streamId: string,
+        voice: { name: string; language: string },
         interruptionMode:
           | "automatic"
           | "allowInterruptions"
@@ -77,9 +78,11 @@ vi.mock("../api/pocketVoice", () => ({
 vi.mock("../api/siriVoice", () => ({
   startSiriVoiceStream: (
     streamId: string,
+    voice: { name: string; language: string },
     interruptionMode: typeof mocks.interruptionMode,
     interruptionSensitivity: "less" | "balanced" | "more",
-  ) => mocks.siriStart(streamId, interruptionMode, interruptionSensitivity),
+  ) =>
+    mocks.siriStart(streamId, voice, interruptionMode, interruptionSensitivity),
   appendSiriVoiceStream: (streamId: string, text: string) =>
     mocks.siriAppend(streamId, text),
   flushSiriVoiceStream: (streamId: string) => mocks.siriFlush(streamId),
@@ -242,7 +245,8 @@ describe("native assistant speech stream", () => {
   it("routes the complete utterance stream through Siri when selected", async () => {
     mocks.backend = "siri";
     mocks.interruptionMode = "allowInterruptions";
-    startNativeAssistantSpeech("session-1", vi.fn());
+    const siriVoice = { name: "Samantha", language: "en-US" };
+    startNativeAssistantSpeech("session-1", vi.fn(), undefined, siriVoice);
     useChatStore
       .getState()
       .setMessages("session-1", [
@@ -252,6 +256,7 @@ describe("native assistant speech stream", () => {
     await vi.waitFor(() => {
       expect(mocks.siriStart).toHaveBeenCalledWith(
         expect.any(String),
+        siriVoice,
         "allowInterruptions",
         "less",
       );
@@ -271,7 +276,12 @@ describe("native assistant speech stream", () => {
   ] as const)("preserves partial delivery when a %s stream fails", async (backend) => {
     mocks.backend = backend;
     const onFailure = vi.fn();
-    startNativeAssistantSpeech("session-1", onFailure);
+    startNativeAssistantSpeech(
+      "session-1",
+      onFailure,
+      undefined,
+      backend === "siri" ? { name: "Samantha", language: "en-US" } : undefined,
+    );
     useChatStore
       .getState()
       .setMessages("session-1", [
@@ -773,7 +783,10 @@ describe("native assistant speech stream", () => {
   it("resumes a false-positive interruption before native startup is invoked", async () => {
     vi.useFakeTimers();
     try {
-      startNativeAssistantSpeech("session-1", vi.fn());
+      startNativeAssistantSpeech("session-1", vi.fn(), undefined, {
+        name: "Samantha",
+        language: "en-US",
+      });
       useChatStore
         .getState()
         .setMessages("session-1", [
@@ -2621,7 +2634,10 @@ describe("native assistant speech stream", () => {
     vi.useFakeTimers();
     try {
       mocks.backend = "siri";
-      startNativeAssistantSpeech("session-1", vi.fn());
+      startNativeAssistantSpeech("session-1", vi.fn(), undefined, {
+        name: "Samantha",
+        language: "en-US",
+      });
       useChatStore
         .getState()
         .setMessages("session-1", [

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -2638,7 +2638,7 @@ describe("native assistant speech stream", () => {
     vi.useFakeTimers();
     try {
       mocks.backend = "siri";
-      let siriVoice = {
+      const initialSiriVoice = {
         name: "Samantha",
         language: "en-US",
       };
@@ -2646,7 +2646,7 @@ describe("native assistant speech stream", () => {
         "session-1",
         vi.fn(),
         undefined,
-        () => siriVoice,
+        () => initialSiriVoice,
       );
       useChatStore
         .getState()
@@ -2671,13 +2671,19 @@ describe("native assistant speech stream", () => {
         error: null,
         delivery: { segments: [] },
       });
-      siriVoice = { name: "Eddy", language: "en-GB" };
+      const refreshedSiriVoice = { name: "Eddy", language: "en-GB" };
+      startNativeAssistantSpeech(
+        "session-1",
+        vi.fn(),
+        undefined,
+        () => refreshedSiriVoice,
+      );
       useVoiceConversationStore.setState({ userSpeaking: false });
       await vi.advanceTimersByTimeAsync(250);
       await vi.runAllTimersAsync();
 
       expect(mocks.siriStart).toHaveBeenCalledTimes(2);
-      expect(mocks.siriStart.mock.calls[1]?.[1]).toEqual(siriVoice);
+      expect(mocks.siriStart.mock.calls[1]?.[1]).toEqual(refreshedSiriVoice);
       expect(mocks.siriAppend).toHaveBeenCalledWith(
         mocks.siriStart.mock.calls[1]?.[0],
         "Siri resumes.",

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -104,6 +104,7 @@ let activeSpeechSessionId: string | null = null;
 let activeSpeechRevision: number | null = null;
 let activeUtterance: ActiveUtterance | null = null;
 let stopActiveVoice: () => Promise<boolean> = stopPocketVoice;
+let getActiveSiriVoice: () => SiriVoiceSelection | null = () => null;
 let activityReportQueue = Promise.resolve();
 let startRequestGeneration = 0;
 const pendingNotices = new Map<string, Map<string, string>>();
@@ -808,6 +809,7 @@ export function stopNativeAssistantSpeech(awaitTerminalDelivery = false): void {
   }
   activeSpeechSessionId = null;
   activeSpeechRevision = null;
+  getActiveSiriVoice = () => null;
 }
 
 export function captureNativeAssistantSpeechHistory(
@@ -820,9 +822,12 @@ export function startNativeAssistantSpeech(
   sessionId: string,
   onFailure: SpeechFailureHandler,
   initialMessages: Message[] = captureNativeAssistantSpeechHistory(sessionId),
-  getSiriVoice: () => SiriVoiceSelection | null = () => null,
+  getSiriVoice?: () => SiriVoiceSelection | null,
 ): void {
-  if (activeSpeechSessionId === sessionId) return;
+  if (activeSpeechSessionId === sessionId) {
+    if (getSiriVoice) getActiveSiriVoice = getSiriVoice;
+    return;
+  }
   const startRequest = ++startRequestGeneration;
   const interruptedUtterance = activeUtterance;
   if (
@@ -848,13 +853,14 @@ export function startNativeAssistantSpeech(
           sessionId,
           onFailure,
           initialMessages,
-          getSiriVoice,
+          getActiveSiriVoice,
         );
       });
     };
     return;
   }
   stopNativeAssistantSpeech();
+  getActiveSiriVoice = getSiriVoice ?? (() => null);
   activeSpeechSessionId = sessionId;
   activeSpeechRevision = useVoiceConversationStore.getState().status.revision;
   const activeGeneration = generation;
@@ -866,7 +872,7 @@ export function startNativeAssistantSpeech(
             interruptionMode: VoiceInterruptionMode,
             interruptionSensitivity: VoiceInterruptionSensitivity,
           ) => {
-            const siriVoice = getSiriVoice();
+            const siriVoice = getActiveSiriVoice();
             if (!siriVoice) {
               return Promise.reject(
                 new Error("No installed Siri voice is available for playback"),

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -104,7 +104,7 @@ let activeSpeechSessionId: string | null = null;
 let activeSpeechRevision: number | null = null;
 let activeUtterance: ActiveUtterance | null = null;
 let stopActiveVoice: () => Promise<boolean> = stopPocketVoice;
-let getActiveSiriVoice: () => SiriVoiceSelection | null = () => null;
+let activeSiriVoice: SiriVoiceSelection | null = null;
 let activityReportQueue = Promise.resolve();
 let startRequestGeneration = 0;
 const pendingNotices = new Map<string, Map<string, string>>();
@@ -809,7 +809,7 @@ export function stopNativeAssistantSpeech(awaitTerminalDelivery = false): void {
   }
   activeSpeechSessionId = null;
   activeSpeechRevision = null;
-  getActiveSiriVoice = () => null;
+  activeSiriVoice = null;
 }
 
 export function captureNativeAssistantSpeechHistory(
@@ -822,10 +822,10 @@ export function startNativeAssistantSpeech(
   sessionId: string,
   onFailure: SpeechFailureHandler,
   initialMessages: Message[] = captureNativeAssistantSpeechHistory(sessionId),
-  getSiriVoice?: () => SiriVoiceSelection | null,
+  siriVoice?: SiriVoiceSelection,
 ): void {
   if (activeSpeechSessionId === sessionId) {
-    if (getSiriVoice) getActiveSiriVoice = getSiriVoice;
+    if (siriVoice) activeSiriVoice = siriVoice;
     return;
   }
   const startRequest = ++startRequestGeneration;
@@ -853,14 +853,14 @@ export function startNativeAssistantSpeech(
           sessionId,
           onFailure,
           initialMessages,
-          getActiveSiriVoice,
+          siriVoice,
         );
       });
     };
     return;
   }
   stopNativeAssistantSpeech();
-  getActiveSiriVoice = getSiriVoice ?? (() => null);
+  activeSiriVoice = siriVoice ?? null;
   activeSpeechSessionId = sessionId;
   activeSpeechRevision = useVoiceConversationStore.getState().status.revision;
   const activeGeneration = generation;
@@ -872,15 +872,14 @@ export function startNativeAssistantSpeech(
             interruptionMode: VoiceInterruptionMode,
             interruptionSensitivity: VoiceInterruptionSensitivity,
           ) => {
-            const siriVoice = getActiveSiriVoice();
-            if (!siriVoice) {
+            if (!activeSiriVoice) {
               return Promise.reject(
                 new Error("No installed Siri voice is available for playback"),
               );
             }
             return startSiriVoiceStream(
               streamId,
-              siriVoice,
+              activeSiriVoice,
               interruptionMode,
               interruptionSensitivity,
             );

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -22,6 +22,7 @@ import {
   startSiriVoiceStream,
   stopSiriVoice,
   type SiriVoiceStreamEvent,
+  type SiriVoiceSelection,
 } from "../api/siriVoice";
 import { setVoiceConversationAssistantSpeaking } from "../api/voiceConversation";
 import {
@@ -819,6 +820,7 @@ export function startNativeAssistantSpeech(
   sessionId: string,
   onFailure: SpeechFailureHandler,
   initialMessages: Message[] = captureNativeAssistantSpeechHistory(sessionId),
+  siriVoice: SiriVoiceSelection | null = null,
 ): void {
   if (activeSpeechSessionId === sessionId) return;
   const startRequest = ++startRequestGeneration;
@@ -842,7 +844,12 @@ export function startNativeAssistantSpeech(
         ) {
           return;
         }
-        startNativeAssistantSpeech(sessionId, onFailure, initialMessages);
+        startNativeAssistantSpeech(
+          sessionId,
+          onFailure,
+          initialMessages,
+          siriVoice,
+        );
       });
     };
     return;
@@ -854,7 +861,23 @@ export function startNativeAssistantSpeech(
   const streamBackend =
     getVoiceOutputBackend() === "siri"
       ? {
-          start: startSiriVoiceStream,
+          start: (
+            streamId: string,
+            interruptionMode: VoiceInterruptionMode,
+            interruptionSensitivity: VoiceInterruptionSensitivity,
+          ) => {
+            if (!siriVoice) {
+              return Promise.reject(
+                new Error("No installed Siri voice is available for playback"),
+              );
+            }
+            return startSiriVoiceStream(
+              streamId,
+              siriVoice,
+              interruptionMode,
+              interruptionSensitivity,
+            );
+          },
           append: appendSiriVoiceStream,
           flush: flushSiriVoiceStream,
           finish: finishSiriVoiceStream,

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -820,7 +820,7 @@ export function startNativeAssistantSpeech(
   sessionId: string,
   onFailure: SpeechFailureHandler,
   initialMessages: Message[] = captureNativeAssistantSpeechHistory(sessionId),
-  siriVoice: SiriVoiceSelection | null = null,
+  getSiriVoice: () => SiriVoiceSelection | null = () => null,
 ): void {
   if (activeSpeechSessionId === sessionId) return;
   const startRequest = ++startRequestGeneration;
@@ -848,7 +848,7 @@ export function startNativeAssistantSpeech(
           sessionId,
           onFailure,
           initialMessages,
-          siriVoice,
+          getSiriVoice,
         );
       });
     };
@@ -866,6 +866,7 @@ export function startNativeAssistantSpeech(
             interruptionMode: VoiceInterruptionMode,
             interruptionSensitivity: VoiceInterruptionSensitivity,
           ) => {
+            const siriVoice = getSiriVoice();
             if (!siriVoice) {
               return Promise.reject(
                 new Error("No installed Siri voice is available for playback"),


### PR DESCRIPTION
## Summary

Use any installed Siri voice when the saved selection is unavailable, and open Voice settings only when no installed Siri voice can be resolved. The saved preference remains intact, while each speech stream receives the current effective fallback across status refreshes, view remounts, and session handoffs.

### Testing

On macOS, select a downloaded Siri voice in Berd, remove that voice in System Settings while another Siri voice remains installed, then start a voice conversation. Berd should speak with the installed fallback without opening Voice settings. Remove all Siri voices and retry; Berd should open Voice settings instead.