### PR TITLE
feat(voice): apply Pocket speed changes during active speech

### DIFF
--- a/src-tauri/native/siri_tts_bridge.h
+++ b/src-tauri/native/siri_tts_bridge.h
@@ -87,6 +87,7 @@ bool berd_pocket_audio_player_enqueue(
     uint32_t frame_count,
     char **error_out
 );
+bool berd_pocket_audio_player_set_rate(void *player, float rate, char **error_out);
 uint64_t berd_pocket_audio_player_completed_source_frames(void *player);
 uint64_t berd_pocket_audio_player_pending_buffers(void *player);
 bool berd_pocket_audio_player_failed(void *player);

--- a/src-tauri/native/siri_tts_bridge.m
+++ b/src-tauri/native/siri_tts_bridge.m
@@ -583,6 +583,7 @@ typedef void (^BerdAudioHandler)(
 - (BOOL)enqueueSamples:(const float *)samples
             frameCount:(AVAudioFrameCount)frameCount
                  error:(NSError **)error;
+- (BOOL)setPlaybackRate:(float)rate error:(NSError **)error;
 - (uint64_t)completedSourceFramesSnapshot;
 - (void)stop;
 @end
@@ -601,11 +602,10 @@ typedef void (^BerdAudioHandler)(
 
     _engine = [AVAudioEngine new];
     _player = [AVAudioPlayerNode new];
-    if (fabsf(rate - 1.0f) > 0.0001f) {
-        _timePitch = [AVAudioUnitTimePitch new];
-        _timePitch.rate = rate;
-        _timePitch.pitch = 0.0f;
-    }
+    _timePitch = [AVAudioUnitTimePitch new];
+    _timePitch.rate = rate;
+    _timePitch.pitch = 0.0f;
+    _timePitch.bypass = fabsf(rate - 1.0f) <= 0.0001f;
     _format = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatFloat32
                                               sampleRate:sampleRate
                                                 channels:1
@@ -616,13 +616,9 @@ typedef void (^BerdAudioHandler)(
     }
 
     [_engine attachNode:_player];
-    if (_timePitch) {
-        [_engine attachNode:_timePitch];
-        [_engine connect:_player to:_timePitch format:_format];
-        [_engine connect:_timePitch to:_engine.mainMixerNode format:_format];
-    } else {
-        [_engine connect:_player to:_engine.mainMixerNode format:_format];
-    }
+    [_engine attachNode:_timePitch];
+    [_engine connect:_player to:_timePitch format:_format];
+    [_engine connect:_timePitch to:_engine.mainMixerNode format:_format];
 
     if (outputDeviceID != kAudioObjectUnknown) {
         AudioUnit outputUnit = _engine.outputNode.audioUnit;
@@ -681,6 +677,22 @@ typedef void (^BerdAudioHandler)(
                   }
               }];
     if (!self.player.isPlaying) [self.player play];
+    return YES;
+}
+
+- (BOOL)setPlaybackRate:(float)rate error:(NSError **)error {
+    if (!isfinite(rate) || rate < 0.75f || rate > 2.0f) {
+        if (error) *error = BerdError(38, @"Pocket playback speed is invalid.");
+        return NO;
+    }
+    @synchronized (self) {
+        if (self.stopped) {
+            if (error) *error = BerdError(NSUserCancelledError, @"Pocket playback stopped.");
+            return NO;
+        }
+        self.timePitch.rate = rate;
+        self.timePitch.bypass = fabsf(rate - 1.0f) <= 0.0001f;
+    }
     return YES;
 }
 
@@ -1318,6 +1330,21 @@ bool berd_pocket_audio_player_enqueue(
             enqueueSamples:samples frameCount:frameCount error:&error];
         if (!enqueued) BerdSetError(errorOut, error ?: BerdError(37, @"Could not queue Pocket audio."));
         return enqueued;
+    }
+}
+
+bool berd_pocket_audio_player_set_rate(void *playerValue, float rate, char **errorOut) {
+    @autoreleasepool {
+        if (errorOut) *errorOut = NULL;
+        if (!playerValue) {
+            BerdSetError(errorOut, BerdError(36, @"Pocket playback is unavailable."));
+            return false;
+        }
+        NSError *error = nil;
+        BOOL updated = [(__bridge BerdPocketAudioPlayer *)playerValue
+            setPlaybackRate:rate error:&error];
+        if (!updated) BerdSetError(errorOut, error ?: BerdError(38, @"Could not update Pocket playback speed."));
+        return updated;
     }
 }
 

--- a/src-tauri/src/commands/pocket_audio_player.rs
+++ b/src-tauri/src/commands/pocket_audio_player.rs
@@ -1,7 +1,8 @@
 //! Safe ownership wrapper for the macOS AVAudioUnitTimePitch Pocket player.
 
