### PR TITLE
chore: show Unity Catalog model names in the chat composer

### DIFF
--- a/src/features/chat/lib/modelDisplayLabel.test.ts
+++ b/src/features/chat/lib/modelDisplayLabel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveDisplayModelLabel } from "./modelDisplayLabel";
+
+const unityCatalogModelId =
+  "data_workflow_tools.production.fraud_detection_model";
+
+describe("resolveDisplayModelLabel", () => {
+  it("shows only the model segment for a Databricks Unity Catalog selection", () => {
+    expect(
+      resolveDisplayModelLabel({
+        currentModelId: unityCatalogModelId,
+        currentModelName: unityCatalogModelId,
+        currentModelProviderId: "databricks_v2",
+      }),
+    ).toBe("Fraud_detection_model");
+  });
+
+  it("repairs a persisted full Unity Catalog display name", () => {
+    expect(
+      resolveDisplayModelLabel({
+        currentModelId: unityCatalogModelId,
+        currentModelName:
+          "Data_workflow_tools.production.fraud_detection_model",
+        currentModelProviderId: "databricks_v2",
+      }),
+    ).toBe("Fraud_detection_model");
+  });
+
+  it("preserves non-Databricks model names", () => {
+    expect(
+      resolveDisplayModelLabel({
+        currentModelId: unityCatalogModelId,
+        currentModelName: "Data workflow production model",
+        currentModelProviderId: "custom_provider",
+      }),
+    ).toBe("Data workflow production model");
+  });
+});

--- a/src/features/chat/lib/modelDisplayLabel.ts
+++ b/src/features/chat/lib/modelDisplayLabel.ts
@@ -1,5 +1,8 @@
 import type { ModelOption } from "../types";
-import { normalizedGooseModelDisplayName } from "@/features/providers/lib/modelRecommendations";
+import {
+  modelDisplayNameFromId,
+  normalizedGooseModelDisplayName,
+} from "@/features/providers/lib/modelRecommendations";
 
 interface ModelDisplayLabelOptions {
   currentModelId?: string | null;
@@ -29,13 +32,25 @@ function getDefaultAvailableModelLabel(availableModels: ModelOption[] = []) {
   return model ? getModelDisplayName(model) : null;
 }
 
-function getExplicitModelIdLabel(modelId?: string | null) {
+function getExplicitModelIdLabel(
+  modelId?: string | null,
+  modelProviderId?: string | null,
+) {
   const selectedModelId = normalizeLabel(modelId);
-  if (!selectedModelId?.startsWith("goose-")) {
+  if (!selectedModelId) {
     return null;
   }
 
-  return normalizedGooseModelDisplayName(selectedModelId);
+  if (
+    modelProviderId === "databricks_v2" &&
+    selectedModelId.indexOf(".") !== selectedModelId.lastIndexOf(".")
+  ) {
+    return modelDisplayNameFromId(modelProviderId, selectedModelId);
+  }
+
+  return selectedModelId.startsWith("goose-")
+    ? normalizedGooseModelDisplayName(selectedModelId)
+    : null;
 }
 
 function findSelectedAvailableModel({
@@ -88,13 +103,19 @@ export function resolveDisplayModelLabel({
   }
 
   const selectedModelId = normalizeLabel(currentModelId);
-  const modelName = normalizeLabel(currentModelName);
+  const rawModelName = normalizeLabel(currentModelName);
+  const modelName =
+    rawModelName &&
+    currentModelProviderId === "databricks_v2" &&
+    rawModelName.indexOf(".") !== rawModelName.lastIndexOf(".")
+      ? modelDisplayNameFromId(currentModelProviderId, rawModelName)
+      : rawModelName;
   if (modelName && modelName !== selectedModelId) {
     return modelName;
   }
 
   return (
-    getExplicitModelIdLabel(selectedModelId) ??
+    getExplicitModelIdLabel(selectedModelId, currentModelProviderId) ??
     (availableModels.length > 0 ? selectedModelId : null)
   );
 }

--- a/src/features/providers/lib/modelRecommendations.test.ts
+++ b/src/features/providers/lib/modelRecommendations.test.ts
@@ -61,6 +61,20 @@ describe("modelRecommendations", () => {
     );
   });
 
+  it("shows only the model name for Unity Catalog model ids", () => {
+    const [option] = providerModelOptionsFromIds("databricks_v2", [
+      "data_workflow_tools.production.fraud_detection_model",
+    ]);
+
+    expect(option).toEqual(
+      expect.objectContaining({
+        id: "data_workflow_tools.production.fraud_detection_model",
+        name: "Fraud_detection_model",
+        displayName: "Fraud_detection_model",
+      }),
+    );
+  });
+
   it("does not feature or rank generic custom provider models", () => {
     const options = providerModelOptionsFromIds("block_openai_compatible", [
       "z-model",

--- a/src/features/providers/lib/modelRecommendations.ts
+++ b/src/features/providers/lib/modelRecommendations.ts
@@ -143,10 +143,21 @@ export function isGooseModelProviderId(providerId: string): boolean {
   return FALLBACK_GOOSE_MODEL_PROVIDER_IDS.has(providerId);
 }
 
+export function modelDisplayNameFromId(providerId: string, id: string): string {
+  const firstDot = id.indexOf(".");
+  const lastDot = id.lastIndexOf(".");
+  const displayId =
+    providerId === "databricks_v2" && firstDot > 0 && lastDot > firstDot
+      ? id.slice(lastDot + 1)
+      : id;
+  return (
+    normalizedGooseModelDisplayName(displayId) ?? humanizeRawModelId(displayId)
+  );
+}
+
 function rawModelIdToOption(providerId: string, id: string): ModelOption {
   const providerName = formatProviderLabel(providerId);
-  const displayName =
-    normalizedGooseModelDisplayName(id) ?? humanizeRawModelId(id);
+  const displayName = modelDisplayNameFromId(providerId, id);
 
   return {
     id,


### PR DESCRIPTION
**Category:** fix
**User Impact:** Databricks users can read the model name in the chat composer without catalog and schema prefixes obscuring it.

**Problem:** Unity Catalog models arrive as fully qualified `$catalog.$schema.<model>` identifiers, so the narrow composer picker truncates the most important final segment. Persisted selections and pre-discovery fallback labels could also continue showing the qualified identifier.

**Solution:** Keep the canonical identifier for selection and search while deriving composer-facing labels from the final model segment. Apply the same formatting to discovered options, direct ID fallbacks, and previously persisted qualified display names.

<details>
<summary>File changes</summary>

**src/features/providers/lib/modelRecommendations.ts**
Centralizes model-label derivation and strips the catalog/schema prefix from discovered Databricks Unity Catalog identifiers while preserving canonical IDs.

**src/features/providers/lib/modelRecommendations.test.ts**
Covers the discovered Unity Catalog option label and verifies the full ID remains intact.

**src/features/chat/lib/modelDisplayLabel.ts**
Uses model-only labels for composer fallbacks and repairs persisted qualified labels before inventory is available.

**src/features/chat/lib/modelDisplayLabel.test.ts**
Covers direct Unity Catalog selections, persisted labels, and non-Databricks behavior.

</details>