### PR TITLE
Manage local Goose schedules from Berd

### DIFF
--- a/src-tauri/crates/berdctl/api-surface-feedback.json
+++ b/src-tauri/crates/berdctl/api-surface-feedback.json
@@ -799,6 +799,132 @@
         }
       }
     },
+    "schedules": {
+      "description": "Manage scheduled recipe jobs in Berd's live embedded Goose scheduler: list, pause, unpause, kill an active run, or remove a schedule.",
+      "actions": {
+        "list": {
+          "description": "List scheduled recipe jobs from the live Goose scheduler embedded in Berd. Unlike a separate goose schedule process, this reads the scheduler instance that is actually running the jobs and does not change app state.",
+          "fields": [],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          }
+        },
+        "pause": {
+          "description": "Pause an idle scheduled recipe job through the live Goose scheduler embedded in Berd. Future scheduled runs stop until the job is unpaused. If a run is active, stop it first with berdctl schedule kill.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to pause.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to pause."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "unpause": {
+          "description": "Unpause a scheduled recipe job through the live Goose scheduler embedded in Berd. Future runs resume on the job's existing cron schedule.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to unpause.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to unpause."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "kill": {
+          "description": "Stop the current run of a scheduled recipe job through Berd's live Goose scheduler. The schedule itself remains registered and can run again later; use remove or pause when future runs must also stop.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job whose active run should stop.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job whose active run should stop."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "remove": {
+          "description": "Remove a scheduled recipe job through the live Goose scheduler embedded in Berd. This updates the scheduler that is actually running jobs, so a stale in-memory copy cannot restore the deleted schedule. The saved recipe file is kept.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to remove.",
+              "min": 1
+            },
+            {
+              "name": "confirm",
+              "required": false,
+              "kind": "boolean",
+              "description": "Confirm removal of the schedule registration. The saved recipe file is kept."
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to remove."
+              },
+              "confirm": {
+                "default": false,
+                "description": "Confirm removal of the schedule registration. The saved recipe file is kept.",
+                "type": "boolean"
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
     "agents": {
       "description": "Manage the user's agents (personas): create, list.",
       "actions": {

--- a/src-tauri/crates/berdctl/api-surface.json
+++ b/src-tauri/crates/berdctl/api-surface.json
@@ -799,6 +799,132 @@
         }
       }
     },
+    "schedules": {
+      "description": "Manage scheduled recipe jobs in Berd's live embedded Goose scheduler: list, pause, unpause, kill an active run, or remove a schedule.",
+      "actions": {
+        "list": {
+          "description": "List scheduled recipe jobs from the live Goose scheduler embedded in Berd. Unlike a separate goose schedule process, this reads the scheduler instance that is actually running the jobs and does not change app state.",
+          "fields": [],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+          }
+        },
+        "pause": {
+          "description": "Pause an idle scheduled recipe job through the live Goose scheduler embedded in Berd. Future scheduled runs stop until the job is unpaused. If a run is active, stop it first with berdctl schedule kill.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to pause.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to pause."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "unpause": {
+          "description": "Unpause a scheduled recipe job through the live Goose scheduler embedded in Berd. Future runs resume on the job's existing cron schedule.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to unpause.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to unpause."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "kill": {
+          "description": "Stop the current run of a scheduled recipe job through Berd's live Goose scheduler. The schedule itself remains registered and can run again later; use remove or pause when future runs must also stop.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job whose active run should stop.",
+              "min": 1
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job whose active run should stop."
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        },
+        "remove": {
+          "description": "Remove a scheduled recipe job through the live Goose scheduler embedded in Berd. This updates the scheduler that is actually running jobs, so a stale in-memory copy cannot restore the deleted schedule. The saved recipe file is kept.",
+          "fields": [
+            {
+              "name": "schedule_id",
+              "required": true,
+              "kind": "string",
+              "description": "Id of the scheduled recipe job to remove.",
+              "min": 1
+            },
+            {
+              "name": "confirm",
+              "required": false,
+              "kind": "boolean",
+              "description": "Confirm removal of the schedule registration. The saved recipe file is kept."
+            }
+          ],
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+              "schedule_id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Id of the scheduled recipe job to remove."
+              },
+              "confirm": {
+                "default": false,
+                "description": "Confirm removal of the schedule registration. The saved recipe file is kept.",
+                "type": "boolean"
+              }
+            },
+            "required": ["schedule_id"],
+            "additionalProperties": false
+          }
+        }
+      }
+    },
     "agents": {
       "description": "Manage the user's agents (personas): create, list.",
       "actions": {

--- a/src-tauri/crates/berdctl/cli-surface-feedback.json
+++ b/src-tauri/crates/berdctl/cli-surface-feedback.json
@@ -124,6 +124,37 @@
         }
       }
     },
+    "schedule": {
+      "group": "schedules",
+      "about": "Manage jobs in Berd's live Goose scheduler: list, pause, unpause, kill, remove",
+      "verbs": {
+        "list": {
+          "action": "list",
+          "about": "List scheduled recipe jobs from Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule list --json\n\nResult:\n  {\"schedules\": [{\"id\": \"daily-report\", \"cron\": \"0 9 * * *\",\n                   \"paused\": false, \"currently_running\": false,\n                   \"source\": \"...\", \"last_run\": null,\n                   \"current_session_id\": null, \"job_start_time\": null}]}"
+        },
+        "pause": {
+          "action": "pause",
+          "about": "Pause a job in Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule pause --schedule-id daily-report\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"paused\": true}"
+        },
+        "unpause": {
+          "action": "unpause",
+          "about": "Resume a paused job in Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule unpause --schedule-id daily-report\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"paused\": false}"
+        },
+        "kill": {
+          "action": "kill",
+          "about": "Stop the active run of a scheduled recipe job",
+          "afterHelp": "Examples:\n  berdctl schedule kill --schedule-id daily-report\n  berdctl schedule kill --schedule-id daily-report && \\\n    berdctl schedule remove --schedule-id daily-report --confirm\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"message\": \"...\"}"
+        },
+        "remove": {
+          "action": "remove",
+          "about": "Remove a job from Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule remove --schedule-id daily-report --confirm\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\"}\n\nIf the job is currently running, use berdctl schedule kill first when you also need to stop that active run."
+        }
+      }
+    },
     "agent": {
       "group": "agents",
       "about": "Manage agents (personas): create, list",

--- a/src-tauri/crates/berdctl/cli-surface.json
+++ b/src-tauri/crates/berdctl/cli-surface.json
@@ -124,6 +124,37 @@
         }
       }
     },
