### PR TITLE
fix(chat): preserve assistant order after batched steers

### DIFF
--- a/src/features/chat/acp/__tests__/acpNotificationHandler.test.ts
+++ b/src/features/chat/acp/__tests__/acpNotificationHandler.test.ts
@@ -787,8 +787,8 @@ describe("acpNotificationHandler", () => {
       useChatStore.getState().messagesBySession["acp-session"],
     ).toMatchObject([
       { id: "backend-steer-1", metadata: { delivery: "steer" } },
-      { id: "local-steer-2", metadata: { delivery: "steering" } },
       { role: "assistant" },
+      { id: "local-steer-2", metadata: { delivery: "steering" } },
     ]);
     expect(
       useChatStore.getState().getSessionRuntime("acp-session")

--- a/src/features/chat/acp/__tests__/acpNotificationHandler.test.ts
+++ b/src/features/chat/acp/__tests__/acpNotificationHandler.test.ts
@@ -575,6 +575,95 @@ describe("acpNotificationHandler", () => {
     ).toBeNull();
   });
 
+  it("keeps assistant responses in canonical order when multiple steers arrive before the next response", async () => {
+    useChatStore.getState().setMessages("acp-session", [
+      {
+        id: "assistant-before-steers",
+        role: "assistant",
+        created: 1,
+        content: [{ type: "text", text: "Browser-level echo cancellation" }],
+        metadata: {
+          userVisible: true,
+          agentVisible: true,
+          completionStatus: "inProgress",
+          personaId: "persona-a",
+        },
+      },
+      {
+        id: "steer-1",
+        role: "user",
+        created: 2,
+        content: [{ type: "text", text: "is it based on the browser?" }],
+        metadata: {
+          userVisible: true,
+          agentVisible: true,
+          delivery: "steer",
+        },
+      },
+      {
+        id: "steer-2",
+        role: "user",
+        created: 2,
+        content: [{ type: "text", text: "are we using a browser?" }],
+        metadata: {
+          userVisible: true,
+          agentVisible: true,
+          delivery: "steer",
+        },
+      },
+    ]);
+    useChatStore
+      .getState()
+      .setStreamingMessageId("acp-session", "assistant-before-steers");
+    useChatStore.getState().setPendingInterventionBoundary("acp-session", {
+      interventionMessageId: "steer-1",
+    });
+
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "user_message_chunk",
+        messageId: "steer-1",
+        content: { type: "text", text: "is it based on the browser?" },
+        _meta: { goose: { steer: true } },
+      },
+    } as never);
+
+    const continuationMessageId =
+      useChatStore.getState().getSessionRuntime("acp-session")
+        .streamingMessageId ?? "";
+
+    await handleSessionNotification({
+      sessionId: "acp-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        messageId: "assistant-after-steers",
+        content: { type: "text", text: "Tauri desktop app" },
+      },
+    } as never);
+
+    flushBufferedStreamingUpdatesForSession("acp-session", {
+      flushSubtitle: true,
+    });
+
+    const messages = useChatStore.getState().messagesBySession["acp-session"];
+    expect(messages).toMatchObject([
+      { id: "assistant-before-steers", role: "assistant" },
+      { id: "steer-1", role: "user" },
+      { id: "steer-2", role: "user" },
+      {
+        id: continuationMessageId,
+        role: "assistant",
+        content: [{ type: "text", text: "Tauri desktop app" }],
+      },
+    ]);
+    expect(messages[0].metadata?.completionStatus).toBe("completed");
+    expect(
+      useChatStore.getState().getSessionRuntime("acp-session")
+        .streamingMessageId,
+    ).toBe(continuationMessageId);
+  });
+
   it("correlates delivery that arrives before the steer acknowledgement", async () => {
     useChatStore.getState().setMessages("acp-session", [
       {
@@ -698,8 +787,8 @@ describe("acpNotificationHandler", () => {
       useChatStore.getState().messagesBySession["acp-session"],
     ).toMatchObject([
       { id: "backend-steer-1", metadata: { delivery: "steer" } },
-      { role: "assistant" },
       { id: "local-steer-2", metadata: { delivery: "steering" } },
+      { role: "assistant" },
     ]);
     expect(
       useChatStore.getState().getSessionRuntime("acp-session")

--- a/src/features/chat/stores/__tests__/chatStore.test.ts
+++ b/src/features/chat/stores/__tests__/chatStore.test.ts
@@ -310,6 +310,99 @@ describe("chatStore", () => {
     expect(useChatStore.getState().sessionStateById.s1).toBe(afterRuntime);
   });
 
+  it("inserts a continuation assistant after a contiguous steer batch", () => {
+    const store = useChatStore.getState();
+    store.setMessages("s1", [
+      makeMessage({
+        id: "assistant-before-steer",
+        role: "assistant",
+        created: 1,
+        content: [{ type: "text", text: "First answer" }],
+        metadata: {
+          userVisible: true,
+          agentVisible: true,
+          completionStatus: "inProgress",
+        },
+      }),
+      makeMessage({
+        id: "steer-1",
+        role: "user",
+        created: 2,
+        content: [{ type: "text", text: "first steer" }],
+        metadata: { userVisible: true, delivery: "steer" },
+      }),
+      makeMessage({
+        id: "steer-2",
+        role: "user",
+        created: 2,
+        content: [{ type: "text", text: "second steer" }],
+        metadata: { userVisible: true, delivery: "steering" },
+      }),
+    ]);
+    store.setStreamingMessageId("s1", "assistant-before-steer");
+    store.setPendingInterventionBoundary("s1", {
+      interventionMessageId: "steer-1",
+    });
+
+    store.startAssistantStreamAfterIntervention("s1");
+    store.updateStreamingText("s1", "Second answer");
+
+    const messages = useChatStore.getState().messagesBySession.s1;
+    expect(messages.map((message) => message.id)).toEqual([
+      "assistant-before-steer",
+      "steer-1",
+      "steer-2",
+      messages[3].id,
+    ]);
+    expect(messages[0].metadata?.completionStatus).toBe("completed");
+    expect(messages[3]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Second answer" }],
+      metadata: { completionStatus: "inProgress" },
+    });
+    expect(getRuntime("s1").streamingMessageId).toBe(messages[3].id);
+    expect(getRuntime("s1").pendingInterventionBoundary).toBeNull();
+  });
+
+  it("reuses an existing continuation assistant after a contiguous steer batch", () => {
+    const store = useChatStore.getState();
+    store.setMessages("s1", [
+      makeMessage({ id: "assistant-before-steer", role: "assistant" }),
+      makeMessage({
+        id: "steer-1",
+        role: "user",
+        metadata: { userVisible: true, delivery: "steer" },
+      }),
+      makeMessage({
+        id: "steer-2",
+        role: "user",
+        metadata: { userVisible: true, delivery: "steering" },
+      }),
+      makeMessage({
+        id: "assistant-after-steers",
+        role: "assistant",
+        metadata: { userVisible: true, completionStatus: "inProgress" },
+      }),
+    ]);
+    store.setStreamingMessageId("s1", "assistant-before-steer");
+    store.setPendingInterventionBoundary("s1", {
+      interventionMessageId: "steer-1",
+    });
+
+    store.startAssistantStreamAfterIntervention("s1");
+
+    expect(
+      useChatStore.getState().messagesBySession.s1.map((m) => m.id),
+    ).toEqual([
+      "assistant-before-steer",
+      "steer-1",
+      "steer-2",
+      "assistant-after-steers",
+    ]);
+    expect(getRuntime("s1").streamingMessageId).toBe("assistant-after-steers");
+    expect(getRuntime("s1").pendingInterventionBoundary).toBeNull();
+  });
+
   it("appends streamed thinking only within the targeted session", () => {
     const streaming = makeMessage({
       id: "stream-1",

--- a/src/features/chat/stores/__tests__/chatStore.test.ts
+++ b/src/features/chat/stores/__tests__/chatStore.test.ts
@@ -310,7 +310,7 @@ describe("chatStore", () => {
     expect(useChatStore.getState().sessionStateById.s1).toBe(afterRuntime);
   });
 
-  it("inserts a continuation assistant after a contiguous steer batch", () => {
+  it("inserts a continuation assistant after a contiguous delivered steer batch", () => {
     const store = useChatStore.getState();
     store.setMessages("s1", [
       makeMessage({
@@ -336,7 +336,7 @@ describe("chatStore", () => {
         role: "user",
         created: 2,
         content: [{ type: "text", text: "second steer" }],
-        metadata: { userVisible: true, delivery: "steering" },
+        metadata: { userVisible: true, delivery: "steer" },
       }),
     ]);
     store.setStreamingMessageId("s1", "assistant-before-steer");
@@ -364,7 +364,7 @@ describe("chatStore", () => {
     expect(getRuntime("s1").pendingInterventionBoundary).toBeNull();
   });
 
-  it("reuses an existing continuation assistant after a contiguous steer batch", () => {
+  it("does not cross a steering message that has not been delivered", () => {
     const store = useChatStore.getState();
     store.setMessages("s1", [
       makeMessage({ id: "assistant-before-steer", role: "assistant" }),
@@ -391,15 +391,19 @@ describe("chatStore", () => {
 
     store.startAssistantStreamAfterIntervention("s1");
 
-    expect(
-      useChatStore.getState().messagesBySession.s1.map((m) => m.id),
-    ).toEqual([
+    const messages = useChatStore.getState().messagesBySession.s1;
+    expect(messages.map((m) => m.id)).toEqual([
       "assistant-before-steer",
       "steer-1",
+      messages[2].id,
       "steer-2",
       "assistant-after-steers",
     ]);
-    expect(getRuntime("s1").streamingMessageId).toBe("assistant-after-steers");
+    expect(messages[2]).toMatchObject({
+      role: "assistant",
+      metadata: { completionStatus: "inProgress" },
+    });
+    expect(getRuntime("s1").streamingMessageId).toBe(messages[2].id);
     expect(getRuntime("s1").pendingInterventionBoundary).toBeNull();
   });
 

--- a/src/features/chat/stores/chatStore.ts
+++ b/src/features/chat/stores/chatStore.ts
@@ -353,12 +353,8 @@ function findLatestInterventionMessageId(messages: Message[]): string | null {
   return null;
 }
 
-function isInterventionMessage(message: Message | undefined): boolean {
-  return (
-    message?.role === "user" &&
-    (message.metadata?.delivery === "steer" ||
-      message.metadata?.delivery === "steering")
-  );
+function isDeliveredInterventionMessage(message: Message | undefined): boolean {
+  return message?.role === "user" && message.metadata?.delivery === "steer";
 }
 
 function findInterventionInsertionAnchorIndex(
@@ -368,7 +364,7 @@ function findInterventionInsertionAnchorIndex(
   let anchorIndex = interventionIndex;
   for (
     let index = interventionIndex + 1;
-    index < messages.length && isInterventionMessage(messages[index]);
+    index < messages.length && isDeliveredInterventionMessage(messages[index]);
     index += 1
   ) {
     anchorIndex = index;

--- a/src/features/chat/stores/chatStore.ts
+++ b/src/features/chat/stores/chatStore.ts
@@ -353,6 +353,29 @@ function findLatestInterventionMessageId(messages: Message[]): string | null {
   return null;
 }
 
+function isInterventionMessage(message: Message | undefined): boolean {
+  return (
+    message?.role === "user" &&
+    (message.metadata?.delivery === "steer" ||
+      message.metadata?.delivery === "steering")
+  );
+}
+
+function findInterventionInsertionAnchorIndex(
+  messages: Message[],
+  interventionIndex: number,
+): number {
+  let anchorIndex = interventionIndex;
+  for (
+    let index = interventionIndex + 1;
+    index < messages.length && isInterventionMessage(messages[index]);
+    index += 1
+  ) {
+    anchorIndex = index;
+  }
+  return anchorIndex;
+}
+
 export type { QueuedMessagePayload, AdmittedQueuedMessagePayload };
 
 export type QueuedMessageRecord =
@@ -1216,8 +1239,15 @@ const createChatStore: StateCreator<
       const interventionIndex = messages.findIndex(
         (message) => message.id === interventionMessageId,
       );
+      const insertionAnchorIndex =
+        interventionIndex >= 0
+          ? findInterventionInsertionAnchorIndex(messages, interventionIndex)
+          : -1;
+      const insertionAnchorId = messages[insertionAnchorIndex]?.id;
       const existingContinuationMessage =
-        interventionIndex >= 0 ? messages[interventionIndex + 1] : undefined;
+        insertionAnchorIndex >= 0
+          ? messages[insertionAnchorIndex + 1]
+          : undefined;
       if (
         existingContinuationMessage?.role === "assistant" &&
         existingContinuationMessage.metadata?.completionStatus === "inProgress"
@@ -1250,11 +1280,13 @@ const createChatStore: StateCreator<
       return {
         messagesBySession: {
           ...state.messagesBySession,
-          [sessionId]: insertMessageAfter(
-            completedMessages,
-            interventionMessageId,
-            assistantContinuationMessage,
-          ),
+          [sessionId]: insertionAnchorId
+            ? insertMessageAfter(
+                completedMessages,
+                insertionAnchorId,
+                assistantContinuationMessage,
+              )
+            : [...completedMessages, assistantContinuationMessage],
         },
         sessionStateById: {
           ...state.sessionStateById,


### PR DESCRIPTION
## Summary

Fixes a chat transcript ordering bug for live steering. When a prior assistant response is completing and multiple user steers are delivered before the next assistant response starts, Berd now anchors the continuation after the contiguous delivered steer batch instead of after only the first delivered steer. Undelivered queued steers still stay ahead of their own later continuation.

### Related issue

none found

### Testing

- `pnpm vitest run src/features/chat/stores/__tests__/chatStore.test.ts src/features/chat/acp/__tests__/acpNotificationHandler.test.ts`
- `just check`

## Reviewer-reproducible examples

Red/green regression proof:

Apply only the regression test to `origin/main`, then run the focused case:

```bash
pnpm vitest run src/features/chat/acp/__tests__/acpNotificationHandler.test.ts \
  -t 'keeps assistant responses in canonical order when multiple steers arrive before the next response'
```

Before this fix, the focused case fails because the continuation assistant is inserted between the two delivered steers:

```diff
 assistant-before-steers
 steer-1
-steer-2
-assistant continuation
+assistant continuation
+steer-2
```

On this PR, the same focused case passes. The seeded live transcript shape matches session `20260826_2`:

1. assistant response with `completionStatus: "inProgress"`
2. two delivered steer user messages with the same timestamp
3. next assistant chunk begins after the first steer boundary is processed

The resulting transcript order remains:

```text
assistant-before-steers
steer-1
steer-2
assistant continuation
```

The store test `does not cross a steering message that has not been delivered` covers the adjacent preserved behavior: if a later local steer is still `delivery: "steering"`, the continuation for the delivered steer is inserted before that undelivered steer.
