### PR TITLE
perf(dev): reduce Rust debug build cost

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[profile.dev]
+# Preserve file and line information for backtraces while avoiding the cost of
+# generating per-variable debug information. Override with
+# CARGO_PROFILE_DEV_DEBUG=2 when inspecting locals in a native debugger.
+debug = "line-tables-only"

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ dist/
 
 # Editor / IDE
 .idea/
-.vscode/
+.vscode/*
+!.vscode/settings.json
 *.swp
 *.swo
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.targetDir": true
+}


### PR DESCRIPTION
## Summary

Use line-table-only debug information for local Rust builds. File and line backtraces remain available, while `CARGO_PROFILE_DEV_DEBUG=2` restores full debugger locals when needed.

Give Rust Analyzer its own target directory so background analysis does not contend with interactive Cargo builds in the same checkout.

## Verification

On a clean Blox checkout, `cargo build --manifest-path src-tauri/Cargo.toml --workspace` improved from 76.19 seconds and 7.8 GB with full debug information to 66.78 seconds and 4.9 GB with this configuration.
