### PR TITLE
fix: folder changes from implicit default workspaces

### DIFF
--- a/src/features/berdctl/__tests__/commands/commands.test.ts
+++ b/src/features/berdctl/__tests__/commands/commands.test.ts
@@ -67,6 +67,7 @@ const mocks = vi.hoisted(() => ({
   checkDirectoriesExist: vi.fn(),
   canonicalizeAuthorizedWorkspaceDirectory: vi.fn(),
   getGitState: vi.fn(),
+  getHomeDir: vi.fn(),
   updateWorkingDir: vi.fn(),
   createPersona: vi.fn(),
   listPersonas: vi.fn(),
@@ -138,6 +139,14 @@ vi.mock("@/shared/api/acpApi", () => ({
 vi.mock("@/shared/api/git", () => ({
   getGitState: (...args: unknown[]) => mocks.getGitState(...args),
 }));
+
+vi.mock("@/shared/api/system", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/api/system")>();
+  return {
+    ...actual,
+    getHomeDir: (...args: unknown[]) => mocks.getHomeDir(...args),
+  };
+});
 
 vi.mock("@/shared/api/pathResolver", () => ({
   resolvePath: (...args: unknown[]) => mocks.resolvePath(...args),
@@ -454,6 +463,7 @@ beforeEach(() => {
     async ({ parts }: { parts: string[] }) => ({ path: parts[0] }),
   );
   mocks.checkDirectoriesExist.mockResolvedValue([]);
+  mocks.getHomeDir.mockReset().mockResolvedValue("/Users/me");
   mocks.getGitState.mockResolvedValue({
     isGitRepo: true,
     currentBranch: "main",
@@ -3542,6 +3552,103 @@ describe("folders.attach", () => {
       ),
       "invalid_args",
     );
+  });
+});
+
+describe("folders implicit default cwd (issue #225)", () => {
+  function seedMixedImplicitDefault(): void {
+    seedSessions({
+      ...makeSession({ workingDir: "/Users/me/goose artifacts" }),
+      workspaceAttachments: [
+        {
+          id: "path:~/goose artifacts",
+          path: "~/goose artifacts",
+          kind: "directory",
+          source: "inferred",
+          usedByAgent: true,
+        },
+      ],
+    });
+    mockSessionFound({ workingDir: "/Users/me/goose artifacts" });
+    mocks.resolvePath.mockImplementation(
+      async ({ parts }: { parts: string[] }) => ({
+        path: parts[0].replace(/^~/, "/Users/me"),
+      }),
+    );
+    mocks.canonicalizeAuthorizedWorkspaceDirectory.mockImplementation(
+      async ({ path }: { path: string }) => ({ path }),
+    );
+  }
+
+  it("attaches in single-workspace mode instead of recommending an impossible replace", async () => {
+    setMultiWorkspaceEnabled(false);
+    seedMixedImplicitDefault();
+
+    await expect(
+      dispatchCommand(
+        "folders",
+        { action: "attach", session_id: "session-1", path: "/repo-wt" },
+        ctx,
+      ),
+    ).resolves.toMatchObject({ ok: true, path: "/repo-wt" });
+    expect(
+      useChatSessionStore
+        .getState()
+        .getSession("session-1")
+        ?.workspaceAttachments?.filter(
+          (attachment) => attachment.source !== "excluded",
+        )
+        .map(({ path }) => path),
+    ).toEqual(["/repo-wt"]);
+  });
+
+  it("replaces the cwd when its attachment uses the other home spelling", async () => {
+    seedMixedImplicitDefault();
+
+    await expect(
+      dispatchCommand(
+        "folders",
+        {
+          action: "replace",
+          session_id: "session-1",
+          old_path: "/Users/me/goose artifacts",
+          new_path: "/repo-wt",
+        },
+        ctx,
+      ),
+    ).resolves.toMatchObject({
+      ok: true,
+      oldPath: "~/goose artifacts",
+      newPath: "/repo-wt",
+      cwdStatus: "pending",
+    });
+  });
+
+  it("marks an expanded attachment as cwd when the session stores ~", async () => {
+    seedSessions({
+      ...makeSession({ workingDir: "~/goose artifacts" }),
+      workspaceAttachments: [
+        {
+          id: "path:/users/me/goose artifacts",
+          path: "/Users/me/goose artifacts",
+          kind: "directory",
+          source: "inferred",
+          usedByAgent: true,
+        },
+      ],
+    });
+    mockSessionFound({ workingDir: "~/goose artifacts" });
+
+    await expect(
+      dispatchCommand(
+        "folders",
+        { action: "list", session_id: "session-1" },
+        ctx,
+      ),
+    ).resolves.toMatchObject({
+      cwd: "~/goose artifacts",
+      folders: [expect.objectContaining({ cwd: true })],
+    });
   });
 });
 

--- a/src/features/berdctl/commands/impl/listSessionFolders.ts
+++ b/src/features/berdctl/commands/impl/listSessionFolders.ts
@@ -24,15 +24,18 @@ Result:
   schema: listSessionFoldersSchema,
   execute: async (args) => {
     const [
-      { getWorkspaceAttachments, isSameWorkspacePath },
+      { getWorkspaceAttachments, isSameWorkspacePathWithHome },
+      { getHomeDir },
       { useChatSessionStore },
       { loadSessionForBerdctl, requireSession },
     ] = await Promise.all([
       import("@/features/chat/lib/workspaceAttachments"),
+      import("@/shared/api/system"),
       import("@/features/chat/stores/chatSessionStore"),
       import("../runtime/sessions"),
     ]);
     await loadSessionForBerdctl(args.session_id);
+    const homeDir = await getHomeDir();
     const session = requireSession(args.session_id);
     const cwd = session.workingDir ?? null;
     const folders = getWorkspaceAttachments(
@@ -43,7 +46,9 @@ Result:
         path: attachment.path,
         kind: attachment.kind,
         branch: attachment.branch ?? null,
-        cwd: cwd != null && isSameWorkspacePath(attachment.path, cwd),
+        cwd:
+          cwd != null &&
+          isSameWorkspacePathWithHome(attachment.path, cwd, homeDir),
       }));
     return { ok: true as const, cwd, folders };
   },

--- a/src/features/chat/lib/__tests__/workspaceAttachments.test.ts
+++ b/src/features/chat/lib/__tests__/workspaceAttachments.test.ts
@@ -10,6 +10,7 @@ import {
   getIncludedWorkspaceAttachments,
   getWorkspaceAttachments,
   getWorkspaceTitle,
+  isSameWorkspacePathWithHome,
   removeWorkspaceAttachment,
   workspaceAttachmentUsesCleanupTarget,
   workspaceAttachmentIdForPath,
@@ -710,5 +711,29 @@ describe("windows identity across dedupe / ensure / exclude", () => {
 
     expect(next.workspaceAttachments).toHaveLength(1);
     expect(next.workspaceAttachments?.[0].source).toBe("excluded");
+  });
+});
+
+describe("isSameWorkspacePathWithHome", () => {
+  it("matches home-relative and expanded spellings", () => {
+    expect(
+      isSameWorkspacePathWithHome(
+        "~/goose artifacts",
+        "/Users/me/goose artifacts",
+        "/Users/me",
+      ),
+    ).toBe(true);
+  });
+
+  it("still distinguishes different paths", () => {
+    expect(
+      isSameWorkspacePathWithHome("~/goose artifacts", "/other", "/Users/me"),
+    ).toBe(false);
+  });
+
+  it("does not treat a mid-path tilde as home-relative", () => {
+    expect(
+      isSameWorkspacePathWithHome("/tmp/~/repo", "/Users/me/repo", "/Users/me"),
+    ).toBe(false);
   });
 });

--- a/src/features/chat/lib/sessionFolderRegistration.test.ts
+++ b/src/features/chat/lib/sessionFolderRegistration.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   canonicalizeAuthorizedWorkspaceDirectory: vi.fn(),
   resolvePath: vi.fn(),
   getGitState: vi.fn(),
+  getHomeDir: vi.fn(),
   resolveArtifactRootPath: vi.fn(),
 }));
 vi.mock("@/shared/api/pathResolver", () => ({
@@ -20,6 +21,13 @@ vi.mock("@/shared/api/pathResolver", () => ({
 vi.mock("@/shared/api/git", () => ({
   getGitState: (...args: unknown[]) => mocks.getGitState(...args),
 }));
+vi.mock("@/shared/api/system", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/api/system")>();
+  return {
+    ...actual,
+    getHomeDir: (...args: unknown[]) => mocks.getHomeDir(...args),
+  };
+});
 vi.mock(
   "@/shared/artifacts/sessionArtifactLocation",
   async (importOriginal) => {
@@ -76,6 +84,7 @@ describe("attachSessionFolder", () => {
         path: parts[0],
       }));
     mocks.getGitState.mockReset().mockResolvedValue(gitState);
+    mocks.getHomeDir.mockReset().mockResolvedValue("/Users/me");
     mocks.resolveArtifactRootPath.mockReset().mockResolvedValue("/artifacts");
   });
 
@@ -610,5 +619,98 @@ describe("attachSessionFolder", () => {
     expect(getPendingSessionWorkspaceActivation("session-1")).toMatchObject({
       path: "/repo-wt",
     });
+  });
+
+  it("attaches over a home-spelled implicit default in single-workspace mode", async () => {
+    const { setMultiWorkspaceEnabled } = await import(
+      "@/features/workspaces/multiWorkspacePreference"
+    );
+    setMultiWorkspaceEnabled(false);
+    try {
+      useChatSessionStore.setState({
+        sessions: [
+          {
+            ...session,
+            workingDir: "/Users/me/goose artifacts",
+            workspaceAttachments: [
+              {
+                id: "path:~/goose artifacts",
+                path: "~/goose artifacts",
+                kind: "directory",
+                source: "inferred",
+                usedByAgent: true,
+              },
+            ],
+          },
+        ],
+      });
+      mocks.resolveArtifactRootPath.mockResolvedValue(
+        "/Users/me/goose artifacts",
+      );
+
+      await expect(
+        attachSessionFolder("session-1", "/repo-wt", {
+          enforceWorkspaceLimit: true,
+        }),
+      ).resolves.toMatchObject({ path: "/repo-wt" });
+      expect(
+        useChatSessionStore
+          .getState()
+          .getSession("session-1")
+          ?.workspaceAttachments?.filter(
+            (attachment) => attachment.source !== "excluded",
+          )
+          .map(({ path }) => path),
+      ).toEqual(["/repo-wt"]);
+    } finally {
+      setMultiWorkspaceEnabled(true);
+    }
+  });
+
+  it("replaces an implicit default whose stored path uses the other home spelling", async () => {
+    useChatSessionStore.setState({
+      sessions: [
+        {
+          ...session,
+          workingDir: "/Users/me/goose artifacts",
+          workspaceAttachments: [
+            {
+              id: "path:~/goose artifacts",
+              path: "~/goose artifacts",
+              kind: "directory",
+              source: "inferred",
+              usedByAgent: true,
+            },
+          ],
+        },
+      ],
+    });
+    mocks.resolvePath.mockImplementation(
+      async ({ parts }: { parts: string[] }) => ({
+        path: parts[0].replace(/^~/, "/Users/me"),
+      }),
+    );
+
+    await expect(
+      replaceSessionFolder(
+        "session-1",
+        "/Users/me/goose artifacts",
+        "/repo-wt",
+      ),
+    ).resolves.toMatchObject({
+      oldPath: "~/goose artifacts",
+      newPath: "/repo-wt",
+      cwd: "/repo-wt",
+      cwdStatus: "pending",
+    });
+    expect(
+      useChatSessionStore
+        .getState()
+        .getSession("session-1")
+        ?.workspaceAttachments?.filter(
+          (attachment) => attachment.source !== "excluded",
+        )
+        .map(({ path }) => path),
+    ).toEqual(["/repo-wt"]);
   });
 });

--- a/src/features/chat/lib/sessionFolderRegistration.ts
+++ b/src/features/chat/lib/sessionFolderRegistration.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceAttachment } from "@/shared/types/chat";
 import { getGitState } from "@/shared/api/git";
+import { getHomeDir } from "@/shared/api/system";
 import {
   canonicalizeAuthorizedWorkspaceDirectory,
   resolvePath,
@@ -8,7 +9,7 @@ import { useProjectStore } from "@/features/projects/stores/projectStore";
 import {
   classifyWorkspaceAttachment,
   getWorkspaceAttachments,
-  isSameWorkspacePath,
+  isSameWorkspacePathWithHome,
   workspaceAttachmentIdForPath,
 } from "@/features/chat/lib/workspaceAttachments";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
@@ -103,6 +104,7 @@ async function canonicalizeForSession(
 async function canonicalizeDetachablePath(
   sessionId: string,
   requestedPath: string,
+  homeDir: string,
 ): Promise<string> {
   const session = useChatSessionStore.getState().getSession(sessionId);
   if (!session) {
@@ -118,7 +120,11 @@ async function canonicalizeDetachablePath(
   const stored = getWorkspaceAttachments(session).find(
     (candidate) =>
       candidate.source !== "excluded" &&
-      isSameWorkspacePath(candidate.path, resolvedRequestedPath),
+      isSameWorkspacePathWithHome(
+        candidate.path,
+        resolvedRequestedPath,
+        homeDir,
+      ),
   );
   return (
     stored?.path ?? canonicalizeForSession(sessionId, requestedPath, "detach")
@@ -132,13 +138,20 @@ export interface AttachSessionFolderOptions {
   replaceExistingInSingleWorkspace?: boolean;
 }
 
-async function isImplicitDefaultCwd(sessionId: string): Promise<boolean> {
+function isImplicitDefaultCwd(
+  sessionId: string,
+  artifactRoot: string,
+  homeDir: string,
+): boolean {
   const session = useChatSessionStore.getState().getSession(sessionId);
   if (!session?.workingDir) return true;
-  const artifactRoot = await resolveArtifactRootPath();
   return (
-    isSameWorkspacePath(session.workingDir, artifactRoot) ||
-    isSameWorkspacePath(session.workingDir, getOptimisticArtifactCwd())
+    isSameWorkspacePathWithHome(session.workingDir, artifactRoot, homeDir) ||
+    isSameWorkspacePathWithHome(
+      session.workingDir,
+      getOptimisticArtifactCwd(),
+      homeDir,
+    )
   );
 }
 
@@ -171,12 +184,14 @@ export async function attachSessionFolder(
 ): Promise<WorkspaceAttachment> {
   const observedIntentGeneration =
     getSessionWorkspaceIntentGeneration(sessionId);
+  const homeDir = await getHomeDir();
   const prepared = await prepareSessionFolder(sessionId, requestedPath);
-  const shouldPromoteDefaultCwd =
-    options.promoteDefaultCwd !== false &&
-    (await isImplicitDefaultCwd(sessionId));
+  const artifactRoot = await resolveArtifactRootPath();
   const { classification } = prepared;
   const path = await canonicalizeForSession(sessionId, prepared.path, "attach");
+  const shouldPromoteDefaultCwd =
+    options.promoteDefaultCwd !== false &&
+    isImplicitDefaultCwd(sessionId, artifactRoot, homeDir);
 
   // Reauthorize after every preparation/promotion await so policy and
   // persistence use the same current session state at the mutation boundary.
@@ -189,8 +204,8 @@ export async function attachSessionFolder(
   const includedAttachments = currentAttachments.filter(
     (candidate) => candidate.source !== "excluded",
   );
-  const alreadyAttached = includedAttachments.some((candidate) =>
-    isSameWorkspacePath(candidate.path, path),
+  const alreadyAttached = includedAttachments.find((candidate) =>
+    isSameWorkspacePathWithHome(candidate.path, path, homeDir),
   );
   const singleWorkspaceReplacement =
     options.replaceExistingInSingleWorkspace &&
@@ -201,8 +216,11 @@ export async function attachSessionFolder(
   if (options.enforceWorkspaceLimit && !getMultiWorkspaceEnabled()) {
     const realAttachments = includedAttachments.filter(
       (candidate) =>
-        !isSameWorkspacePath(candidate.path, currentSession.workingDir) ||
-        !shouldPromoteDefaultCwd,
+        !isSameWorkspacePathWithHome(
+          candidate.path,
+          currentSession.workingDir,
+          homeDir,
+        ) || !shouldPromoteDefaultCwd,
     );
     if (!alreadyAttached && realAttachments.length > 0) {
       throw new FolderAttachmentError(
@@ -221,26 +239,30 @@ export async function attachSessionFolder(
     });
   } else {
     currentStore.attachWorkspace(sessionId, {
-      path,
+      path: alreadyAttached?.path ?? path,
       source: "inferred",
       usedByAgent: true,
       ...classification,
     });
   }
 
-  if (await isImplicitDefaultCwd(sessionId)) {
+  if (isImplicitDefaultCwd(sessionId, artifactRoot, homeDir)) {
     const promotedSession = currentStore.getSession(sessionId);
     const implicitAttachment = promotedSession
       ? getWorkspaceAttachments(promotedSession).find(
           (candidate) =>
             candidate.source !== "excluded" &&
-            isSameWorkspacePath(candidate.path, promotedSession.workingDir),
+            isSameWorkspacePathWithHome(
+              candidate.path,
+              promotedSession.workingDir,
+              homeDir,
+            ),
         )
       : undefined;
     if (
       promotedSession &&
       implicitAttachment &&
-      !isSameWorkspacePath(implicitAttachment.path, path)
+      !isSameWorkspacePathWithHome(implicitAttachment.path, path, homeDir)
     ) {
       currentStore.patchSession(sessionId, {
         workspaceAttachments: getWorkspaceAttachments(promotedSession).filter(
@@ -259,7 +281,7 @@ export async function attachSessionFolder(
     ?.workspaceAttachments?.find(
       (candidate) =>
         candidate.source !== "excluded" &&
-        isSameWorkspacePath(candidate.path, path),
+        isSameWorkspacePathWithHome(candidate.path, path, homeDir),
     );
   if (!attachment) {
     throw new FolderAttachmentError(
@@ -270,7 +292,7 @@ export async function attachSessionFolder(
     shouldPromoteDefaultCwd &&
     getSessionWorkspaceIntentGeneration(sessionId) ===
       observedIntentGeneration &&
-    (await isImplicitDefaultCwd(sessionId))
+    isImplicitDefaultCwd(sessionId, artifactRoot, homeDir)
   ) {
     const intentGeneration = claimSessionWorkspaceIntent(sessionId);
     queueSessionWorkspaceActivation({
@@ -300,7 +322,12 @@ export async function detachSessionFolder(
   requestedPath: string,
   options: DetachSessionFolderOptions = {},
 ): Promise<DetachSessionFolderResult> {
-  const path = await canonicalizeDetachablePath(sessionId, requestedPath);
+  const homeDir = await getHomeDir();
+  const path = await canonicalizeDetachablePath(
+    sessionId,
+    requestedPath,
+    homeDir,
+  );
 
   const currentStore = useChatSessionStore.getState();
   const session = currentStore.getSession(sessionId);
@@ -311,7 +338,7 @@ export async function detachSessionFolder(
   const attachment = getWorkspaceAttachments(session).find(
     (candidate) =>
       candidate.source !== "excluded" &&
-      isSameWorkspacePath(candidate.path, path),
+      isSameWorkspacePathWithHome(candidate.path, path, homeDir),
   );
   if (!attachment) {
     return {
@@ -326,7 +353,11 @@ export async function detachSessionFolder(
   const pendingActivation = getPendingSessionWorkspaceActivation(sessionId);
   if (
     pendingActivation &&
-    isSameWorkspacePath(pendingActivation.path, attachment.path)
+    isSameWorkspacePathWithHome(
+      pendingActivation.path,
+      attachment.path,
+      homeDir,
+    )
   ) {
     await supersedePendingSessionWorkspaceActivation(sessionId);
   }
@@ -348,7 +379,7 @@ export async function detachSessionFolder(
   }
   const detachingCwd =
     latestSession.workingDir != null &&
-    isSameWorkspacePath(latestSession.workingDir, path);
+    isSameWorkspacePathWithHome(latestSession.workingDir, path, homeDir);
   const intentGeneration =
     detachingCwd && options.updateCwd !== false
       ? claimSessionWorkspaceIntent(sessionId)
@@ -379,7 +410,7 @@ export async function detachSessionFolder(
     intentGeneration == null ||
     !isCurrentSessionWorkspaceIntent(sessionId, intentGeneration) ||
     finalSession?.workingDir == null ||
-    !isSameWorkspacePath(finalSession.workingDir, path)
+    !isSameWorkspacePathWithHome(finalSession.workingDir, path, homeDir)
   ) {
     return {
       path,
@@ -421,13 +452,18 @@ export async function replaceSessionFolder(
   newRequestedPath: string,
   options: ReplaceSessionFolderOptions = {},
 ): Promise<ReplaceSessionFolderResult> {
-  const oldPath = await canonicalizeDetachablePath(sessionId, oldRequestedPath);
+  const homeDir = await getHomeDir();
+  const oldPath = await canonicalizeDetachablePath(
+    sessionId,
+    oldRequestedPath,
+    homeDir,
+  );
   const session = useChatSessionStore.getState().getSession(sessionId);
   const oldAttachment = session
     ? getWorkspaceAttachments(session).find(
         (candidate) =>
           candidate.source !== "excluded" &&
-          isSameWorkspacePath(candidate.path, oldPath),
+          isSameWorkspacePathWithHome(candidate.path, oldPath, homeDir),
       )
     : undefined;
   if (!oldAttachment) {
@@ -477,12 +513,20 @@ export async function replaceSessionFolder(
   const replacingPendingCwd =
     !newerPendingActivation &&
     currentPendingActivation != null &&
-    isSameWorkspacePath(currentPendingActivation.path, oldPath);
+    isSameWorkspacePathWithHome(
+      currentPendingActivation.path,
+      oldPath,
+      homeDir,
+    );
   const replacingCwd =
     !newerPendingActivation &&
     (replacingPendingCwd ||
       (currentSession?.workingDir != null &&
-        isSameWorkspacePath(currentSession.workingDir, oldPath)));
+        isSameWorkspacePathWithHome(
+          currentSession.workingDir,
+          oldPath,
+          homeDir,
+        )));
   const intentGeneration = replacingCwd
     ? claimSessionWorkspaceIntent(sessionId)
     : null;
@@ -511,12 +555,12 @@ export async function replaceSessionFolder(
   const stillOwnsCwd =
     replacingPendingCwd ||
     (latestWorkingDir != null &&
-      isSameWorkspacePath(latestWorkingDir, oldPath));
+      isSameWorkspacePathWithHome(latestWorkingDir, oldPath, homeDir));
   const shouldMoveCwd =
     intentGeneration != null &&
     isCurrentSessionWorkspaceIntent(sessionId, intentGeneration) &&
     replacingCwd &&
-    !isSameWorkspacePath(oldPath, attachment.path) &&
+    !isSameWorkspacePathWithHome(oldPath, attachment.path, homeDir) &&
     stillOwnsCwd;
   if (shouldMoveCwd) {
     queueSessionWorkspaceActivation({

--- a/src/features/chat/lib/workspaceAttachments.ts
+++ b/src/features/chat/lib/workspaceAttachments.ts
@@ -1,4 +1,4 @@
-import { expandHomePath } from "@/shared/lib/homePath";
+import { expandHomePath, isHomeRelativePath } from "@/shared/lib/homePath";
 import type {
   WorkspaceAttachment,
   WorkspaceAttachmentLifecycle,
@@ -88,6 +88,22 @@ export function isSameWorkspacePath(
   b: string | null | undefined,
 ): boolean {
   return isSamePath(a, b);
+}
+
+/** Compare persisted workspace paths that may mix `~` and expanded spellings. */
+export function isSameWorkspacePathWithHome(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  homeDir: string,
+): boolean {
+  if (isSameWorkspacePath(a, b)) return true;
+  if (!a || !b || (!isHomeRelativePath(a) && !isHomeRelativePath(b))) {
+    return false;
+  }
+  return isSameWorkspacePath(
+    expandHomePath(a, homeDir),
+    expandHomePath(b, homeDir),
+  );
 }
 
 function normalizeLifecycleString(value: string | null | undefined) {


### PR DESCRIPTION
**Category:** fix
**User Impact:** Chats using Berd's default folder can now move to a new folder through berdctl.

**Problem:** `folder attach` treated the implicit default cwd as an existing workspace, while `folder replace` could not find that same attachment when its stored path used `~` and the live cwd used the expanded home path. This left agents with contradictory recovery instructions and no working command.

**Solution:** Compare workspace paths with a home-aware identity function throughout session folder attach, replace, detach, and list flows. The commands now recognize `~/…` and expanded paths as the same folder, remove all equivalent implicit aliases, preserve the effective replacement path, and report the cwd entry correctly.

<details>
<summary>File changes</summary>

**src/features/chat/lib/workspaceAttachments.ts**
Adds a focused home-aware workspace path comparator while preserving the existing raw identity helper.

**src/features/chat/lib/sessionFolderRegistration.ts**
Uses home-aware identity for implicit cwd detection, workspace-limit checks, attach/replace/detach lookup, cwd ownership, alias cleanup, and replacement-path selection.

**src/features/berdctl/commands/impl/listSessionFolders.ts**
Marks cwd entries using the same home-aware identity as folder mutations.

**src/features/chat/lib/sessionFolderRegistration.test.ts**
Covers mixed-spelling attach, replace, detach, alias cleanup, pending cwd behavior, and mutation ordering.

**src/features/chat/lib/__tests__/workspaceAttachments.test.ts**
Covers home-relative identity and separator normalization.

**src/features/berdctl/__tests__/commands/commands.test.ts**
Covers the reported attach/replace contradiction and incorrect list cwd flag through command dispatch.

</details>

### Validation

- `just ci`
- `cargo test -p berdctl` (52 passed, 1 ignored)
- Post-merge full Vitest suite (7,353 passed, 1 skipped)

Closes #225

