### PR TITLE
fix(berd-help): verify feedback route availability before recommending it

### DIFF
--- a/distro/skills/berd-help/references/reporting-problems.md
+++ b/distro/skills/berd-help/references/reporting-problems.md
@@ -1,9 +1,22 @@
 # Reporting Problems
 
-Route app-level bugs, crashes, and feedback through Berd's built-in feedback
-flow rather than improvising a report. The default path mirrors the in-app
-Feedback dialog: prefill a report and let the user review it before anything
-is sent.
+Route app-level bugs, crashes, and feedback through an available feedback
+route rather than improvising a report. Routes vary by build — verify which
+exist before recommending one, and use the first that applies:
+
+1. Run `berdctl feedback --help`. If the `feedback` subcommand exists,
+   follow the guidance below. If invoking it reports that feedback is
+   unavailable or disabled, continue to the next route.
+2. Otherwise, check whether the app shows a visible in-app feedback action
+   (labeled "Send feedback"). If it's visible, point the user there —
+   don't assume it's present.
+3. Otherwise, the fallback is the public issue tracker:
+   https://github.com/block/berd/issues. You may help the user draft a
+   report (title, description, steps to reproduce, app version, OS), but
+   the user reviews and files it themselves. Never file on their behalf,
+   and never invent another URL or email for reports.
+
+When `berdctl feedback` exists:
 
 - Prefer `berdctl feedback open --title <title> --description <description>`
   (add `--include-logs` only when the user wants diagnostics attached). This


### PR DESCRIPTION
**Category:** fix
**User Impact:** Agents helping users report Berd problems no longer recommend a `berdctl feedback` command that doesn't exist on public builds.

**Problem:** The bundled `berd-help` skill instructed agents to prefer `berdctl feedback open` / `berdctl feedback submit`, but the `feedback` noun is only compiled into builds with `VITE_FEEDBACK=1`. Public releases (e.g. 0.6.2) ship without it, so an agent following Berd's own bundled bug-reporting instructions hit `error: unrecognized subcommand 'feedback'` — a dead end in the exact moment a user is trying to report a problem.

**Solution:** Rewrite the skill reference as an availability-ordered decision instead of an unconditional recommendation: probe `berdctl feedback --help` first (falling through if the command reports feedback is disabled at runtime), then check for the visible in-app "Send feedback" action, and finally fall back to the public issue tracker with the user reviewing and filing the report themselves. This matches the parent skill's existing First Principles (verify against `--help`, treat current app behavior as source of truth) and keeps the existing open-vs-submit and privacy guidance intact for builds where the flow exists.

Closes #227

<details>
<summary>File changes</summary>

**distro/skills/berd-help/references/reporting-problems.md**
Restructured the guidance as a verify-first decision list: (1) `berdctl feedback --help` probe with a runtime-disabled fall-through, (2) visible in-app "Send feedback" action, (3) public GitHub issue tracker with the user filing themselves. The previous `berdctl feedback` usage and privacy-posture guidance is preserved verbatim under a "When `berdctl feedback` exists:" section.

</details>