+    "schedule": {
+      "group": "schedules",
+      "about": "Manage jobs in Berd's live Goose scheduler: list, pause, unpause, kill, remove",
+      "verbs": {
+        "list": {
+          "action": "list",
+          "about": "List scheduled recipe jobs from Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule list --json\n\nResult:\n  {\"schedules\": [{\"id\": \"daily-report\", \"cron\": \"0 9 * * *\",\n                   \"paused\": false, \"currently_running\": false,\n                   \"source\": \"...\", \"last_run\": null,\n                   \"current_session_id\": null, \"job_start_time\": null}]}"
+        },
+        "pause": {
+          "action": "pause",
+          "about": "Pause a job in Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule pause --schedule-id daily-report\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"paused\": true}"
+        },
+        "unpause": {
+          "action": "unpause",
+          "about": "Resume a paused job in Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule unpause --schedule-id daily-report\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"paused\": false}"
+        },
+        "kill": {
+          "action": "kill",
+          "about": "Stop the active run of a scheduled recipe job",
+          "afterHelp": "Examples:\n  berdctl schedule kill --schedule-id daily-report\n  berdctl schedule kill --schedule-id daily-report && \\\n    berdctl schedule remove --schedule-id daily-report --confirm\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\", \"message\": \"...\"}"
+        },
+        "remove": {
+          "action": "remove",
+          "about": "Remove a job from Berd's live Goose scheduler",
+          "afterHelp": "Example:\n  berdctl schedule remove --schedule-id daily-report --confirm\n\nResult:\n  {\"ok\": true, \"schedule_id\": \"daily-report\"}\n\nIf the job is currently running, use berdctl schedule kill first when you also need to stop that active run."
+        }
+      }
+    },
     "agent": {
       "group": "agents",
       "about": "Manage agents (personas): create, list",

--- a/src-tauri/crates/berdctl/src/main.rs
+++ b/src-tauri/crates/berdctl/src/main.rs
@@ -297,6 +297,11 @@ mod tests {
                 vec!["--project-id", "p", "--mode", "worktree"]
             }
             ("project", "archive") => vec!["--project-id", "p"],
+            ("schedule", "list") => vec![],
+            ("schedule", "pause") | ("schedule", "unpause") | ("schedule", "kill") => {
+                vec!["--schedule-id", "s"]
+            }
+            ("schedule", "remove") => vec!["--schedule-id", "s", "--confirm"],
             ("agent", "create") => vec!["--name", "n", "--system-prompt", "sp"],
             ("agent", "list") => vec![],
             ("skill", "create") => {

--- a/src-tauri/crates/berdctl/src/tree.rs
+++ b/src-tauri/crates/berdctl/src/tree.rs
@@ -26,6 +26,7 @@ sees there:
                                   move-to-group, send, clear-project,
                                   fork, archive
   project   projects             create, list, get, set-startup-mode, archive
+  schedule  scheduled jobs       list, pause, unpause, kill, remove
   agent     agents (personas)    create, list
   skill     skills (SKILL.md)    create, list, get
   info      read-only lookups    harnesses, models, context
@@ -67,7 +68,7 @@ pub fn build_cli(contract: &Contract) -> Command {
     let mut cmd = Command::new("berdctl")
         .bin_name("berdctl")
         .term_width(HELP_WIDTH)
-        .about("Control the Berd desktop app (sessions, projects, agents, skills) from the command line")
+        .about("Control the Berd desktop app (sessions, projects, schedules, agents, skills) from the command line")
         .long_about(TOP_LEVEL_LONG_ABOUT)
         .after_long_help(TOP_LEVEL_EXAMPLES)
         .subcommand_required(true)

--- a/src/features/automations/api/localSchedules.test.ts
+++ b/src/features/automations/api/localSchedules.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getClient } from "@/shared/api/acpConnection";
+import { removeLocalSchedule } from "./localSchedules";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  pause: vi.fn(),
+  unpause: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acpConnection", () => ({
+  getClient: vi.fn(async () => ({
+    goose: {
+      GooseUnstableSchedulesList: mocks.list,
+      GooseUnstableSchedulesPause: mocks.pause,
+      GooseUnstableSchedulesUnpause: mocks.unpause,
+      GooseUnstableSchedulesDelete: mocks.remove,
+    },
+  })),
+}));
+
+describe("removeLocalSchedule", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.list.mockResolvedValue({
+      jobs: [{ id: "daily-report", paused: false, currentlyRunning: false }],
+    });
+    mocks.pause.mockResolvedValue(undefined);
+    mocks.unpause.mockResolvedValue(undefined);
+    mocks.remove.mockResolvedValue(undefined);
+  });
+
+  it("pauses an idle schedule before removing it", async () => {
+    await removeLocalSchedule("daily-report");
+
+    expect(getClient).toHaveBeenCalledOnce();
+    expect(mocks.pause).toHaveBeenCalledWith({ scheduleId: "daily-report" });
+    expect(mocks.remove).toHaveBeenCalledWith({ scheduleId: "daily-report" });
+    expect(mocks.unpause).not.toHaveBeenCalled();
+  });
+
+  it("restores the prior state when removal fails", async () => {
+    mocks.remove.mockRejectedValue(new Error("delete failed"));
+
+    await expect(removeLocalSchedule("daily-report")).rejects.toThrow(
+      "delete failed",
+    );
+    expect(mocks.unpause).toHaveBeenCalledWith({ scheduleId: "daily-report" });
+  });
+
+  it("does not alter an already-paused schedule when removal fails", async () => {
+    mocks.list.mockResolvedValue({
+      jobs: [{ id: "daily-report", paused: true, currentlyRunning: false }],
+    });
+    mocks.remove.mockRejectedValue(new Error("delete failed"));
+
+    await expect(removeLocalSchedule("daily-report")).rejects.toThrow(
+      "delete failed",
+    );
+    expect(mocks.pause).not.toHaveBeenCalled();
+    expect(mocks.unpause).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/automations/api/localSchedules.ts
+++ b/src/features/automations/api/localSchedules.ts
@@ -1,0 +1,50 @@
+import { getClient } from "@/shared/api/acpConnection";
+import type { ScheduledJobDto } from "@aaif/goose-sdk";
+
+export const LOCAL_SCHEDULES_QUERY_KEY = ["local-goose-schedules"] as const;
+
+export async function listLocalSchedules(): Promise<ScheduledJobDto[]> {
+  const client = await getClient();
+  const response = await client.goose.GooseUnstableSchedulesList({});
+  return response.jobs;
+}
+
+export async function pauseLocalSchedule(scheduleId: string): Promise<void> {
+  const client = await getClient();
+  await client.goose.GooseUnstableSchedulesPause({ scheduleId });
+}
+
+export async function unpauseLocalSchedule(scheduleId: string): Promise<void> {
+  const client = await getClient();
+  await client.goose.GooseUnstableSchedulesUnpause({ scheduleId });
+}
+
+export async function removeLocalSchedule(scheduleId: string): Promise<void> {
+  const client = await getClient();
+  const { jobs } = await client.goose.GooseUnstableSchedulesList({});
+  const schedule = jobs.find((job) => job.id === scheduleId);
+  if (schedule?.currentlyRunning) {
+    throw new Error(
+      `Schedule "${scheduleId}" is still running. Stop the active run before removing it.`,
+    );
+  }
+  const pausedForRemoval = schedule != null && !schedule.paused;
+  if (pausedForRemoval) {
+    await client.goose.GooseUnstableSchedulesPause({ scheduleId });
+  }
+  try {
+    await client.goose.GooseUnstableSchedulesDelete({ scheduleId });
+  } catch (error) {
+    if (pausedForRemoval) {
+      await client.goose.GooseUnstableSchedulesUnpause({ scheduleId });
+    }
+    throw error;
+  }
+}
+
+export async function killLocalScheduleRun(scheduleId: string): Promise<void> {
+  const client = await getClient();
+  await client.goose.GooseUnstableSchedulesRunningJobKill({
+    jobId: scheduleId,
+  });
+}

--- a/src/features/automations/ui/AutomationsView.test.tsx
+++ b/src/features/automations/ui/AutomationsView.test.tsx
@@ -13,6 +13,12 @@ import {
   updateAutomationTile,
 } from "@/features/automations/api/kgooseAutomations";
 import {
+  listLocalSchedules,
+  killLocalScheduleRun,
+  pauseLocalSchedule,
+  removeLocalSchedule,
+} from "@/features/automations/api/localSchedules";
+import {
   TopBarActionsProvider,
   useTopBarActions,
 } from "@/app/contexts/TopBarActionsContext";
@@ -42,6 +48,15 @@ vi.mock("@/features/automations/api/kgooseAutomations", () => ({
   updateAutomationTile: vi.fn(),
   deleteAutomationTile: vi.fn(),
   refreshAutomationTile: vi.fn(),
+}));
+
+vi.mock("@/features/automations/api/localSchedules", () => ({
+  LOCAL_SCHEDULES_QUERY_KEY: ["local-goose-schedules"],
+  listLocalSchedules: vi.fn(),
+  pauseLocalSchedule: vi.fn(),
+  unpauseLocalSchedule: vi.fn(),
+  removeLocalSchedule: vi.fn(),
+  killLocalScheduleRun: vi.fn(),
 }));
 
 vi.mock("@/features/automations/ui/AutomationBuilderView", () => ({
@@ -108,6 +123,10 @@ describe("AutomationsView", () => {
   beforeEach(() => {
     resetHomeWidgetStoreForTests();
     vi.clearAllMocks();
+    vi.mocked(listLocalSchedules).mockResolvedValue([]);
+    vi.mocked(pauseLocalSchedule).mockResolvedValue(undefined);
+    vi.mocked(removeLocalSchedule).mockResolvedValue(undefined);
+    vi.mocked(killLocalScheduleRun).mockResolvedValue(undefined);
     vi.mocked(getAutomationTiles).mockResolvedValue({
       tiles: [
         {
@@ -236,6 +255,70 @@ describe("AutomationsView", () => {
     expect(screen.getByText("Revenue was up.")).toBeInTheDocument();
   });
 
+  it("shows and controls local Goose schedules through the live scheduler", async () => {
+    const user = userEvent.setup({ delay: null });
+    vi.mocked(listLocalSchedules).mockResolvedValue([
+      {
+        id: "daily-report",
+        source: "/recipes/daily-report.yaml",
+        cron: "0 9 * * *",
+        lastRun: null,
+        currentlyRunning: false,
+        paused: false,
+        currentSessionId: null,
+        jobStartTime: null,
+      },
+    ]);
+
+    renderAutomationsView();
+
+    expect(await screen.findByText("Local schedules")).toBeInTheDocument();
+    expect(screen.getByText("daily-report")).toBeInTheDocument();
+    expect(screen.getByText("0 9 * * *")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Pause" }));
+    await waitFor(() =>
+      expect(pauseLocalSchedule).toHaveBeenCalledWith("daily-report"),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove schedule" }));
+    expect(
+      await screen.findByText(/Remove local schedule "daily-report"\?/),
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Remove schedule" }));
+    await waitFor(() =>
+      expect(removeLocalSchedule).toHaveBeenCalledWith("daily-report"),
+    );
+  });
+
+  it("stops the active run without removing its local schedule", async () => {
+    const user = userEvent.setup({ delay: null });
+    vi.mocked(listLocalSchedules).mockResolvedValue([
+      {
+        id: "running-report",
+        source: "/recipes/running-report.yaml",
+        cron: "0 9 * * *",
+        lastRun: null,
+        currentlyRunning: true,
+        paused: false,
+        currentSessionId: "session-1",
+        jobStartTime: "2026-08-28T09:00:00Z",
+      },
+    ]);
+
+    renderAutomationsView();
+
+    expect(await screen.findByRole("button", { name: "Pause" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove schedule" }),
+    ).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Stop run" }));
+    await waitFor(() =>
+      expect(killLocalScheduleRun).toHaveBeenCalledWith("running-report"),
+    );
+    expect(removeLocalSchedule).not.toHaveBeenCalled();
+  });
+
   it("renders markdown emphasis in overview summaries", async () => {
     vi.mocked(getAutomationTiles).mockResolvedValue({
       tiles: [
@@ -255,6 +338,19 @@ describe("AutomationsView", () => {
     const emphasizedText = await screen.findByText("Great Blue Heron");
     expect(emphasizedText.tagName).toBe("STRONG");
     expect(screen.queryByText(/\*\*Great Blue Heron\*\*/)).toBeNull();
+  });
+
+  it("surfaces local schedule load failures", async () => {
+    vi.mocked(listLocalSchedules).mockRejectedValue(
+      new Error("Live scheduler unavailable"),
+    );
+
+    renderAutomationsView();
+
+    expect(
+      await screen.findByText("Local schedules failed to load"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Live scheduler unavailable")).toBeInTheDocument();
   });
 
   it("opens automation details from the overview", async () => {

--- a/src/features/automations/ui/AutomationsView.tsx
+++ b/src/features/automations/ui/AutomationsView.tsx
@@ -28,8 +28,17 @@ import {
 import { AutomationBuilderView } from "@/features/automations/ui/AutomationBuilderView";
 import type { AutomationBuilderLeaveAction } from "@/features/automations/ui/AutomationBuilderView";
 import { AutomationDetailPage } from "@/features/automations/ui/AutomationDetailPage";
+import {
+  killLocalScheduleRun,
+  listLocalSchedules,
+  LOCAL_SCHEDULES_QUERY_KEY,
+  pauseLocalSchedule,
+  removeLocalSchedule,
+  unpauseLocalSchedule,
+} from "@/features/automations/api/localSchedules";
 import { AutomationHistoryFeed } from "@/features/automations/ui/AutomationHistoryFeed";
 import { AutomationsOverview } from "@/features/automations/ui/AutomationsOverview";
+import { LocalSchedulesPanel } from "@/features/automations/ui/LocalSchedulesPanel";
 import { EmptyState } from "@/features/automations/ui/RunOutput";
 import { Badge } from "@/shared/ui/badge";
 import { PageHeaderButton } from "@/shared/ui/page-header-button";
@@ -112,6 +121,9 @@ export function AutomationsWorkbench({
     null,
   );
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [removeLocalScheduleId, setRemoveLocalScheduleId] = useState<
+    string | null
+  >(null);
 
   const setNavigationRoute = useCallback(
     (
@@ -138,6 +150,16 @@ export function AutomationsWorkbench({
   });
 
   const automations = useMemo(() => automationsData ?? [], [automationsData]);
+  const {
+    data: localSchedules = [],
+    error: localSchedulesError,
+    isLoading: isLocalSchedulesLoading,
+    refetch: refetchLocalSchedules,
+  } = useQuery({
+    queryKey: LOCAL_SCHEDULES_QUERY_KEY,
+    queryFn: listLocalSchedules,
+    refetchInterval: AUTOMATIONS_REFETCH_INTERVAL_MS,
+  });
 
   useEffect(() => {
     if (!automations.length) {
@@ -348,6 +370,38 @@ export function AutomationsWorkbench({
     },
   });
 
+  const localScheduleMutation = useMutation({
+    mutationFn: async ({
+      action,
+      scheduleId,
+    }: {
+      action: "pause" | "unpause" | "kill" | "remove";
+      scheduleId: string;
+    }) => {
+      switch (action) {
+        case "pause":
+          return pauseLocalSchedule(scheduleId);
+        case "unpause":
+          return unpauseLocalSchedule(scheduleId);
+        case "kill":
+          return killLocalScheduleRun(scheduleId);
+        case "remove":
+          return removeLocalSchedule(scheduleId);
+      }
+    },
+    onSuccess: async () => {
+      setRemoveLocalScheduleId(null);
+      await queryClient.invalidateQueries({
+        queryKey: LOCAL_SCHEDULES_QUERY_KEY,
+      });
+    },
+    onError: (error) => {
+      toast.error(t("localSchedules.actionError"), {
+        description: errorMessage(error, t("localSchedules.actionError")),
+      });
+    },
+  });
+
   const duplicateMutation = useMutation({
     mutationFn: (tile: AutomationTile) => {
       const request = buildDuplicateAutomationRequest(
@@ -463,7 +517,10 @@ export function AutomationsWorkbench({
       <>
         <PageHeaderButton
           type="button"
-          onClick={() => refetchAutomations()}
+          onClick={() => {
+            void refetchAutomations();
+            void refetchLocalSchedules();
+          }}
           aria-label={t("actions.refresh")}
           tooltip={t("actions.refresh")}
           leftIcon={<IconRefresh aria-hidden="true" />}
@@ -490,6 +547,7 @@ export function AutomationsWorkbench({
     openBuilder,
     refetchAutomations,
     refetchDetail,
+    refetchLocalSchedules,
     refreshMutate,
     setTopBarActions,
     t,
@@ -623,7 +681,49 @@ export function AutomationsWorkbench({
               </TabsTrigger>
             </TabsList>
 
-            <TabsContent value="overview" className="mt-6">
+            <TabsContent value="overview" className="mt-6 space-y-6">
+              {isLocalSchedulesLoading ? (
+                <div
+                  role="status"
+                  className="h-[74px] rounded-xl border bg-card"
+                  aria-label={t("localSchedules.loading")}
+                />
+              ) : localSchedulesError ? (
+                <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+                  <div className="font-medium">
+                    {t("localSchedules.loadErrorTitle")}
+                  </div>
+                  <div className="mt-1 text-xs">
+                    {errorMessage(
+                      localSchedulesError,
+                      t("localSchedules.loadErrorDescription"),
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <LocalSchedulesPanel
+                  schedules={localSchedules}
+                  actions={{
+                    pending: localScheduleMutation.isPending,
+                    onPause: (scheduleId) =>
+                      localScheduleMutation.mutate({
+                        action: "pause",
+                        scheduleId,
+                      }),
+                    onUnpause: (scheduleId) =>
+                      localScheduleMutation.mutate({
+                        action: "unpause",
+                        scheduleId,
+                      }),
+                    onKill: (scheduleId) =>
+                      localScheduleMutation.mutate({
+                        action: "kill",
+                        scheduleId,
+                      }),
+                    onRemove: setRemoveLocalScheduleId,
+                  }}
+                />
+              )}
               {isAutomationsLoading ? (
                 <div className="space-y-3">
                   <div className="h-[86px] rounded-md bg-card" />
@@ -643,12 +743,12 @@ export function AutomationsWorkbench({
                   automations={automations}
                   onOpenDetail={openDetail}
                 />
-              ) : (
+              ) : localSchedules.length === 0 && !localSchedulesError ? (
                 <EmptyState
                   title={t("list.emptyTitle")}
                   body={t("list.emptyBody")}
                 />
-              )}
+              ) : null}
             </TabsContent>
 
             <TabsContent value="history" className="mt-6">
@@ -676,6 +776,29 @@ export function AutomationsWorkbench({
           </Tabs>
         )}
       </PageShell>
+
+      <ConfirmDialog
+        open={Boolean(removeLocalScheduleId)}
+        onOpenChange={(open) => {
+          if (!open) setRemoveLocalScheduleId(null);
+        }}
+        title={t("localSchedules.removeTitle")}
+        description={t("localSchedules.removeDescription", {
+          name: removeLocalScheduleId,
+        })}
+        cancelLabel={t("actions.cancel")}
+        confirmLabel={t("localSchedules.remove")}
+        loadingLabel={t("actions.deleting")}
+        isLoading={localScheduleMutation.isPending}
+        onConfirm={() => {
+          if (removeLocalScheduleId) {
+            localScheduleMutation.mutate({
+              action: "remove",
+              scheduleId: removeLocalScheduleId,
+            });
+          }
+        }}
+      />
 
       <ConfirmDialog
         open={Boolean(deleteAutomationId)}

--- a/src/features/automations/ui/LocalSchedulesPanel.tsx
+++ b/src/features/automations/ui/LocalSchedulesPanel.tsx
@@ -1,0 +1,108 @@
+import type { ScheduledJobDto } from "@aaif/goose-sdk";
+import { useTranslation } from "react-i18next";
+import {
+  IconPlayerPause,
+  IconPlayerPlay,
+  IconPlayerStop,
+  IconTrash,
+} from "@tabler/icons-react";
+import { Button } from "@/shared/ui/button";
+
+export interface LocalScheduleActions {
+  onPause: (scheduleId: string) => void;
+  onUnpause: (scheduleId: string) => void;
+  onKill: (scheduleId: string) => void;
+  onRemove: (scheduleId: string) => void;
+  pending: boolean;
+}
+
+export function LocalSchedulesPanel({
+  schedules,
+  actions,
+}: {
+  schedules: ScheduledJobDto[];
+  actions: LocalScheduleActions;
+}) {
+  const { t } = useTranslation("automations");
+  if (schedules.length === 0) return null;
+
+  return (
+    <section aria-labelledby="local-schedules-heading" className="space-y-3">
+      <div>
+        <h2 id="local-schedules-heading" className="text-sm font-medium">
+          {t("localSchedules.title")}
+        </h2>
+        <p className="text-xs text-muted-foreground">
+          {t("localSchedules.description")}
+        </p>
+      </div>
+      <div className="divide-y rounded-xl border bg-card">
+        {schedules.map((schedule) => (
+          <div
+            key={schedule.id}
+            className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+          >
+            <div className="min-w-0">
+              <div className="truncate text-sm font-medium">{schedule.id}</div>
+              <div className="text-xs text-muted-foreground">
+                {schedule.cron}
+                {schedule.paused ? ` · ${t("localSchedules.paused")}` : ""}
+                {schedule.currentlyRunning
+                  ? ` · ${t("localSchedules.running")}`
+                  : ""}
+              </div>
+            </div>
+            <div className="flex items-center gap-1.5">
+              {schedule.paused ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  disabled={actions.pending}
+                  onClick={() => actions.onUnpause(schedule.id)}
+                >
+                  <IconPlayerPlay aria-hidden="true" />
+                  {t("localSchedules.resume")}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  disabled={actions.pending || schedule.currentlyRunning}
+                  onClick={() => actions.onPause(schedule.id)}
+                >
+                  <IconPlayerPause aria-hidden="true" />
+                  {t("localSchedules.pause")}
+                </Button>
+              )}
+              {schedule.currentlyRunning ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  disabled={actions.pending}
+                  onClick={() => actions.onKill(schedule.id)}
+                >
+                  <IconPlayerStop aria-hidden="true" />
+                  {t("localSchedules.kill")}
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                destructive
+                disabled={actions.pending || schedule.currentlyRunning}
+                onClick={() => actions.onRemove(schedule.id)}
+              >
+                <IconTrash aria-hidden="true" />
+                {t("localSchedules.remove")}
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -73,6 +73,11 @@ const mocks = vi.hoisted(() => ({
   createSkill: vi.fn(),
   listSkills: vi.fn(),
   getVoiceConversationStatus: vi.fn(),
+  listSchedules: vi.fn(),
+  deleteSchedule: vi.fn(),
+  pauseSchedule: vi.fn(),
+  unpauseSchedule: vi.fn(),
+  killSchedule: vi.fn(),
 }));
 
 vi.mock("@/shared/api/acp", () => ({
@@ -115,6 +120,22 @@ vi.mock(
   },
 );
 
+vi.mock("@/shared/api/acpConnection", () => ({
+  getClient: vi.fn(async () => ({
+    goose: {
+      GooseUnstableSchedulesList: (...args: unknown[]) =>
+        mocks.listSchedules(...args),
+      GooseUnstableSchedulesDelete: (...args: unknown[]) =>
+        mocks.deleteSchedule(...args),
+      GooseUnstableSchedulesPause: (...args: unknown[]) =>
+        mocks.pauseSchedule(...args),
+      GooseUnstableSchedulesUnpause: (...args: unknown[]) =>
+        mocks.unpauseSchedule(...args),
+      GooseUnstableSchedulesRunningJobKill: (...args: unknown[]) =>
+        mocks.killSchedule(...args),
+    },
+  })),
+}));
 vi.mock("@/features/chat/lib/sessionActivation", () => ({
   loadSessionMessages: (...args: unknown[]) =>
     mocks.loadSessionMessages(...args),
@@ -612,6 +633,11 @@ describe("action schemas", () => {
       "projects.get": { project_id: "p1" },
       "projects.set_startup_mode": { project_id: "p1", mode: "worktree" },
       "projects.archive": { project_id: "p1" },
+      "schedules.list": {},
+      "schedules.pause": { schedule_id: "daily-report" },
+      "schedules.unpause": { schedule_id: "daily-report" },
+      "schedules.kill": { schedule_id: "daily-report" },
+      "schedules.remove": { schedule_id: "daily-report", confirm: true },
       "agents.create": { name: "Agent", system_prompt: "Be helpful" },
       "agents.list": {},
       "skills.create": { name: "Skill", description: "Does X", content: "#" },
@@ -3914,6 +3940,190 @@ describe("skills", () => {
       dispatchCommand("skills", { action: "get", skill_id: "nope" }, ctx),
       "skill_not_found",
     );
+  });
+});
+
+describe("schedules", () => {
+  it("lists jobs from the live embedded Goose scheduler", async () => {
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [
+        {
+          id: "daily-report",
+          source: "/recipes/daily-report.yaml",
+          cron: "0 9 * * *",
+          lastRun: "2026-08-28T09:00:00Z",
+          currentlyRunning: true,
+          paused: false,
+          currentSessionId: "session-1",
+          jobStartTime: "2026-08-28T09:00:01Z",
+        },
+      ],
+    });
+
+    await expect(
+      dispatchCommand("schedules", { action: "list" }, ctx),
+    ).resolves.toEqual({
+      schedules: [
+        {
+          id: "daily-report",
+          source: "/recipes/daily-report.yaml",
+          cron: "0 9 * * *",
+          last_run: "2026-08-28T09:00:00Z",
+          currently_running: true,
+          paused: false,
+          current_session_id: "session-1",
+          job_start_time: "2026-08-28T09:00:01Z",
+        },
+      ],
+    });
+    expect(mocks.listSchedules).toHaveBeenCalledWith({});
+  });
+
+  it("pauses before removing a schedule through the live scheduler client", async () => {
+    mocks.pauseSchedule.mockResolvedValue(undefined);
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [{ id: "daily-report", currentlyRunning: false }],
+    });
+    mocks.deleteSchedule.mockResolvedValue(undefined);
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "remove", schedule_id: "daily-report", confirm: true },
+        ctx,
+      ),
+    ).resolves.toEqual({ ok: true, schedule_id: "daily-report" });
+    expect(mocks.pauseSchedule).toHaveBeenCalledWith({
+      scheduleId: "daily-report",
+    });
+    expect(mocks.deleteSchedule).toHaveBeenCalledWith({
+      scheduleId: "daily-report",
+    });
+  });
+
+  it("restores the pause state when schedule removal fails", async () => {
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [
+        {
+          id: "daily-report",
+          paused: false,
+          currentlyRunning: false,
+        },
+      ],
+    });
+    mocks.pauseSchedule.mockResolvedValue(undefined);
+    mocks.deleteSchedule.mockRejectedValue(new Error("delete failed"));
+    mocks.unpauseSchedule.mockResolvedValue(undefined);
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "remove", schedule_id: "daily-report", confirm: true },
+        ctx,
+      ),
+    ).rejects.toThrow("delete failed");
+    expect(mocks.unpauseSchedule).toHaveBeenCalledWith({
+      scheduleId: "daily-report",
+    });
+  });
+
+  it("refuses to remove a schedule while its run is active", async () => {
+    mocks.pauseSchedule.mockResolvedValue(undefined);
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [{ id: "daily-report", currentlyRunning: true }],
+    });
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "remove", schedule_id: "daily-report", confirm: true },
+        ctx,
+      ),
+    ).rejects.toThrow("Stop the active run");
+    expect(mocks.deleteSchedule).not.toHaveBeenCalled();
+  });
+
+  it("refuses schedule removal without explicit confirmation", async () => {
+    await expectCommandError(
+      dispatchCommand(
+        "schedules",
+        { action: "remove", schedule_id: "daily-report" },
+        ctx,
+      ),
+      "confirmation_required",
+    );
+    expect(mocks.deleteSchedule).not.toHaveBeenCalled();
+  });
+
+  it("pauses and unpauses through the live scheduler client", async () => {
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [{ id: "daily-report", currentlyRunning: false }],
+    });
+    mocks.pauseSchedule.mockResolvedValue(undefined);
+    mocks.unpauseSchedule.mockResolvedValue(undefined);
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "pause", schedule_id: "daily-report" },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      schedule_id: "daily-report",
+      paused: true,
+    });
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "unpause", schedule_id: "daily-report" },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      schedule_id: "daily-report",
+      paused: false,
+    });
+    expect(mocks.pauseSchedule).toHaveBeenCalledWith({
+      scheduleId: "daily-report",
+    });
+    expect(mocks.unpauseSchedule).toHaveBeenCalledWith({
+      scheduleId: "daily-report",
+    });
+  });
+
+  it("refuses to pause a schedule while its run is active", async () => {
+    mocks.listSchedules.mockResolvedValue({
+      jobs: [{ id: "daily-report", currentlyRunning: true }],
+    });
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "pause", schedule_id: "daily-report" },
+        ctx,
+      ),
+    ).rejects.toThrow("Stop the active run");
+    expect(mocks.pauseSchedule).not.toHaveBeenCalled();
+  });
+
+  it("kills only the active run and leaves the schedule registered", async () => {
+    mocks.killSchedule.mockResolvedValue({ message: "Scheduled job stopped" });
+
+    await expect(
+      dispatchCommand(
+        "schedules",
+        { action: "kill", schedule_id: "daily-report" },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      schedule_id: "daily-report",
+      message: "Scheduled job stopped",
+    });
+    expect(mocks.killSchedule).toHaveBeenCalledWith({
+      jobId: "daily-report",
+    });
   });
 });
 

--- a/src/features/berdctl/appPreamble.ts
+++ b/src/features/berdctl/appPreamble.ts
@@ -24,6 +24,7 @@ Usage: berdctl <noun> <verb> [--json]
 - session: create, send, open, list, get, rename, fork, archive, move
 - folder: attach, detach, replace, set-cwd, list
 - project: create, list, get, archive
+- schedule: list, pause, unpause, kill, remove
 - agent: create, list
 - skill: create, list, get
 - info: context, harnesses, models

--- a/src/features/berdctl/commands/impl/killSchedule.ts
+++ b/src/features/berdctl/commands/impl/killSchedule.ts
@@ -1,0 +1,34 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+
+const killScheduleSchema = z
+  .object({
+    schedule_id: z
+      .string()
+      .min(1)
+      .describe("Id of the scheduled recipe job whose active run should stop."),
+  })
+  .strict();
+
+export const killScheduleCommand = defineCommand({
+  effect: "update",
+  visibility: "discoverable",
+  destructive: false,
+  summary: "Stop the active run of a scheduled recipe job",
+  description:
+    "Stop the current run of a scheduled recipe job through Berd's live Goose scheduler. The schedule itself remains registered and can run again later; use remove or pause when future runs must also stop.",
+  helpFooter: `Examples:
+  berdctl schedule kill --schedule-id daily-report
+  berdctl schedule kill --schedule-id daily-report && \\
+    berdctl schedule remove --schedule-id daily-report --confirm
+
+Result:
+  {"ok": true, "schedule_id": "daily-report", "message": "..."}`,
+  schema: killScheduleSchema,
+  execute: async (args) => {
+    const { killLiveSchedule } = await import("../runtime/schedules");
+    const message = await killLiveSchedule(args.schedule_id);
+    return { ok: true as const, schedule_id: args.schedule_id, message };
+  },
+});

--- a/src/features/berdctl/commands/impl/listSchedules.ts
+++ b/src/features/berdctl/commands/impl/listSchedules.ts
@@ -1,0 +1,27 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+
+const listSchedulesSchema = z.object({}).strict();
+
+export const listSchedulesCommand = defineCommand({
+  effect: "read",
+  visibility: "none",
+  destructive: false,
+  summary: "List scheduled recipe jobs from Berd's live Goose scheduler",
+  description:
+    "List scheduled recipe jobs from the live Goose scheduler embedded in Berd. Unlike a separate goose schedule process, this reads the scheduler instance that is actually running the jobs and does not change app state.",
+  helpFooter: `Example:
+  berdctl schedule list --json
+
+Result:
+  {"schedules": [{"id": "daily-report", "cron": "0 9 * * *",
+                   "paused": false, "currently_running": false,
+                   "source": "...", "last_run": null,
+                   "current_session_id": null, "job_start_time": null}]}`,
+  schema: listSchedulesSchema,
+  execute: async () => {
+    const { listLiveSchedules } = await import("../runtime/schedules");
+    return { schedules: await listLiveSchedules() };
+  },
+});

--- a/src/features/berdctl/commands/impl/pauseSchedule.ts
+++ b/src/features/berdctl/commands/impl/pauseSchedule.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+
+const pauseScheduleSchema = z
+  .object({
+    schedule_id: z
+      .string()
+      .min(1)
+      .describe("Id of the scheduled recipe job to pause."),
+  })
+  .strict();
+
+export const pauseScheduleCommand = defineCommand({
+  effect: "update",
+  visibility: "discoverable",
+  destructive: false,
+  summary: "Pause a job in Berd's live Goose scheduler",
+  description:
+    "Pause an idle scheduled recipe job through the live Goose scheduler embedded in Berd. Future scheduled runs stop until the job is unpaused. If a run is active, stop it first with berdctl schedule kill.",
+  helpFooter: `Example:
+  berdctl schedule pause --schedule-id daily-report
+
+Result:
+  {"ok": true, "schedule_id": "daily-report", "paused": true}`,
+  schema: pauseScheduleSchema,
+  execute: async (args) => {
+    const { pauseLiveSchedule } = await import("../runtime/schedules");
+    await pauseLiveSchedule(args.schedule_id);
+    return { ok: true as const, schedule_id: args.schedule_id, paused: true };
+  },
+});

--- a/src/features/berdctl/commands/impl/removeSchedule.ts
+++ b/src/features/berdctl/commands/impl/removeSchedule.ts
@@ -1,0 +1,48 @@
+import { z } from "zod/v4";
+
+import { CommandError, defineCommand } from "../types";
+
+const removeScheduleSchema = z
+  .object({
+    schedule_id: z
+      .string()
+      .min(1)
+      .describe("Id of the scheduled recipe job to remove."),
+    confirm: z
+      .boolean()
+      .default(false)
+      .describe(
+        "Confirm removal of the schedule registration. The saved recipe file is kept.",
+      ),
+  })
+  .strict();
+
+export const removeScheduleCommand = defineCommand({
+  effect: "archive",
+  visibility: "discoverable",
+  destructive: false,
+  summary: "Remove a job from Berd's live Goose scheduler",
+  description:
+    "Remove a scheduled recipe job through the live Goose scheduler embedded in Berd. This updates the scheduler that is actually running jobs, so a stale in-memory copy cannot restore the deleted schedule. The saved recipe file is kept.",
+  helpFooter: `Example:
+  berdctl schedule remove --schedule-id daily-report --confirm
+
+Result:
+  {"ok": true, "schedule_id": "daily-report"}
+
+If the job is currently running, use berdctl schedule kill first when you also need to stop that active run.`,
+  schema: removeScheduleSchema,
+  precheck: (args) => {
+    if (!args.confirm) {
+      throw new CommandError(
+        "confirmation_required",
+        `Refusing to remove schedule "${args.schedule_id}" without --confirm. The saved recipe file will be kept.`,
+      );
+    }
+  },
+  execute: async (args) => {
+    const { deleteLiveSchedule } = await import("../runtime/schedules");
+    await deleteLiveSchedule(args.schedule_id);
+    return { ok: true as const, schedule_id: args.schedule_id };
+  },
+});

--- a/src/features/berdctl/commands/impl/unpauseSchedule.ts
+++ b/src/features/berdctl/commands/impl/unpauseSchedule.ts
@@ -1,0 +1,32 @@
+import { z } from "zod/v4";
+
+import { defineCommand } from "../types";
+
+const unpauseScheduleSchema = z
+  .object({
+    schedule_id: z
+      .string()
+      .min(1)
+      .describe("Id of the scheduled recipe job to unpause."),
+  })
+  .strict();
+
+export const unpauseScheduleCommand = defineCommand({
+  effect: "update",
+  visibility: "discoverable",
+  destructive: false,
+  summary: "Resume a paused job in Berd's live Goose scheduler",
+  description:
+    "Unpause a scheduled recipe job through the live Goose scheduler embedded in Berd. Future runs resume on the job's existing cron schedule.",
+  helpFooter: `Example:
+  berdctl schedule unpause --schedule-id daily-report
+
+Result:
+  {"ok": true, "schedule_id": "daily-report", "paused": false}`,
+  schema: unpauseScheduleSchema,
+  execute: async (args) => {
+    const { unpauseLiveSchedule } = await import("../runtime/schedules");
+    await unpauseLiveSchedule(args.schedule_id);
+    return { ok: true as const, schedule_id: args.schedule_id, paused: false };
+  },
+});

--- a/src/features/berdctl/commands/registry.ts
+++ b/src/features/berdctl/commands/registry.ts
@@ -21,16 +21,21 @@ import { listAgentsCommand } from "./impl/listAgents";
 import { listHarnessesCommand } from "./impl/listHarnesses";
 import { listModelsCommand } from "./impl/listModels";
 import { listProjectsCommand } from "./impl/listProjects";
+import { listSchedulesCommand } from "./impl/listSchedules";
 import { listSessionsCommand } from "./impl/listSessions";
 import { listSkillsCommand } from "./impl/listSkills";
 import { moveSessionCommand } from "./impl/moveSession";
 import { moveSessionToGroupCommand } from "./impl/moveSessionToGroup";
 import { openFeedbackCommand } from "./impl/openFeedback";
 import { openSessionCommand } from "./impl/openSession";
+import { pauseScheduleCommand } from "./impl/pauseSchedule";
+import { removeScheduleCommand } from "./impl/removeSchedule";
 import { renameSessionCommand } from "./impl/renameSession";
 import { sendSessionCommand } from "./impl/sendSession";
 import { setProjectStartupModeCommand } from "./impl/setProjectStartupMode";
 import { submitFeedbackCommand } from "./impl/submitFeedback";
+import { unpauseScheduleCommand } from "./impl/unpauseSchedule";
+import { killScheduleCommand } from "./impl/killSchedule";
 import { commandBridgeTimeoutMs } from "./timeouts";
 import { CommandError, type CommandContext, type ToolGroup } from "./types";
 
@@ -131,6 +136,29 @@ export const ALL_TOOL_GROUPS = {
       get: getProjectCommand,
       set_startup_mode: setProjectStartupModeCommand,
       archive: archiveProjectCommand,
+    },
+  },
+  schedules: {
+    description:
+      "Manage scheduled recipe jobs in Berd's live embedded Goose scheduler: list, pause, unpause, kill an active run, or remove a schedule.",
+    cli: {
+      noun: "schedule",
+      about:
+        "Manage jobs in Berd's live Goose scheduler: list, pause, unpause, kill, remove",
+      verbs: {
+        list: "list",
+        pause: "pause",
+        unpause: "unpause",
+        kill: "kill",
+        remove: "remove",
+      },
+    },
+    actions: {
+      list: listSchedulesCommand,
+      pause: pauseScheduleCommand,
+      unpause: unpauseScheduleCommand,
+      kill: killScheduleCommand,
+      remove: removeScheduleCommand,
     },
   },
   agents: {

--- a/src/features/berdctl/commands/runtime/schedules.ts
+++ b/src/features/berdctl/commands/runtime/schedules.ts
@@ -1,0 +1,91 @@
+import type { ScheduledJobDto } from "@aaif/goose-sdk";
+
+import { getClient } from "@/shared/api/acpConnection";
+
+export interface BerdctlSchedule {
+  id: string;
+  source: string;
+  cron: string;
+  last_run: string | null;
+  currently_running: boolean;
+  paused: boolean;
+  current_session_id: string | null;
+  job_start_time: string | null;
+}
+
+function normalizeSchedule(job: ScheduledJobDto): BerdctlSchedule {
+  return {
+    id: job.id,
+    source: job.source,
+    cron: job.cron,
+    last_run: job.lastRun ?? null,
+    currently_running: job.currentlyRunning,
+    paused: job.paused,
+    current_session_id: job.currentSessionId ?? null,
+    job_start_time: job.jobStartTime ?? null,
+  };
+}
+
+export async function listLiveSchedules(): Promise<BerdctlSchedule[]> {
+  const client = await getClient();
+  const response = await client.goose.GooseUnstableSchedulesList({});
+  return response.jobs.map(normalizeSchedule);
+}
+
+async function requireIdleSchedule(
+  scheduleId: string,
+  remediation: string,
+): Promise<{
+  client: Awaited<ReturnType<typeof getClient>>;
+  schedule: ScheduledJobDto | undefined;
+}> {
+  const client = await getClient();
+  const response = await client.goose.GooseUnstableSchedulesList({});
+  const schedule = response.jobs.find((job) => job.id === scheduleId);
+  if (schedule?.currentlyRunning) {
+    throw new Error(
+      `Schedule "${scheduleId}" is still running. ${remediation}`,
+    );
+  }
+  return { client, schedule };
+}
+
+export async function deleteLiveSchedule(scheduleId: string): Promise<void> {
+  const { client, schedule } = await requireIdleSchedule(
+    scheduleId,
+    `Stop the active run with \`berdctl schedule kill --schedule-id ${scheduleId}\` before removing it.`,
+  );
+  const pausedForRemoval = schedule != null && !schedule.paused;
+  if (pausedForRemoval) {
+    await client.goose.GooseUnstableSchedulesPause({ scheduleId });
+  }
+  try {
+    await client.goose.GooseUnstableSchedulesDelete({ scheduleId });
+  } catch (error) {
+    if (pausedForRemoval) {
+      await client.goose.GooseUnstableSchedulesUnpause({ scheduleId });
+    }
+    throw error;
+  }
+}
+
+export async function pauseLiveSchedule(scheduleId: string): Promise<void> {
+  const { client } = await requireIdleSchedule(
+    scheduleId,
+    `Stop the active run with \`berdctl schedule kill --schedule-id ${scheduleId}\` before pausing it.`,
+  );
+  await client.goose.GooseUnstableSchedulesPause({ scheduleId });
+}
+
+export async function unpauseLiveSchedule(scheduleId: string): Promise<void> {
+  const client = await getClient();
+  await client.goose.GooseUnstableSchedulesUnpause({ scheduleId });
+}
+
+export async function killLiveSchedule(scheduleId: string): Promise<string> {
+  const client = await getClient();
+  const response = await client.goose.GooseUnstableSchedulesRunningJobKill({
+    jobId: scheduleId,
+  });
+  return response.message;
+}

--- a/src/features/berdctl/commands/types.ts
+++ b/src/features/berdctl/commands/types.ts
@@ -78,6 +78,7 @@ export const COMMAND_ERROR_CODES = [
   "harness_not_ready",
   "model_not_found",
   "blocked_unsaved_changes",
+  "confirmation_required",
   "backend_read_failed",
   "backend_archive_failed",
   "voice_stop_failed",

--- a/src/shared/i18n/locales/en/automations.json
+++ b/src/shared/i18n/locales/en/automations.json
@@ -167,6 +167,22 @@
     "errorDescription": "The automation could not be started. Please try again.",
     "started": "Automation started"
   },
+  "localSchedules": {
+    "actionError": "Failed to update local schedule.",
+    "description": "Recipe jobs run by Goose inside Berd on this computer.",
+    "kill": "Stop run",
+    "loadErrorDescription": "Berd could not read the local Goose scheduler.",
+    "loadErrorTitle": "Local schedules failed to load",
+    "loading": "Loading local schedules",
+    "paused": "Paused",
+    "pause": "Pause",
+    "remove": "Remove schedule",
+    "removeDescription": "Remove local schedule \"{{name}}\"? The saved recipe file is kept.",
+    "removeTitle": "Remove local schedule",
+    "resume": "Resume",
+    "running": "Running",
+    "title": "Local schedules"
+  },
   "list": {
     "ariaLabel": "Automation list",
     "emptyBody": "Create your first automation to schedule recurring work.",

--- a/src/shared/i18n/locales/es/automations.json
+++ b/src/shared/i18n/locales/es/automations.json
@@ -167,6 +167,22 @@
     "errorDescription": "No se pudo iniciar la automatizacion. Intentalo de nuevo.",
     "started": "Automatizacion iniciada"
   },
+  "localSchedules": {
+    "actionError": "No se pudo actualizar la programación local.",
+    "description": "Tareas de recetas que Goose ejecuta dentro de Berd en esta computadora.",
+    "kill": "Detener ejecución",
+    "loadErrorDescription": "Berd no pudo leer el programador local de Goose.",
+    "loadErrorTitle": "No se pudieron cargar las programaciones locales",
+    "loading": "Cargando programaciones locales",
+    "paused": "En pausa",
+    "pause": "Pausar",
+    "remove": "Eliminar programación",
+    "removeDescription": "¿Eliminar la programación local \"{{name}}\"? El archivo de receta guardado se conserva.",
+    "removeTitle": "Eliminar programación local",
+    "resume": "Reanudar",
+    "running": "En ejecución",
+    "title": "Programaciones locales"
+  },
   "list": {
     "ariaLabel": "Lista de automatizaciones",
     "emptyBody": "Crea tu primera automatización para programar trabajo recurrente.",


### PR DESCRIPTION
## Summary

- show local Goose schedules in Berd's Automations view
- pause, resume, stop active runs, and remove schedules through the live embedded scheduler
- expose the same controls as `berdctl schedule` commands
- require explicit confirmation for CLI schedule removal

## Why

Berd starts a long-lived `goosed --enable-scheduler` process, but local Goose schedules were invisible in Berd and could only be managed with a separate `goose schedule` CLI process. That creates split scheduler state: an out-of-process removal can update `schedule.json` while the embedded scheduler still holds the job in memory, allowing a later status write to restore the deleted job.

This change routes user and agent controls through Berd's live ACP client, so they operate on the scheduler instance that actually owns and runs the jobs.

## User-visible behavior

The Automations overview now has a **Local schedules** section. Each job shows its cron and running/paused state, with actions to:

- pause or resume future runs
- stop the active run without removing the schedule
- remove the schedule registration after confirmation (the saved recipe file is kept)

Agents get matching commands:

```text
berdctl schedule list
berdctl schedule pause --schedule-id <id>
berdctl schedule unpause --schedule-id <id>
berdctl schedule kill --schedule-id <id>
berdctl schedule remove --schedule-id <id> --confirm
```

## Validation

- `just check`
- `just test` — 6,000+ frontend tests pass
- `cargo test -p berdctl` — 52 passed, 1 ignored
- pre-push `fmt-check`, `check`, `tauri-check`, and `clippy` all pass

## Architectural laws

Read `LAWS/README.md`, `LAWS/AGENTS.md`, and `LAWS/CHAT.md`. This change does not alter agent invocation or composer queue behavior. The UI and CLI operate on the same live schedule state.
