### PR TITLE
fix(voice): normalize streamed Siri audio

### DIFF
--- a/justfile
+++ b/justfile
@@ -220,6 +220,12 @@ _tauri-check-windows:
 tauri-test:
     just _tauri-test-{{ os_family() }}
 
+# Exercise two independent Siri requests through the native streaming decoder.
+# This is opt-in because it requires macOS private Siri APIs and an installed voice.
+[macos]
+test-siri-tts-stream-regression:
+    ./scripts/test-siri-tts-stream-regression.sh
+
 [unix]
 _tauri-test-unix:
     just _tauri-cargo-unix test -p tauri-plugin-berdctl --features server

--- a/scripts/test-siri-tts-stream-regression.sh
+++ b/scripts/test-siri-tts-stream-regression.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/berd-siri-stream-regression.XXXXXX")"
+test_binary="$build_dir/siri-tts-stream-regression"
+
+trap 'rm -rf "$build_dir"' EXIT
+
+clang \
+  -fobjc-arc \
+  -fblocks \
+  -Wno-nullability-completeness \
+  -framework Foundation \
+  -framework AVFoundation \
+  -framework AudioToolbox \
+  -framework CoreAudio \
+  "$repo_root/src-tauri/native/tests/siri_tts_stream_regression.m" \
+  -o "$test_binary"
+
+"$test_binary"

--- a/src-tauri/native/siri_tts_bridge.m
+++ b/src-tauri/native/siri_tts_bridge.m
@@ -11,6 +11,19 @@
 static NSString *const BerdSiriTTSErrorDomain = @"com.block.berd.sirittsd";
 static void *BerdSiriSpeechQueueKey = &BerdSiriSpeechQueueKey;
 
+static AVAudioFormat *BerdSiriPlaybackFormat(void) {
+    static AVAudioFormat *format;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        format = [[AVAudioFormat alloc]
+            initWithCommonFormat:AVAudioPCMFormatFloat32
+                      sampleRate:48000
+                        channels:1
+                     interleaved:NO];
+    });
+    return format;
+}
+
 @protocol BerdSiriTTSAvailabilityProtocol <NSObject>
 - (void)downloadedVoicesMatching:(id)voice
                            reply:(void (^)(NSArray *voices))reply;
