### PR TITLE
fix(chat): stop stranding queued sends rejected before commit

### DIFF
--- a/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
@@ -1318,6 +1318,93 @@ describe("useMessageQueue", () => {
     vi.useRealTimers();
   });
 
+  it("stops automatic retries for a persistently rejected payload despite readiness churn", async () => {
+    // A failed auto-compaction returns false, appends an error notification,
+    // and sets the session back to idle. That idle edge re-triggers the drain,
+    // so without a ceiling the send loops as fast as compaction can fail and
+    // grows the transcript every pass.
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(false);
+    useChatStore.getState().enqueueTransportReadyMessage("s1", {
+      persona: { kind: "inherit" },
+      text: "queued",
+    });
+
+    renderHook(() => useMessageQueue("s1", "idle", sendMessage));
+    await act(async () => Promise.resolve());
+
+    for (let pass = 0; pass < 12; pass += 1) {
+      await act(async () => {
+        useChatStore.getState().setChatState("s1", "compacting");
+        useChatStore.getState().setChatState("s1", "idle");
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+    }
+
+    expect(sendMessage).toHaveBeenCalledTimes(5);
+    expect(
+      useChatStore.getState().queuedMessageBySession.s1?.[0]?.payload,
+    ).toMatchObject({ text: "queued" });
+    vi.useRealTimers();
+  });
+
+  it("backs off the readiness wait instead of re-arming every second", async () => {
+    vi.useFakeTimers();
+    const sendMessage = vi.fn().mockResolvedValue(false);
+    useChatStore.getState().enqueueTransportReadyMessage("s1", {
+      persona: { kind: "inherit" },
+      text: "queued",
+    });
+
+    const { rerender } = renderHook(
+      ({ ready }: { ready: boolean }) =>
+        useMessageQueue(
+          "s1",
+          ready ? "idle" : "thinking",
+          sendMessage,
+          false,
+          false,
+          ready,
+        ),
+      { initialProps: { ready: true } },
+    );
+    await act(async () => Promise.resolve());
+    expect(sendMessage).toHaveBeenCalledOnce();
+
+    // Capture re-arm delays only; installing this earlier would intercept the
+    // scheduling that produces the first attempt.
+    const delays: number[] = [];
+    const fakeSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = ((
+      fn: Parameters<typeof fakeSetTimeout>[0],
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      if (typeof ms === "number" && ms >= 1_000) delays.push(ms);
+      return (
+        fakeSetTimeout as unknown as (
+          ...args: unknown[]
+        ) => ReturnType<typeof fakeSetTimeout>
+      )(fn, ms, ...rest);
+    }) as unknown as typeof globalThis.setTimeout;
+
+    try {
+      rerender({ ready: false });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(600_000);
+      });
+    } finally {
+      globalThis.setTimeout = fakeSetTimeout;
+    }
+
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(delays.slice(0, 5)).toEqual([2_000, 4_000, 8_000, 16_000, 30_000]);
+    expect(Math.max(...delays)).toBe(30_000);
+    // Flat one-second re-arming would be 600 wakeups over the same window.
+    expect(delays.length).toBeLessThan(40);
+    vi.useRealTimers();
+  });
+
   it("waits for preparation readiness before a timed retry", async () => {
     vi.useFakeTimers();
     const sendMessage = vi.fn().mockResolvedValue(false);

--- a/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
+++ b/src/features/chat/hooks/__tests__/useMessageQueue.test.ts
@@ -1279,7 +1279,10 @@ describe("useMessageQueue", () => {
     expect(useChatStore.getState().queuedMessageBySession.s1).toBeUndefined();
   });
 
-  it("retries a retained pre-commit failure once while the session stays ready", async () => {
+  it("keeps retrying a retained pre-commit failure with backoff while the session stays ready", async () => {
+    // LAWS/CHAT.md: the queue must resume sending when the session is ready.
+    // Pre-commit rejections are silent and leave no store transition behind,
+    // so abandoning the record after a fixed retry count strands it forever.
     vi.useFakeTimers();
     const sendMessage = vi.fn().mockResolvedValue(false);
     useChatStore.getState().enqueueTransportReadyMessage("s1", {
@@ -1297,12 +1300,21 @@ describe("useMessageQueue", () => {
     expect(sendMessage).toHaveBeenCalledTimes(2);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(2_000);
     });
-    expect(sendMessage).toHaveBeenCalledTimes(2);
-    expect(
-      useChatStore.getState().queuedMessageBySession.s1?.[0]?.payload,
-    ).toMatchObject({ text: "queued" });
+    expect(sendMessage).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(4);
+
+    sendMessage.mockResolvedValue(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8_000);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(5);
+    expect(useChatStore.getState().queuedMessageBySession.s1).toBeUndefined();
     vi.useRealTimers();
   });
 
@@ -1428,7 +1440,7 @@ describe("useMessageQueue", () => {
     });
   });
 
-  it("restores one automatic retry on every later readiness transition", async () => {
+  it("resets the retry backoff on every later readiness transition", async () => {
     vi.useFakeTimers();
     const sendMessage = vi.fn().mockReturnValue(false);
     useChatStore.getState().enqueueTransportReadyMessage("s1", {
@@ -1441,23 +1453,23 @@ describe("useMessageQueue", () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_000);
     });
-    expect(sendMessage).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(sendMessage).toHaveBeenCalledTimes(3);
 
     act(() => {
       useChatStore.getState().setChatState("s1", "streaming");
       useChatStore.getState().setChatState("s1", "idle");
     });
-    expect(sendMessage).toHaveBeenCalledTimes(3);
+    expect(sendMessage).toHaveBeenCalledTimes(4);
 
+    // The idle transition cleared the backoff, so the next automatic retry
+    // fires at the initial one-second delay again.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_000);
     });
-    expect(sendMessage).toHaveBeenCalledTimes(4);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(60_000);
-    });
-    expect(sendMessage).toHaveBeenCalledTimes(4);
+    expect(sendMessage).toHaveBeenCalledTimes(5);
     expect(
       useChatStore.getState().queuedMessageBySession.s1?.[0]?.payload,
     ).toMatchObject({ text: "queued" });

--- a/src/features/chat/hooks/useMessageQueue.ts
+++ b/src/features/chat/hooks/useMessageQueue.ts
@@ -46,6 +46,14 @@ const queueAttemptLeaseBySession = new Map<string, QueueAttemptLease>();
 // follow-up store transition to re-trigger the drain.
 const MAX_AUTO_RETRY_DELAY_MS = 30_000;
 
+// Waiting for readiness is unbounded; actually dispatching and being rejected
+// is not. A persistent pre-commit failure is not a race: auto-compaction
+// returns false on every failed compaction and appends an error notification
+// per failure, and the failure itself sets the session back to idle, which
+// reads as a readiness edge and re-triggers the drain. Without a ceiling that
+// spins as fast as compaction can fail, growing the transcript every pass.
+const MAX_CONSECUTIVE_REJECTIONS = 5;
+
 function getQueuedMessageKey(
   queuedMessage: QueuedMessageRecord | null,
 ): string | null {
@@ -106,6 +114,12 @@ export function useMessageQueue(
     payload: QueuedMessageRecord["payload"];
     attempts: number;
   } | null>(null);
+  // Deliberately survives readiness transitions, unlike autoRetryRef: the
+  // transition a failed send causes must not hand it a fresh retry budget.
+  const consecutiveRejectionsRef = useRef<{
+    payload: QueuedMessageRecord["payload"];
+    count: number;
+  } | null>(null);
   const suppressNextRenderIdleCycleRef = useRef(false);
   const dismissedRecordIdRef = useRef<string | null>(null);
   const queuedMessageKey = useMemo(
@@ -156,6 +170,16 @@ export function useMessageQueue(
 
       const key = getQueuedMessageKey(queuedMsg);
       if (!key) {
+        return false;
+      }
+
+      // Single choke point for the rejection ceiling, so every drain trigger
+      // (retry timer, readiness edge, lease release, store subscription) is
+      // covered rather than just the timer.
+      if (
+        consecutiveRejectionsRef.current?.payload === payload &&
+        consecutiveRejectionsRef.current.count >= MAX_CONSECUTIVE_REJECTIONS
+      ) {
         return false;
       }
 
@@ -287,6 +311,24 @@ export function useMessageQueue(
           if (autoRetryRef.current?.payload !== retryPayload) {
             autoRetryRef.current = { payload: retryPayload, attempts: 0 };
           }
+          const rejections =
+            consecutiveRejectionsRef.current?.payload === retryPayload
+              ? consecutiveRejectionsRef.current.count + 1
+              : 1;
+          consecutiveRejectionsRef.current = {
+            payload: retryPayload,
+            count: rejections,
+          };
+          if (rejections >= MAX_CONSECUTIVE_REJECTIONS) {
+            // Stop automatically. The record stays queued and showInComposer
+            // was forced true above, so it is visible and the user can resend.
+            autoRetryRef.current = null;
+            if (retryTimerRef.current !== null) {
+              clearTimeout(retryTimerRef.current);
+              retryTimerRef.current = null;
+            }
+            return;
+          }
           const scheduleAutoRetry = () => {
             if (retryTimerRef.current !== null) return;
             const attempts = autoRetryRef.current?.attempts ?? 0;
@@ -310,8 +352,16 @@ export function useMessageQueue(
               ) {
                 // Readiness can return without a transition this hook
                 // observes; keep the retry armed instead of abandoning the
-                // record.
+                // record. No dispatch was attempted, so this costs no rejection
+                // budget — but it must still back off, or an unready session
+                // polls at a flat one second forever.
                 lastAttemptRef.current = null;
+                if (autoRetryRef.current?.payload === retryPayload) {
+                  autoRetryRef.current = {
+                    payload: retryPayload,
+                    attempts: autoRetryRef.current.attempts + 1,
+                  };
+                }
                 scheduleAutoRetry();
                 return;
               }
@@ -330,6 +380,7 @@ export function useMessageQueue(
         }
 
         autoRetryRef.current = null;
+        consecutiveRejectionsRef.current = null;
         lastAttemptRef.current = null;
         useChatStore
           .getState()
@@ -403,7 +454,11 @@ export function useMessageQueue(
       }
 
       if (editedCurrentRecord || advancedToNextRecord) {
+        // A user edit or a new head is a materially different send, so the
+        // rejection budget resets here. Readiness edges below deliberately do
+        // not reset it.
         autoRetryRef.current = null;
+        consecutiveRejectionsRef.current = null;
         if (retryTimerRef.current !== null) {
           clearTimeout(retryTimerRef.current);
           retryTimerRef.current = null;
@@ -463,6 +518,7 @@ export function useMessageQueue(
     if (queuedMessageKey !== lastAttemptRef.current?.key) {
       lastAttemptRef.current = null;
       autoRetryRef.current = null;
+      consecutiveRejectionsRef.current = null;
       if (retryTimerRef.current !== null) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;

--- a/src/features/chat/hooks/useMessageQueue.ts
+++ b/src/features/chat/hooks/useMessageQueue.ts
@@ -40,6 +40,12 @@ interface QueueAttemptLease {
 // the replacement owner from overlapping the still-live attempt.
 const queueAttemptLeaseBySession = new Map<string, QueueAttemptLease>();
 
+// LAWS/CHAT.md: the queue must resume sending when the session becomes ready.
+// Rejected attempts back off but never abandon the record — a rejection can be
+// silent (pre-commit ownership/readiness races around draft promotion) with no
+// follow-up store transition to re-trigger the drain.
+const MAX_AUTO_RETRY_DELAY_MS = 30_000;
+
 function getQueuedMessageKey(
   queuedMessage: QueuedMessageRecord | null,
 ): string | null {
@@ -96,9 +102,10 @@ export function useMessageQueue(
   const dispatchReleasePayloadRef = useRef<
     QueuedMessageRecord["payload"] | null
   >(null);
-  const automaticallyRetriedPayloadRef = useRef<
-    QueuedMessageRecord["payload"] | null
-  >(null);
+  const autoRetryRef = useRef<{
+    payload: QueuedMessageRecord["payload"];
+    attempts: number;
+  } | null>(null);
   const suppressNextRenderIdleCycleRef = useRef(false);
   const dismissedRecordIdRef = useRef<string | null>(null);
   const queuedMessageKey = useMemo(
@@ -277,31 +284,52 @@ export function useMessageQueue(
                 retryPayload,
               );
           }
-          if (
-            retryTimerRef.current === null &&
-            automaticallyRetriedPayloadRef.current !== retryPayload
-          ) {
+          if (autoRetryRef.current?.payload !== retryPayload) {
+            autoRetryRef.current = { payload: retryPayload, attempts: 0 };
+          }
+          const scheduleAutoRetry = () => {
+            if (retryTimerRef.current !== null) return;
+            const attempts = autoRetryRef.current?.attempts ?? 0;
+            const delayMs = Math.min(
+              1_000 * 2 ** attempts,
+              MAX_AUTO_RETRY_DELAY_MS,
+            );
             retryTimerRef.current = setTimeout(() => {
               retryTimerRef.current = null;
               const state = useChatStore.getState();
               const runtime = state.getSessionRuntime(sessionId);
               const retryHead = state.queuedMessageBySession[sessionId]?.[0];
               if (
-                !isQueuedSessionReady(runtime, isPreparationReadyRef.current) ||
                 getQueuedMessageKey(retryHead) !== key ||
                 retryHead?.payload !== retryPayload
               ) {
                 return;
               }
-              automaticallyRetriedPayloadRef.current = retryPayload;
+              if (
+                !isQueuedSessionReady(runtime, isPreparationReadyRef.current)
+              ) {
+                // Readiness can return without a transition this hook
+                // observes; keep the retry armed instead of abandoning the
+                // record.
+                lastAttemptRef.current = null;
+                scheduleAutoRetry();
+                return;
+              }
+              if (autoRetryRef.current?.payload === retryPayload) {
+                autoRetryRef.current = {
+                  payload: retryPayload,
+                  attempts: autoRetryRef.current.attempts + 1,
+                };
+              }
               idleCycleRef.current += 1;
               tryDrainQueuedMessage(retryHead);
-            }, 1_000);
-          }
+            }, delayMs);
+          };
+          scheduleAutoRetry();
           return;
         }
 
-        automaticallyRetriedPayloadRef.current = null;
+        autoRetryRef.current = null;
         lastAttemptRef.current = null;
         useChatStore
           .getState()
@@ -375,7 +403,7 @@ export function useMessageQueue(
       }
 
       if (editedCurrentRecord || advancedToNextRecord) {
-        automaticallyRetriedPayloadRef.current = null;
+        autoRetryRef.current = null;
         if (retryTimerRef.current !== null) {
           clearTimeout(retryTimerRef.current);
           retryTimerRef.current = null;
@@ -383,7 +411,7 @@ export function useMessageQueue(
       }
 
       if (becameIdle || becameReadyWhileIdle) {
-        automaticallyRetriedPayloadRef.current = null;
+        autoRetryRef.current = null;
         if (retryTimerRef.current !== null) {
           clearTimeout(retryTimerRef.current);
           retryTimerRef.current = null;
@@ -434,7 +462,7 @@ export function useMessageQueue(
     }
     if (queuedMessageKey !== lastAttemptRef.current?.key) {
       lastAttemptRef.current = null;
-      automaticallyRetriedPayloadRef.current = null;
+      autoRetryRef.current = null;
       if (retryTimerRef.current !== null) {
         clearTimeout(retryTimerRef.current);
         retryTimerRef.current = null;

--- a/src/features/chat/stores/queuePersistence.test.ts
+++ b/src/features/chat/stores/queuePersistence.test.ts
@@ -9,12 +9,14 @@ import {
   loadPersistedMessageQueues,
   persistMessageQueues,
 } from "./queuePersistence";
+import { useChatSessionStore, type ChatSession } from "./chatSessionStore";
 
 describe("queuePersistence", () => {
   beforeEach(() => {
     mockInvoke.mockReset();
     window.localStorage.clear();
     window.__TAURI_INTERNALS__ = {};
+    useChatSessionStore.setState({ sessions: [] });
   });
 
   it("loads inline image attachments from native persistence when localStorage is over quota", async () => {
@@ -263,6 +265,71 @@ describe("queuePersistence", () => {
       main: [{ recordId: "main-record" }],
       detached: [{ recordId: "detached-record" }],
     });
+  });
+
+  it("drops queue writes for sessions whose creation has not settled", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    useChatSessionStore.setState({
+      sessions: [
+        { id: "draft-1", creationState: "pending" } as unknown as ChatSession,
+        { id: "draft-2", creationState: "failed" } as unknown as ChatSession,
+      ],
+    });
+
+    persistMessageQueues(
+      {
+        "draft-1": [
+          {
+            kind: "transport-ready",
+            recordId: "pending-record",
+            payload: admitSystemInheritedQueuedMessage({ text: "pending" }),
+          },
+        ],
+        "draft-2": [
+          {
+            kind: "transport-ready",
+            recordId: "failed-record",
+            payload: admitSystemInheritedQueuedMessage({ text: "failed" }),
+          },
+        ],
+      },
+      ["draft-1", "draft-2"],
+    );
+
+    await vi.waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("persist_message_queue_updates", {
+        serializedUpdates: JSON.stringify({ "draft-1": null, "draft-2": null }),
+      }),
+    );
+    expect(
+      window.localStorage.getItem("goose:chat-message-queues:v1"),
+    ).toBeNull();
+  });
+
+  it("persists queues again once the session id belongs to a settled session", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    useChatSessionStore.setState({
+      sessions: [{ id: "backend-1" } as unknown as ChatSession],
+    });
+
+    persistMessageQueues(
+      {
+        "backend-1": [
+          {
+            kind: "transport-ready",
+            recordId: "promoted-record",
+            payload: admitSystemInheritedQueuedMessage({ text: "promoted" }),
+          },
+        ],
+      },
+      ["backend-1"],
+    );
+
+    await vi.waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("persist_message_queue_updates", {
+        serializedUpdates: expect.stringContaining("promoted-record"),
+      }),
+    );
   });
 
   it("writes only changed sessions through native read-modify-write persistence", async () => {

--- a/src/features/chat/stores/queuePersistence.ts
+++ b/src/features/chat/stores/queuePersistence.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { useChatSessionStore } from "./chatSessionStore";
 import type { QueuedMessagePayload, QueuedMessageRecord } from "./chatStore";
 import {
   isAdmittedQueuedMessagePayload,
@@ -186,6 +187,13 @@ export function loadCachedMessageQueues(): PersistedQueues {
   }
 }
 
+// A session still creating (or failed to create) only exists under a
+// client-local draft id that no restart can resolve, so persisting its queue
+// would strand unreachable records; quitting mid-creation drops the message.
+function isSessionPersistable(sessionId: string): boolean {
+  return !useChatSessionStore.getState().getSession(sessionId)?.creationState;
+}
+
 export function persistMessageQueues(
   queues: PersistedQueues,
   changedSessionIds: string[],
@@ -194,7 +202,9 @@ export function persistMessageQueues(
   const updates = Object.fromEntries(
     changedSessionIds.map((sessionId) => [
       sessionId,
-      queues[sessionId]?.length ? queues[sessionId] : null,
+      queues[sessionId]?.length && isSessionPersistable(sessionId)
+        ? queues[sessionId]
+        : null,
     ]),
   );
   if (window.__TAURI_INTERNALS__) {


### PR DESCRIPTION
## Why

Two latent bugs in the window where a chat session is still being created. Both are silent: the user sees a message accepted into the queue and then nothing, with no error and no visible failure state.

**A pre-commit rejection stranded the message forever.** A queued send rejected before commit was retried exactly once, and that retry bailed out if the session was not ready when the timer fired:

```ts
if (!isQueuedSessionReady(runtime, ...) || getQueuedMessageKey(retryHead) !== key || ...) {
  return;   // burns the single retry and gives up
}
```

During draft promotion the session is not ready yet, so the one retry is spent on the readiness check. Pre-commit rejection is silent and leaves no store transition behind, so nothing ever re-triggers the drain. `LAWS/CHAT.md` requires that "when a chat's session becomes ready, that chat's queue MUST resume dispatching its first message to that session" — this violated it.

**Quitting mid-creation replayed into an unreachable id.** Queues are keyed by session id, and a session that is still creating only has a client-local draft id. Persisting its queue means the next launch restores a record bound to an id no backend session will ever have, so it can never drain.

## What

- `useMessageQueue`: replace the single-retry latch with exponential backoff capped at 30s. A retry that fires while the session is still not ready re-arms instead of abandoning the record, and backs off as it does so. Any later readiness transition resets the backoff to the initial 1s.
- `useMessageQueue`: bound *rejections* to 5 per payload while leaving the *readiness wait* unbounded. See the note below — this is the important half of the change.
- `queuePersistence`: skip queue writes for sessions with an unsettled `creationState` (pending or failed). The write becomes an explicit `null`, so quitting mid-creation drops the message rather than stranding an undrainable record.

### Why retries are bounded but readiness waiting is not

Retrying until the session is ready is right for a readiness or ownership race. Applying it to *every* pre-commit rejection is not, because some rejections are permanent.

`sendQueuedMessageWithAutoCompact` returns `false` whenever compaction fails (`useChatSessionController.ts:2062`), and each failure appends an error notification and calls `setChatState(sessionId, "idle")` (`useChat.ts:424-430`). Since `isQueuedSessionReady` requires `chatState === "idle"`, that failure reads as a readiness edge — which both reset the backoff and fell through to `tryDrainQueuedMessage`. So a persistently failing send did not retry every second; it looped as fast as compaction could fail, appending an error notification to the transcript every pass. A test driving twelve such cycles dispatched **73 times**.

The ceiling is counted at the single drain choke point rather than in the retry timer, so every trigger is covered (timer, readiness edge, lease release, store subscription). The counter deliberately survives readiness edges — the transition a failed send *causes* must not hand it a fresh budget — while a user edit or a new head does reset it. The record stays queued with `showInComposer` forced true, so it remains visible and manually retryable.

Waiting for readiness stays unbounded, since giving up there is the original stranding bug. But it now backs off to the 30s cap instead of re-arming at a flat 1s: measured, an unready session woke **960 times in 16 minutes** before this change.

## Risk Assessment

Moderate — this is shared chat code on the send path, not behind any experiment flag, so it affects every user.

The behavior change is bounded to sessions that are not ready, not yet created, or persistently rejecting. A send into a ready session that succeeds is unaffected: the retry and rejection state both clear on success exactly as before.

The remaining judgement call is the ceiling of 5. Too low and a genuine multi-attempt ownership race gives up early; too high and a persistent failure appends more error notifications before stopping. Five spans ~31s of backoff, and the failure mode when it is wrong is a visible retryable record rather than a lost message. Reviewers should push back if a real race is known to need more.

Not addressed here: the rejection reason is not actually classified. `finalize(false)` is reached both from a thrown `PreCommitSendRejectedError` and from a plain `false` return, and the `catch` at the call site discards the error. Distinguishing ownership races from terminal transport/preparation failures by type would be a better fix than a count, and is a reasonable follow-up.

Validation: `just check` passes clean. `src/features/chat` passes 2505 tests across 169 files. Both new tests were confirmed to fail without the fix — 73 dispatches instead of 5, and `[1000, 1000, 1000, 1000, 1000]` instead of a growing backoff — so neither is vacuous.

## References

- `LAWS/CHAT.md` — queue dispatch and readiness rules
- Split out of #209, which surfaced the original bugs; that PR now stacks on this branch

Generated with [Claude Code](https://claude.ai/code)
