### PR TITLE
fix(voice): default speech output to Siri

### DIFF
--- a/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.test.ts
@@ -26,10 +26,10 @@ describe("voice output preference", () => {
     });
   });
 
-  it("defaults to Pocket on macOS", () => {
+  it("defaults to Siri on macOS", () => {
     setPlatform("Macintosh");
-    expect(getDefaultVoiceOutputBackend()).toBe("pocket");
-    expect(getVoiceOutputBackend()).toBe("pocket");
+    expect(getDefaultVoiceOutputBackend()).toBe("siri");
+    expect(getVoiceOutputBackend()).toBe("siri");
   });
 
   it("defaults to Pocket and rejects persisted Siri off macOS", () => {

--- a/src/features/voice-conversation/lib/voiceOutputPreference.ts
+++ b/src/features/voice-conversation/lib/voiceOutputPreference.ts
@@ -7,7 +7,7 @@ const STORAGE_KEY = "goose:voice-output-backend";
 const CHANGED_EVENT = "goose:voice-output-backend-changed";
 let inMemoryBackend: VoiceOutputBackend | null = null;
 export function getDefaultVoiceOutputBackend(): VoiceOutputBackend {
-  return "pocket";
+  return getPlatform() === "mac" ? "siri" : "pocket";
 }
 
 function normalize(value: unknown): VoiceOutputBackend {


### PR DESCRIPTION
**Category:** fix
**User Impact:** New macOS voice conversations now use Siri speech output by default while preserving any voice output the user explicitly selected.

**Problem:** Berd temporarily defaulted to Pocket TTS on macOS to avoid garbled Siri playback. The Siri audio path has since been normalized, so that workaround no longer reflects the preferred native voice experience.

**Solution:** Restore Siri as the macOS default while keeping Pocket as the default on other platforms and preserving saved Pocket or Siri selections.

<details>
<summary>File changes</summary>

**src/features/voice-conversation/lib/voiceOutputPreference.ts**
Selects Siri as the default output backend on macOS and Pocket elsewhere.

**src/features/voice-conversation/lib/voiceOutputPreference.test.ts**
Updates the macOS default assertions while retaining coverage for non-macOS fallback and explicit saved preferences.

</details>
