### PR TITLE
fix(chat): improve markdown table readability

### DIFF
--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -1918,6 +1918,17 @@ html[data-window-kind="voice-buddy"] #root {
   padding-block-end: var(--streamdown-table-scrollbar-block-size, 0px);
 }
 
+[data-streamdown="table"] th {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1rem;
+  white-space: normal;
+}
+
+[data-streamdown="table"] td {
+  font-size: 0.8125rem;
+}
+
 /* Streamdown paints its table scroll container with bg-background. Keep the
  * table chrome transparent so rows match whatever container hosts them
  * (doc viewer card, chat card); the muted header band and row borders carry

--- a/src/shared/styles/globals.streamdown-table.test.ts
+++ b/src/shared/styles/globals.streamdown-table.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const globalsCss = readFileSync(
+  resolve(process.cwd(), "src/shared/styles/globals.css"),
+  "utf8",
+);
+
+describe("Streamdown table styles", () => {
+  it("allows header cells to wrap without changing body-cell wrapping", () => {
+    expect(globalsCss).toMatch(
+      /\[data-streamdown="table"\]\s+th\s*\{[^}]*font-size:\s*0\.6875rem;[^}]*font-weight:\s*600;[^}]*line-height:\s*1rem;[^}]*white-space:\s*normal;/s,
+    );
+    expect(globalsCss).not.toMatch(
+      /\[data-streamdown="table"\]\s+th\s*\{[^}]*(?:letter-spacing|text-transform):/s,
+    );
+    expect(globalsCss).toMatch(
+      /\[data-streamdown="table"\]\s+td\s*\{[^}]*font-size:\s*0\.8125rem;/s,
+    );
+    expect(globalsCss).not.toMatch(
+      /\[data-streamdown="table"\]\s+td\s*\{[^}]*white-space:\s*normal;/s,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Updates table header to smaller font that wraps so columns are a more appropriate length

### Related issue
none found

### Testing
Before: 
<img width="694" height="434" alt="Screenshot 2026-08-24 at 11 08 22 PM" src="https://github.com/user-attachments/assets/70c1e1d0-bcc4-40f7-a469-e07cd8b94e1a" />

After:
<img width="595" height="581" alt="Screenshot 2026-08-24 at 11 08 15 PM" src="https://github.com/user-attachments/assets/f2aef66d-fc1b-4ca2-b9ca-82e151114473" />
