### PR TITLE
fix(voice): expose active calls to restart guards

### DIFF
--- a/src-tauri/crates/berdctl/cli-surface-feedback.json
+++ b/src-tauri/crates/berdctl/cli-surface-feedback.json
@@ -194,7 +194,7 @@
         "context": {
           "action": "get_context",
           "about": "Read what the user is looking at in the app right now",
-          "afterHelp": "Example:\n  berdctl info context --json\n\nResult:\n  {\"view\": \"...\", \"active_session_id\": \"...\"|null,\n   \"active_project_id\": \"...\"|null, \"app_version\": \"...\"}"
+          "afterHelp": "Example:\n  berdctl info context --json\n\nResult:\n  {\"view\": \"...\", \"active_session_id\": \"...\"|null,\n   \"active_project_id\": \"...\"|null, \"voice_session_active\": true|false,\n   \"app_version\": \"...\"}"
         }
       }
     }

--- a/src-tauri/crates/berdctl/cli-surface.json
+++ b/src-tauri/crates/berdctl/cli-surface.json
@@ -178,7 +178,7 @@
         "context": {
           "action": "get_context",
           "about": "Read what the user is looking at in the app right now",
-          "afterHelp": "Example:\n  berdctl info context --json\n\nResult:\n  {\"view\": \"...\", \"active_session_id\": \"...\"|null,\n   \"active_project_id\": \"...\"|null, \"app_version\": \"...\"}"
+          "afterHelp": "Example:\n  berdctl info context --json\n\nResult:\n  {\"view\": \"...\", \"active_session_id\": \"...\"|null,\n   \"active_project_id\": \"...\"|null, \"voice_session_active\": true|false,\n   \"app_version\": \"...\"}"
         }
       }
     }

--- a/src-tauri/src/commands/native_voice.rs
+++ b/src-tauri/src/commands/native_voice.rs
@@ -991,7 +991,22 @@ async fn shutdown_pipeline(mut pipeline: SttPipeline) {
     }
 }
 
-async fn status(app: &AppHandle, state: &NativeVoiceState) -> NativeVoiceStatus {
+async fn status_with_availability(
+    state: &NativeVoiceState,
+    parakeet_available: bool,
+    macos_status: impl std::future::Future<Output = bool>,
+) -> NativeVoiceStatus {
+    let session_active = state
+        .runtime
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .session_id
+        .is_some();
+    let macos_available = if needs_macos_status(session_active, parakeet_available) {
+        macos_status.await
+    } else {
+        false
+    };
     let (session_id, owner_window_label, revision) = {
         let runtime = state
             .runtime
@@ -1006,18 +1021,6 @@ async fn status(app: &AppHandle, state: &NativeVoiceState) -> NativeVoiceStatus 
             runtime.revision,
         )
     };
-    let parakeet_available = parakeet_model_dir(app).is_ok();
-    #[cfg(target_os = "macos")]
-    let macos_available = if needs_macos_status(session_id.is_some(), parakeet_available) {
-        mac_speech::status_async()
-            .await
-            .map(|status| status.model_installed)
-            .unwrap_or(false)
-    } else {
-        false
-    };
-    #[cfg(not(target_os = "macos"))]
-    let macos_available = false;
     let (available, unavailable_reason) =
         if session_id.is_some() || parakeet_available || macos_available {
             (true, None)
@@ -1042,7 +1045,20 @@ async fn status(app: &AppHandle, state: &NativeVoiceState) -> NativeVoiceStatus 
     }
 }
 
-#[cfg(any(target_os = "macos", test))]
+async fn status(app: &AppHandle, state: &NativeVoiceState) -> NativeVoiceStatus {
+    let parakeet_available = parakeet_model_dir(app).is_ok();
+    #[cfg(target_os = "macos")]
+    let macos_status = async {
+        mac_speech::status_async()
+            .await
+            .map(|status| status.model_installed)
+            .unwrap_or(false)
+    };
+    #[cfg(not(target_os = "macos"))]
+    let macos_status = async { false };
+    status_with_availability(state, parakeet_available, macos_status).await
+}
+
 fn needs_macos_status(session_active: bool, parakeet_available: bool) -> bool {
     !session_active && !parakeet_available
 }
