### PR TITLE
Keep feedback surveys visible after remount

### DIFF
--- a/src/features/chat/response-feedback/sessionFeedbackSurveyState.test.ts
+++ b/src/features/chat/response-feedback/sessionFeedbackSurveyState.test.ts
@@ -73,7 +73,7 @@ describe("sessionFeedbackSurveyState", () => {
     expect(claimCooldown).toHaveBeenCalledTimes(2);
   });
 
-  it("blocks remount presentation while the appeared owner can respond", async () => {
+  it("keeps an appeared survey presentable across virtualized remounts", async () => {
     const survey = await claim("appeared-once");
     expect(survey).not.toBeNull();
     if (!survey) throw new Error("expected survey to be selected");
@@ -81,7 +81,7 @@ describe("sessionFeedbackSurveyState", () => {
 
     expect(
       isSessionFeedbackSurveyPresentable("appeared-once", survey.appearanceId),
-    ).toBe(false);
+    ).toBe(true);
     recordSessionFeedbackSurveyResponse(
       "appeared-once",
       survey.appearanceId,

--- a/src/features/chat/response-feedback/sessionFeedbackSurveyState.ts
+++ b/src/features/chat/response-feedback/sessionFeedbackSurveyState.ts
@@ -198,11 +198,7 @@ export function isSessionFeedbackSurveyPresentable(
   appearanceId: string,
 ): boolean {
   const record = readSessionRecord(sessionId);
-  return (
-    record?.active?.appearanceId === appearanceId &&
-    !record.appeared &&
-    !record.response
-  );
+  return record?.active?.appearanceId === appearanceId && !record.response;
 }
 
 export function markSessionFeedbackSurveyAppeared(


### PR DESCRIPTION
## Why

Virtualized transcript rows can remount after a session feedback survey has appeared. The unanswered survey should remain visible rather than disappearing after that remount.

## What

- Keep active unanswered session surveys presentable after their first appearance
- Cover remount behavior with a focused regression test

## Risk Assessment

Low risk. This only changes visibility for an already-selected, unanswered survey; responded and expired surveys remain hidden.

Generated with Amp