### PR TITLE
fix(sidebar): always show "View all chats" when more sessions exist

### DIFF
--- a/src/features/sessions/capabilities/SessionListCapability.tsx
+++ b/src/features/sessions/capabilities/SessionListCapability.tsx
@@ -889,8 +889,7 @@ export function SessionListCapability({
   );
 
   const hasFlatChatOverflow =
-    flatSessionCandidates.length > MAX_FLAT_SIDEBAR_CHATS ||
-    (flatSessionCandidates.length >= MAX_FLAT_SIDEBAR_CHATS && hasMoreSessions);
+    flatSessionCandidates.length > MAX_FLAT_SIDEBAR_CHATS || hasMoreSessions;
   const standaloneChatCount = groupChatsByProject
     ? projectSessions.standalone.length
     : flatSessionCandidates.length;

--- a/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
+++ b/src/features/sessions/ui/session-list/SidebarProjectsSection.tsx
@@ -198,18 +198,15 @@ export function SidebarProjectsSection({
   const showChatsEmptyState = projectSessions.standalone.length === 0;
   const showCombinedEmptyState = showProjectsEmptyState && !hasVisibleChats;
   const showProjects = collapsed || projectsSectionOpen;
-  // Only surface the Session History route when the grouped view actually
-  // hides chats: loaded standalone chats were truncated to the recents cap,
-  // or the backend has more sessions than are loaded. The hasMoreSessions
-  // case is gated on having any loaded chats (not standalone ones
-  // specifically): grouped auto-loading is bounded, so a user whose loaded
-  // chats all belong to projects must still get a route to older sessions.
-  // Brand-new users have no chats and no backend pages, so they never see
-  // the link.
+  // Surface the Session History route whenever the grouped view can hide
+  // chats: loaded standalone chats were truncated to the recents cap, or the
+  // backend has more sessions than are loaded. Gating on loaded chat counts
+  // would hide the link exactly when loading failed to reach the user's
+  // chats, which is when the escape hatch is needed most. Brand-new users
+  // have no chats and no backend pages, so they never see the link.
   const showGroupedHistoryLink =
     !collapsed &&
-    ((projectSessions.standaloneOverflow ?? false) ||
-      (hasMoreSessions && hasVisibleChats));
+    ((projectSessions.standaloneOverflow ?? false) || hasMoreSessions);
   const emptyActionClasses = cn(
     SIDEBAR_ROW_HEIGHT_CLASS,
     SIDEBAR_ROW_HOVER_CLASS,

--- a/src/features/sessions/ui/session-list/__tests__/SidebarFlatChatsSection.test.tsx
+++ b/src/features/sessions/ui/session-list/__tests__/SidebarFlatChatsSection.test.tsx
@@ -75,6 +75,36 @@ describe("SidebarFlatChatsSection", () => {
     expect(onNewChat).toHaveBeenCalledOnce();
   });
 
+  it("offers the Session History route even when few chats are loaded", () => {
+    // Regression: the escape hatch used to be gated on loaded-chat counts,
+    // which hid it exactly when sessions failed to load (BOT-1688).
+    renderFlatChatsSection({
+      onNewChat: vi.fn(),
+      onNavigate: vi.fn(),
+      showViewAllInHistory: true,
+      groups: [
+        {
+          id: "last-hour",
+          sessions: [
+            {
+              id: "only-chat",
+              title: "Only Chat",
+              updatedAt: "2026-04-09T12:00:00.000Z",
+              projectId: "project-1",
+              projectName: "Project One",
+              projectIcon: "",
+              projectColor: "",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole("button", { name: "View all chats" }),
+    ).toBeInTheDocument();
+  });
+
   it("offers grouping in the flat chats menu", async () => {
     const user = userEvent.setup();
     const onGroupChatsByProjectChange = vi.fn();
@@ -185,6 +215,48 @@ describe("SidebarFlatChatsSection", () => {
     expect(showTimestamps).not.toBeChecked();
     await user.click(showTimestamps);
     expect(onShowTimestampsChange).toHaveBeenCalledWith(true);
+  });
+
+  it("shows the Session History route in grouped mode when more sessions exist but none are loaded", () => {
+    // Regression: hasMoreSessions && hasVisibleChats meant a project list
+    // whose chats never loaded (BOT-1688) had no route to Session History.
+    render(
+      <SidebarProjectsSection
+        projects={[project]}
+        projectSessions={{ byProject: {}, standalone: [] }}
+        hasVisibleChats={false}
+        flatChatGroups={[]}
+        hasFlatChatOverflow={false}
+        groupChatsByProject
+        pinnedShowChatIcons={false}
+        onPinnedShowChatIconsChange={vi.fn()}
+        pinnedShowTimestamps={false}
+        onPinnedShowTimestampsChange={vi.fn()}
+        projectShowChatIcons={false}
+        onProjectShowChatIconsChange={vi.fn()}
+        projectShowTimestamps={false}
+        onProjectShowTimestampsChange={vi.fn()}
+        chatShowChatIcons={false}
+        onChatShowChatIconsChange={vi.fn()}
+        chatShowTimestamps={false}
+        onChatShowTimestampsChange={vi.fn()}
+        expandedProjects={{}}
+        toggleProject={vi.fn()}
+        collapsed={false}
+        labelTransition=""
+        labelVisible
+        projectsSectionOpen
+        recentsSectionOpen
+        onToggleProjectsSection={vi.fn()}
+        onToggleRecentsSection={vi.fn()}
+        hasMoreSessions
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "View all chats" }),
+    ).toBeInTheDocument();
   });
 
   it("uses icon-only flat chat rows when collapsed", async () => {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users whose chats fail to load in the sidebar now always see the "View all chats" link into Session History, instead of losing the escape hatch exactly when they need it.

**Problem:** When session loading doesn't reach a user's chats — e.g. BOT-1688, where scheduler-generated sessions push real chats past the first page — the sidebar shows empty projects AND hides the "View all chats" link, leaving no UI path to sessions that are still intact on disk. Both sidebar paths gated the link on loaded-session counts: the flat path required ≥30 loaded candidates before `hasMoreSessions` could surface it, and the grouped path required `hasVisibleChats` alongside `hasMoreSessions`. Counting loaded rows to decide whether to show the link to the place that loads more rows is circular — the link hides itself exactly when loading falls short.

**Solution:** Show the link whenever the backend reports more sessions (`hasMoreSessions`), regardless of how many are loaded. Brand-new users still never see it: with zero sessions there is no second page and `hasMoreSessions` is false. This is Fix 0 (immediate unblock) from the BOT-1688 handoff; the durable fixes (per-project query, server-side search) remain follow-ups.

<details>
<summary>File changes</summary>

**src/features/sessions/capabilities/SessionListCapability.tsx**
Removed the `flatSessionCandidates.length >= MAX_FLAT_SIDEBAR_CHATS` term from `hasFlatChatOverflow` so `hasMoreSessions` alone surfaces the flat-mode link.

**src/features/sessions/ui/session-list/SidebarProjectsSection.tsx**
Removed the `hasVisibleChats` dependency from `showGroupedHistoryLink` so `hasMoreSessions` alone surfaces the grouped-mode link; updated the comment to explain why loaded-count gating is circular.

**src/features/sessions/ui/session-list/__tests__/SidebarFlatChatsSection.test.tsx**
Added regression tests for both paths: flat mode shows the link with a single loaded chat, and grouped mode shows it with zero loaded chats but more pages on the backend (the BOT-1688 condition). Verified the grouped test fails against the pre-fix code.

</details>

Closes #256

Refs BOT-1688 (Linear)