@@ -2805,6 +2821,40 @@ mod tests {
         assert!(!needs_macos_status(true, false));
         assert!(!needs_macos_status(false, true));
         assert!(needs_macos_status(false, false));
+    }
+
+    #[tokio::test]
+    async fn status_resamples_runtime_after_availability_check() {
+        let state = NativeVoiceState::default();
+        let (availability_tx, availability_rx) = tokio::sync::oneshot::channel();
+        let status = status_with_availability(&state, false, async {
+            availability_rx.await.expect("finish availability refresh")
+        });
+        tokio::pin!(status);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), status.as_mut())
+                .await
+                .is_err()
+        );
+
+        {
+            let mut runtime = state.runtime.lock().expect("lock native runtime");
+            runtime.session_id = Some("session-1".to_string());
+            runtime.owner = Some(RuntimeOwner {
+                window_label: "main".to_string(),
+            });
+            runtime.revision = 7;
+        }
+
+        availability_tx
+            .send(false)
+            .expect("availability refresh is still pending");
+        let status = status.await;
+        assert!(status.available);
+        assert!(matches!(status.lifecycle, Lifecycle::Running));
+        assert_eq!(status.session_id.as_deref(), Some("session-1"));
+        assert_eq!(status.owner_window_label.as_deref(), Some("main"));
+        assert_eq!(status.revision, 7);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/native_voice.rs
+++ b/src-tauri/src/commands/native_voice.rs
@@ -991,23 +991,28 @@ async fn shutdown_pipeline(mut pipeline: SttPipeline) {
     }
 }
 
