### PR TITLE
fix(sidebar): hydrate project chats beyond the first session page

### DIFF
--- a/src/app/views/__tests__/NavigationPanesView.test.tsx
+++ b/src/app/views/__tests__/NavigationPanesView.test.tsx
@@ -27,6 +27,7 @@ import {
   type RuntimeConfig,
 } from "@/shared/runtime-config/schema";
 import { MAX_FLAT_SIDEBAR_CHATS } from "@/features/sidebar/lib/sidebarFlatChats";
+import { resetProjectSessionHydrationAccounting } from "@/features/sessions/hooks/useProjectSessionHydration";
 import {
   resetHomeWidgetStoreForTests,
   useHomeWidgetStore,
@@ -330,6 +331,8 @@ vi.mock("@/features/chat/stores/chatSessionStore", () => ({
       selector({
         sessions: mockSessions,
         activeWorkspaceBySession: mockActiveWorkspaceBySession,
+        hasHydratedSessions: true,
+        sessionListReloadCount: 0,
         hasMoreSessions: mockHasMoreSessions,
         isLoadingMoreSessions: mockIsLoadingMoreSessions,
         sessionPageCursor: mockSessionPageCursor,
@@ -339,6 +342,8 @@ vi.mock("@/features/chat/stores/chatSessionStore", () => ({
       getState: () => ({
         sessions: mockSessions,
         activeWorkspaceBySession: mockActiveWorkspaceBySession,
+        hasHydratedSessions: true,
+        sessionListReloadCount: 0,
         hasMoreSessions: mockHasMoreSessions,
         isLoadingMoreSessions: mockIsLoadingMoreSessions,
         loadMoreSessions: mockLoadMoreSessions,
@@ -379,6 +384,8 @@ describe("NavigationPanesView", () => {
     mockActiveWorkspaceBySession = {};
     mockSessionStateById = {};
     mockLoadMoreSessions.mockReset();
+    mockLoadMoreSessions.mockResolvedValue("applied");
+    resetProjectSessionHydrationAccounting();
     mockAcpSearchSessions.mockReset();
     mockAcpSearchSessions.mockResolvedValue([]);
     mockGetGitState.mockReset();
@@ -661,10 +668,9 @@ describe("NavigationPanesView", () => {
   });
 
   it("keeps the view-all-chats row when all loaded chats belong to projects and more sessions remain", () => {
-    // Grouped auto-loading stops at MAX_FLAT_SIDEBAR_CHATS * 2 chats. Seed
-    // that bound split across two projects with zero standalone chats: the
-    // Recents list is empty, but older sessions remain on the backend, so
-    // the history route must stay visible.
+    // Seed a large chat set split across two projects with zero standalone
+    // chats: the Recents list is empty, but older sessions remain on the
+    // backend, so the history route must stay visible.
     mockHasMoreSessions = true;
     seedSessions(
       ...Array.from({ length: MAX_FLAT_SIDEBAR_CHATS * 2 }, (_, index) => ({
@@ -1291,8 +1297,11 @@ describe("NavigationPanesView", () => {
     await waitFor(() => expect(mockLoadMoreSessions).toHaveBeenCalledOnce());
   });
 
-  it("bounds grouped chat auto-loading when project chats dominate", async () => {
+  it("hydrates project chats beyond the old grouped auto-load cap", async () => {
+    // project-2 has no chat in the loaded slice; previously grouped mode
+    // stopped paging at MAX_AUTO_LOADED_GROUPED_CHATS, leaving it empty (#259).
     mockHasMoreSessions = true;
+    mockSessionPageCursor = "cursor-1";
     seedSessions(
       ...Array.from({ length: MAX_FLAT_SIDEBAR_CHATS * 2 }, (_, index) => ({
         id: `loaded-project-chat-${index + 1}`,
@@ -1303,7 +1312,36 @@ describe("NavigationPanesView", () => {
       })),
     );
 
-    renderSidebar({ projects: [mockProject()] });
+    renderSidebar({
+      projects: [
+        mockProject(),
+        mockProject({ id: "project-2", name: "Project Two", order: 1 }),
+      ],
+    });
+
+    await waitFor(() => expect(mockLoadMoreSessions).toHaveBeenCalled());
+  });
+
+  it("does not hydrate projects when grouping is disabled", async () => {
+    disableProjectGrouping();
+    mockHasMoreSessions = true;
+    mockSessionPageCursor = "cursor-1";
+    // Flat mode keeps its own recents cap: with the flat list full and no
+    // grouped projects to hydrate, no auto-load fires at all.
+    seedSessions(
+      ...Array.from({ length: MAX_FLAT_SIDEBAR_CHATS }, (_, index) => ({
+        id: `loaded-flat-chat-${index + 1}`,
+        title: `Loaded Flat Chat ${index + 1}`,
+        updatedAt: `2026-04-09T12:${String(index).padStart(2, "0")}:00.000Z`,
+        messageCount: 3,
+      })),
+    );
+
+    renderSidebar({
+      projects: [
+        mockProject({ id: "project-2", name: "Project Two", order: 1 }),
+      ],
+    });
     await waitForAnimationFrame();
 
     expect(mockLoadMoreSessions).not.toHaveBeenCalled();

--- a/src/features/chat/stores/__tests__/chatSessionStore.test.ts
+++ b/src/features/chat/stores/__tests__/chatSessionStore.test.ts
@@ -72,6 +72,7 @@ function resetStore() {
     isLoading: false,
     isLoadingMoreSessions: false,
     hasHydratedSessions: false,
+    sessionListReloadCount: 0,
     sessionPageCursor: null,
     hasMoreSessions: false,
     isRightRailOpen: false,
@@ -1669,8 +1670,9 @@ describe("chatSessionStore", () => {
       expect(mocks.acpListSessionsPage).toHaveBeenCalledOnce();
 
       deferred.resolve(mockPage());
-      await Promise.all([firstLoad, secondLoad]);
+      const results = await Promise.all([firstLoad, secondLoad]);
 
+      expect(results).toEqual(["applied", "skipped"]);
       expect(useChatSessionStore.getState().isLoadingMoreSessions).toBe(false);
     });
 
@@ -1759,6 +1761,25 @@ describe("chatSessionStore", () => {
       expect(state.sessionPageCursor).toBeNull();
       expect(state.hasMoreSessions).toBe(false);
       expect(state.isLoadingMoreSessions).toBe(false);
+    });
+
+    it("reports a stale rejected page as superseded, not failed", async () => {
+      const loadMore = createDeferredPromise<ReturnType<typeof mockPage>>();
+      useChatSessionStore.setState({
+        sessionPageCursor: "cursor-2",
+        hasMoreSessions: true,
+      });
+      mocks.acpListSessionsPage
+        .mockReturnValueOnce(loadMore.promise)
+        .mockResolvedValueOnce(mockPage([], null));
+
+      const loadMorePromise = useChatSessionStore.getState().loadMoreSessions();
+      const loadSessionsPromise = useChatSessionStore.getState().loadSessions();
+
+      loadMore.reject(new Error("network down"));
+      await loadSessionsPromise;
+
+      await expect(loadMorePromise).resolves.toBe("superseded");
     });
 
     it("dedupes sessions by id and refreshes existing metadata", async () => {

--- a/src/features/chat/stores/chatSessionStore.ts
+++ b/src/features/chat/stores/chatSessionStore.ts
@@ -166,6 +166,12 @@ interface ChatSessionStoreState {
   isLoading: boolean;
   isLoadingMoreSessions: boolean;
   hasHydratedSessions: boolean;
+  /**
+   * Bumped each time a full loadSessions() reload applies a fresh first page.
+   * Consumers that page loadMoreSessions in the background use it to detect
+   * pagination rewinds (and dropped in-flight pages) even while unmounted.
+   */
+  sessionListReloadCount: number;
   sessionPageCursor: string | null;
   hasMoreSessions: boolean;
   isRightRailOpen: boolean;
@@ -206,6 +212,13 @@ type ChatSessionPromotionPatch = ChatSessionPatch & {
   executionTarget?: SessionExecutionTarget;
 };
 
+/** Outcome of a loadMoreSessions() page attempt. */
+export type LoadMoreSessionsOutcome =
+  | "applied"
+  | "superseded"
+  | "skipped"
+  | "failed";
+
 interface ChatSessionStoreActions {
   createSession: (opts?: CreateSessionOpts) => Promise<ChatSession>;
   createDraftSession: (opts?: CreateSessionOpts) => ChatSession;
@@ -218,7 +231,14 @@ interface ChatSessionStoreActions {
   resetSessionCreation: (id: string) => void;
   ensurePinnedSessionPlaceholder: (id: string) => void;
   loadSessions: () => Promise<void>;
-  loadMoreSessions: () => Promise<void>;
+  /**
+   * Page in the next slice of sessions.
+   * - "applied": a page was merged into the store.
+   * - "superseded": a loadSessions() reload dropped the in-flight page.
+   * - "skipped": another page is in flight or pagination is exhausted.
+   * - "failed": the request failed (the store logs it).
+   */
+  loadMoreSessions: () => Promise<LoadMoreSessionsOutcome>;
   patchSession: (id: string, patch: ChatSessionPatch) => void;
   updateSessionSubtitleFromText: (sessionId: string, text: string) => void;
   addSession: (session: ChatSession) => void;
@@ -494,6 +514,7 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
   isLoading: false,
   isLoadingMoreSessions: false,
   hasHydratedSessions: false,
+  sessionListReloadCount: 0,
   sessionPageCursor: null,
   hasMoreSessions: false,
   isRightRailOpen: loadRightRailOpenPreference(),
@@ -783,7 +804,12 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
     try {
       const page = await acpListSessionsPage();
       if (sessionLoadEpoch !== loadEpoch) return;
-      set((state) => mergeAcpSessionPage(state, page, null));
+      set((state) => ({
+        ...mergeAcpSessionPage(state, page, null),
+        // Only a successfully applied first page starts a new pagination
+        // generation; failed reloads must not rewind background pagers.
+        sessionListReloadCount: state.sessionListReloadCount + 1,
+      }));
     } catch (error) {
       if (sessionLoadEpoch === loadEpoch) {
         console.error("Failed to load sessions from ACP:", error);
@@ -798,19 +824,20 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
   loadMoreSessions: async () => {
     const { sessionPageCursor, hasMoreSessions, isLoadingMoreSessions } = get();
     if (isLoadingMoreSessions || !hasMoreSessions) {
-      return;
+      return "skipped";
     }
 
     const loadEpoch = sessionLoadEpoch;
     set({ isLoadingMoreSessions: true });
     try {
       const page = await acpListSessionsPage({ cursor: sessionPageCursor });
-      if (sessionLoadEpoch !== loadEpoch) return;
+      if (sessionLoadEpoch !== loadEpoch) return "superseded";
       set((state) => mergeAcpSessionPage(state, page, sessionPageCursor));
+      return "applied";
     } catch (error) {
-      if (sessionLoadEpoch === loadEpoch) {
-        console.error("Failed to load more sessions from ACP:", error);
-      }
+      if (sessionLoadEpoch !== loadEpoch) return "superseded";
+      console.error("Failed to load more sessions from ACP:", error);
+      return "failed";
     } finally {
       set({ isLoadingMoreSessions: false });
     }

--- a/src/features/home/ui/WidgetCanvas.test.tsx
+++ b/src/features/home/ui/WidgetCanvas.test.tsx
@@ -392,7 +392,7 @@ describe("WidgetCanvas", () => {
     mocks.profileCapabilities.automations = true;
     mocks.hasMoreSessions = false;
     mocks.isLoadingMoreSessions = false;
-    mocks.loadMoreSessions.mockResolvedValue(undefined);
+    mocks.loadMoreSessions.mockResolvedValue("skipped");
     mocks.getAutomationTiles.mockResolvedValue({
       tiles: [
         {

--- a/src/features/sessions/capabilities/SessionListCapability.tsx
+++ b/src/features/sessions/capabilities/SessionListCapability.tsx
@@ -44,6 +44,7 @@ import { useHomeWidgetStore } from "@/features/home/stores/homeWidgetStore";
 import type { ProjectInfo } from "@/features/projects/api/projects";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { useBulkSessionActions } from "@/features/sessions/hooks/useBulkSessionActions";
+import { useProjectSessionHydration } from "@/features/sessions/hooks/useProjectSessionHydration";
 import {
   areSetsEqual,
   getRenderedSessionIdsInOrder,
@@ -78,7 +79,6 @@ const SECTION_VISIBILITY_STORAGE_KEY = "goose:sidebar:section-visibility";
 const DISPLAY_OPTIONS_STORAGE_KEY = "goose:sidebar:display-options";
 const PINNED_NAV_ORDER_STORAGE_KEY = "goose:sidebar:pinned-nav-order";
 const MAX_RECENTS = MAX_FLAT_SIDEBAR_CHATS;
-const MAX_AUTO_LOADED_GROUPED_CHATS = MAX_FLAT_SIDEBAR_CHATS * 2;
 const FLAT_CHAT_GROUP_REFRESH_INTERVAL_MS = 60 * 1000;
 
 type SessionListSectionVisibility = {
@@ -891,26 +891,19 @@ export function SessionListCapability({
   const hasFlatChatOverflow =
     flatSessionCandidates.length > MAX_FLAT_SIDEBAR_CHATS ||
     (flatSessionCandidates.length >= MAX_FLAT_SIDEBAR_CHATS && hasMoreSessions);
-  const standaloneChatCount = groupChatsByProject
-    ? projectSessions.standalone.length
-    : flatSessionCandidates.length;
-  const groupedChatCount = useMemo(
-    () =>
-      projectSessions.standalone.length +
-      Object.values(projectSessions.byProject).reduce(
-        (count, chats) => count + chats.length,
-        0,
-      ),
-    [projectSessions],
-  );
-  const reachedAutoLoadLimit = groupChatsByProject
-    ? standaloneChatCount >= MAX_FLAT_SIDEBAR_CHATS ||
-      groupedChatCount >= MAX_AUTO_LOADED_GROUPED_CHATS
-    : standaloneChatCount >= MAX_FLAT_SIDEBAR_CHATS;
+  const reachedAutoLoadLimit =
+    !groupChatsByProject &&
+    flatSessionCandidates.length >= MAX_FLAT_SIDEBAR_CHATS;
   const chatLoadMoreCursorKey = sessionPageCursor ?? "__initial__";
+
+  // Grouped mode pages until every project has a chat loaded, pagination is
+  // exhausted, or the hook's page/retry budgets are spent — instead of
+  // stopping at a fixed recents cap.
+  useProjectSessionHydration(groupChatsByProject && !surface.preview, projects);
 
   useEffect(() => {
     if (
+      groupChatsByProject ||
       surface.preview ||
       !hasMoreSessions ||
       isLoadingMoreSessions ||
@@ -926,6 +919,7 @@ export function SessionListCapability({
     void loadMoreSessions();
   }, [
     chatLoadMoreCursorKey,
+    groupChatsByProject,
     hasMoreSessions,
     isLoadingMoreSessions,
     loadMoreSessions,

--- a/src/features/sessions/hooks/__tests__/useProjectSessionHydration.test.tsx
+++ b/src/features/sessions/hooks/__tests__/useProjectSessionHydration.test.tsx
@@ -1,0 +1,1112 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcpSessionInfo } from "@/shared/api/acp";
+import type { ChatSession } from "@/features/chat/stores/chatSessionStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import type { ProjectInfo } from "@/features/projects/api/projects";
+import { useProjectStore } from "@/features/projects/stores/projectStore";
+import {
+  resetProjectSessionHydrationAccounting,
+  useProjectSessionHydration,
+} from "../useProjectSessionHydration";
+
+const mocks = vi.hoisted(() => ({
+  acpCreateSession: vi.fn(),
+  acpListSessionsPage: vi.fn(),
+  archiveSession: vi.fn(),
+  releaseSession: vi.fn(),
+  unarchiveSession: vi.fn(),
+}));
+
+vi.mock("@/shared/api/acp", () => ({
+  acpCreateSession: (...args: unknown[]) => mocks.acpCreateSession(...args),
+  acpListSessionsPage: (...args: unknown[]) =>
+    mocks.acpListSessionsPage(...args),
+}));
+
+vi.mock("@/shared/profile/buildProfile", () => ({
+  getBuildFeatureState: () => ({
+    authGate: false,
+    agentTools: true,
+    automations: true,
+    builderbot: true,
+    byoKeyProviders: false,
+    telemetry: true,
+    voiceDictation: true,
+    managedConnections: true,
+    securityMl: true,
+    updater: true,
+  }),
+}));
+
+vi.mock("@/shared/api/acpApi", () => ({
+  archiveSession: (...args: unknown[]) => mocks.archiveSession(...args),
+  unarchiveSession: (...args: unknown[]) => mocks.unarchiveSession(...args),
+}));
+
+vi.mock("@/features/chat/lib/sessionWindowCommands", () => ({
+  releaseSession: (...args: unknown[]) => mocks.releaseSession(...args),
+}));
+
+const PAGE_SIZE = 3;
+
+function makeProject(
+  id: string,
+  archivedAt: string | null = null,
+): ProjectInfo {
+  return {
+    id,
+    path: `/projects/${id}`,
+    name: id,
+    description: "",
+    prompt: "",
+    icon: "",
+    color: "",
+    projectWorkspaces: [],
+    workingDirs: [],
+    useWorktrees: false,
+    order: 0,
+    archivedAt,
+  };
+}
+
+function makeSession(
+  id: string,
+  overrides: Partial<ChatSession> = {},
+): ChatSession {
+  return {
+    id,
+    title: id,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    messageCount: 1,
+    ...overrides,
+  };
+}
+
+function makeAcpSession(
+  id: string,
+  activityOffset: number,
+  projectId: string | null = null,
+): AcpSessionInfo {
+  const lastMessageAt = new Date(
+    Date.UTC(2026, 3, 1) - activityOffset * 60_000,
+  ).toISOString();
+  return {
+    sessionId: id,
+    title: id,
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    createdAt: "2026-03-01T00:00:00.000Z",
+    lastMessageAt,
+    archivedAt: null,
+    userSetName: false,
+    messageCount: 1,
+    subtitle: null,
+    workingDir: null,
+    projectId,
+    providerId: null,
+    modelId: null,
+    personaId: null,
+  };
+}
+
+/**
+ * Sessions ordered newest-first like the backend: standalone chats, then
+ * `projectSessionsPerProject` chats per project in order. A project whose
+ * chats sit past `loadedPages` pages only hydrates through the hook.
+ */
+function buildBackendCatalog(
+  projectIds: string[],
+  projectSessionsPerProject: number,
+  standaloneCount = 2,
+): AcpSessionInfo[] {
+  const catalog: AcpSessionInfo[] = [];
+  for (let index = 0; index < standaloneCount; index += 1) {
+    catalog.push(makeAcpSession(`standalone-${index + 1}`, index));
+  }
+  let offset = standaloneCount;
+  for (const projectId of projectIds) {
+    for (let index = 0; index < projectSessionsPerProject; index += 1) {
+      catalog.push(
+        makeAcpSession(`${projectId}-chat-${index + 1}`, offset, projectId),
+      );
+      offset += 1;
+    }
+  }
+  return catalog;
+}
+
+function pageFromCatalog(
+  catalog: AcpSessionInfo[],
+  cursor: string | null | undefined,
+): { sessions: AcpSessionInfo[]; nextCursor: string | null } {
+  const start = cursor ? Number.parseInt(cursor, 10) : 0;
+  const sessions = catalog.slice(start, start + PAGE_SIZE);
+  const nextOffset = start + sessions.length;
+  return {
+    sessions,
+    nextCursor: nextOffset < catalog.length ? String(nextOffset) : null,
+  };
+}
+
+function seedLoadedState(
+  catalog: AcpSessionInfo[],
+  loadedPages: number,
+  extraSessions: ChatSession[] = [],
+) {
+  const sessions = catalog.slice(0, loadedPages * PAGE_SIZE);
+  const nextOffset = sessions.length;
+  useChatSessionStore.setState({
+    sessions: [
+      ...extraSessions,
+      ...sessions.map((session) =>
+        makeSession(session.sessionId, {
+          projectId: session.projectId ?? undefined,
+          messageCount: session.messageCount,
+          lastMessageAt: session.lastMessageAt ?? undefined,
+        }),
+      ),
+    ],
+    hasHydratedSessions: true,
+    sessionPageCursor: nextOffset < catalog.length ? String(nextOffset) : null,
+    hasMoreSessions: nextOffset < catalog.length,
+  });
+}
+
+async function flushHydration() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function renderHydration(enabled = true) {
+  return renderHook(() => {
+    const projects = useProjectStore((state) => state.projects);
+    useProjectSessionHydration(enabled, projects);
+  });
+}
+
+function resetStores() {
+  window.localStorage.clear();
+  useProjectStore.setState({
+    projects: [],
+    loading: false,
+    hasFetchedProjects: false,
+    activeProjectId: null,
+  });
+  useChatSessionStore.setState({
+    sessions: [],
+    activeSessionId: null,
+    isLoading: false,
+    isLoadingMoreSessions: false,
+    hasHydratedSessions: false,
+    sessionListReloadCount: 0,
+    sessionPageCursor: null,
+    hasMoreSessions: false,
+    activeWorkspaceBySession: {},
+    archiveMutationBySessionId: {},
+  });
+}
+
+describe("useProjectSessionHydration", () => {
+  beforeEach(() => {
+    resetStores();
+    resetProjectSessionHydrationAccounting();
+    vi.clearAllMocks();
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.reject(
+          new Error(`unexpected session/list call (cursor: ${cursor})`),
+        ),
+    );
+  });
+
+  it("hydrates a project whose chats sit many pages deep", {
+    timeout: 20_000,
+  }, async () => {
+    // project-b's newest chat sits past 60 sessions — beyond the previous
+    // grouped auto-load cap — so this reproduces the zero-chats bug from #259.
+    const catalog = buildBackendCatalog(["project-a", "project-b"], 61);
+    expect(
+      catalog.findIndex((session) => session.projectId === "project-b"),
+    ).toBeGreaterThan(60);
+    useProjectStore.setState({
+      projects: [makeProject("project-a"), makeProject("project-b")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+
+    await waitFor(() => {
+      const projectIds = new Set(
+        useChatSessionStore
+          .getState()
+          .sessions.map((session) => session.projectId),
+      );
+      expect(projectIds).toContain("project-a");
+      expect(projectIds).toContain("project-b");
+    });
+    expect(mocks.acpListSessionsPage.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("stops paging as soon as every visible project has a loaded chat", async () => {
+    const catalog = buildBackendCatalog(["project-a"], 4);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    // Only the two standalone chats are loaded; project-a's chats start on
+    // the next page, which still has more pages behind it.
+    seedLoadedState(catalog, 0, [
+      makeSession("standalone-1", {
+        lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+      }),
+      makeSession("standalone-2", {
+        lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+      }),
+    ]);
+    useChatSessionStore.setState({
+      sessionPageCursor: "2",
+      hasMoreSessions: true,
+    });
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+
+    // Wait until the single needed page has actually merged project-a's
+    // first chat, then drain effects and assert no further page is requested.
+    await waitFor(() => {
+      expect(
+        useChatSessionStore
+          .getState()
+          .sessions.some((session) => session.projectId === "project-a"),
+      ).toBe(true);
+    });
+    await flushHydration();
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledWith({ cursor: "2" });
+    expect(useChatSessionStore.getState().hasMoreSessions).toBe(true);
+  });
+
+  it("does not page when disabled", async () => {
+    const catalog = buildBackendCatalog(["project-a"], 5);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockResolvedValue(pageFromCatalog(catalog, null));
+
+    renderHydration(false);
+    await flushHydration();
+
+    expect(mocks.acpListSessionsPage).not.toHaveBeenCalled();
+  });
+
+  it("does not page before projects have been fetched from the backend", async () => {
+    const catalog = buildBackendCatalog(["project-a"], 5);
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockResolvedValue(pageFromCatalog(catalog, null));
+
+    renderHydration();
+    await flushHydration();
+
+    expect(mocks.acpListSessionsPage).not.toHaveBeenCalled();
+  });
+
+  it("ignores archived projects when deciding what still needs chats", async () => {
+    // other-project's chat is already in the first page, so the archived
+    // project is the only thing that could trigger paging. If archived
+    // projects counted as pending, a request would fire here.
+    const catalog = buildBackendCatalog(["other-project"], 5);
+    useProjectStore.setState({
+      projects: [
+        makeProject("other-project"),
+        makeProject("archived-project", "2026-03-01T00:00:00.000Z"),
+      ],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+    await flushHydration();
+
+    expect(mocks.acpListSessionsPage).not.toHaveBeenCalled();
+  });
+
+  it("does not count zero-message placeholder sessions toward hydration", async () => {
+    // A placeholder renders in the project section only while locally
+    // relevant; it cannot stand in for the project's real chats, so the hook
+    // keeps paging until a started chat for the project lands.
+    const catalog = buildBackendCatalog(["project-a"], 2);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 0, [
+      makeSession("standalone-1", {
+        lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+      }),
+      makeSession("standalone-2", {
+        lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+      }),
+      makeSession("pinned-placeholder", {
+        projectId: "project-a",
+        messageCount: 0,
+        pinnedLoadState: "loading",
+      }),
+    ]);
+    useChatSessionStore.setState({
+      sessionPageCursor: "2",
+      hasMoreSessions: true,
+    });
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+
+    await waitFor(() => {
+      const started = useChatSessionStore
+        .getState()
+        .sessions.some(
+          (session) =>
+            session.projectId === "project-a" && session.messageCount > 0,
+        );
+      expect(started).toBe(true);
+    });
+  });
+
+  it("walks to the end of the catalog for a project that owns no sessions", async () => {
+    const catalog = buildBackendCatalog(["other-project"], 9);
+    useProjectStore.setState({
+      projects: [makeProject("empty-project"), makeProject("other-project")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+
+    await waitFor(() => {
+      expect(useChatSessionStore.getState().hasMoreSessions).toBe(false);
+    });
+    const pageCount = mocks.acpListSessionsPage.mock.calls.length;
+    expect(pageCount).toBeGreaterThan(1);
+    expect(pageCount).toBeLessThanOrEqual(40);
+
+    // Once pagination is exhausted the hook stays idle.
+    const callsAtExhaustion = mocks.acpListSessionsPage.mock.calls.length;
+    await flushHydration();
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(callsAtExhaustion);
+  });
+
+  it("stops paging when the backend repeats a cursor", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const catalog = buildBackendCatalog(["project-a"], 3);
+    useProjectStore.setState({
+      projects: [makeProject("project-a"), makeProject("missing-project")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) => {
+        const page = pageFromCatalog(catalog, cursor);
+        return Promise.resolve({ ...page, nextCursor: cursor ?? null });
+      },
+    );
+
+    renderHydration();
+
+    await waitFor(() => {
+      expect(useChatSessionStore.getState().hasMoreSessions).toBe(false);
+    });
+    const callsAtStop = mocks.acpListSessionsPage.mock.calls.length;
+    expect(callsAtStop).toBe(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("same pagination cursor"),
+    );
+
+    await flushHydration();
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(callsAtStop);
+  });
+
+  it("bounds paging when the catalog never ends", {
+    timeout: 20_000,
+  }, async () => {
+    useProjectStore.setState({
+      projects: [makeProject("missing-project")],
+      hasFetchedProjects: true,
+    });
+    useChatSessionStore.setState({
+      sessions: [],
+      hasHydratedSessions: true,
+      sessionPageCursor: "0",
+      hasMoreSessions: true,
+    });
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) => {
+        const start = cursor ? Number.parseInt(cursor, 10) : 0;
+        return Promise.resolve({
+          sessions: [makeAcpSession(`other-${start}`, start)],
+          nextCursor: String(start + 1),
+        });
+      },
+    );
+
+    renderHydration();
+
+    await waitFor(
+      () => {
+        expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(40);
+      },
+      { timeout: 10_000 },
+    );
+    const cappedCalls = mocks.acpListSessionsPage.mock.calls.length;
+    await flushHydration();
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(cappedCalls);
+  });
+
+  it("recovers when a page request fails after a backoff retry", async () => {
+    vi.useFakeTimers();
+    try {
+      const catalog = buildBackendCatalog(["project-a"], 6);
+      useProjectStore.setState({
+        projects: [makeProject("project-a")],
+        hasFetchedProjects: true,
+      });
+      // Project-a's chats all sit past the loaded standalone chats.
+      seedLoadedState(catalog, 0, [
+        makeSession("standalone-1", {
+          lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+        }),
+        makeSession("standalone-2", {
+          lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+        }),
+      ]);
+      useChatSessionStore.setState({
+        sessionPageCursor: "2",
+        hasMoreSessions: true,
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let shouldFail = true;
+      mocks.acpListSessionsPage.mockImplementation(
+        ({ cursor }: { cursor?: string | null } = {}) => {
+          if (shouldFail) {
+            shouldFail = false;
+            return Promise.reject(new Error("network down"));
+          }
+          return Promise.resolve(pageFromCatalog(catalog, cursor));
+        },
+      );
+
+      renderHydration();
+      // First attempt fails without advancing pagination; no immediate retry.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to load more sessions from ACP:",
+        expect.any(Error),
+      );
+
+      // The backoff timer retries, the next page lands, and hydration
+      // continues until project-a has a started chat loaded.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      const hydrated = () =>
+        useChatSessionStore
+          .getState()
+          .sessions.some((session) => session.projectId === "project-a");
+      for (let step = 0; step < 10 && !hydrated(); step += 1) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1_000);
+        });
+      }
+      expect(hydrated()).toBe(true);
+      expect(mocks.acpListSessionsPage.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying after repeated failures", async () => {
+    vi.useFakeTimers();
+    try {
+      const catalog = buildBackendCatalog(["project-a"], 6);
+      useProjectStore.setState({
+        projects: [makeProject("project-a")],
+        hasFetchedProjects: true,
+      });
+      seedLoadedState(catalog, 0, [
+        makeSession("standalone-1", {
+          lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+        }),
+        makeSession("standalone-2", {
+          lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+        }),
+      ]);
+      useChatSessionStore.setState({
+        sessionPageCursor: "2",
+        hasMoreSessions: true,
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      mocks.acpListSessionsPage.mockRejectedValue(new Error("network down"));
+
+      renderHydration();
+      // 1 initial attempt + 4 backoff retries = 5 total failures, then stop.
+      for (const delayMs of [0, 2_000, 4_000, 8_000, 16_000]) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delayMs);
+        });
+      }
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(5);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops paging after unmount", async () => {
+    let releasePage!: (page: {
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }) => void;
+    const pendingPage = new Promise<{
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }>((resolve) => {
+      releasePage = resolve;
+    });
+    const catalog = buildBackendCatalog(["project-a", "project-b"], 5);
+    useProjectStore.setState({
+      projects: [makeProject("project-a"), makeProject("project-b")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage
+      .mockReturnValueOnce(pendingPage)
+      .mockImplementation(({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+      );
+
+    const { unmount } = renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    });
+    unmount();
+    await act(async () => {
+      releasePage(pageFromCatalog(catalog, "3"));
+    });
+    await flushHydration();
+
+    expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes a pending backoff retry after unmount and remount", async () => {
+    vi.useFakeTimers();
+    try {
+      const catalog = buildBackendCatalog(["project-a"], 6);
+      useProjectStore.setState({
+        projects: [makeProject("project-a")],
+        hasFetchedProjects: true,
+      });
+      seedLoadedState(catalog, 0, [
+        makeSession("standalone-1", {
+          lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+        }),
+        makeSession("standalone-2", {
+          lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+        }),
+      ]);
+      useChatSessionStore.setState({
+        sessionPageCursor: "2",
+        hasMoreSessions: true,
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      let shouldFail = true;
+      mocks.acpListSessionsPage.mockImplementation(
+        ({ cursor }: { cursor?: string | null } = {}) => {
+          if (shouldFail) {
+            shouldFail = false;
+            return Promise.reject(new Error("network down"));
+          }
+          return Promise.resolve(pageFromCatalog(catalog, cursor));
+        },
+      );
+
+      // Fail once so a backoff deadline is pending, then unmount before the
+      // original instance's wake timer can fire.
+      const first = renderHydration();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+      first.unmount();
+
+      // A new instance mounts during the backoff window; it must honor the
+      // shared deadline and then retry on its own timer.
+      renderHydration();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      const hydrated = () =>
+        useChatSessionStore
+          .getState()
+          .sessions.some((session) => session.projectId === "project-a");
+      for (let step = 0; step < 10 && !hydrated(); step += 1) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1_000);
+        });
+      }
+      expect(hydrated()).toBe(true);
+      expect(mocks.acpListSessionsPage.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes hydration after a loadSessions() refresh rewinds the cursor", async () => {
+    // project-a's chats start at index 12. The second hydration page is held
+    // deferred so hydration cannot reach project-a before the refresh; the
+    // refresh then rewinds the cursor to "3", a position already attempted.
+    const catalog = buildBackendCatalog(["project-a"], 12, 12);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    let releaseSecondPage!: (page: {
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }) => void;
+    const secondPage = new Promise<{
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }>((resolve) => {
+      releaseSecondPage = resolve;
+    });
+    let calls = 0;
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) => {
+        calls += 1;
+        if (calls === 1) return secondPage;
+        return Promise.resolve(pageFromCatalog(catalog, cursor));
+      },
+    );
+
+    renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    });
+    // One position attempted, project-a still absent.
+    expect(
+      useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.projectId === "project-a"),
+    ).toBe(false);
+
+    // Refresh while the first hydration page is held; the stale completion is
+    // dropped by the store's epoch guard.
+    await act(async () => {
+      const refresh = useChatSessionStore.getState().loadSessions();
+      releaseSecondPage(pageFromCatalog(catalog, "3"));
+      await refresh;
+    });
+
+    // Hydration resumes from the rewound cursor — re-requesting the already
+    // attempted "3" position — and walks until project-a is hydrated.
+    await waitFor(() => {
+      expect(
+        mocks.acpListSessionsPage.mock.calls.filter(
+          (args) =>
+            (args[0] as { cursor?: string } | undefined)?.cursor === "3",
+        ).length,
+      ).toBeGreaterThanOrEqual(2);
+    });
+    await waitFor(() => {
+      const hydrated = useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.projectId === "project-a");
+      expect(hydrated).toBe(true);
+    });
+  });
+
+  it("drops an in-flight hydration page superseded by a refresh", async () => {
+    let releaseStalePage!: (page: {
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }) => void;
+    const stalePage = new Promise<{
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }>((resolve) => {
+      releaseStalePage = resolve;
+    });
+    const catalog = buildBackendCatalog(["project-a"], 12, 12);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage
+      .mockReturnValueOnce(stalePage)
+      .mockImplementation(({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+      );
+
+    renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    });
+
+    // Refresh while the hydration page is in flight; the store's epoch guard
+    // discards the stale page when it finally resolves. The sentinel id would
+    // appear in the store if the stale merge were applied.
+    await act(async () => {
+      const refresh = useChatSessionStore.getState().loadSessions();
+      releaseStalePage({
+        sessions: [makeAcpSession("stale-sentinel", 99, "project-a")],
+        nextCursor: "6",
+      });
+      await refresh;
+    });
+    expect(
+      useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.id === "stale-sentinel"),
+    ).toBe(false);
+
+    await waitFor(() => {
+      const hydrated = useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.projectId === "project-a");
+      expect(hydrated).toBe(true);
+    });
+  });
+
+  it("resets the consecutive-failure count after a successful page", async () => {
+    vi.useFakeTimers();
+    try {
+      // project-a's chats start at index 30, so hydration keeps walking.
+      const catalog = buildBackendCatalog(["project-a"], 6, 30);
+      useProjectStore.setState({
+        projects: [makeProject("project-a")],
+        hasFetchedProjects: true,
+      });
+      seedLoadedState(catalog, 0, [
+        makeSession("standalone-1", {
+          lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+        }),
+        makeSession("standalone-2", {
+          lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+        }),
+      ]);
+      useChatSessionStore.setState({
+        sessionPageCursor: "2",
+        hasMoreSessions: true,
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      // Fail the first attempt, succeed for a while, then fail persistently.
+      // The success must reset the failure counter so the later outage gets a
+      // fresh set of five attempts (1 + 4 retries) instead of stopping early.
+      let callCount = 0;
+      mocks.acpListSessionsPage.mockImplementation(
+        ({ cursor }: { cursor?: string | null } = {}) => {
+          callCount += 1;
+          if (callCount === 1 || callCount >= 4) {
+            return Promise.reject(new Error("network down"));
+          }
+          return Promise.resolve(pageFromCatalog(catalog, cursor));
+        },
+      );
+
+      renderHydration();
+      // Attempt 1 fails immediately; the 2s backoff retry succeeds, the next
+      // page chains immediately and succeeds, and the following page fails —
+      // four calls by t=2s.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(4);
+
+      // The success reset the failure counter, so the new outage gets a full
+      // set of retries: failures 2-5 at 4s, 8s, 16s, and 32s, then stop.
+      for (const delayMs of [4_000, 8_000, 16_000, 32_000]) {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(delayMs);
+        });
+      }
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(8);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(8);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps paging when a project is added mid-hydration", async () => {
+    let releasePage!: (page: {
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }) => void;
+    const pendingPage = new Promise<{
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }>((resolve) => {
+      releasePage = resolve;
+    });
+    // Both projects' chats sit past page 1, so hydration is in flight when
+    // project-b appears.
+    const catalog = buildBackendCatalog(["project-a", "project-b"], 5, 8);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage
+      .mockReturnValueOnce(pendingPage)
+      .mockImplementation(({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+      );
+
+    renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    });
+
+    // project-b appears while a page for project-a is still in flight.
+    await act(async () => {
+      useProjectStore.setState({
+        projects: [makeProject("project-a"), makeProject("project-b")],
+      });
+      releasePage(pageFromCatalog(catalog, "3"));
+    });
+
+    await waitFor(() => {
+      const projectIds = new Set(
+        useChatSessionStore
+          .getState()
+          .sessions.map((session) => session.projectId),
+      );
+      expect(projectIds).toContain("project-a");
+      expect(projectIds).toContain("project-b");
+    });
+  });
+
+  it("does not count archived chats toward their project's hydration", async () => {
+    // project-a's only loaded chat is archived; its active chat sits on the
+    // next page, so hydration must keep paging rather than trusting the
+    // archived row.
+    const catalog = buildBackendCatalog(["project-a"], 2, 8);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 0, [
+      makeSession("archived-chat", {
+        projectId: "project-a",
+        messageCount: 3,
+        archivedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ]);
+    useChatSessionStore.setState({
+      sessionPageCursor: "0",
+      hasMoreSessions: true,
+    });
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    renderHydration();
+
+    await waitFor(() => {
+      const active = useChatSessionStore
+        .getState()
+        .sessions.some(
+          (session) => session.projectId === "project-a" && !session.archivedAt,
+        );
+      expect(active).toBe(true);
+    });
+  });
+
+  it("stops retrying after 15 lifetime failures even across refreshes", async () => {
+    vi.useFakeTimers();
+    try {
+      const catalog = buildBackendCatalog(["project-a"], 6, 30);
+      useProjectStore.setState({
+        projects: [makeProject("project-a")],
+        hasFetchedProjects: true,
+      });
+      seedLoadedState(catalog, 0, [
+        makeSession("standalone-1", {
+          lastMessageAt: catalog[0].lastMessageAt ?? undefined,
+        }),
+        makeSession("standalone-2", {
+          lastMessageAt: catalog[1].lastMessageAt ?? undefined,
+        }),
+      ]);
+      useChatSessionStore.setState({
+        sessionPageCursor: "2",
+        hasMoreSessions: true,
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      // First-page reloads succeed (each re-arms the consecutive-failure
+      // breaker); deeper pages always fail.
+      mocks.acpListSessionsPage.mockImplementation(
+        ({ cursor }: { cursor?: string | null } = {}) =>
+          cursor == null || cursor === "0"
+            ? Promise.resolve(pageFromCatalog(catalog, cursor))
+            : Promise.reject(new Error("network down")),
+      );
+
+      renderHydration();
+      // Three rounds of five consecutive failures, each followed by a
+      // successful loadSessions() reload that resets the consecutive breaker.
+      for (let round = 0; round < 3; round += 1) {
+        for (const delayMs of [0, 2_000, 4_000, 8_000, 16_000]) {
+          await act(async () => {
+            await vi.advanceTimersByTimeAsync(delayMs);
+          });
+        }
+        await act(async () => {
+          await useChatSessionStore.getState().loadSessions();
+        });
+      }
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(15 + 3);
+
+      // The lifetime breaker holds despite further successful refreshes.
+      await act(async () => {
+        await useChatSessionStore.getState().loadSessions();
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(15 + 4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resumes hydration when a refresh happens while unmounted", async () => {
+    // project-a's chats start at index 12. Hydrate one page, unmount, run a
+    // full refresh (rewinding the cursor), then remount: the rewound position
+    // must be re-attempted rather than treated as already visited.
+    const catalog = buildBackendCatalog(["project-a"], 12, 12);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) =>
+        Promise.resolve(pageFromCatalog(catalog, cursor)),
+    );
+
+    const { unmount } = renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalled();
+    });
+    const callsBeforeUnmount = mocks.acpListSessionsPage.mock.calls.length;
+    unmount();
+
+    await act(async () => {
+      await useChatSessionStore.getState().loadSessions();
+    });
+
+    renderHydration();
+    await waitFor(() => {
+      const hydrated = useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.projectId === "project-a");
+      expect(hydrated).toBe(true);
+    });
+    // The refresh rewound pagination while unmounted; the remounted hook must
+    // have requested further pages to finish hydrating project-a.
+    expect(mocks.acpListSessionsPage.mock.calls.length).toBeGreaterThan(
+      callsBeforeUnmount,
+    );
+  });
+
+  it("retries its position when a concurrent page request wins the race", async () => {
+    // project-a's chats start at index 12. The hook's first request is held
+    // while a competing loadMoreSessions (as the flat sidebar or history view
+    // could issue) wins the in-flight guard; the hook's attempt resolves
+    // "skipped" and must retry once the winner settles.
+    const catalog = buildBackendCatalog(["project-a"], 6, 12);
+    useProjectStore.setState({
+      projects: [makeProject("project-a")],
+      hasFetchedProjects: true,
+    });
+    seedLoadedState(catalog, 1);
+    let releaseHeld!: (page: {
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }) => void;
+    const heldPage = new Promise<{
+      sessions: AcpSessionInfo[];
+      nextCursor: string | null;
+    }>((resolve) => {
+      releaseHeld = resolve;
+    });
+    let calls = 0;
+    mocks.acpListSessionsPage.mockImplementation(
+      ({ cursor }: { cursor?: string | null } = {}) => {
+        calls += 1;
+        if (calls === 1) return heldPage;
+        return Promise.resolve(pageFromCatalog(catalog, cursor));
+      },
+    );
+
+    renderHydration();
+    await waitFor(() => {
+      expect(mocks.acpListSessionsPage).toHaveBeenCalledTimes(1);
+    });
+
+    // A competing pager issues a request while the hook's page is held; the
+    // hook's own next attempt (after the held page lands) must still walk to
+    // project-a instead of stalling on a skipped position.
+    await act(async () => {
+      releaseHeld(pageFromCatalog(catalog, "3"));
+    });
+    await act(async () => {
+      await useChatSessionStore.getState().loadMoreSessions();
+    });
+
+    await waitFor(() => {
+      const hydrated = useChatSessionStore
+        .getState()
+        .sessions.some((session) => session.projectId === "project-a");
+      expect(hydrated).toBe(true);
+    });
+  });
+});

--- a/src/features/sessions/hooks/useProjectSessionHydration.ts
+++ b/src/features/sessions/hooks/useProjectSessionHydration.ts
@@ -1,0 +1,260 @@
+import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import type { ProjectInfo } from "@/features/projects/api/projects";
+import { useProjectStore } from "@/features/projects/stores/projectStore";
+
+/**
+ * Upper bound on page requests issued per app session while hydrating
+ * projects. Guards against pathological paging when a project owns no
+ * sessions at all: without a server-side project filter we can only discover
+ * that by walking to the end of the list, which this cap keeps bounded.
+ * Failed pages retry separately, with backoff, up to consecutive and lifetime
+ * failure limits.
+ */
+const MAX_PROJECT_HYDRATION_PAGES = 40;
+
+/** Upper bound on consecutive failed page attempts before hydration stops. */
+const MAX_PROJECT_HYDRATION_FAILURES = 5;
+
+/** Upper bound on total failed attempts per app session, across refreshes. */
+const MAX_PROJECT_HYDRATION_LIFETIME_FAILURES = 15;
+
+/** Base delay between retries after a failed page; doubles per failure. */
+const PROJECT_HYDRATION_RETRY_BASE_MS = 2_000;
+
+interface ProjectSessionHydrationAccounting {
+  attemptedKeys: Set<string>;
+  /** Page requests issued this app session; bounds total background paging.
+   *  Incremented synchronously at issue time so a burst of merged pages
+   *  cannot slip extra requests past the cap. */
+  issuedPages: number;
+  consecutiveFailures: number;
+  /** Failed attempts this app session; refresh-resistant companion to the
+   *  consecutive-failure breaker so a sustained outage cannot re-arm retries
+   *  on every periodic reload. */
+  lifetimeFailures: number;
+  /** Epoch ms when a backoff retry becomes due; 0 when no retry is pending. */
+  retryNotBefore: number;
+  /** Last store sessionListReloadCount the accounting has synced with. */
+  syncedReloadCount: number;
+}
+
+function createProjectSessionHydrationAccounting(): ProjectSessionHydrationAccounting {
+  return {
+    attemptedKeys: new Set(),
+    issuedPages: 0,
+    consecutiveFailures: 0,
+    lifetimeFailures: 0,
+    retryNotBefore: 0,
+    syncedReloadCount: 0,
+  };
+}
+
+// App-session lifetime accounting, so collapsing the sidebar (which unmounts
+// the capability) cannot reset the page budget. Generation state syncs from
+// the store's sessionListReloadCount, so refreshes that happen while no
+// instance is mounted are still observed on the next mount.
+let accounting = createProjectSessionHydrationAccounting();
+
+// Page completions mutate accounting from promise continuations, which can
+// settle after the issuing instance unmounted. Broadcast each change so any
+// currently mounted instance re-runs its effect instead of relying on the
+// (possibly dead) issuer's reducer.
+const accountingListeners = new Set<() => void>();
+let accountingRevision = 0;
+
+function notifyAccountingChanged(): void {
+  accountingRevision += 1;
+  for (const listener of accountingListeners) listener();
+}
+
+function subscribeAccounting(listener: () => void): () => void {
+  accountingListeners.add(listener);
+  return () => {
+    accountingListeners.delete(listener);
+  };
+}
+
+/**
+ * Sync accounting with the store's pagination generation. A successful
+ * loadSessions() reload rewinds pagination to the first page's cursor, drops
+ * in-flight load-more pages via the epoch guard, and confirms connectivity —
+ * so attempted positions may be revisited and the failure breaker resets.
+ */
+function syncAccountingWithReloadCount(reloadCount: number): void {
+  if (reloadCount === accounting.syncedReloadCount) return;
+  accounting.syncedReloadCount = reloadCount;
+  accounting.attemptedKeys.clear();
+  accounting.consecutiveFailures = 0;
+  accounting.retryNotBefore = 0;
+}
+
+/** Test-only: reset module-level hydration accounting between tests. */
+export function resetProjectSessionHydrationAccounting(): void {
+  accounting = createProjectSessionHydrationAccounting();
+  accountingRevision = 0;
+}
+
+/**
+ * Keeps paging `session/list` in the background until every sidebar project
+ * has at least one of its chats loaded, pagination is exhausted, the page
+ * budget is spent, or retries keep failing. Without this, projects whose
+ * newest chat falls past the initially loaded slice render with zero chats.
+ *
+ * TODO: once the goose backend `SessionListFilters` supports a `project_id`
+ * filter (tracked separately from #259 as upstream follow-up), replace this
+ * page-walking hydration with per-project `session/list?projectId=X` queries.
+ */
+export function useProjectSessionHydration(
+  enabled: boolean,
+  projects: ProjectInfo[],
+): void {
+  const hasFetchedProjects = useProjectStore(
+    (state) => state.hasFetchedProjects,
+  );
+  const hasHydratedSessions = useChatSessionStore(
+    (state) => state.hasHydratedSessions,
+  );
+  const sessionPageCursor = useChatSessionStore(
+    (state) => state.sessionPageCursor,
+  );
+  const hasMoreSessions = useChatSessionStore((state) => state.hasMoreSessions);
+  const isLoadingMoreSessions = useChatSessionStore(
+    (state) => state.isLoadingMoreSessions,
+  );
+  const sessions = useChatSessionStore((state) => state.sessions);
+  const isRefreshingSessions = useChatSessionStore((state) => state.isLoading);
+  const sessionListReloadCount = useChatSessionStore(
+    (state) => state.sessionListReloadCount,
+  );
+  const loadMoreSessions = useChatSessionStore(
+    (state) => state.loadMoreSessions,
+  );
+  // Re-runs the effect when accounting changes settle from page completions
+  // (including ones issued by an instance that has since unmounted).
+  const accountingTick = useSyncExternalStore(
+    subscribeAccounting,
+    () => accountingRevision,
+  );
+
+  // Ids of visible projects that still have no started, unarchived chat in the
+  // loaded slice. Zero-message placeholder sessions (drafts, pinned
+  // placeholders) do not count: the sidebar only guarantees them a row while
+  // they are locally relevant, so they cannot stand in for a project's chats.
+  const pendingProjectIds = useMemo(() => {
+    if (!enabled || !hasFetchedProjects) return [];
+    const visibleProjects = projects.filter((project) => !project.archivedAt);
+    if (visibleProjects.length === 0) return [];
+    const hydratedProjectIds = new Set<string>();
+    for (const session of sessions) {
+      if (
+        session.messageCount > 0 &&
+        !session.archivedAt &&
+        session.projectId
+      ) {
+        hydratedProjectIds.add(session.projectId);
+      }
+    }
+    return visibleProjects
+      .filter((project) => !hydratedProjectIds.has(project.id))
+      .map((project) => project.id)
+      .sort();
+  }, [enabled, hasFetchedProjects, projects, sessions]);
+
+  const allProjectsHydrated =
+    enabled && hasFetchedProjects && pendingProjectIds.length === 0;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `accountingTick` is bumped by page completions and backoff timers to force a re-run
+  useEffect(() => {
+    if (!enabled || !hasFetchedProjects || !hasHydratedSessions) return;
+    if (isRefreshingSessions) return;
+    syncAccountingWithReloadCount(sessionListReloadCount);
+    if (allProjectsHydrated || !hasMoreSessions || isLoadingMoreSessions) {
+      return;
+    }
+    if (accounting.issuedPages >= MAX_PROJECT_HYDRATION_PAGES) return;
+    if (
+      accounting.consecutiveFailures >= MAX_PROJECT_HYDRATION_FAILURES ||
+      accounting.lifetimeFailures >= MAX_PROJECT_HYDRATION_LIFETIME_FAILURES
+    ) {
+      return;
+    }
+    if (Date.now() < accounting.retryNotBefore) {
+      // A backoff retry is due later. Wake this mounted instance when it is;
+      // each instance owns its timer so an unmount/remount cycle cannot lose
+      // the shared deadline's wakeup.
+      const wakeTimer = setTimeout(
+        notifyAccountingChanged,
+        accounting.retryNotBefore - Date.now(),
+      );
+      return () => clearTimeout(wakeTimer);
+    }
+
+    // Attempt each (projects, cursor) position once per pagination
+    // generation; syncAccountingWithReloadCount clears the set when a
+    // loadSessions() refresh rewinds the cursor.
+    const hydrationKey = [
+      pendingProjectIds.join(","),
+      sessionPageCursor ?? "__initial__",
+    ].join("|");
+    if (accounting.attemptedKeys.has(hydrationKey)) return;
+    accounting.attemptedKeys.add(hydrationKey);
+    accounting.issuedPages += 1;
+
+    // loadMoreSessions reports the page's exact outcome. Only "failed" trips
+    // the breakers; skipped/superseded pages relinquish their position so the
+    // next effect run can retry them.
+    void loadMoreSessions().then((outcome) => {
+      syncAccountingWithReloadCount(
+        useChatSessionStore.getState().sessionListReloadCount,
+      );
+      if (outcome === "applied") {
+        accounting.consecutiveFailures = 0;
+        accounting.retryNotBefore = 0;
+        return;
+      }
+      accounting.attemptedKeys.delete(hydrationKey);
+      if (outcome === "superseded") {
+        // A refresh dropped this page via the epoch guard; the sync above
+        // reset generation state, and the next effect run re-issues from the
+        // current cursor. Not a failure.
+        notifyAccountingChanged();
+        return;
+      }
+      if (outcome === "skipped") {
+        // Another page is in flight; its completion re-runs this effect and
+        // retries the position. Not a failure.
+        notifyAccountingChanged();
+        return;
+      }
+      accounting.consecutiveFailures += 1;
+      accounting.lifetimeFailures += 1;
+      if (accounting.consecutiveFailures >= MAX_PROJECT_HYDRATION_FAILURES) {
+        notifyAccountingChanged();
+        return;
+      }
+      accounting.retryNotBefore =
+        Date.now() +
+        PROJECT_HYDRATION_RETRY_BASE_MS *
+          2 ** (accounting.consecutiveFailures - 1);
+      // Re-run the effect so the guard above schedules this instance's
+      // wake timer for the deadline (or retries immediately).
+      notifyAccountingChanged();
+    });
+    // accountingTick retriggers this effect when page-completion bookkeeping
+    // lands or a backoff wake timer fires.
+  }, [
+    accountingTick,
+    allProjectsHydrated,
+    enabled,
+    hasFetchedProjects,
+    hasHydratedSessions,
+    hasMoreSessions,
+    isLoadingMoreSessions,
+    isRefreshingSessions,
+    loadMoreSessions,
+    pendingProjectIds,
+    sessionListReloadCount,
+    sessionPageCursor,
+  ]);
+}

--- a/src/features/sessions/ui/__tests__/SessionHistoryView.test.tsx
+++ b/src/features/sessions/ui/__tests__/SessionHistoryView.test.tsx
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import {
   type ChatSession,
+  type LoadMoreSessionsOutcome,
   useChatSessionStore,
 } from "@/features/chat/stores/chatSessionStore";
 import { useSessionWindowStore } from "@/features/chat/stores/sessionWindowStore";
@@ -385,17 +386,20 @@ describe("SessionHistoryView", () => {
       title: "Chat Two",
       updatedAt: "2026-04-09T12:01:00.000Z",
     });
-    const loadMoreSessions = vi.fn(async () => {
-      useChatSessionStore.setState((state) => ({
-        sessions: [...state.sessions, secondPageSession],
-        hasMoreSessions: true,
-        isLoadingMoreSessions: false,
-        sessionPageCursor: "cursor-2",
-      }));
-      if (scroller) {
-        setScrollMetrics(scroller, { scrollHeight: 2200, clientHeight: 600 });
-      }
-    });
+    const loadMoreSessions = vi.fn(
+      async (): Promise<LoadMoreSessionsOutcome> => {
+        useChatSessionStore.setState((state) => ({
+          sessions: [...state.sessions, secondPageSession],
+          hasMoreSessions: true,
+          isLoadingMoreSessions: false,
+          sessionPageCursor: "cursor-2",
+        }));
+        if (scroller) {
+          setScrollMetrics(scroller, { scrollHeight: 2200, clientHeight: 600 });
+        }
+        return "applied";
+      },
+    );
     setSessionStoreState({
       sessions: [session()],
       hasMoreSessions: true,
@@ -423,7 +427,7 @@ describe("SessionHistoryView", () => {
   });
 
   it("loads another page when the viewport is underfilled and exposes loading status", async () => {
-    const loadMoreSessions = vi.fn().mockResolvedValue(undefined);
+    const loadMoreSessions = vi.fn().mockResolvedValue("applied");
     setSessionStoreState({
       sessions: [session()],
       hasMoreSessions: true,
@@ -460,13 +464,16 @@ describe("SessionHistoryView", () => {
       title: "Second Needle Session",
       updatedAt: "2026-04-09T12:01:00.000Z",
     });
-    const loadMoreSessions = vi.fn(async () => {
-      useChatSessionStore.setState((state) => ({
-        sessions: [...state.sessions, secondPageSession],
-        hasMoreSessions: false,
-        sessionPageCursor: null,
-      }));
-    });
+    const loadMoreSessions = vi.fn(
+      async (): Promise<LoadMoreSessionsOutcome> => {
+        useChatSessionStore.setState((state) => ({
+          sessions: [...state.sessions, secondPageSession],
+          hasMoreSessions: false,
+          sessionPageCursor: null,
+        }));
+        return "applied";
+      },
+    );
     setSessionStoreState({
       sessions: [session()],
       hasMoreSessions: true,
@@ -506,22 +513,25 @@ describe("SessionHistoryView", () => {
     const pageGate = new Promise<void>((resolve) => {
       releasePage = resolve;
     });
-    const loadMoreSessions = vi.fn(async () => {
-      await pageGate;
-      useChatSessionStore.setState((state) => ({
-        sessions: [
-          ...state.sessions,
-          session({
-            id: "session-3",
-            title: "Late Archived Needle",
-            archivedAt: "2026-04-09T12:06:00.000Z",
-            updatedAt: "2026-04-09T12:02:00.000Z",
-          }),
-        ],
-        hasMoreSessions: false,
-        sessionPageCursor: null,
-      }));
-    });
+    const loadMoreSessions = vi.fn(
+      async (): Promise<LoadMoreSessionsOutcome> => {
+        await pageGate;
+        useChatSessionStore.setState((state) => ({
+          sessions: [
+            ...state.sessions,
+            session({
+              id: "session-3",
+              title: "Late Archived Needle",
+              archivedAt: "2026-04-09T12:06:00.000Z",
+              updatedAt: "2026-04-09T12:02:00.000Z",
+            }),
+          ],
+          hasMoreSessions: false,
+          sessionPageCursor: null,
+        }));
+        return "applied";
+      },
+    );
     setSessionStoreState({
       sessions: [
         session({ id: "session-1", title: "Active Needle" }),
@@ -654,21 +664,24 @@ describe("SessionHistoryView", () => {
       { id: "project-a", name: "Project A", workingDirs: ["/a"] },
       { id: "project-b", name: "Project B", workingDirs: ["/b"] },
     ];
-    const loadMoreSessions = vi.fn(async () => {
-      useChatSessionStore.setState((state) => ({
-        sessions: [
-          ...state.sessions,
-          session({
-            id: "session-2",
-            title: "Other Project Needle",
-            projectId: "project-b",
-            updatedAt: "2026-04-09T12:01:00.000Z",
-          }),
-        ],
-        hasMoreSessions: false,
-        sessionPageCursor: null,
-      }));
-    });
+    const loadMoreSessions = vi.fn(
+      async (): Promise<LoadMoreSessionsOutcome> => {
+        useChatSessionStore.setState((state) => ({
+          sessions: [
+            ...state.sessions,
+            session({
+              id: "session-2",
+              title: "Other Project Needle",
+              projectId: "project-b",
+              updatedAt: "2026-04-09T12:01:00.000Z",
+            }),
+          ],
+          hasMoreSessions: false,
+          sessionPageCursor: null,
+        }));
+        return "applied";
+      },
+    );
     setSessionStoreState({
       sessions: [
         session({
@@ -763,20 +776,23 @@ describe("SessionHistoryView", () => {
       messageCount: 0,
       updatedAt: "2026-04-09T12:01:00.000Z",
     });
-    const loadMoreSessions = vi.fn(async () => {
-      useChatStore.setState({
-        queuedMessageBySession: {
-          "session-queued": [
-            { kind: "transport-ready", recordId: "q1", payload: {} },
-          ],
-        },
-      } as never);
-      useChatSessionStore.setState((state) => ({
-        sessions: [...state.sessions, queuedOnlySession],
-        hasMoreSessions: false,
-        sessionPageCursor: null,
-      }));
-    });
+    const loadMoreSessions = vi.fn(
+      async (): Promise<LoadMoreSessionsOutcome> => {
+        useChatStore.setState({
+          queuedMessageBySession: {
+            "session-queued": [
+              { kind: "transport-ready", recordId: "q1", payload: {} },
+            ],
+          },
+        } as never);
+        useChatSessionStore.setState((state) => ({
+          sessions: [...state.sessions, queuedOnlySession],
+          hasMoreSessions: false,
+          sessionPageCursor: null,
+        }));
+        return "applied";
+      },
+    );
     setSessionStoreState({
       sessions: [session()],
       hasMoreSessions: true,


### PR DESCRIPTION
## Summary

The grouped sidebar derived each project's chat list from the sessions loaded at startup: `session/list` returns 50 sessions per page and the background auto-loader stopped at 60 grouped chats, so any project whose newest chat sat past that slice rendered with **zero chats** (#259).

This replaces the fixed cap with project-aware session hydration: a new `useProjectSessionHydration` hook keeps paging `session/list` in the background until every visible project has at least one started, unarchived chat loaded — stopping only when all projects are hydrated, pagination is exhausted, a 40-page request budget is spent, or failure breakers trip (5 consecutive with exponential backoff, 15 lifetime per app session).

Design notes:
- Module-level accounting broadcasts to mounted instances, so sidebar collapse/expand can neither reset budgets nor lose retry wakeups.
- `loadMoreSessions` now returns an explicit `LoadMoreSessionsOutcome` (`applied`/`superseded`/`skipped`/`failed`), and the store bumps a `sessionListReloadCount` generation only on successfully applied first pages — refresh races can no longer strand hydration or misclassify stale pages as failures.
- The flat (non-grouped) sidebar path and its recents cap are unchanged.

### Related issue

Fixes #259

### Testing

- `just check` — passed (biome, design-system, i18n, typecheck)
- `just lint` / `just fmt-check` / `just typecheck` — passed
- `just test` — full Vitest suite passed: 611 files, 7291 passed, 1 skipped
- New coverage: 21 hook tests (deep hydration past the old 60-chat cap, stop-when-hydrated, archived projects/chats, placeholder exclusion, repeated-cursor guard, page budget, backoff retry, failure breakers, unmount/remount and refresh races, concurrent pagers) and 2 sidebar capability wiring tests (grouped mode hydrates past the old cap; flat mode does not)