-use std::cell::Cell;
 use std::ffi::{c_char, c_void, CStr};
+
+const MAX_POCKET_PLAYBACK_SPEED: f32 = 2.0;
 
 unsafe extern "C" {
     fn berd_pocket_audio_player_create(
@@ -31,9 +32,7 @@ unsafe extern "C" {
 
 pub(super) struct PocketAudioPlayer {
     raw: *mut c_void,
-    sample_rate: u32,
-    delivery_safety_frames: Cell<u64>,
-    reported_played_frames: Cell<u64>,
+    delivery_safety_frames: u64,
 }
 
 impl PocketAudioPlayer {
@@ -60,9 +59,7 @@ impl PocketAudioPlayer {
         }
         Ok(Self {
             raw,
-            sample_rate,
-            delivery_safety_frames: Cell::new(delivery_safety_frames(sample_rate, rate)),
-            reported_played_frames: Cell::new(0),
+            delivery_safety_frames: delivery_safety_frames(sample_rate, MAX_POCKET_PLAYBACK_SPEED),
         })
     }
 
@@ -71,19 +68,14 @@ impl PocketAudioPlayer {
         // SAFETY: `self.raw` is a live retained player and the bridge validates
         // the rate before updating the connected time-pitch unit.
         let updated = unsafe { berd_pocket_audio_player_set_rate(self.raw, rate, &mut error) };
-        if !updated {
-            return Err(take_error(
+        if updated {
+            Ok(())
+        } else {
+            Err(take_error(
                 error,
                 "Could not update native Pocket playback speed",
-            ));
+            ))
         }
-        self.delivery_safety_frames
-            .set(updated_delivery_safety_frames(
-                self.delivery_safety_frames.get(),
-                self.sample_rate,
-                rate,
-            ));
-        Ok(())
     }
 
     pub(super) fn enqueue(&self, samples: &[f32]) -> Result<(), String> {
@@ -108,13 +100,7 @@ impl PocketAudioPlayer {
     pub(super) fn played_frames(&self) -> u64 {
         // SAFETY: `self.raw` is a live retained player. The bridge counts only
         // source buffers confirmed played back, so idle queue gaps add nothing.
-        let played_frames = monotonic_played_frames(
-            self.reported_played_frames.get(),
-            self.completed_source_frames(),
-            self.delivery_safety_frames.get(),
-        );
-        self.reported_played_frames.set(played_frames);
-        played_frames
+        apply_delivery_safety(self.completed_source_frames(), self.delivery_safety_frames)
     }
 
     pub(super) fn completed_source_frames(&self) -> u64 {
@@ -142,23 +128,8 @@ fn delivery_safety_frames(sample_rate: u32, rate: f32) -> u64 {
     (f64::from(sample_rate) * 0.1 * f64::from(rate)).ceil() as u64
 }
 
-fn updated_delivery_safety_frames(current: u64, sample_rate: u32, rate: f32) -> u64 {
-    current.max(delivery_safety_frames(sample_rate, rate))
-}
-
 fn apply_delivery_safety(completed_source_frames: u64, safety_frames: u64) -> u64 {
     completed_source_frames.saturating_sub(safety_frames)
-}
-
-fn monotonic_played_frames(
-    reported_played_frames: u64,
-    completed_source_frames: u64,
-    safety_frames: u64,
-) -> u64 {
-    reported_played_frames.max(apply_delivery_safety(
-        completed_source_frames,
-        safety_frames,
-    ))
 }
 
 fn playback_health(failed: bool) -> Result<(), String> {
@@ -192,8 +163,7 @@ fn take_error(error: *mut c_char, fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_delivery_safety, delivery_safety_frames, monotonic_played_frames, playback_health,
-        updated_delivery_safety_frames,
+        apply_delivery_safety, delivery_safety_frames, playback_health, MAX_POCKET_PLAYBACK_SPEED,
     };
 
     #[test]
@@ -220,28 +190,10 @@ mod tests {
     }
 
     #[test]
-    fn live_rate_changes_keep_delivery_safety_conservative() {
-        let initial = delivery_safety_frames(24_000, 0.75);
-        let accelerated = updated_delivery_safety_frames(initial, 24_000, 2.0);
-        assert_eq!(accelerated, 4_800);
-        assert_eq!(
-            updated_delivery_safety_frames(accelerated, 24_000, 1.0),
-            4_800
-        );
-    }
-
-    #[test]
-    fn live_rate_changes_do_not_move_reported_delivery_backward() {
-        let previously_reported = apply_delivery_safety(10_000, 2_400);
-        assert_eq!(previously_reported, 7_600);
-        assert_eq!(
-            monotonic_played_frames(previously_reported, 10_000, 4_800),
-            7_600
-        );
-        assert_eq!(
-            monotonic_played_frames(previously_reported, 13_000, 4_800),
-            8_200
-        );
+    fn live_rate_changes_reserve_maximum_delivery_safety() {
+        let safety = delivery_safety_frames(24_000, MAX_POCKET_PLAYBACK_SPEED);
+        assert_eq!(safety, 4_800);
+        assert_eq!(apply_delivery_safety(10_000, safety), 5_200);
     }
 
     #[test]

--- a/src-tauri/src/commands/pocket_audio_player.rs
+++ b/src-tauri/src/commands/pocket_audio_player.rs
@@ -33,6 +33,7 @@ pub(super) struct PocketAudioPlayer {
     raw: *mut c_void,
     sample_rate: u32,
     delivery_safety_frames: Cell<u64>,
+    reported_played_frames: Cell<u64>,
 }
 
 impl PocketAudioPlayer {
@@ -61,6 +62,7 @@ impl PocketAudioPlayer {
             raw,
             sample_rate,
             delivery_safety_frames: Cell::new(delivery_safety_frames(sample_rate, rate)),
+            reported_played_frames: Cell::new(0),
         })
     }
 
@@ -106,10 +108,13 @@ impl PocketAudioPlayer {
     pub(super) fn played_frames(&self) -> u64 {
         // SAFETY: `self.raw` is a live retained player. The bridge counts only
         // source buffers confirmed played back, so idle queue gaps add nothing.
-        apply_delivery_safety(
+        let played_frames = monotonic_played_frames(
+            self.reported_played_frames.get(),
             self.completed_source_frames(),
             self.delivery_safety_frames.get(),
-        )
+        );
+        self.reported_played_frames.set(played_frames);
+        played_frames
     }
 
     pub(super) fn completed_source_frames(&self) -> u64 {
@@ -145,6 +150,17 @@ fn apply_delivery_safety(completed_source_frames: u64, safety_frames: u64) -> u6
     completed_source_frames.saturating_sub(safety_frames)
 }
 
+fn monotonic_played_frames(
+    reported_played_frames: u64,
+    completed_source_frames: u64,
+    safety_frames: u64,
+) -> u64 {
+    reported_played_frames.max(apply_delivery_safety(
+        completed_source_frames,
+        safety_frames,
+    ))
+}
+
 fn playback_health(failed: bool) -> Result<(), String> {
     if failed {
         Err("Pocket audio output stopped unexpectedly".to_string())
@@ -176,7 +192,7 @@ fn take_error(error: *mut c_char, fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_delivery_safety, delivery_safety_frames, playback_health,
+        apply_delivery_safety, delivery_safety_frames, monotonic_played_frames, playback_health,
         updated_delivery_safety_frames,
     };
 
@@ -211,6 +227,20 @@ mod tests {
         assert_eq!(
             updated_delivery_safety_frames(accelerated, 24_000, 1.0),
             4_800
+        );
+    }
+
+    #[test]
+    fn live_rate_changes_do_not_move_reported_delivery_backward() {
+        let previously_reported = apply_delivery_safety(10_000, 2_400);
+        assert_eq!(previously_reported, 7_600);
+        assert_eq!(
+            monotonic_played_frames(previously_reported, 10_000, 4_800),
+            7_600
+        );
+        assert_eq!(
+            monotonic_played_frames(previously_reported, 13_000, 4_800),
+            8_200
         );
     }
 

--- a/src-tauri/src/commands/pocket_audio_player.rs
+++ b/src-tauri/src/commands/pocket_audio_player.rs
@@ -1,5 +1,6 @@
 //! Safe ownership wrapper for the macOS AVAudioUnitTimePitch Pocket player.
 
+use std::cell::Cell;
 use std::ffi::{c_char, c_void, CStr};
 
 unsafe extern "C" {
@@ -15,6 +16,11 @@ unsafe extern "C" {
         frame_count: u32,
         error_out: *mut *mut c_char,
     ) -> bool;
+    fn berd_pocket_audio_player_set_rate(
+        player: *mut c_void,
+        rate: f32,
+        error_out: *mut *mut c_char,
+    ) -> bool;
     fn berd_pocket_audio_player_completed_source_frames(player: *mut c_void) -> u64;
     fn berd_pocket_audio_player_pending_buffers(player: *mut c_void) -> u64;
     fn berd_pocket_audio_player_failed(player: *mut c_void) -> bool;
@@ -25,7 +31,8 @@ unsafe extern "C" {
 
 pub(super) struct PocketAudioPlayer {
     raw: *mut c_void,
-    delivery_safety_frames: u64,
+    sample_rate: u32,
+    delivery_safety_frames: Cell<u64>,
 }
 
 impl PocketAudioPlayer {
@@ -52,8 +59,29 @@ impl PocketAudioPlayer {
         }
         Ok(Self {
             raw,
-            delivery_safety_frames: delivery_safety_frames(sample_rate, rate),
+            sample_rate,
+            delivery_safety_frames: Cell::new(delivery_safety_frames(sample_rate, rate)),
         })
+    }
+
+    pub(super) fn set_rate(&self, rate: f32) -> Result<(), String> {
+        let mut error = std::ptr::null_mut();
+        // SAFETY: `self.raw` is a live retained player and the bridge validates
+        // the rate before updating the connected time-pitch unit.
+        let updated = unsafe { berd_pocket_audio_player_set_rate(self.raw, rate, &mut error) };
+        if !updated {
+            return Err(take_error(
+                error,
+                "Could not update native Pocket playback speed",
+            ));
+        }
+        self.delivery_safety_frames
+            .set(updated_delivery_safety_frames(
+                self.delivery_safety_frames.get(),
+                self.sample_rate,
+                rate,
+            ));
+        Ok(())
     }
 
     pub(super) fn enqueue(&self, samples: &[f32]) -> Result<(), String> {
@@ -78,7 +106,10 @@ impl PocketAudioPlayer {
     pub(super) fn played_frames(&self) -> u64 {
         // SAFETY: `self.raw` is a live retained player. The bridge counts only
         // source buffers confirmed played back, so idle queue gaps add nothing.
-        apply_delivery_safety(self.completed_source_frames(), self.delivery_safety_frames)
+        apply_delivery_safety(
+            self.completed_source_frames(),
+            self.delivery_safety_frames.get(),
+        )
     }
 
     pub(super) fn completed_source_frames(&self) -> u64 {
@@ -104,6 +135,10 @@ impl PocketAudioPlayer {
 
 fn delivery_safety_frames(sample_rate: u32, rate: f32) -> u64 {
     (f64::from(sample_rate) * 0.1 * f64::from(rate)).ceil() as u64
+}
+
+fn updated_delivery_safety_frames(current: u64, sample_rate: u32, rate: f32) -> u64 {
+    current.max(delivery_safety_frames(sample_rate, rate))
 }
 
 fn apply_delivery_safety(completed_source_frames: u64, safety_frames: u64) -> u64 {
@@ -140,7 +175,10 @@ fn take_error(error: *mut c_char, fallback: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_delivery_safety, delivery_safety_frames, playback_health};
+    use super::{
+        apply_delivery_safety, delivery_safety_frames, playback_health,
+        updated_delivery_safety_frames,
+    };
 
     #[test]
     fn delivery_safety_tracks_playback_rate_in_source_frames() {
@@ -162,6 +200,17 @@ mod tests {
         assert_eq!(
             apply_delivery_safety(second_buffer_completed, safety),
             7_200
+        );
+    }
+
+    #[test]
+    fn live_rate_changes_keep_delivery_safety_conservative() {
+        let initial = delivery_safety_frames(24_000, 0.75);
+        let accelerated = updated_delivery_safety_frames(initial, 24_000, 2.0);
+        assert_eq!(accelerated, 4_800);
+        assert_eq!(
+            updated_delivery_safety_frames(accelerated, 24_000, 1.0),
+            4_800
         );
     }
 

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -2769,8 +2769,11 @@ fn synthesize_and_stream(
         player.stop();
         return Ok(());
     }
-    let drain_timeout =
-        pocket_native_drain_timeout(total_source_frames, player.completed_source_frames(), speed);
+    let drain_timeout = pocket_native_drain_timeout(
+        total_source_frames,
+        player.completed_source_frames(),
+        MIN_POCKET_PLAYBACK_SPEED,
+    );
     let drain_started = Instant::now();
     loop {
         sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)?;

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -6,7 +6,7 @@ use std::io::Read;
 #[cfg(target_os = "macos")]
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -189,8 +189,14 @@ pub struct PocketVoiceState {
 #[derive(Debug, Default)]
 struct PlaybackRuntime {
     active: Option<Arc<AtomicBool>>,
+    playback_rate: Option<Arc<AtomicU32>>,
     #[cfg(target_os = "macos")]
     stream: Option<ActivePocketStream>,
+}
+
+struct PlaybackSession {
+    active: Arc<AtomicBool>,
+    playback_rate: Arc<AtomicU32>,
 }
 
 #[cfg(target_os = "macos")]
@@ -881,7 +887,11 @@ pub fn select_pocket_voice(app: AppHandle, voice_id: String) -> Result<(), Strin
 }
 
 #[tauri::command]
-pub fn set_pocket_playback_speed(app: AppHandle, speed: f32) -> Result<(), String> {
+pub fn set_pocket_playback_speed(
+    app: AppHandle,
+    state: State<'_, PocketVoiceState>,
+    speed: f32,
+) -> Result<(), String> {
     if !speed.is_finite() || !(0.75..=2.0).contains(&speed) {
         return Err("Pocket playback speed must be between 0.75 and 2.0".to_string());
     }
@@ -895,7 +905,19 @@ pub fn set_pocket_playback_speed(app: AppHandle, speed: f32) -> Result<(), Strin
     let temporary = base.join("settings.json.tmp");
     fs::write(&temporary, data).map_err(|error| format!("write Pocket settings: {error}"))?;
     fs::rename(&temporary, base.join("settings.json"))
-        .map_err(|error| format!("publish Pocket settings: {error}"))
+        .map_err(|error| format!("publish Pocket settings: {error}"))?;
+    update_active_playback_speed(&state, speed)
+}
+
+fn update_active_playback_speed(state: &PocketVoiceState, speed: f32) -> Result<(), String> {
+    let playback = state
+        .playback
+        .lock()
+        .map_err(|_| "Pocket TTS playback state lock was poisoned".to_string())?;
+    if let Some(playback_rate) = playback.playback_rate.as_ref() {
+        playback_rate.store(speed.to_bits(), Ordering::SeqCst);
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -914,8 +936,11 @@ pub async fn preview_pocket_voice(
     if !pocket_installation_valid(&base) {
         return Err("Pocket TTS must be downloaded before previewing a voice".to_string());
     }
-    let active = begin_playback(&state, "Another Pocket voice preview is already playing")?;
-    let speed = playback_speed(&base);
+    let session = begin_playback(
+        &state,
+        "Another Pocket voice preview is already playing",
+        &base,
+    )?;
     let output_device = selected_output_device();
     let effective_output_device = effective_output_device_name(output_device.as_deref());
     let capture_suppression =
@@ -925,7 +950,7 @@ pub async fn preview_pocket_voice(
         });
 
     let playback = state.playback.clone();
-    let playback_active = active.clone();
+    let playback_active = session.active.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let _capture_suppression = capture_suppression;
         let result = synthesize_and_stream(
@@ -933,8 +958,8 @@ pub async fn preview_pocket_voice(
             voice,
             "Hello. This is a preview of my voice.",
             output_device.as_deref(),
-            active,
-            speed,
+            session.active,
+            session.playback_rate,
         );
         finish_playback(&playback, &playback_active);
         result
@@ -964,8 +989,7 @@ pub async fn speak_pocket_voice(
         .find(|voice| voice.id == voice_id)
         .copied()
         .ok_or_else(|| format!("Unknown selected Pocket voice: {voice_id}"))?;
-    let active = begin_playback(&state, "Pocket voice playback is already active")?;
-    let speed = playback_speed(&base);
+    let session = begin_playback(&state, "Pocket voice playback is already active", &base)?;
     let output_device = selected_output_device();
     let effective_output_device = effective_output_device_name(output_device.as_deref());
     let capture_suppression =
@@ -975,11 +999,17 @@ pub async fn speak_pocket_voice(
         });
 
     let playback = state.playback.clone();
-    let playback_active = active.clone();
+    let playback_active = session.active.clone();
     tauri::async_runtime::spawn_blocking(move || {
         let _capture_suppression = capture_suppression;
-        let result =
-            synthesize_and_stream(&base, voice, &text, output_device.as_deref(), active, speed);
+        let result = synthesize_and_stream(
+            &base,
+            voice,
+            &text,
+            output_device.as_deref(),
+            session.active,
+            session.playback_rate,
+        );
         finish_playback(&playback, &playback_active);
         result
     })
@@ -1024,8 +1054,7 @@ pub fn start_pocket_voice_stream(
             .find(|voice| voice.id == voice_id)
             .copied()
             .ok_or_else(|| format!("Unknown selected Pocket voice: {voice_id}"))?;
-        let active = begin_playback(&state, "Pocket voice playback is already active")?;
-        let speed = playback_speed(&base);
+        let session = begin_playback(&state, "Pocket voice playback is already active", &base)?;
         let output_device = selected_output_device();
         let effective_output_device = effective_output_device_name(output_device.as_deref());
         let suppress_capture =
@@ -1042,6 +1071,10 @@ pub fn start_pocket_voice_stream(
             });
         }
 
+        let PlaybackSession {
+            active,
+            playback_rate,
+        } = session;
         let playback = state.playback.clone();
         let playback_active = active.clone();
         let native_voice_state = native_voice.inner().clone();
@@ -1054,7 +1087,7 @@ pub fn start_pocket_voice_stream(
                     voice,
                     output_device.as_deref(),
                     active.clone(),
-                    speed,
+                    playback_rate,
                     receiver,
                     native_voice_state,
                     interruption_sensitivity,
@@ -1388,14 +1421,16 @@ fn clone_cache_path(source: &Path, destination: &Path) -> Result<(), String> {
 fn begin_playback(
     state: &State<'_, PocketVoiceState>,
     already_active: &str,
-) -> Result<Arc<AtomicBool>, String> {
-    begin_playback_runtime(state.inner(), already_active)
+    base: &Path,
+) -> Result<PlaybackSession, String> {
+    begin_playback_runtime(state.inner(), already_active, || playback_speed(base))
 }
 
 fn begin_playback_runtime(
     state: &PocketVoiceState,
     already_active: &str,
-) -> Result<Arc<AtomicBool>, String> {
+    current_playback_speed: impl FnOnce() -> f32,
+) -> Result<PlaybackSession, String> {
     let install = state
         .install
         .lock()
@@ -1411,9 +1446,14 @@ fn begin_playback_runtime(
         return Err(already_active.to_string());
     }
     let active = Arc::new(AtomicBool::new(true));
+    let playback_rate = Arc::new(AtomicU32::new(current_playback_speed().to_bits()));
     playback.active = Some(active.clone());
+    playback.playback_rate = Some(playback_rate.clone());
     drop(install);
-    Ok(active)
+    Ok(PlaybackSession {
+        active,
+        playback_rate,
+    })
 }
 
 fn wait_for_pocket_playback_to_stop(
@@ -1444,6 +1484,7 @@ fn finish_playback(playback: &std::sync::Mutex<PlaybackRuntime>, completed: &Arc
             .is_some_and(|active| Arc::ptr_eq(active, completed))
         {
             playback.active = None;
+            playback.playback_rate = None;
             #[cfg(target_os = "macos")]
             {
                 playback.stream = None;
@@ -2160,7 +2201,7 @@ fn run_pocket_voice_stream(
     voice: PocketVoice,
     output_device: Option<&str>,
     active: Arc<AtomicBool>,
-    speed: f32,
+    playback_rate: Arc<AtomicU32>,
     receiver: mpsc::Receiver<PocketStreamCommand>,
     native_voice: NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
@@ -2173,7 +2214,12 @@ fn run_pocket_voice_stream(
             .ok_or_else(|| "Pocket model path is not valid UTF-8".to_string())?,
     )?;
     let style = load_voice_style(&version.join("voices").join(voice.filename))?;
-    let player = PocketAudioPlayer::new(SAMPLE_RATE, speed, output_device)?;
+    let mut applied_rate_bits = playback_rate.load(Ordering::SeqCst);
+    let player = PocketAudioPlayer::new(
+        SAMPLE_RATE,
+        f32::from_bits(applied_rate_bits),
+        output_device,
+    )?;
     let mut pending = String::new();
     let mut first_chunk_pending = true;
     let mut playback_started = false;
@@ -2184,6 +2230,7 @@ fn run_pocket_voice_stream(
     let mut last_progress_emit = Instant::now();
 
     let result: Result<PocketStreamOutcome, String> = (|| loop {
+        sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)?;
         update_pocket_assistant_speech(
             player.is_empty(),
             &mut assistant_speech,
@@ -2211,6 +2258,8 @@ fn run_pocket_voice_stream(
                     &style,
                     &active,
                     &player,
+                    &playback_rate,
+                    &mut applied_rate_bits,
                     &mut pending,
                     &mut first_chunk_pending,
                     &mut playback_started,
@@ -2241,6 +2290,8 @@ fn run_pocket_voice_stream(
                     &style,
                     &active,
                     &player,
+                    &playback_rate,
+                    &mut applied_rate_bits,
                     &mut pending,
                     &mut first_chunk_pending,
                     &mut playback_started,
@@ -2271,6 +2322,8 @@ fn run_pocket_voice_stream(
                     &style,
                     &active,
                     &player,
+                    &playback_rate,
+                    &mut applied_rate_bits,
                     &mut pending,
                     &mut first_chunk_pending,
                     &mut playback_started,
@@ -2295,11 +2348,12 @@ fn run_pocket_voice_stream(
                 let drain_timeout = pocket_native_drain_timeout(
                     delivery_ledger.total_frames(),
                     player.completed_source_frames(),
-                    speed,
+                    f32::from_bits(applied_rate_bits),
                 );
                 let drain_started = Instant::now();
                 let mut completion_timed_out = false;
                 loop {
+                    sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)?;
                     if !active.load(Ordering::SeqCst) {
                         let delivery = pocket_delivery_snapshot(&delivery_ledger, &player);
                         player.stop();
@@ -2478,6 +2532,20 @@ fn pocket_native_drain_timeout(
 }
 
 #[cfg(target_os = "macos")]
+fn sync_pocket_playback_rate(
+    player: &PocketAudioPlayer,
+    playback_rate: &AtomicU32,
+    applied_rate_bits: &mut u32,
+) -> Result<(), String> {
+    let requested_rate_bits = playback_rate.load(Ordering::SeqCst);
+    if requested_rate_bits != *applied_rate_bits {
+        player.set_rate(f32::from_bits(requested_rate_bits))?;
+        *applied_rate_bits = requested_rate_bits;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 fn mark_pocket_playback_started(
     app: &AppHandle,
@@ -2512,6 +2580,8 @@ fn synthesize_pocket_stream_ready(
     style: &VoiceStyle,
     active: &Arc<AtomicBool>,
     player: &PocketAudioPlayer,
+    playback_rate: &AtomicU32,
+    applied_rate_bits: &mut u32,
     pending: &mut String,
     first_chunk_pending: &mut bool,
     playback_started: &mut bool,
@@ -2542,6 +2612,12 @@ fn synthesize_pocket_stream_ready(
                 }
                 if samples.is_empty() {
                     return true;
+                }
+                if let Err(error) =
+                    sync_pocket_playback_rate(player, playback_rate, applied_rate_bits)
+                {
+                    callback_error = Some(error);
+                    return false;
                 }
                 if let Err(error) = player.ensure_healthy() {
                     callback_error = Some(error);
@@ -2596,7 +2672,7 @@ fn synthesize_and_stream(
     text: &str,
     output_device: Option<&str>,
     active: Arc<AtomicBool>,
-    speed: f32,
+    playback_rate: Arc<AtomicU32>,
 ) -> Result<(), String> {
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2608,7 +2684,12 @@ fn synthesize_and_stream(
             .ok_or_else(|| "Pocket model path is not valid UTF-8".to_string())?,
     )?;
     let style = load_voice_style(&version.join("voices").join(voice.filename))?;
-    let player = PocketAudioPlayer::new(SAMPLE_RATE, speed, output_device)?;
+    let mut applied_rate_bits = playback_rate.load(Ordering::SeqCst);
+    let player = PocketAudioPlayer::new(
+        SAMPLE_RATE,
+        f32::from_bits(applied_rate_bits),
+        output_device,
+    )?;
     let callback_error = Arc::new(Mutex::new(None::<String>));
     let playback_started = Arc::new(AtomicBool::new(false));
     let mut total_source_frames = 0_u64;
@@ -2622,6 +2703,14 @@ fn synthesize_and_stream(
         }
         if samples.is_empty() {
             return true;
+        }
+        if let Err(error) =
+            sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)
+        {
+            if let Ok(mut callback_error) = callback_error_slot.lock() {
+                *callback_error = Some(error);
+            }
+            return false;
         }
         if let Err(error) = player.ensure_healthy() {
             if let Ok(mut callback_error) = callback_error_slot.lock() {
@@ -2666,6 +2755,7 @@ fn synthesize_and_stream(
         pocket_native_drain_timeout(total_source_frames, player.completed_source_frames(), speed);
     let drain_started = Instant::now();
     loop {
+        sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)?;
         if !active.load(Ordering::SeqCst) {
             player.stop();
             break;
@@ -2696,7 +2786,7 @@ fn synthesize_and_stream(
     _text: &str,
     _output_device: Option<&str>,
     _active: Arc<AtomicBool>,
-    _speed: f32,
+    _playback_rate: Arc<AtomicU32>,
 ) -> Result<(), String> {
     Err("Pocket voice playback is currently supported on macOS only".to_string())
 }
@@ -2704,6 +2794,30 @@ fn synthesize_and_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn active_playback_observes_live_speed_changes() {
+        let state = PocketVoiceState::default();
+        let session =
+            begin_playback_runtime(&state, "already active", || 1.0).expect("start playback");
+        assert_eq!(
+            f32::from_bits(session.playback_rate.load(Ordering::SeqCst)),
+            1.0
+        );
+
+        update_active_playback_speed(&state, 1.75).expect("update active playback");
+        assert_eq!(
+            f32::from_bits(session.playback_rate.load(Ordering::SeqCst)),
+            1.75
+        );
+
+        finish_playback(&state.playback, &session.active);
+        update_active_playback_speed(&state, 0.75).expect("ignore completed playback");
+        assert_eq!(
+            f32::from_bits(session.playback_rate.load(Ordering::SeqCst)),
+            1.75
+        );
+    }
 
     #[test]
     fn playback_ledger_maps_consumed_frames_to_text_segments_conservatively() {

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -2357,7 +2357,6 @@ fn run_pocket_voice_stream(
                 let drain_started = Instant::now();
                 let mut completion_timed_out = false;
                 loop {
-                    sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)?;
                     if !active.load(Ordering::SeqCst) {
                         let delivery = pocket_delivery_snapshot(&delivery_ledger, &player);
                         player.stop();
@@ -2366,6 +2365,9 @@ fn run_pocket_voice_stream(
                             delivery: Some(delivery),
                         });
                     }
+                    sync_pocket_playback_rate_before_timeout(completion_timed_out, || {
+                        sync_pocket_playback_rate(&player, &playback_rate, &mut applied_rate_bits)
+                    })?;
                     if !completion_timed_out {
                         player.ensure_healthy()?;
                         match pocket_native_drain_status(
@@ -2533,6 +2535,18 @@ fn pocket_native_drain_timeout(
         remaining_source_frames as f64 / f64::from(berd_voice::SAMPLE_RATE) / f64::from(rate);
     Duration::from_secs_f64(remaining_playback_seconds)
         .saturating_add(POCKET_SOURCE_COMPLETION_TIMEOUT)
+}
+
+#[cfg(any(test, target_os = "macos"))]
+fn sync_pocket_playback_rate_before_timeout(
+    completion_timed_out: bool,
+    sync: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    if completion_timed_out {
+        Ok(())
+    } else {
+        sync()
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -3402,6 +3416,22 @@ mod tests {
             Duration::from_secs_f64(2.0 / f64::from(MIN_POCKET_PLAYBACK_SPEED))
                 .saturating_add(POCKET_SOURCE_COMPLETION_TIMEOUT)
         );
+    }
+
+    #[test]
+    fn post_timeout_grace_ignores_live_rate_changes() {
+        let mut sync_count = 0;
+        sync_pocket_playback_rate_before_timeout(false, || {
+            sync_count += 1;
+            Ok(())
+        })
+        .expect("sync while native playback is active");
+        sync_pocket_playback_rate_before_timeout(true, || {
+            sync_count += 1;
+            Err("stopped player rejected rate change".to_string())
+        })
+        .expect("ignore rate change after native timeout");
+        assert_eq!(sync_count, 1);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -64,6 +64,8 @@ const AIRPLAY_PLAYBACK_LATENCY_SAFETY_DURATION: Duration = Duration::from_secs(2
 const UNKNOWN_PLAYBACK_LATENCY_SAFETY_DURATION: Duration = Duration::from_secs(2);
 #[cfg(any(test, target_os = "macos"))]
 const POCKET_SOURCE_COMPLETION_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(any(test, target_os = "macos"))]
+const MIN_POCKET_PLAYBACK_SPEED: f32 = 0.75;
 
 #[cfg(target_os = "macos")]
 fn playback_latency_safety_duration_for_transport(transport: Option<u32>) -> Duration {
@@ -2345,10 +2347,12 @@ fn run_pocket_voice_stream(
                         delivery: Some(delivery),
                     });
                 }
+                // Playback speed can change while buffers drain. Use the slowest
+                // supported rate so a later slowdown cannot truncate valid audio.
                 let drain_timeout = pocket_native_drain_timeout(
                     delivery_ledger.total_frames(),
                     player.completed_source_frames(),
-                    f32::from_bits(applied_rate_bits),
+                    MIN_POCKET_PLAYBACK_SPEED,
                 );
                 let drain_started = Instant::now();
                 let mut completion_timed_out = false;
@@ -3384,6 +3388,19 @@ mod tests {
         assert_eq!(
             pocket_native_drain_status(true, timeout, timeout),
             PocketNativeDrainStatus::Drained
+        );
+    }
+
+    #[test]
+    fn native_drain_timeout_covers_a_live_slowdown() {
+        let fastest_timeout = pocket_native_drain_timeout(72_000, 24_000, 2.0);
+        let live_rate_timeout =
+            pocket_native_drain_timeout(72_000, 24_000, MIN_POCKET_PLAYBACK_SPEED);
+        assert!(live_rate_timeout > fastest_timeout);
+        assert_eq!(
+            live_rate_timeout,
+            Duration::from_secs_f64(2.0 / f64::from(MIN_POCKET_PLAYBACK_SPEED))
+                .saturating_add(POCKET_SOURCE_COMPLETION_TIMEOUT)
         );
     }
 


### PR DESCRIPTION
## Summary

Pocket playback speed was previously captured when an utterance started, so changing the setting affected only later speech. This makes speed changes apply to the current preview, one-shot utterance, or streaming response without restarting playback. The native audio graph remains stable through 1x transitions, and spoken-delivery progress stays conservative and monotonic as the rate changes.

## Reviewer-reproducible examples

1. Select Pocket for speech output and start a voice conversation with a multi-paragraph response.
2. While the response is speaking, change playback speed from 1x to 2x, then back to 1x.
3. Confirm the current utterance changes speed without restarting, dropping queued speech, or changing pitch.