### PR TITLE
fix(berdctl): surface goose backend error detail instead of dropping it

### DIFF
--- a/src/app/AppShell.berdctl.test.tsx
+++ b/src/app/AppShell.berdctl.test.tsx
@@ -476,7 +476,14 @@ describe("AppShell berdctl integration", () => {
   });
 
   it("archiveSession reports backend failure and keeps the session unarchived", async () => {
-    mockAcpArchiveSession.mockRejectedValue(new Error("backend down"));
+    // ACP-shaped error: the formatted detail must surface the `data` payload,
+    // not String(error)'s "Error: Internal error".
+    mockAcpArchiveSession.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "session row missing",
+      }),
+    );
     useChatSessionStore.setState({ sessions: [makeSession()] });
     render(<AppShell />);
 
@@ -484,7 +491,11 @@ describe("AppShell berdctl integration", () => {
       getAppNavigationController().archiveSession("session-1", "reject"),
     );
 
-    expect(outcome).toEqual({ ok: false, reason: "backend_archive_failed" });
+    expect(outcome).toEqual({
+      ok: false,
+      reason: "backend_archive_failed",
+      detail: "session row missing",
+    });
     expect(
       useChatSessionStore.getState().getSession("session-1")?.archivedAt,
     ).toBeUndefined();
@@ -506,7 +517,11 @@ describe("AppShell berdctl integration", () => {
       getAppNavigationController().archiveSession("session-1", "reject"),
     );
 
-    expect(outcome).toEqual({ ok: false, reason: "backend_archive_failed" });
+    expect(outcome).toEqual({
+      ok: false,
+      reason: "backend_archive_failed",
+      detail: "backend down",
+    });
     expect(useChatSessionStore.getState().activeSessionId).toBe("session-1");
     expect(screen.getByTestId("active-view")).toHaveTextContent("chat");
     expect(

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -3950,6 +3950,10 @@ export function AppShell({
                 error instanceof SessionNotFoundError
                   ? ("session_not_found" as const)
                   : ("backend_archive_failed" as const),
+              detail:
+                error instanceof SessionNotFoundError
+                  ? undefined
+                  : formatAcpErrorMessage(error),
             };
           }
           let cleanupFailureReason:

--- a/src/features/berdctl/__tests__/bridge/berdctlBridge.test.tsx
+++ b/src/features/berdctl/__tests__/bridge/berdctlBridge.test.tsx
@@ -266,6 +266,36 @@ describe("BerdctlBridge request handling", () => {
     });
   });
 
+  it("surfaces the ACP error data payload for non-CommandError failures", async () => {
+    renderBridge();
+    await flushAsync();
+    mocks.dispatchCommand.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "fork failed: session row missing",
+      }),
+    );
+
+    emitRequest({
+      id: "req-acp",
+      command: "sessions",
+      args: { action: "fork", session_id: "other" },
+      timeoutMs: 60_000,
+    });
+    await flushAsync();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("plugin:berdctl|submit_result", {
+      result: {
+        id: "req-acp",
+        ok: false,
+        error: {
+          code: "internal_error",
+          message: "fork failed: session row missing",
+        },
+      },
+    });
+  });
+
   it("never rejects: a failed submit_result is logged and dropped", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mocks.dispatchCommand.mockResolvedValue({ ok: true });

--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -1956,14 +1956,20 @@ describe("sessions.open", () => {
 });
 
 describe("sessions.list", () => {
-  it("throws backend_read_failed when the backend session read fails", async () => {
-    mocks.acpListSessionsPage.mockRejectedValue(new Error("backend down"));
+  it("throws backend_read_failed with the backend error detail when the session read fails", async () => {
+    mocks.acpListSessionsPage.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "database is locked",
+      }),
+    );
 
-    await expectCommandError(
+    const error = await expectCommandError(
       dispatchCommand("sessions", { action: "list" }, ctx),
       "backend_read_failed",
     );
 
+    expect(error.message).toContain("database is locked");
     expect(useChatSessionStore.getState().hasHydratedSessions).toBe(false);
   });
 
@@ -2092,6 +2098,26 @@ describe("sessions.list", () => {
 });
 
 describe("sessions.get", () => {
+  it("surfaces the ACP error data payload when the session read fails", async () => {
+    mocks.acpGetSessionInfo.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "session store corrupted",
+      }),
+    );
+
+    const error = await expectCommandError(
+      dispatchCommand(
+        "sessions",
+        { action: "get", session_id: "session-1" },
+        ctx,
+      ),
+      "backend_read_failed",
+    );
+
+    expect(error.message).toContain("session store corrupted");
+  });
+
   it("returns metadata without touching the export when messages is omitted", async () => {
     mockSessionFound({
       providerId: "codex-acp",
@@ -2525,6 +2551,47 @@ describe("sessions.archive", () => {
       ),
       "backend_archive_failed",
     );
+  });
+
+  it("relays the backend error detail from a failed facade outcome", async () => {
+    mockSessionFound();
+    controller.archiveSession.mockResolvedValue({
+      ok: false,
+      reason: "backend_archive_failed",
+      detail: "session store write failed",
+    });
+
+    const error = await expectCommandError(
+      dispatchCommand(
+        "sessions",
+        { action: "archive", session_id: "session-1" },
+        ctx,
+      ),
+      "backend_archive_failed",
+    );
+
+    expect(error.message).toContain("session store write failed");
+  });
+
+  it("caps an oversized facade detail before it reaches the wire", async () => {
+    mockSessionFound();
+    controller.archiveSession.mockResolvedValue({
+      ok: false,
+      reason: "backend_archive_failed",
+      detail: "x".repeat(5000),
+    });
+
+    const error = await expectCommandError(
+      dispatchCommand(
+        "sessions",
+        { action: "archive", session_id: "session-1" },
+        ctx,
+      ),
+      "backend_archive_failed",
+    );
+
+    expect(error.message.length).toBeLessThan(2300);
+    expect(error.message).toContain("…");
   });
 });
 
@@ -3529,19 +3596,25 @@ describe("projects", () => {
     });
   });
 