@@ -287,7 +300,10 @@ typedef void (^BerdAudioHandler)(
 @property(nonatomic, strong) dispatch_queue_t queue;
 @property(nonatomic, strong) AVAudioEngine *engine;
 @property(nonatomic, strong) AVAudioPlayerNode *player;
-@property(nonatomic, strong) AVAudioConverter *converter;
+@property(nonatomic, strong) AVAudioConverter *opusConverter;
+@property(nonatomic, strong) AVAudioFormat *opusSourceFormat;
+@property(nonatomic, strong) AVAudioConverter *pcmConverter;
+@property(nonatomic, strong) AVAudioFormat *pcmSourceFormat;
 @property(nonatomic, strong) BerdSiriSynthesisSession *session;
 @property(nonatomic, strong) NSMutableArray<BerdSiriDeliverySegment *> *pendingTexts;
 @property(nonatomic, strong) NSMutableArray<BerdSiriDeliverySegment *> *deliverySegments;
@@ -349,25 +365,66 @@ typedef void (^BerdAudioHandler)(
         }
         AVAudioFormat *format = [[AVAudioFormat alloc] initWithStreamDescription:&description];
         AVAudioFrameCount count = (AVAudioFrameCount)(data.length / description.mBytesPerFrame);
-        AVAudioPCMBuffer *buffer = [[AVAudioPCMBuffer alloc]
+        AVAudioPCMBuffer *sourceBuffer = [[AVAudioPCMBuffer alloc]
             initWithPCMFormat:format frameCapacity:count];
-        buffer.frameLength = count;
-        AudioBuffer *destination = &buffer.mutableAudioBufferList->mBuffers[0];
-        memcpy(destination->mData, data.bytes, MIN(data.length, destination->mDataByteSize));
-        return buffer;
+        sourceBuffer.frameLength = count;
+        AudioBuffer *sourceDestination = &sourceBuffer.mutableAudioBufferList->mBuffers[0];
+        memcpy(sourceDestination->mData, data.bytes,
+               MIN(data.length, sourceDestination->mDataByteSize));
+
+        AVAudioFormat *playbackFormat = BerdSiriPlaybackFormat();
+        if ([format isEqual:playbackFormat]) return sourceBuffer;
+
+        if (!self.pcmConverter || ![self.pcmSourceFormat isEqual:format]) {
+            self.pcmSourceFormat = format;
+            self.pcmConverter = [[AVAudioConverter alloc]
+                initFromFormat:format toFormat:playbackFormat];
+        }
+        if (!self.pcmConverter) {
+            if (error) *error = BerdError(20, @"Could not create a Siri PCM converter.");
+            return nil;
+        }
+        double sampleRateRatio = playbackFormat.sampleRate / MAX(format.sampleRate, 1);
+        AVAudioFrameCount capacity = (AVAudioFrameCount)ceil(count * sampleRateRatio) + 32;
+        AVAudioPCMBuffer *normalized = [[AVAudioPCMBuffer alloc]
+            initWithPCMFormat:playbackFormat frameCapacity:capacity];
+        __block BOOL supplied = NO;
+        NSError *conversionError = nil;
+        AVAudioConverterOutputStatus status = [self.pcmConverter
+            convertToBuffer:normalized error:&conversionError
+            withInputFromBlock:^AVAudioBuffer *(__unused AVAudioPacketCount requested,
+                                                 AVAudioConverterInputStatus *inputStatus) {
+                if (supplied) {
+                    *inputStatus = AVAudioConverterInputStatus_NoDataNow;
+                    return nil;
+                }
+                supplied = YES;
+                *inputStatus = AVAudioConverterInputStatus_HaveData;
+                return sourceBuffer;
+            }];
+        if (conversionError || status == AVAudioConverterOutputStatus_Error) {
+            if (error) {
+                *error = conversionError ?: BerdError(21, @"Could not normalize Siri PCM audio.");
+            }
+            return nil;
+        }
+        return normalized.frameLength ? normalized : nil;
     }
     if (description.mFormatID != kAudioFormatOpus) {
         if (error) *error = BerdError(17, @"Siri returned an unsupported audio format.");
         return nil;
     }
     AVAudioFormat *source = [[AVAudioFormat alloc] initWithStreamDescription:&description];
-    AVAudioFormat *destination = [[AVAudioFormat alloc]
-        initWithCommonFormat:AVAudioPCMFormatFloat32
-                  sampleRate:description.mSampleRate
-                    channels:description.mChannelsPerFrame
-                 interleaved:NO];
-    if (!self.converter) self.converter = [[AVAudioConverter alloc] initFromFormat:source
-                                                                         toFormat:destination];
+    AVAudioFormat *destination = BerdSiriPlaybackFormat();
+    if (!self.opusConverter || ![self.opusSourceFormat isEqual:source]) {
+        self.opusSourceFormat = source;
+        self.opusConverter = [[AVAudioConverter alloc] initFromFormat:source
+                                                             toFormat:destination];
+    }
+    if (!self.opusConverter) {
+        if (error) *error = BerdError(22, @"Could not create a Siri Opus converter.");
+        return nil;
+    }
     UInt32 count = MAX(packetCount, 1);
     AVAudioCompressedBuffer *compressed = [[AVAudioCompressedBuffer alloc]
         initWithFormat:source packetCapacity:count maximumPacketSize:MAX((UInt32)data.length, 1)];
@@ -386,11 +443,13 @@ typedef void (^BerdAudioHandler)(
         if (error) *error = BerdError(18, @"Siri omitted Opus packet descriptions.");
         return nil;
     }
+    double sampleRateRatio = destination.sampleRate / MAX(source.sampleRate, 1);
+    AVAudioFrameCount capacity = (AVAudioFrameCount)ceil(count * 5760 * sampleRateRatio) + 32;
     AVAudioPCMBuffer *pcm = [[AVAudioPCMBuffer alloc]
-        initWithPCMFormat:destination frameCapacity:count * 5760];
+        initWithPCMFormat:destination frameCapacity:capacity];
     __block BOOL supplied = NO;
     NSError *conversionError = nil;
