### PR TITLE
fix(deps): bump js-yaml override to 4.3.2 to patch GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   uuid: '>=11.1.1 <12.0.0'
   hono: 4.12.34
   '@hono/node-server': 2.0.12
-  js-yaml: 4.3.0
+  js-yaml: 4.3.2
   path-to-regexp: '>=8.4.0'
   mermaid: 11.16.1
   fast-uri: 3.1.5
@@ -568,12 +568,14 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.9':
     resolution: {integrity: sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.9':
     resolution: {integrity: sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==}
@@ -2231,7 +2233,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.5':
     resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
@@ -2274,6 +2275,7 @@ packages:
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-win32-arm64-msvc@4.62.4':
     resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
@@ -4039,8 +4041,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -6079,7 +6081,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.2
 
   '@hey-api/openapi-ts@0.99.0(magicast@0.5.4)(typescript@5.9.3)':
     dependencies:
@@ -9217,7 +9219,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ overrides:
   uuid: ">=11.1.1 <12.0.0"
   hono: "4.12.34"
   "@hono/node-server": "2.0.12"
-  js-yaml: "4.3.0"
+  js-yaml: "4.3.2"
   path-to-regexp: ">=8.4.0"
   mermaid: "11.16.1"
   fast-uri: "3.1.5"


### PR DESCRIPTION
## Summary

`pnpm audit` surfaced one live high-severity finding. The `js-yaml` override in `pnpm-workspace.yaml` exact-pinned `4.3.0`, which is vulnerable to quadratic CPU consumption when resolving `!!omap` sequences (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870). Because it was an override, it force-pinned every consumer to the vulnerable release.

Bumped to `4.3.2`, the latest patched 4.x. Staying on 4.x keeps `@hey-api/json-schema-ref-parser` — the sole consumer — on the line it declares; 5.x is an API-breaking rewrite.

## Validation

- `pnpm audit` reports no known vulnerabilities
- SDK OpenAPI codegen output is byte-identical
- `just check`, `just test` (7268 tests), and `just build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)