-  it("list throws backend_read_failed when the backend project read fails", async () => {
+  it("list throws backend_read_failed with the backend error detail when the project read fails", async () => {
     const staleProject = makeProject({ id: "stale" });
     useProjectStore.setState({
       projects: [staleProject],
       hasFetchedProjects: false,
     });
-    mocks.listProjects.mockRejectedValue(new Error("backend down"));
+    mocks.listProjects.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "project source unavailable",
+      }),
+    );
 
-    await expectCommandError(
+    const error = await expectCommandError(
       dispatchCommand("projects", { action: "list" }, ctx),
       "backend_read_failed",
     );
 
+    expect(error.message).toContain("project source unavailable");
     expect(useProjectStore.getState().hasFetchedProjects).toBe(false);
     expect(useProjectStore.getState().projects).toEqual([staleProject]);
   });
@@ -3707,7 +3780,12 @@ describe("projects", () => {
       hasFetchedProjects: true,
     });
     mocks.listProjects.mockResolvedValue([project]);
-    mocks.archiveProject.mockRejectedValue(new Error("backend down"));
+    mocks.archiveProject.mockRejectedValue(
+      Object.assign(new Error("Internal error"), {
+        code: -32603,
+        data: "project store write failed",
+      }),
+    );
 
     const error = await expectCommandError(
       dispatchCommand(
@@ -3717,6 +3795,7 @@ describe("projects", () => {
       ),
       "backend_archive_failed",
     );
+    expect(error.message).toContain("project store write failed");
     expect(error.message).toContain("berdctl project list");
   });
 

--- a/src/features/berdctl/bridge/appNavigationController.ts
+++ b/src/features/berdctl/bridge/appNavigationController.ts
@@ -19,7 +19,13 @@ export type CommandOutcome =
         "target_session_running" | "workspace_cleanup_failed" | "timed_out"
       >;
     }