-async fn status_with_availability(
+async fn status_with_availability<F, Fut>(
     state: &NativeVoiceState,
     parakeet_available: bool,
-    macos_status: impl std::future::Future<Output = bool>,
-) -> NativeVoiceStatus {
-    let session_active = state
-        .runtime
-        .lock()
-        .unwrap_or_else(|error| error.into_inner())
-        .session_id
-        .is_some();
+    mut macos_status: F,
+) -> NativeVoiceStatus
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let (session_active, revision_before_availability) = {
+        let runtime = state
+            .runtime
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        (runtime.session_id.is_some(), runtime.revision)
+    };
     let macos_available = if needs_macos_status(session_active, parakeet_available) {
-        macos_status.await
+        macos_status().await
     } else {
         false
     };
-    let (session_id, owner_window_label, revision) = {
+    let mut snapshot = {
         let runtime = state
             .runtime
             .lock()
@@ -1021,6 +1026,29 @@ async fn status_with_availability(
             runtime.revision,
         )
     };
+    let macos_available = if snapshot.2 != revision_before_availability
+        && needs_macos_status(snapshot.0.is_some(), parakeet_available)
+    {
+        let available = macos_status().await;
+        snapshot = {
+            let runtime = state
+                .runtime
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            (
+                runtime.session_id.clone(),
+                runtime
+                    .owner
+                    .as_ref()
+                    .map(|owner| owner.window_label.clone()),
+                runtime.revision,
+            )
+        };
+        available
+    } else {
+        macos_available
+    };
+    let (session_id, owner_window_label, revision) = snapshot;
     let (available, unavailable_reason) =
         if session_id.is_some() || parakeet_available || macos_available {
             (true, None)
@@ -1048,14 +1076,14 @@ async fn status_with_availability(
 async fn status(app: &AppHandle, state: &NativeVoiceState) -> NativeVoiceStatus {
     let parakeet_available = parakeet_model_dir(app).is_ok();
     #[cfg(target_os = "macos")]
-    let macos_status = async {
+    let macos_status = || async {
         mac_speech::status_async()
             .await
             .map(|status| status.model_installed)
             .unwrap_or(false)
     };
     #[cfg(not(target_os = "macos"))]
-    let macos_status = async { false };
+    let macos_status = || async { false };
     status_with_availability(state, parakeet_available, macos_status).await
 }
 
@@ -2827,8 +2855,10 @@ mod tests {
     async fn status_resamples_runtime_after_availability_check() {
         let state = NativeVoiceState::default();
         let (availability_tx, availability_rx) = tokio::sync::oneshot::channel();
-        let status = status_with_availability(&state, false, async {
-            availability_rx.await.expect("finish availability refresh")
+        let mut availability_rx = Some(availability_rx);
+        let status = status_with_availability(&state, false, || {
+            let availability_rx = availability_rx.take().expect("availability queried once");
+            async move { availability_rx.await.expect("finish availability refresh") }
         });
         tokio::pin!(status);
         assert!(
@@ -2855,6 +2885,42 @@ mod tests {
         assert_eq!(status.session_id.as_deref(), Some("session-1"));
         assert_eq!(status.owner_window_label.as_deref(), Some("main"));
         assert_eq!(status.revision, 7);
+    }
+
+    #[tokio::test]
+    async fn status_rechecks_availability_after_lifecycle_changes() {
+        let state = NativeVoiceState::default();
+        let (first_tx, first_rx) = tokio::sync::oneshot::channel();
+        let (second_tx, second_rx) = tokio::sync::oneshot::channel();
+        let mut responses = VecDeque::from([first_rx, second_rx]);
+        let status = status_with_availability(&state, false, || {
+            let response = responses.pop_front().expect("availability response");
+            async move { response.await.expect("finish availability refresh") }
+        });
+        tokio::pin!(status);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), status.as_mut())
+                .await
+                .is_err()
+        );
+
+        state.runtime.lock().expect("lock native runtime").revision = 2;
+        first_tx
+            .send(false)
+            .expect("finish first availability check");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), status.as_mut())
+                .await
+                .is_err()
+        );
+
+        second_tx
+            .send(true)
+            .expect("finish replacement availability check");
+        let status = status.await;
+        assert!(status.available);
+        assert!(matches!(status.lifecycle, Lifecycle::Stopped));
+        assert_eq!(status.revision, 2);
     }
 
     #[cfg(target_os = "macos")]

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -4163,6 +4163,34 @@ describe("info", () => {
       voice_session_active: true,
     });
   });
+
+  it("get_context ignores renderer activity older than native voice state", async () => {
+    useVoiceConversationStore.setState({
+      status: {
+        available: true,
+        unavailableReason: null,
+        lifecycle: "running",
+        sessionId: "session-2",
+        ownerWindowLabel: "main",
+        microphoneMuted: false,
+        revision: 3,
+      },
+      uiState: "listening",
+    });
+    mocks.getVoiceConversationStatus.mockResolvedValue({
+      available: true,
+      unavailableReason: null,
+      lifecycle: "stopped",
+      sessionId: null,
+      ownerWindowLabel: null,
+      microphoneMuted: false,
+      revision: 4,
+    });
+
+    await expect(
+      dispatchCommand("info", { action: "get_context" }, ctx),
+    ).resolves.toMatchObject({ voice_session_active: false });
+  });
 });
 
 describe("feedback schemas", () => {

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -35,6 +35,7 @@ import { getModelProviders } from "@/features/providers/providerCatalog";
 import { useProviderModelCacheStore } from "@/features/providers/stores/providerModelCacheStore";
 import { setMultiWorkspaceEnabled } from "@/features/workspaces/multiWorkspacePreference";
 import { resolveSkillPillTone } from "@/features/skills/lib/resolveSkillPillTone";
+import { useVoiceConversationStore } from "@/features/voice-conversation/stores/voiceConversationStore";
 import type { AcpSessionInfo, AcpSessionsPage } from "@/shared/api/acp";
 import { createUserMessage, getTextContent } from "@/shared/types/messages";
 
@@ -359,6 +360,18 @@ beforeEach(() => {
   useProviderModelCacheStore.setState({
     providers: emptyModelProviderCache(),
     refreshingProviderIds: new Set(),
+  });
+  useVoiceConversationStore.setState({
+    status: {
+      available: false,
+      unavailableReason: null,
+      lifecycle: "stopped",
+      sessionId: null,
+      ownerWindowLabel: null,
+      microphoneMuted: false,
+      revision: 0,
+    },
+    uiState: "off",
   });
 
   window.localStorage.clear();
@@ -4040,11 +4053,23 @@ describe("info", () => {
     );
   });
 
-  it("get_context reports the app context from the navigation controller", async () => {
+  it("get_context reports app and active voice context", async () => {
     controller.getAppContext.mockReturnValue({
       view: "chat",
       activeSessionId: "session-2",
       activeProjectId: "project-9",
+    });
+    useVoiceConversationStore.setState({
+      status: {
+        available: true,
+        unavailableReason: null,
+        lifecycle: "running",
+        sessionId: "session-2",
+        ownerWindowLabel: "main",
+        microphoneMuted: false,
+        revision: 4,
+      },
+      uiState: "listening",
     });
 
     const result = (await dispatchCommand(
@@ -4055,12 +4080,14 @@ describe("info", () => {
       view: string;
       active_session_id: string | null;
       active_project_id: string | null;
+      voice_session_active: boolean;
       app_version: string;
     };
 
     expect(result.view).toBe("chat");
     expect(result.active_session_id).toBe("session-2");
     expect(result.active_project_id).toBe("project-9");
+    expect(result.voice_session_active).toBe(true);
     expect(result.app_version.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -72,6 +72,7 @@ const mocks = vi.hoisted(() => ({
   listPersonas: vi.fn(),
   createSkill: vi.fn(),
   listSkills: vi.fn(),
+  getVoiceConversationStatus: vi.fn(),
 }));
 
 vi.mock("@/shared/api/acp", () => ({
@@ -98,6 +99,21 @@ vi.mock("@/shared/api/acp", () => ({
   discoverAcpProviders: (...args: unknown[]) =>
     mocks.discoverAcpProviders(...args),
 }));
+
+vi.mock(
+  "@/features/voice-conversation/api/voiceConversation",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/features/voice-conversation/api/voiceConversation")
+      >();
+    return {
+      ...actual,
+      getVoiceConversationStatus: (...args: unknown[]) =>
+        mocks.getVoiceConversationStatus(...args),
+    };
+  },
+);
 
 vi.mock("@/features/chat/lib/sessionActivation", () => ({
   loadSessionMessages: (...args: unknown[]) =>
@@ -416,6 +432,15 @@ beforeEach(() => {
   mocks.listProjects.mockResolvedValue([]);
   mocks.listPersonas.mockResolvedValue([]);
   mocks.listSkills.mockResolvedValue([]);
+  mocks.getVoiceConversationStatus.mockResolvedValue({
+    available: false,
+    unavailableReason: null,
+    lifecycle: "stopped",
+    sessionId: null,
+    ownerWindowLabel: null,
+    microphoneMuted: false,
+    revision: 0,
+  });
   mocks.updateSessionTitle.mockResolvedValue(undefined);
   mocks.moveSessionToProject.mockResolvedValue(undefined);
   mocks.updateProject.mockImplementation(
@@ -4059,17 +4084,14 @@ describe("info", () => {
       activeSessionId: "session-2",
       activeProjectId: "project-9",
     });
-    useVoiceConversationStore.setState({
-      status: {
-        available: true,
-        unavailableReason: null,
-        lifecycle: "running",
-        sessionId: "session-2",
-        ownerWindowLabel: "main",
-        microphoneMuted: false,
-        revision: 4,
-      },
-      uiState: "listening",
+    mocks.getVoiceConversationStatus.mockResolvedValue({
+      available: true,
+      unavailableReason: null,
+      lifecycle: "running",
+      sessionId: "session-2",
+      ownerWindowLabel: "main",
+      microphoneMuted: false,
+      revision: 4,
     });
 
     const result = (await dispatchCommand(

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -4112,6 +4112,57 @@ describe("info", () => {
     expect(result.voice_session_active).toBe(true);
     expect(result.app_version.length).toBeGreaterThan(0);
   });
+
+  it("get_context preserves voice activity that starts during native refresh", async () => {
+    let resolveStatus!: (status: {
+      available: boolean;
+      unavailableReason: null;
+      lifecycle: "stopped";
+      sessionId: null;
+      ownerWindowLabel: null;
+      microphoneMuted: boolean;
+      revision: number;
+    }) => void;
+    mocks.getVoiceConversationStatus.mockReturnValue(
+      new Promise((resolve) => {
+        resolveStatus = resolve;
+      }),
+    );
+
+    const contextRequest = dispatchCommand(
+      "info",
+      { action: "get_context" },
+      ctx,
+    );
+    await vi.waitFor(() => {
+      expect(mocks.getVoiceConversationStatus).toHaveBeenCalledOnce();
+    });
+    useVoiceConversationStore.setState({
+      status: {
+        available: true,
+        unavailableReason: null,
+        lifecycle: "running",
+        sessionId: "session-2",
+        ownerWindowLabel: "main",
+        microphoneMuted: false,
+        revision: 5,
+      },
+      uiState: "listening",
+    });
+    resolveStatus({
+      available: false,
+      unavailableReason: null,
+      lifecycle: "stopped",
+      sessionId: null,
+      ownerWindowLabel: null,
+      microphoneMuted: false,
+      revision: 4,
+    });
+
+    await expect(contextRequest).resolves.toMatchObject({
+      voice_session_active: true,
+    });
+  });
 });
 
 describe("feedback schemas", () => {

--- a/src/features/berdctl/commands/impl/getContext.ts
+++ b/src/features/berdctl/commands/impl/getContext.ts
@@ -12,14 +12,18 @@ interface GetContextResult {
   app_version: string;
 }
 
-function rendererVoiceSessionActive(voice: {
-  status: { sessionId: string | null };
-  uiState: string;
-}): boolean {
+function rendererVoiceSessionActive(
+  voice: {
+    status: { sessionId: string | null; revision: number };
+    uiState: string;
+  },
+  nativeRevision: number,
+): boolean {
   return (
-    voice.status.sessionId !== null ||
-    voice.uiState === "starting" ||
-    voice.uiState === "stopping"
+    voice.status.revision >= nativeRevision &&
+    (voice.status.sessionId !== null ||
+      voice.uiState === "starting" ||
+      voice.uiState === "stopping")
   );
 }
 
@@ -62,8 +66,14 @@ Result:
       active_project_id: context.activeProjectId,
       voice_session_active:
         nativeVoiceStatus.sessionId !== null ||
-        rendererVoiceSessionActive(voiceBeforeRefresh) ||
-        rendererVoiceSessionActive(voiceAfterRefresh),
+        rendererVoiceSessionActive(
+          voiceBeforeRefresh,
+          nativeVoiceStatus.revision,
+        ) ||
+        rendererVoiceSessionActive(
+          voiceAfterRefresh,
+          nativeVoiceStatus.revision,
+        ),
       // Match telemetry's resolution: prefer the build-injected version
       // (git-derived for non-release builds), fall back to package.json.
       app_version: import.meta.env.VITE_APP_VERSION ?? packageJson.version,

--- a/src/features/berdctl/commands/impl/getContext.ts
+++ b/src/features/berdctl/commands/impl/getContext.ts
@@ -42,8 +42,8 @@ Result:
       import("@/features/voice-conversation/stores/voiceConversationStore"),
     ]);
     const context = getAppNavigationController().getAppContext();
-    const voice = useVoiceConversationStore.getState();
     const nativeVoiceStatus = await getVoiceConversationStatus();
+    const voice = useVoiceConversationStore.getState();
     return {
       view: context.view,
       active_session_id: context.activeSessionId,

--- a/src/features/berdctl/commands/impl/getContext.ts
+++ b/src/features/berdctl/commands/impl/getContext.ts
@@ -8,6 +8,7 @@ interface GetContextResult {
   view: string;
   active_session_id: string | null;
   active_project_id: string | null;
+  voice_session_active: boolean;
   app_version: string;
 }
 
@@ -25,19 +26,29 @@ export const getContextCommand = defineCommand({
 
 Result:
   {"view": "...", "active_session_id": "..."|null,
-   "active_project_id": "..."|null, "app_version": "..."}`,
+   "active_project_id": "..."|null, "voice_session_active": true|false,
+   "app_version": "..."}`,
   schema: getContextSchema,
   execute: async (): Promise<GetContextResult> => {
-    const [{ default: packageJson }, { getAppNavigationController }] =
-      await Promise.all([
-        import("../../../../../package.json"),
-        import("../../navigation"),
-      ]);
+    const [
+      { default: packageJson },
+      { getAppNavigationController },
+      { useVoiceConversationStore },
+    ] = await Promise.all([
+      import("../../../../../package.json"),
+      import("../../navigation"),
+      import("@/features/voice-conversation/stores/voiceConversationStore"),
+    ]);
     const context = getAppNavigationController().getAppContext();
+    const voice = useVoiceConversationStore.getState();
     return {
       view: context.view,
       active_session_id: context.activeSessionId,
       active_project_id: context.activeProjectId,
+      voice_session_active:
+        voice.status.sessionId !== null ||
+        voice.uiState === "starting" ||
+        voice.uiState === "stopping",
       // Match telemetry's resolution: prefer the build-injected version
       // (git-derived for non-release builds), fall back to package.json.
       app_version: import.meta.env.VITE_APP_VERSION ?? packageJson.version,

--- a/src/features/berdctl/commands/impl/getContext.ts
+++ b/src/features/berdctl/commands/impl/getContext.ts
@@ -33,20 +33,23 @@ Result:
     const [
       { default: packageJson },
       { getAppNavigationController },
+      { getVoiceConversationStatus },
       { useVoiceConversationStore },
     ] = await Promise.all([
       import("../../../../../package.json"),
       import("../../navigation"),
+      import("@/features/voice-conversation/api/voiceConversation"),
       import("@/features/voice-conversation/stores/voiceConversationStore"),
     ]);
     const context = getAppNavigationController().getAppContext();
     const voice = useVoiceConversationStore.getState();
+    const nativeVoiceStatus = await getVoiceConversationStatus();
     return {
       view: context.view,
       active_session_id: context.activeSessionId,
       active_project_id: context.activeProjectId,
       voice_session_active:
-        voice.status.sessionId !== null ||
+        nativeVoiceStatus.sessionId !== null ||
         voice.uiState === "starting" ||
         voice.uiState === "stopping",
       // Match telemetry's resolution: prefer the build-injected version

--- a/src/features/berdctl/commands/impl/getContext.ts
+++ b/src/features/berdctl/commands/impl/getContext.ts
@@ -12,6 +12,17 @@ interface GetContextResult {
   app_version: string;
 }
 
+function rendererVoiceSessionActive(voice: {
+  status: { sessionId: string | null };
+  uiState: string;
+}): boolean {
+  return (
+    voice.status.sessionId !== null ||
+    voice.uiState === "starting" ||
+    voice.uiState === "stopping"
+  );
+}
+
 export const getContextCommand = defineCommand({
   effect: "read",
   visibility: "none",
@@ -42,16 +53,17 @@ Result:
       import("@/features/voice-conversation/stores/voiceConversationStore"),
     ]);
     const context = getAppNavigationController().getAppContext();
+    const voiceBeforeRefresh = useVoiceConversationStore.getState();
     const nativeVoiceStatus = await getVoiceConversationStatus();
-    const voice = useVoiceConversationStore.getState();
+    const voiceAfterRefresh = useVoiceConversationStore.getState();
     return {
       view: context.view,
       active_session_id: context.activeSessionId,
       active_project_id: context.activeProjectId,
       voice_session_active:
         nativeVoiceStatus.sessionId !== null ||
-        voice.uiState === "starting" ||
-        voice.uiState === "stopping",
+        rendererVoiceSessionActive(voiceBeforeRefresh) ||
+        rendererVoiceSessionActive(voiceAfterRefresh),
       // Match telemetry's resolution: prefer the build-injected version
       // (git-derived for non-release builds), fall back to package.json.
       app_version: import.meta.env.VITE_APP_VERSION ?? packageJson.version,


### PR DESCRIPTION
## Summary

Restart guards can observe running chat sessions but cannot distinguish an otherwise idle app from an active voice conversation. That allows a reconciliation to close and relaunch Berd during a call.

Add `voice_session_active` to `berdctl info context`. The value refreshes process-wide native state, preserves renderer transitions that occur during that refresh, and rejects renderer observations older than the native lifecycle revision. Restart guards can now wait until both chat and voice activity are idle.

## Reviewer-reproducible examples

1. Run `berdctl info context --json` with no voice conversation and observe `"voice_session_active": false`.
2. Start a voice conversation and run the command again; observe `"voice_session_active": true`.
3. End the conversation and repeat the command; observe `"voice_session_active": false`.