-    AVAudioConverterOutputStatus status = [self.converter
+    AVAudioConverterOutputStatus status = [self.opusConverter
         convertToBuffer:pcm error:&conversionError
         withInputFromBlock:^AVAudioBuffer *(AVAudioPacketCount requested,
                                              AVAudioConverterInputStatus *inputStatus) {
@@ -409,29 +468,63 @@ typedef void (^BerdAudioHandler)(
     }
     return pcm.frameLength ? pcm : nil;
 }
-- (BOOL)ensurePlayer:(AVAudioFormat *)format error:(NSError **)error {
+- (NSArray<AVAudioPCMBuffer *> *)finishConversion:(NSError **)error {
+    NSMutableArray<AVAudioPCMBuffer *> *buffers = [NSMutableArray array];
+    NSMutableArray<AVAudioConverter *> *converters = [NSMutableArray array];
+    if (self.pcmConverter) [converters addObject:self.pcmConverter];
+    if (self.opusConverter) [converters addObject:self.opusConverter];
+    for (AVAudioConverter *converter in converters) {
+        for (;;) {
+            AVAudioPCMBuffer *buffer = [[AVAudioPCMBuffer alloc]
+                initWithPCMFormat:BerdSiriPlaybackFormat() frameCapacity:16384];
+            NSError *conversionError = nil;
+            AVAudioConverterOutputStatus status = [converter
+                convertToBuffer:buffer error:&conversionError
+                withInputFromBlock:^AVAudioBuffer *(__unused AVAudioPacketCount requested,
+                                                     AVAudioConverterInputStatus *inputStatus) {
+                    *inputStatus = AVAudioConverterInputStatus_EndOfStream;
+                    return nil;
+                }];
+            if (conversionError || status == AVAudioConverterOutputStatus_Error) {
+                if (error) {
+                    *error = conversionError ?:
+                        BerdError(24, @"Could not finish converting Siri audio.");
+                }
+                return nil;
+            }
+            if (buffer.frameLength) [buffers addObject:buffer];
+            if (status == AVAudioConverterOutputStatus_EndOfStream ||
+                status == AVAudioConverterOutputStatus_InputRanDry || !buffer.frameLength) {
+                break;
+            }
+        }
+    }
+    self.pcmConverter = nil;
+    self.pcmSourceFormat = nil;
+    self.opusConverter = nil;
+    self.opusSourceFormat = nil;
+    return buffers;
+}
+- (BOOL)ensurePlayer:(NSError **)error {
     if (self.player) return YES;
     self.engine = [AVAudioEngine new];
     self.player = [AVAudioPlayerNode new];
     [self.engine attachNode:self.player];
-    [self.engine connect:self.player to:self.engine.mainMixerNode format:format];
+    [self.engine connect:self.player
+                      to:self.engine.mainMixerNode
+                  format:BerdSiriPlaybackFormat()];
     [self.engine prepare];
     if (![self.engine startAndReturnError:error]) return NO;
     return YES;
 }
-- (void)enqueueData:(NSData *)data format:(AudioStreamBasicDescription)format
-         packetCount:(UInt32)packetCount packetDescriptions:(NSData *)packetDescriptions
-         deliverySegment:(BerdSiriDeliverySegment *)deliverySegment {
-    if (self.finished || !data.length) return;
-    self.progressGeneration += 1;
-    NSError *error = nil;
-    AVAudioPCMBuffer *buffer = [self decodeData:data format:format packetCount:packetCount
-                            packetDescriptions:packetDescriptions error:&error];
-    if (error || !buffer) {
-        if (error) [self finish:error];
+- (void)scheduleBuffer:(AVAudioPCMBuffer *)buffer
+       deliverySegment:(BerdSiriDeliverySegment *)deliverySegment {
+    if (![buffer.format isEqual:BerdSiriPlaybackFormat()]) {
+        [self finish:BerdError(23, @"Siri audio did not match the playback format.")];
         return;
     }
-    if (![self ensurePlayer:buffer.format error:&error]) {
+    NSError *error = nil;
+    if (![self ensurePlayer:&error]) {
         [self finish:error];
         return;
     }
@@ -457,6 +550,20 @@ typedef void (^BerdAudioHandler)(
         if (self.startedCallback) self.startedCallback(self.callbackContext);
         [self.player play];
     }
+}
+- (void)enqueueData:(NSData *)data format:(AudioStreamBasicDescription)format
+         packetCount:(UInt32)packetCount packetDescriptions:(NSData *)packetDescriptions
+         deliverySegment:(BerdSiriDeliverySegment *)deliverySegment {
+    if (self.finished || !data.length) return;
+    self.progressGeneration += 1;
+    NSError *error = nil;
+    AVAudioPCMBuffer *buffer = [self decodeData:data format:format packetCount:packetCount
+                            packetDescriptions:packetDescriptions error:&error];
+    if (error || !buffer) {
+        if (error) [self finish:error];
+        return;
+    }
+    [self scheduleBuffer:buffer deliverySegment:deliverySegment];
 }
 - (void)startNextSynthesis {
     if (self.finished || self.session || self.pendingTexts.count == 0) {
@@ -485,7 +592,20 @@ typedef void (^BerdAudioHandler)(
                 [weakSelf finish:error];
                 return;
             }
-            if (!error) deliverySegment.synthesisComplete = YES;
+            if (!error) {
+                NSError *conversionError = nil;
+                NSArray<AVAudioPCMBuffer *> *buffers =
+                    [weakSelf finishConversion:&conversionError];
+                if (!buffers) {
+                    [weakSelf finish:conversionError];
+                    return;
+                }
+                for (AVAudioPCMBuffer *buffer in buffers) {
+                    [weakSelf scheduleBuffer:buffer deliverySegment:deliverySegment];
+                    if (weakSelf.finished) return;
+                }
+                deliverySegment.synthesisComplete = YES;
+            }
             [weakSelf startNextSynthesis];
         });
     }];

--- a/src-tauri/native/tests/siri_tts_stream_regression.m
+++ b/src-tauri/native/tests/siri_tts_stream_regression.m
@@ -1,0 +1,307 @@
+#import <AVFoundation/AVFoundation.h>
+#import <Foundation/Foundation.h>
+
+#import "../siri_tts_bridge.m"
+
+@interface BerdCapturedSiriPacket : NSObject
+@property(nonatomic, strong) NSData *data;
+@property(nonatomic, assign) AudioStreamBasicDescription format;
+@property(nonatomic, assign) UInt32 packetCount;
+@property(nonatomic, strong) NSData *packetDescriptions;
+@end
+
+@implementation BerdCapturedSiriPacket
+@end
+
+static NSArray<BerdCapturedSiriPacket *> *BerdCaptureSiriPackets(
+    NSString *text,
+    NSString *language,
+    NSString *voiceName,
+    NSError **error
+) {
+    NSMutableArray<BerdCapturedSiriPacket *> *packets = [NSMutableArray array];
+    dispatch_semaphore_t completion = dispatch_semaphore_create(0);
+    __block NSError *synthesisError = nil;
+    __block BerdSiriSynthesisSession *session = [[BerdSiriSynthesisSession alloc]
+        initWithAudioHandler:^(NSData *data, AudioStreamBasicDescription format,
+                               UInt32 packetCount, NSData *packetDescriptions) {
+            BerdCapturedSiriPacket *packet = [BerdCapturedSiriPacket new];
+            packet.data = [data copy];
+            packet.format = format;
+            packet.packetCount = packetCount;
+            packet.packetDescriptions = [packetDescriptions copy];
+            @synchronized (packets) { [packets addObject:packet]; }
+        }];
+    [session synthesizeText:text language:language voiceName:voiceName rate:1.0f
+                  completion:^(NSError *failure) {
+        synthesisError = failure;
+        dispatch_semaphore_signal(completion);
+    }];
+    if (dispatch_semaphore_wait(
+            completion,
+            dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30 * NSEC_PER_SEC))) != 0) {
+        [session cancel];
+        if (error) *error = BerdError(100, @"Timed out capturing Siri synthesis.");
+        return nil;
+    }
+    session = nil;
+    if (synthesisError) {
+        if (error) *error = synthesisError;
+        return nil;
+    }
+    return [packets copy];
+}
+
+static NSDictionary *BerdSelectInstalledEnglishVoice(NSError **error) {
+    NSDictionary *environment = NSProcessInfo.processInfo.environment;
+    NSString *configuredName = environment[@"BERD_SIRI_TEST_VOICE"];
+    NSString *configuredLanguage = environment[@"BERD_SIRI_TEST_LANGUAGE"] ?: @"en-US";
+    if (configuredName.length) {
+        return @{ @"name": configuredName, @"language": configuredLanguage };
+    }
+    char *bridgeError = NULL;
+    char *catalogJSON = berd_siri_tts_catalog_json(configuredLanguage.UTF8String, &bridgeError);
+    if (!catalogJSON) {
+        NSString *message = bridgeError
+            ? [NSString stringWithUTF8String:bridgeError]
+            : @"Could not read the Siri voice catalog.";
+        berd_siri_tts_free_string(bridgeError);
+        if (error) *error = BerdError(101, message);
+        return nil;
+    }
+    NSData *data = [[NSData alloc] initWithBytes:catalogJSON length:strlen(catalogJSON)];
+    berd_siri_tts_free_string(catalogJSON);
+    NSArray *voices = [NSJSONSerialization JSONObjectWithData:data options:0 error:error];
+    for (NSDictionary *voice in voices) {
+        if ([voice[@"installed"] boolValue]) return voice;
+    }
+    if (error) {
+        *error = BerdError(
+            102,
+            @"No installed English Siri voice is available. Set BERD_SIRI_TEST_VOICE "
+             "to the voice selected in Berd."
+        );
+    }
+    return nil;
+}
+
+static BOOL BerdDecodePackets(
+    NSArray<BerdCapturedSiriPacket *> *packets,
+    BerdSiriSpeechPlayer *decoder,
+    NSMutableData *samples,
+    NSError **error
+) {
+    for (BerdCapturedSiriPacket *packet in packets) {
+        AVAudioPCMBuffer *buffer = [decoder decodeData:packet.data
+                                                format:packet.format
+                                           packetCount:packet.packetCount
+                                    packetDescriptions:packet.packetDescriptions
+                                                 error:error];
+        if (*error) return NO;
+        if (!buffer) continue;
+        if (samples &&
+            (buffer.format.commonFormat != AVAudioPCMFormatFloat32 ||
+             buffer.format.interleaved || buffer.format.channelCount != 1)) {
+            if (error) *error = BerdError(103, @"Expected mono, non-interleaved Float32 PCM.");
+            return NO;
+        }
+        if (samples) {
+            [samples appendBytes:buffer.floatChannelData[0]
+                          length:buffer.frameLength * sizeof(float)];
+        }
+    }
+    return YES;
+}
+
+static BOOL BerdTestPCMNormalization(NSError **error) {
+    AudioStreamBasicDescription format = {
+        .mSampleRate = 48000,
+        .mFormatID = kAudioFormatLinearPCM,
+        .mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked,
+        .mBytesPerPacket = sizeof(int16_t),
+        .mFramesPerPacket = 1,
+        .mBytesPerFrame = sizeof(int16_t),
+        .mChannelsPerFrame = 1,
+        .mBitsPerChannel = 16,
+    };
+    const int16_t sourceSamples[] = { 0, INT16_MAX, INT16_MIN, 16384, -16384 };
+    NSData *data = [NSData dataWithBytes:sourceSamples length:sizeof(sourceSamples)];
+    BerdSiriSpeechPlayer *decoder = [BerdSiriSpeechPlayer new];
+    AVAudioPCMBuffer *buffer = [decoder decodeData:data
+                                            format:format
+                                       packetCount:5
+                                packetDescriptions:[NSData data]
+                                             error:error];
+    if (!buffer || (error && *error)) return NO;
+    if (buffer.format.commonFormat != AVAudioPCMFormatFloat32 ||
+        buffer.format.interleaved || buffer.format.channelCount != 1 ||
+        buffer.frameLength != 5) {
+        if (error) *error = BerdError(104, @"Linear PCM was not normalized for playback.");
+        return NO;
+    }
+    const float *samples = buffer.floatChannelData[0];
+    const float expected[] = { 0.0f, 32767.0f / 32768.0f, -1.0f, 0.5f, -0.5f };
+    for (NSUInteger index = 0; index < 5; index += 1) {
+        if (!isfinite(samples[index]) || fabsf(samples[index] - expected[index]) > 0.0001f) {
+            if (error) *error = BerdError(105, @"Linear PCM normalization changed sample values.");
+            return NO;
+        }
+    }
+    return YES;
+}
+
+typedef struct {
+    NSInteger lag;
+    NSUInteger unmatchedFrames;
+    double correlation;
+    double normalizedRMSE;
+} BerdAudioComparison;
+
+static BerdAudioComparison BerdCompareAudio(NSData *actualData, NSData *expectedData) {
+    NSUInteger actualFrames = actualData.length / sizeof(float);
+    NSUInteger expectedFrames = expectedData.length / sizeof(float);
+    if (actualFrames == 0 || expectedFrames == 0) {
+        return (BerdAudioComparison){ .normalizedRMSE = INFINITY };
+    }
+    const float *actual = actualData.bytes;
+    const float *expected = expectedData.bytes;
+    NSInteger bestLag = 0;
+    double bestCorrelation = -1;
+    for (NSInteger lag = -512; lag <= 512; lag += 1) {
+        NSUInteger actualStart = lag > 0 ? (NSUInteger)lag : 0;
+        NSUInteger expectedStart = lag < 0 ? (NSUInteger)-lag : 0;
+        if (actualStart >= actualFrames || expectedStart >= expectedFrames) continue;
+        NSUInteger frames = MIN(actualFrames - actualStart, expectedFrames - expectedStart);
+        frames = MIN(frames, 24000);
+        double crossProduct = 0;
+        double actualPower = 0;
+        double expectedPower = 0;
+        for (NSUInteger index = 0; index < frames; index += 1) {
+            double actualSample = actual[actualStart + index];
+            double expectedSample = expected[expectedStart + index];
+            crossProduct += actualSample * expectedSample;
+            actualPower += actualSample * actualSample;
+            expectedPower += expectedSample * expectedSample;
+        }
+        double correlation = crossProduct / sqrt(MAX(actualPower * expectedPower, DBL_MIN));
+        if (correlation > bestCorrelation) {
+            bestCorrelation = correlation;
+            bestLag = lag;
+        }
+    }
+    NSUInteger actualStart = bestLag > 0 ? (NSUInteger)bestLag : 0;
+    NSUInteger expectedStart = bestLag < 0 ? (NSUInteger)-bestLag : 0;
+    NSUInteger frames = MIN(actualFrames - actualStart, expectedFrames - expectedStart);
+    NSUInteger unmatchedFrames = actualFrames + expectedFrames - (2 * frames);
+    double squaredError = 0;
+    double squaredSignal = 0;
+    for (NSUInteger index = 0; index < frames; index += 1) {
+        double difference = actual[actualStart + index] - expected[expectedStart + index];
+        squaredError += difference * difference;
+        squaredSignal += expected[expectedStart + index] * expected[expectedStart + index];
+    }
+    return (BerdAudioComparison){
+        .lag = bestLag,
+        .unmatchedFrames = unmatchedFrames,
+        .correlation = bestCorrelation,
+        .normalizedRMSE = sqrt(squaredError / MAX(squaredSignal, DBL_MIN)),
+    };
+}
+
+int main(void) {
+    @autoreleasepool {
+        NSError *error = nil;
+        if (!BerdTestPCMNormalization(&error)) {
+            fprintf(stderr, "normalize PCM: %s\n", error.localizedDescription.UTF8String);
+            return 1;
+        }
+        NSDictionary *voice = BerdSelectInstalledEnglishVoice(&error);
+        if (!voice) {
+            fprintf(stderr, "select Siri voice: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+        NSString *language = voice[@"language"];
+        NSString *voiceName = voice[@"name"];
+        NSDictionary *environment = NSProcessInfo.processInfo.environment;
+        NSString *firstText = environment[@"BERD_SIRI_TEST_FIRST_TEXT"] ?: @"Yes.";
+        NSString *secondText = environment[@"BERD_SIRI_TEST_SECOND_TEXT"] ?:
+            @"A gentle breeze is moving through the trees outside while the afternoon light "
+             "stretches across the room.";
+        NSArray *firstPackets = BerdCaptureSiriPackets(firstText, language, voiceName, &error);
+        if (!firstPackets) {
+            fprintf(stderr, "synthesize first sentence: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+        NSArray *secondPackets = BerdCaptureSiriPackets(
+            secondText, language, voiceName, &error);
+        if (!secondPackets) {
+            fprintf(stderr, "synthesize second sentence: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+
+        BerdSiriSpeechPlayer *reusedDecoder = [BerdSiriSpeechPlayer new];
+        if (!BerdDecodePackets(firstPackets, reusedDecoder, nil, &error)) {
+            fprintf(stderr, "decode first sentence: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+        if (![reusedDecoder finishConversion:&error]) {
+            fprintf(stderr, "finish first sentence: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+
+        NSMutableData *reusedSamples = [NSMutableData data];
+        if (!BerdDecodePackets(secondPackets, reusedDecoder, reusedSamples, &error)) {
+            fprintf(stderr, "decode second sentence with reused decoder: %s\n",
+                    error.localizedDescription.UTF8String);
+            return 2;
+        }
+        NSArray<AVAudioPCMBuffer *> *reusedTail = [reusedDecoder finishConversion:&error];
+        if (!reusedTail) {
+            fprintf(stderr, "finish reused decoder: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+        for (AVAudioPCMBuffer *buffer in reusedTail) {
+            [reusedSamples appendBytes:buffer.floatChannelData[0]
+                                length:buffer.frameLength * sizeof(float)];
+        }
+
+        BerdSiriSpeechPlayer *freshDecoder = [BerdSiriSpeechPlayer new];
+        NSMutableData *freshSamples = [NSMutableData data];
+        if (!BerdDecodePackets(secondPackets, freshDecoder, freshSamples, &error)) {
+            fprintf(stderr, "decode second sentence with fresh decoder: %s\n",
+                    error.localizedDescription.UTF8String);
+            return 2;
+        }
+        NSArray<AVAudioPCMBuffer *> *freshTail = [freshDecoder finishConversion:&error];
+        if (!freshTail) {
+            fprintf(stderr, "finish fresh decoder: %s\n", error.localizedDescription.UTF8String);
+            return 2;
+        }
+        for (AVAudioPCMBuffer *buffer in freshTail) {
+            [freshSamples appendBytes:buffer.floatChannelData[0]
+                               length:buffer.frameLength * sizeof(float)];
+        }
+
+        BerdAudioComparison comparison = BerdCompareAudio(reusedSamples, freshSamples);
+        printf("voice=%s (%s)\n", voiceName.UTF8String, language.UTF8String);
+        printf("first_packets=%lu second_packets=%lu\n",
+               (unsigned long)firstPackets.count, (unsigned long)secondPackets.count);
+        printf("reused_frames=%lu fresh_frames=%lu lag=%ld unmatched_frames=%lu correlation=%.12f "
+               "aligned_normalized_rmse=%.12f\n",
+               (unsigned long)(reusedSamples.length / sizeof(float)),
+               (unsigned long)(freshSamples.length / sizeof(float)),
+               (long)comparison.lag, (unsigned long)comparison.unmatchedFrames,
+               comparison.correlation, comparison.normalizedRMSE);
+
+        if (labs(comparison.lag) > 512 ||
+            comparison.unmatchedFrames > (NSUInteger)labs(comparison.lag) + 1 ||
+            comparison.correlation < 0.9999 ||
+            comparison.normalizedRMSE > 0.001) {
+            fprintf(stderr,
+                    "FAIL: the second independent Siri stream is distorted after alignment.\n");
+            return 1;
+        }
+        printf("PASS: the second Siri stream matches a fresh decoder after delay alignment.\n");
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary

Siri can return Opus for one synthesized sentence and signed Int16 PCM for the next. The playback graph remained configured for the first buffer format, so scheduling the second format directly could produce garbled audio.

This bug fix normalizes every Siri packet to one Float32, 48 kHz, mono playback format before scheduling it. Each synthesis stream is finalized independently so buffered converter output is preserved without carrying decoder state into the next sentence.

## Reviewer-reproducible examples

1. On macOS, select an installed Siri voice in Berd and start a voice conversation.
2. Interrupt an agent reply, then ask the agent to answer with a short first sentence such as "Yes." followed by another sentence.
3. Repeat the interruption and response sequence. Playback remains clear across the sentence boundary, including when Siri returns different formats for consecutive synthesis requests.