-  | { ok: false; reason: CommandFailureReason };
+  | {
+      ok: false;
+      reason: CommandFailureReason;
+      /** Backend error detail (e.g. the ACP error `data` payload) to relay to
+       *  the caller; omitted for refusal reasons that are self-explanatory. */
+      detail?: string;
+    };
 
 export interface AppContext {
   view: string;

--- a/src/features/berdctl/commands/helpers.test.ts
+++ b/src/features/berdctl/commands/helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { berdctlErrorDetail } from "./helpers";
+
+function requestError(message: string, data?: unknown) {
+  const error = new Error(message) as Error & { code: number; data?: unknown };
+  error.name = "RequestError";
+  error.code = -32603;
+  error.data = data;
+  return error;
+}
+
+describe("berdctlErrorDetail", () => {
+  it("surfaces the ACP error data payload that String(error) drops", () => {
+    expect(
+      berdctlErrorDetail(requestError("Internal error", "database is locked")),
+    ).toBe("database is locked");
+  });
+
+  it("keeps structured data visible without interpreting the payload shape", () => {
+    expect(
+      berdctlErrorDetail(
+        requestError("Internal error", { providerId: "missing_provider" }),
+      ),
+    ).toBe('Internal error: {"providerId":"missing_provider"}');
+  });
+
+  it("falls back to the error message when there is no data payload", () => {
+    expect(berdctlErrorDetail(new Error("network down"))).toBe("network down");
+  });
+
+  it("caps pre-formatted string detail without reformatting it", () => {
+    expect(berdctlErrorDetail("short detail")).toBe("short detail");
+    const capped = berdctlErrorDetail("x".repeat(5000));
+    expect(capped).toHaveLength(2001);
+    expect(capped.endsWith("…")).toBe(true);
+  });
+
+  it("bounds oversized string payloads so the wire result stays bounded", () => {
+    const detail = berdctlErrorDetail(
+      requestError("Internal error", "x".repeat(5000)),
+    );
+    expect(detail).toHaveLength(2001);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+
+  it("bounds oversized structured payloads before serializing them", () => {
+    const detail = berdctlErrorDetail(
+      requestError("Internal error", { blob: "x".repeat(5000) }),
+    );
+    expect(detail.length).toBeLessThanOrEqual(2001);
+    expect(detail.endsWith("…")).toBe(true);
+  });
+});

--- a/src/features/berdctl/commands/helpers.ts
+++ b/src/features/berdctl/commands/helpers.ts
@@ -1,6 +1,61 @@
+import { formatAcpErrorMessage } from "@/shared/api/acpErrors";
+
 /** Truncate with an ellipsis; shared by previews/summaries/message bodies. */
 export function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Bound on any backend error detail berdctl relays onto the wire. */
+const ERROR_DETAIL_LIMIT = 2000;
+
+/** Bound `data` before it is stringified so a pathological payload is never
+ *  fully serialized; a pre-bound marker preserves the structured-data path. */
+function capRawData(data: unknown): unknown {
+  if (typeof data === "string") {
+    return truncate(data, ERROR_DETAIL_LIMIT);
+  }
+  if (data === undefined || data === null) {
+    return data;
+  }
+  try {
+    const serialized = JSON.stringify(data);
+    if (typeof serialized !== "string") return data;
+    return serialized.length <= ERROR_DETAIL_LIMIT
+      ? data
+      : { detail: `${serialized.slice(0, ERROR_DETAIL_LIMIT)}…` };
+  } catch {
+    return data;
+  }
+}
+
+/**
+ * Format a backend failure for berdctl callers. formatAcpErrorMessage
+ * surfaces an ACP error's `data` payload, where goose puts the underlying
+ * message (String(error) drops it); the cap keeps a pathological payload
+ * from bloating the wire result.
+ */
+export function berdctlErrorDetail(error: unknown): string {
+  if (typeof error === "string") {
+    return truncate(error, ERROR_DETAIL_LIMIT);
+  }
+  if (typeof error === "object" && error !== null && "data" in error) {
+    // Spread drops the Error prototype (and `message` is non-enumerable), so
+    // re-attach it explicitly or formatAcpErrorMessage falls back to
+    // String(error) — "[object Object]" — for the structured-data path.
+    const message =
+      "message" in error && typeof error.message === "string"
+        ? error.message
+        : undefined;
+    return truncate(
+      formatAcpErrorMessage({
+        ...error,
+        ...(message === undefined ? {} : { message }),
+        data: capRawData(error.data),
+      }),
+      ERROR_DETAIL_LIMIT,
+    );
+  }
+  return truncate(formatAcpErrorMessage(error), ERROR_DETAIL_LIMIT);
 }
 
 export const sessionNotFoundMessage = (id: string) =>
@@ -9,5 +64,6 @@ export const sessionNotFoundMessage = (id: string) =>
 export const backendArchiveFailedMessage = (
   kind: "session" | "project",
   id: string,
+  detail?: string,
 ) =>
-  `The app backend refused to archive "${id}"; confirm the id with \`berdctl ${kind} list\` and retry.`;
+  `The app backend refused to archive "${id}"${detail ? `: ${detail}` : ""}; confirm the id with \`berdctl ${kind} list\` and retry.`;

--- a/src/features/berdctl/commands/impl/archiveProject.ts
+++ b/src/features/berdctl/commands/impl/archiveProject.ts
@@ -1,6 +1,6 @@
 import { z } from "zod/v4";
 
-import { backendArchiveFailedMessage } from "../helpers";
+import { berdctlErrorDetail, backendArchiveFailedMessage } from "../helpers";
 import { CommandError, defineCommand } from "../types";
 
 const archiveProjectSchema = z
@@ -36,10 +36,14 @@ Result:
     await findProjectOrThrow(args.project_id);
     try {
       await archiveProject(args.project_id);
-    } catch {
+    } catch (error) {
       throw new CommandError(
         "backend_archive_failed",
-        backendArchiveFailedMessage("project", args.project_id),
+        backendArchiveFailedMessage(
+          "project",
+          args.project_id,
+          berdctlErrorDetail(error),
+        ),
       );
     }
     // Mirror AppShell's archive handler: refetch so the sidebar drops the

--- a/src/features/berdctl/commands/impl/archiveSession.ts
+++ b/src/features/berdctl/commands/impl/archiveSession.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import type { CommandFailureReason } from "../../navigation";
 import {
   backendArchiveFailedMessage,
+  berdctlErrorDetail,
   sessionNotFoundMessage,
 } from "../helpers";
 import { CommandError, defineCommand } from "../types";
@@ -56,7 +57,7 @@ Result:
     if (!outcome.ok) {
       throw new CommandError(
         outcome.reason,
-        archiveFailureMessage(args.session_id, outcome.reason),
+        archiveFailureMessage(args.session_id, outcome.reason, outcome.detail),
       );
     }
     if (outcome.cleanupIncomplete) {
@@ -93,12 +94,17 @@ function archiveCleanupIncompleteMessage(
 function archiveFailureMessage(
   sessionId: string,
   reason: CommandFailureReason,
+  detail?: string,
 ): string {
   switch (reason) {
     case "session_not_found":
       return sessionNotFoundMessage(sessionId);
     case "backend_archive_failed":
-      return backendArchiveFailedMessage("session", sessionId);
+      return backendArchiveFailedMessage(
+        "session",
+        sessionId,
+        detail === undefined ? undefined : berdctlErrorDetail(detail),
+      );
     case "voice_stop_failed":
       return `Could not stop voice for session "${sessionId}"; the session was not archived.`;
     case "target_session_running":

--- a/src/features/berdctl/commands/runtime/projects.ts
+++ b/src/features/berdctl/commands/runtime/projects.ts
@@ -3,7 +3,7 @@ import {
   type ProjectInfo,
 } from "@/features/projects/api/projects";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
-
+import { berdctlErrorDetail } from "../helpers";
 import { CommandError } from "../types";
 
 export async function loadProjectsForBerdctl(): Promise<void> {
@@ -13,7 +13,7 @@ export async function loadProjectsForBerdctl(): Promise<void> {
   } catch (error) {
     throw new CommandError(
       "backend_read_failed",
-      `Failed to read projects from the app backend: ${String(error)}`,
+      `Failed to read projects from the app backend: ${berdctlErrorDetail(error)}`,
     );
   }
 }

--- a/src/features/berdctl/commands/runtime/sessions.ts
+++ b/src/features/berdctl/commands/runtime/sessions.ts
@@ -11,7 +11,7 @@ import {
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useSessionWindowStore } from "@/features/chat/stores/sessionWindowStore";
 import { acpGetSessionInfo, acpListSessionsPage } from "@/shared/api/acp";
-import { sessionNotFoundMessage } from "../helpers";
+import { berdctlErrorDetail, sessionNotFoundMessage } from "../helpers";
 import { CommandError } from "../types";
 
 export async function loadAllSessionsForBerdctl(): Promise<void> {
@@ -20,7 +20,7 @@ export async function loadAllSessionsForBerdctl(): Promise<void> {
   } catch (error) {
     throw new CommandError(
       "backend_read_failed",
-      `Failed to read sessions from the app backend: ${String(error)}`,
+      `Failed to read sessions from the app backend: ${berdctlErrorDetail(error)}`,
     );
   }
 }
@@ -40,7 +40,7 @@ export async function loadSessionForBerdctl(sessionId: string): Promise<void> {
     }
     throw new CommandError(
       "backend_read_failed",
-      `Failed to read session from the app backend: ${String(error)}`,
+      `Failed to read session from the app backend: ${berdctlErrorDetail(error)}`,
     );
   }
 }

--- a/src/features/berdctl/commands/types.ts
+++ b/src/features/berdctl/commands/types.ts
@@ -1,5 +1,7 @@
 import type { ZodType } from "zod/v4";
 
+import { berdctlErrorDetail } from "./helpers";
+
 export interface CommandContext {
   /** Absolute time (ms epoch) the broker reports this call as timed out.
    *  Commands with slow pre-mutation work must not mutate state past it —
@@ -107,5 +109,5 @@ export function toCommandError(e: unknown): { code: string; message: string } {
   if (e instanceof CommandError) {
     return { code: e.code, message: e.message };
   }
-  return { code: "internal_error", message: String(e) };
+  return { code: "internal_error", message: berdctlErrorDetail(e) };
 }


### PR DESCRIPTION
## Summary
berdctl session/project commands reported only the generic ACP error message ("Internal error") and discarded the error's `.data` payload, where goose puts the real underlying message. The `String(error)` wrap at the backend-read catch sites dropped it. This makes backend failures undiagnosable from the CLI.

This replaces the `String(error)` wraps with `formatAcpErrorMessage` (which already surfaces `.data`) via a single bounded helper `berdctlErrorDetail` (`commands/helpers.ts`) that caps extraction before serializing. Applied at every point a backend error crosses the berdctl wire: `runtime/sessions.ts`, `runtime/projects.ts`, the `toCommandError` bridge boundary, `impl/archiveProject.ts`, and the archive-session facade. Tauri-invoke and UI-notification sites that carry no ACP `.data` payload are left unchanged.

### Related issue
Fixes #258

### Testing
- `pnpm generate:berdctl-contract` ✓ (no contract diff)
- `cargo test -p berdctl` — 52 passed ✓
- `pnpm vitest run src/features/berdctl` — 259 passed ✓
- `just check` ✓, `just test` — 7281 passed ✓, `just lint` ✓, `just typecheck` ✓, `just fmt-check` ✓
- New `helpers.test.ts` + additions to `commands.test.ts`, `berdctlBridge.test.tsx`, `AppShell.berdctl.test.tsx` assert `.data` detail surfaces in the CLI error message
- 3 adversarial review rounds (4 reviewers each), final ratings all ≥ 9/10, no open findings
