### PR TITLE
fix(voice): default speech output to Pocket

### DIFF
--- a/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
@@ -26,10 +26,10 @@ describe("voice output preference", () => {
     });
   });
 
-  it("defaults to Siri on macOS", () => {
+  it("defaults to Pocket on macOS", () => {
     setPlatform("Macintosh");
-    expect(getDefaultVoiceOutputBackend()).toBe("siri");
-    expect(getVoiceOutputBackend()).toBe("siri");
+    expect(getDefaultVoiceOutputBackend()).toBe("pocket");
+    expect(getVoiceOutputBackend()).toBe("pocket");
   });
 
   it("defaults to Pocket and rejects persisted Siri off macOS", () => {

--- a/src/features/voice-conversation/lib/voiceOutputPreference.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.ts
@@ -7,7 +7,7 @@ const STORAGE_KEY = "goose:voice-output-backend";
 const CHANGED_EVENT = "goose:voice-output-backend-changed";
 let inMemoryBackend: VoiceOutputBackend | null = null;
 export function getDefaultVoiceOutputBackend(): VoiceOutputBackend {
-  return getPlatform() === "mac" ? "siri" : "pocket";
+  return "pocket";
 }
 
 function normalize(value: unknown): VoiceOutputBackend {


### PR DESCRIPTION
## Summary

Siri voice playback can occasionally become garbled at full-scale volume. This restores Pocket TTS as the default speech output on every platform while preserving an explicitly saved Siri selection.

## Reviewer-reproducible examples

1. On macOS with no saved voice output preference, open Voice settings. Pocket TTS is selected.
2. Select a Siri voice explicitly, then reopen Voice settings. The saved Siri selection remains selected.