### PR TITLE
defer agent description errors until save

### DIFF
--- a/src/features/agents/ui/AgentBuilderRail.tsx
+++ b/src/features/agents/ui/AgentBuilderRail.tsx
@@ -126,6 +126,8 @@ export function AgentBuilderRail({
       onWritePersisted: handleWritePersisted,
     });
   const [isPromoting, setIsPromoting] = useState(false);
+  const saveAttemptKey = `${sessionId}:${targetAgentPath ?? "pending"}`;
+  const [attemptedSaveKey, setAttemptedSaveKey] = useState<string | null>(null);
   const [avatarPanel, setAvatarPanel] = useState<"closed" | "library">(
     "closed",
   );
@@ -296,14 +298,24 @@ export function AgentBuilderRail({
     contentFieldValue !== PLACEHOLDER_AGENT_BODY;
   const missingRequiredFields = [
     requiresNewDraftFields && !avatarRequired
-      ? t("builderRail.requiredAvatar")
+      ? { label: t("builderRail.requiredAvatar"), blocksSaveAttempt: true }
       : null,
-    !nameRequired ? t("builderRail.requiredName") : null,
-    !descriptionRequired ? t("builderRail.requiredDescription") : null,
+    !nameRequired
+      ? { label: t("builderRail.requiredName"), blocksSaveAttempt: true }
+      : null,
+    !descriptionRequired
+      ? {
+          label: t("builderRail.requiredDescription"),
+          blocksSaveAttempt: false,
+        }
+      : null,
     requiresNewDraftFields && !instructionsRequired
-      ? t("builderRail.requiredInstructions")
+      ? {
+          label: t("builderRail.requiredInstructions"),
+          blocksSaveAttempt: true,
+        }
       : null,
-  ].filter((field): field is string => field !== null);
+  ].filter((field) => field !== null);
   useEffect(() => {
     if (!data) {
       onSaveDraftHandlerChange?.(null);
@@ -385,6 +397,7 @@ export function AgentBuilderRail({
         : "idle";
 
   const handleSaveChanges = useCallback(async () => {
+    setAttemptedSaveKey(saveAttemptKey);
     if (!canPromoteDraft) {
       return;
     }
@@ -425,13 +438,18 @@ export function AgentBuilderRail({
     defaultAvatarId,
     onDraftPromoted,
     requiresNewDraftFields,
+    saveAttemptKey,
     saveNow,
     sessionId,
     trimmedAvatar.length,
     update,
   ]);
 
-  const saveButtonUnavailable = !canPromoteDraft;
+  const saveButtonUnavailable =
+    missingRequiredFields.some((field) => field.blocksSaveAttempt) ||
+    saveStatus === "saving" ||
+    isPromoting ||
+    blockingError;
   const footerNode = data ? (
     <div className="mt-4 border-t border-border/70 pt-4">
       <Button
@@ -459,7 +477,9 @@ export function AgentBuilderRail({
       >
         {missingRequiredFields.length > 0
           ? t("builderRail.completeRequiredFields", {
-              fields: missingRequiredFields.join(", "),
+              fields: missingRequiredFields
+                .map((field) => field.label)
+                .join(", "),
             })
           : saveStatus === "unsaved"
             ? t("builderRail.unsavedChanges")
@@ -677,7 +697,9 @@ export function AgentBuilderRail({
           id="builder-rail-description"
           value={descriptionFieldValue}
           required
-          aria-invalid={!descriptionRequired}
+          aria-invalid={
+            attemptedSaveKey === saveAttemptKey && !descriptionRequired
+          }
           placeholder={t("builderRail.descriptionPlaceholder")}
           onChange={(event) => update({ description: event.target.value })}
           className={FIELD_CLASS}

--- a/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
+++ b/src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx
@@ -283,8 +283,52 @@ describe("AgentBuilderRail", () => {
     ).toBeInTheDocument();
   });
 
-  it("disables save changes until required fields are complete", () => {
-    mockHook();
+  it("only marks an empty description invalid after a save attempt", () => {
+    const { saveNow } = mockHook({
+      data: {
+        ...baseSource,
+        name: "Reviewer",
+        content: "Review code carefully.",
+        properties: {
+          ...baseSource.properties,
+          avatar: "app-avatar:gloopy-1",
+        },
+      },
+    });
+    renderWithProviders(
+      <AgentBuilderRail
+        sessionId="s1"
+        targetAgentPath={baseSource.path}
+        targetAgentSlug="draft-1"
+      />,
+    );
+
+    const saveButton = screen.getByRole("button", { name: /save changes/i });
+    const description = screen.getByLabelText(/description/i);
+
+    expect(saveButton).not.toHaveAttribute("aria-disabled");
+    expect(description).toBeRequired();
+    expect(description).toHaveAttribute("aria-invalid", "false");
+
+    fireEvent.click(saveButton);
+
+    expect(description).toHaveAttribute("aria-invalid", "true");
+    expect(saveNow).not.toHaveBeenCalled();
+    expect(promoteDraft).not.toHaveBeenCalled();
+  });
+
+  it("keeps save unavailable when another required field is missing", () => {
+    mockHook({
+      data: {
+        ...baseSource,
+        description: "Reviews code carefully.",
+        content: "Review code carefully.",
+        properties: {
+          ...baseSource.properties,
+          avatar: "app-avatar:gloopy-1",
+        },
+      },
+    });
     renderWithProviders(
       <AgentBuilderRail
         sessionId="s1"
@@ -296,13 +340,6 @@ describe("AgentBuilderRail", () => {
     expect(
       screen.getByRole("button", { name: /save changes/i }),
     ).toHaveAttribute("aria-disabled", "true");
-    expect(screen.getByText(/required:/i)).toHaveTextContent(/avatar/i);
-    expect(screen.getByText(/required:/i)).toHaveTextContent(/description/i);
-    expect(screen.getByLabelText(/description/i)).toBeRequired();
-    expect(screen.getByLabelText(/description/i)).toHaveAttribute(
-      "aria-invalid",
-      "true",
-    );
   });
 
   it("does not persist a default avatar when the draft opens", async () => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** New agent descriptions now appear neutral while editing and show an error only after an incomplete save attempt.

**Problem:** The required description field displayed an error immediately when a new agent draft opened, before the user had interacted with it. **Solution:** Keep the field neutral initially, allow a description-only incomplete save attempt to reveal validation, and preserve the existing disabled state when other required fields are missing.

<details>
<summary>File changes</summary>

**src/features/agents/ui/AgentBuilderRail.tsx**
Scopes attempted-save validation to the active agent draft and derives save availability from the same required-field model used by promotion, preventing silent incomplete saves.

**src/features/agents/ui/__tests__/AgentBuilderRail.test.tsx**
Adds regression coverage for deferred description validation, blocked persistence after an invalid attempt, and unchanged blocking behavior for other missing required fields.

</details>
