### PR TITLE
fix: prevent duplicate instances on windows by focusing existing window

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
@@ -6676,6 +6677,22 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.20",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.20",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -90,6 +90,7 @@ tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-single-instance = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-window-state = "2"
 time = { version = "0.3", features = ["formatting"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,7 +109,21 @@ pub fn run() {
             .unwrap_or_else(|error| panic!("failed to initialize isolated E2E mode: {error}"));
     }
 
-    let builder = tauri::Builder::default()
+    let builder = tauri::Builder::default();
+
+    // Single-instance enforcement: on Windows, a second launch exits early
+    // and focuses the existing window instead of starting a duplicate app
+    // (log files, db connections, goose serve, etc.). macOS handles this
+    // via RunEvent::Reopen further below.
+    #[cfg(target_os = "windows")]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+    }));
+
+    let builder = builder
         .plugin(tauri_plugin_shell::init())
         .plugin(
             tauri_plugin_log::Builder::new()


### PR DESCRIPTION
**Category:** fix
**User Impact:** On Windows, clicking the app icon when Berd is already running now focuses the existing window instead of launching a duplicate instance.

**Problem:** On Windows, launching Berd when it's already running starts a second full instance — duplicating log files, database connections, and the `goose serve` sidecar. macOS already handles this correctly via `RunEvent::Reopen`.

**Solution:** Register `tauri-plugin-single-instance` as the first plugin in the builder chain, gated behind `#[cfg(target_os = "windows")]`. The plugin uses a named mutex to detect an existing instance; the second instance exits early (before initializing any other plugins) and sends a message that triggers the existing instance to show and focus the main window. macOS continues using its existing `RunEvent::Reopen` handler, which does the same `show()` + `set_focus()` pattern.

Linear: BOT-1678

<details>
<summary>File changes</summary>

**src-tauri/Cargo.toml**
Added `tauri-plugin-single-instance = "2"` dependency, matching the version pattern of all other tauri-plugin-* deps.

**src-tauri/Cargo.lock**
Auto-generated lockfile entry for tauri-plugin-single-instance 2.4.3 and its transitive dependencies.

**src-tauri/src/lib.rs**
Registered the single-instance plugin as the first `.plugin()` call on the builder, before all other plugins. Gated behind `#[cfg(target_os = "windows")]` so macOS (which uses `RunEvent::Reopen` at ~line 716) is unaffected. The callback calls `show()` then `set_focus()` on the `"main"` webview window — `show()` is required because the window starts hidden (`visible: false` in tauri.conf.json).

</details>
