### PR TITLE
harden remote daemon recovery and log draining

### DIFF
--- a/src-tauri/src/commands/remote_backend.rs
+++ b/src-tauri/src/commands/remote_backend.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, State};
 
 use crate::services::remote_backend::{
     self, daemon::RemoteDirListing, daemon::RemoteToolProbe, RemoteBackendConnection,
-    RemoteBackendError, RemoteBackendRegistry, RemoteBackendStatus,
+    RemoteBackendError, RemoteBackendErrorKind, RemoteBackendRegistry, RemoteBackendStatus,
 };
 
 #[tauri::command]
@@ -41,8 +41,16 @@ pub async fn remote_backend_disconnect(
     host: String,
     expected_generation: Option<u64>,
 ) -> Result<(), RemoteBackendError> {
-    remote_backend::disconnect_generation(&app, &registry, &host, expected_generation);
-    Ok(())
+    if remote_backend::disconnect_generation(&app, &registry, &host, expected_generation) {
+        Ok(())
+    } else if expected_generation.is_some() {
+        Err(RemoteBackendError::new(
+            RemoteBackendErrorKind::DaemonChanged,
+            "Remote backend changed before disconnect completed",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 #[tauri::command]
@@ -65,8 +73,16 @@ pub async fn remote_backend_shutdown(
     registry: State<'_, RemoteBackendRegistry>,
     host: String,
     expected_instance_token: Option<String>,
+    expected_generation: Option<u64>,
 ) -> Result<(), RemoteBackendError> {
-    remote_backend::shutdown(&app, &registry, &host, expected_instance_token.as_deref()).await
+    remote_backend::shutdown(
+        &app,
+        &registry,
+        &host,
+        expected_instance_token.as_deref(),
+        expected_generation,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/remote_backend.rs
+++ b/src-tauri/src/commands/remote_backend.rs
@@ -46,6 +46,20 @@ pub async fn remote_backend_disconnect(
 }
 
 #[tauri::command]
+pub async fn remote_backend_forget(
+    registry: State<'_, RemoteBackendRegistry>,
+    host: String,
+) -> Result<(), RemoteBackendError> {
+    if registry.forget(&host) {
+        Ok(())
+    } else {
+        Err(RemoteBackendError::internal(
+            "Cannot forget an active remote backend",
+        ))
+    }
+}
+
+#[tauri::command]
 pub async fn remote_backend_shutdown(
     app: AppHandle,
     registry: State<'_, RemoteBackendRegistry>,

--- a/src-tauri/src/commands/remote_backend.rs
+++ b/src-tauri/src/commands/remote_backend.rs
@@ -50,7 +50,7 @@ pub async fn remote_backend_forget(
     registry: State<'_, RemoteBackendRegistry>,
     host: String,
 ) -> Result<(), RemoteBackendError> {
-    if registry.forget(&host) {
+    if registry.forget(&host).await {
         Ok(())
     } else {
         Err(RemoteBackendError::internal(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -553,6 +553,7 @@ pub fn run() {
             commands::remote_backend::list_ssh_config_hosts,
             commands::remote_backend::remote_backend_connect,
             commands::remote_backend::remote_backend_disconnect,
+            commands::remote_backend::remote_backend_forget,
             commands::remote_backend::remote_backend_shutdown,
             commands::remote_backend::list_remote_backends,
             commands::remote_backend::check_remote_host,

--- a/src-tauri/src/services/remote_backend/daemon.rs
+++ b/src-tauri/src/services/remote_backend/daemon.rs
@@ -867,7 +867,9 @@ if [ "$1" = "serve" ]; then
   port=""
   while [ $# -gt 0 ]; do [ "$1" = "--port" ] && port="$2"; shift; done
   exec python3 -c 'import socket,sys,time
-sys.stderr.write("x" * (5 * 1024 * 1024) + "\nBOUNDED-TAIL\n"); sys.stderr.flush()
+for start in range(0, 80000, 1000):
+ sys.stderr.write("".join(f"{i:08d} " + "x" * 54 + "\n" for i in range(start, start + 1000)))
+sys.stderr.flush()
 s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
 s.bind(("127.0.0.1",int(sys.argv[1]))); s.listen(5); time.sleep(120)' "$port"
 fi
@@ -1153,21 +1155,17 @@ fi
         }
 
         #[test]
-        fn a_crash_after_reclaim_does_not_block_future_daemon_operations() {
+        fn a_crashed_legacy_reclaimer_does_not_block_future_daemon_operations() {
             let home = tempfile::tempdir().unwrap();
             let state_dir = home.path().join(".state/berd/remote");
             let lock_dir = state_dir.join("daemon.lock");
             std::fs::create_dir_all(&lock_dir).unwrap();
             std::fs::write(lock_dir.join("owner"), "999999 invalid-identity").unwrap();
 
-            // Pause a test-only copy immediately after its atomic claim. The
-            // production script contains no pause hook; replacing this exact
-            // cleanup statement lets the test kill the real shell at the
-            // otherwise tiny rename-to-delete boundary deterministically.
             let paused_marker = state_dir.join("reclaim-paused");
             let paused_script = BOOTSTRAP_SCRIPT.replace(
-                "    rm -rf -- \"$claimed_lock\"",
-                "    : > \"$STATE_DIR/reclaim-paused\"\n    while [ ! -f \"$STATE_DIR/reclaim-continue\" ]; do sleep 0.01; done\n    rm -rf -- \"$claimed_lock\"",
+                "  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
+                "  : > \"$STATE_DIR/reclaim-paused\"\n  while [ ! -f \"$STATE_DIR/reclaim-continue\" ]; do sleep 0.01; done\n  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
             );
             assert_ne!(paused_script, BOOTSTRAP_SCRIPT);
             let mut reclaimer =
@@ -1180,7 +1178,7 @@ fi
             }
             assert!(
                 paused_marker.exists(),
-                "reclaimer never claimed the stale lock"
+                "reclaimer never reached the stale legacy generation"
             );
             assert!(StdCommand::new("kill")
                 .arg("-KILL")
@@ -1189,14 +1187,10 @@ fi
                 .unwrap()
                 .success());
             assert_eq!(reclaimer.wait().unwrap().code(), None);
-            assert!(
-                !lock_dir.exists(),
-                "claimed generation returned to lock path"
-            );
 
-            // Also leave the ownerless mutex used by the previous
-            // implementation. Neither crash artifact may participate in the
-            // new acquisition protocol.
+            // Neither the stale legacy lock nor the ownerless reclaim mutex
+            // used by the previous implementation participates in the unique
+            // ticket protocol.
             std::fs::create_dir(state_dir.join("daemon.lock.reclaim")).unwrap();
             let (lines, code) = run_script(&["shutdown"], None, home.path());
             assert_eq!(code, Some(0), "lines: {lines:?}");
@@ -1204,26 +1198,96 @@ fi
         }
 
         #[test]
-        fn synchronized_reclaimers_do_not_remove_a_successor_lock() {
+        fn a_delayed_legacy_reclaimer_cannot_remove_a_live_successor_ticket() {
             let home = tempfile::tempdir().unwrap();
             let state_dir = home.path().join(".state/berd/remote");
-            let lock_dir = state_dir.join("daemon.lock");
-            std::fs::create_dir_all(&lock_dir).unwrap();
-            std::fs::write(lock_dir.join("owner"), "999999 invalid-identity").unwrap();
+            let legacy_lock = state_dir.join("daemon.lock");
+            std::fs::create_dir_all(&legacy_lock).unwrap();
+            std::fs::write(legacy_lock.join("owner"), "999999 invalid-identity").unwrap();
 
-            let reclaimers = (0..6)
+            let observer_script = BOOTSTRAP_SCRIPT.replace(
+                "  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
+                "  : > \"$STATE_DIR/observer-paused\"\n  while [ ! -f \"$STATE_DIR/observer-continue\" ]; do sleep 0.01; done\n  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
+            ).replace(
+                "  [ ! -d \"$LEGACY_LOCK_DIR\" ]",
+                "  : > \"$STATE_DIR/observer-resumed\"\n  [ ! -d \"$LEGACY_LOCK_DIR\" ]",
+            );
+            assert_ne!(observer_script, BOOTSTRAP_SCRIPT);
+            let observer = spawn_script_source(&["shutdown"], None, home.path(), &observer_script);
+            for _ in 0..500 {
+                if state_dir.join("observer-paused").exists() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(state_dir.join("observer-paused").exists());
+
+            let holder_script = BOOTSTRAP_SCRIPT.replace(
+                "      lock_held=1\n      return 0",
+                "      lock_held=1\n      : > \"$STATE_DIR/successor-held\"\n      while [ ! -f \"$STATE_DIR/successor-release\" ]; do sleep 0.01; done\n      return 0",
+            );
+            assert_ne!(holder_script, BOOTSTRAP_SCRIPT);
+            let holder = spawn_script_source(&["shutdown"], None, home.path(), &holder_script);
+            for _ in 0..500 {
+                if state_dir.join("successor-held").exists() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                state_dir.join("successor-held").exists(),
+                "successor never acquired its ticket"
+            );
+            let live_ticket = std::fs::read_dir(state_dir.join("daemon.locks"))
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .find(|path| {
+                    path.file_name()
+                        .unwrap()
+                        .to_string_lossy()
+                        .starts_with("ticket.")
+                })
+                .expect("live successor ticket");
+
+            std::fs::write(state_dir.join("observer-continue"), "").unwrap();
+            for _ in 0..500 {
+                if state_dir.join("observer-resumed").exists() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                state_dir.join("observer-resumed").exists(),
+                "delayed observer did not attempt its stale-generation move"
+            );
+            assert!(
+                live_ticket.join("owner").exists(),
+                "delayed observer removed the successor generation"
+            );
+
+            std::fs::write(state_dir.join("successor-release"), "").unwrap();
+            let (holder_lines, holder_code) = collect_script(holder);
+            assert_eq!(holder_code, Some(0), "lines: {holder_lines:?}");
+            let (observer_lines, observer_code) = collect_script(observer);
+            assert_eq!(observer_code, Some(0), "lines: {observer_lines:?}");
+        }
+
+        #[test]
+        fn synchronized_ticket_holders_serialize_daemon_mutations() {
+            let home = tempfile::tempdir().unwrap();
+            let state_dir = home.path().join(".state/berd/remote");
+
+            let holders = (0..6)
                 .map(|_| spawn_script(&["shutdown"], None, home.path()))
                 .collect::<Vec<_>>();
-            for child in reclaimers {
+            for child in holders {
                 let (lines, code) = collect_script(child);
                 assert_eq!(code, Some(0), "lines: {lines:?}");
             }
 
-            assert!(!lock_dir.exists(), "lock remained after all shutdowns");
-            let leftovers = std::fs::read_dir(&state_dir)
+            let leftovers = std::fs::read_dir(state_dir.join("daemon.locks"))
                 .unwrap()
                 .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
-                .filter(|name| name.contains("daemon.lock"))
                 .collect::<Vec<_>>();
             assert!(
                 leftovers.is_empty(),
@@ -1283,11 +1347,14 @@ fi
             let bin = tempfile::tempdir().unwrap();
             let goose = write_noisy_goose_shim(bin.path());
             let goose_arg = b64_arg(&goose.to_string_lossy());
+            let log_path = home.path().join(".state/berd/remote/goose-serve.log");
+            std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
+            std::fs::write(&log_path, b"!").unwrap();
 
             let (lines, code) = run_script(&["ensure", "-", &goose_arg], None, home.path());
             assert_eq!(code, Some(0), "lines: {lines:?}");
-            let log_path = home.path().join(".state/berd/remote/goose-serve.log");
             let mut log_len = 0;
+            let mut retained_ids = Vec::new();
             for _ in 0..100 {
                 let contents = std::fs::read(&log_path).unwrap_or_default();
                 log_len = contents.len() as u64;
@@ -1295,7 +1362,12 @@ fi
                     log_len <= 4 * 1024 * 1024,
                     "log transiently grew to {log_len} bytes"
                 );
-                if contents.ends_with(b"BOUNDED-TAIL\n") {
+                retained_ids = contents
+                    .split(|byte| *byte == b'\n')
+                    .filter(|line| line.len() == 63 && line[8] == b' ')
+                    .filter_map(|line| std::str::from_utf8(&line[..8]).ok()?.parse::<u32>().ok())
+                    .collect();
+                if retained_ids.last() == Some(&79_999) {
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(20));
@@ -1303,10 +1375,13 @@ fi
             assert!(log_len > 0);
             assert!(log_len <= 4 * 1024 * 1024, "log grew to {log_len} bytes");
             assert!(
-                std::fs::read(&log_path)
-                    .unwrap_or_default()
-                    .ends_with(b"BOUNDED-TAIL\n"),
-                "bounded writer did not retain the final record tail"
+                retained_ids.len() > 1,
+                "bounded writer did not retain complete sequence records"
+            );
+            assert_eq!(retained_ids.last(), Some(&79_999));
+            assert!(
+                retained_ids.windows(2).all(|pair| pair[1] == pair[0] + 1),
+                "bounded writer dropped a sequence record"
             );
 
             let (_, code) = run_script(&["shutdown"], None, home.path());

--- a/src-tauri/src/services/remote_backend/daemon.rs
+++ b/src-tauri/src/services/remote_backend/daemon.rs
@@ -806,6 +806,46 @@ mod tests {
             (lines, out.status.code())
         }
 
+        fn legacy_lock_holder_script(marker: &str, release: &str) -> String {
+            format!(
+                r#"#!/usr/bin/env bash
+set -u
+STATE_DIR="${{XDG_STATE_HOME:-$HOME/.local/state}}/berd/remote"
+LOCK_DIR="$STATE_DIR/daemon.lock"
+LOCK_OWNER="$LOCK_DIR/owner"
+b64() {{ printf %s "$1" | base64 | tr -d '\n'; }}
+process_identity() {{
+  if [ -r "/proc/$$/stat" ]; then
+    start="$(sed 's/^.*) //' "/proc/$$/stat" | awk '{{print $20}}')"
+    printf 'proc:%s' "$start"
+  else
+    ps -p "$$" -o lstart= -o command= | sed 's/^/ps:/'
+  fi
+}}
+mkdir -p "$STATE_DIR"
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do sleep 0.01; done
+owner="$$ $(b64 "$(process_identity)")"
+printf '%s\n' "$owner" >"$LOCK_OWNER"
+: >"$STATE_DIR/{marker}"
+while [ ! -f "$STATE_DIR/{release}" ]; do sleep 0.01; done
+if [ "$(cat "$LOCK_OWNER" 2>/dev/null)" = "$owner" ]; then
+  rm -f "$LOCK_OWNER"
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+fi
+"#
+            )
+        }
+
+        fn wait_for_path(path: &std::path::Path, message: &str) {
+            for _ in 0..500 {
+                if path.exists() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("{message}");
+        }
+
         fn b64_arg(value: &str) -> String {
             base64::engine::general_purpose::STANDARD.encode(value)
         }
@@ -897,6 +937,28 @@ for _ in range(80):
  sys.stderr.write("z" * 65536); sys.stderr.flush(); time.sleep(0.005)
 open(os.path.join(os.environ["HOME"],"no-newline-complete"),"w").close()
 time.sleep(120)' "$port"
+fi
+"#,
+            )
+            .unwrap();
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            path
+        }
+
+        fn write_diagnostic_goose_shim(dir: &std::path::Path) -> std::path::PathBuf {
+            let path = dir.join("goose-diagnostic");
+            std::fs::write(
+                &path,
+                r#"#!/usr/bin/env bash
+if [ "$1" = "--version" ]; then echo "goose diagnostic"; exit 0; fi
+if [ "$1" = "serve" ]; then
+  port=""
+  while [ $# -gt 0 ]; do [ "$1" = "--port" ] && port="$2"; shift; done
+  exec python3 -c 'import socket,sys,time
+sys.stderr.write("IMPORTANT-STARTUP-DIAGNOSTIC\n"); sys.stderr.flush()
+s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind(("127.0.0.1",int(sys.argv[1]))); s.listen(5); time.sleep(120)' "$port"
 fi
 "#,
             )
@@ -1198,78 +1260,70 @@ fi
         }
 
         #[test]
-        fn a_delayed_legacy_reclaimer_cannot_remove_a_live_successor_ticket() {
+        fn legacy_holder_blocks_ticket_client_until_release() {
             let home = tempfile::tempdir().unwrap();
             let state_dir = home.path().join(".state/berd/remote");
-            let legacy_lock = state_dir.join("daemon.lock");
-            std::fs::create_dir_all(&legacy_lock).unwrap();
-            std::fs::write(legacy_lock.join("owner"), "999999 invalid-identity").unwrap();
-
-            let observer_script = BOOTSTRAP_SCRIPT.replace(
-                "  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
-                "  : > \"$STATE_DIR/observer-paused\"\n  while [ ! -f \"$STATE_DIR/observer-continue\" ]; do sleep 0.01; done\n  if mv \"$LEGACY_LOCK_DIR\" \"$legacy_claim\" 2>/dev/null; then",
-            ).replace(
-                "  [ ! -d \"$LEGACY_LOCK_DIR\" ]",
-                "  : > \"$STATE_DIR/observer-resumed\"\n  [ ! -d \"$LEGACY_LOCK_DIR\" ]",
+            let legacy_source = legacy_lock_holder_script("legacy-held", "legacy-release");
+            let legacy = spawn_script_source(&["shutdown"], None, home.path(), &legacy_source);
+            wait_for_path(
+                &state_dir.join("legacy-held"),
+                "legacy client never acquired",
             );
-            assert_ne!(observer_script, BOOTSTRAP_SCRIPT);
-            let observer = spawn_script_source(&["shutdown"], None, home.path(), &observer_script);
-            for _ in 0..500 {
-                if state_dir.join("observer-paused").exists() {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            assert!(state_dir.join("observer-paused").exists());
 
-            let holder_script = BOOTSTRAP_SCRIPT.replace(
+            let ticket_source = BOOTSTRAP_SCRIPT.replace(
                 "      lock_held=1\n      return 0",
-                "      lock_held=1\n      : > \"$STATE_DIR/successor-held\"\n      while [ ! -f \"$STATE_DIR/successor-release\" ]; do sleep 0.01; done\n      return 0",
+                "      lock_held=1\n      : > \"$STATE_DIR/ticket-held\"\n      while [ ! -f \"$STATE_DIR/ticket-release\" ]; do sleep 0.01; done\n      return 0",
             );
-            assert_ne!(holder_script, BOOTSTRAP_SCRIPT);
-            let holder = spawn_script_source(&["shutdown"], None, home.path(), &holder_script);
-            for _ in 0..500 {
-                if state_dir.join("successor-held").exists() {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
+            assert_ne!(ticket_source, BOOTSTRAP_SCRIPT);
+            let ticket = spawn_script_source(&["shutdown"], None, home.path(), &ticket_source);
+            std::thread::sleep(Duration::from_millis(250));
             assert!(
-                state_dir.join("successor-held").exists(),
-                "successor never acquired its ticket"
+                !state_dir.join("ticket-held").exists(),
+                "ticket client overlapped a live legacy holder"
             );
-            let live_ticket = std::fs::read_dir(state_dir.join("daemon.locks"))
-                .unwrap()
-                .map(|entry| entry.unwrap().path())
-                .find(|path| {
-                    path.file_name()
-                        .unwrap()
-                        .to_string_lossy()
-                        .starts_with("ticket.")
-                })
-                .expect("live successor ticket");
+            std::fs::write(state_dir.join("legacy-release"), "").unwrap();
+            assert_eq!(legacy.wait_with_output().unwrap().status.code(), Some(0));
+            wait_for_path(
+                &state_dir.join("ticket-held"),
+                "ticket client never acquired",
+            );
+            std::fs::write(state_dir.join("ticket-release"), "").unwrap();
+            let (lines, code) = collect_script(ticket);
+            assert_eq!(code, Some(0), "lines: {lines:?}");
+        }
 
-            std::fs::write(state_dir.join("observer-continue"), "").unwrap();
-            for _ in 0..500 {
-                if state_dir.join("observer-resumed").exists() {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            assert!(
-                state_dir.join("observer-resumed").exists(),
-                "delayed observer did not attempt its stale-generation move"
+        #[test]
+        fn ticket_holder_blocks_legacy_client_until_release() {
+            let home = tempfile::tempdir().unwrap();
+            let state_dir = home.path().join(".state/berd/remote");
+            let ticket_source = BOOTSTRAP_SCRIPT.replace(
+                "      lock_held=1\n      return 0",
+                "      lock_held=1\n      : > \"$STATE_DIR/ticket-held\"\n      while [ ! -f \"$STATE_DIR/ticket-release\" ]; do sleep 0.01; done\n      return 0",
             );
-            assert!(
-                live_ticket.join("owner").exists(),
-                "delayed observer removed the successor generation"
+            assert_ne!(ticket_source, BOOTSTRAP_SCRIPT);
+            let ticket = spawn_script_source(&["shutdown"], None, home.path(), &ticket_source);
+            wait_for_path(
+                &state_dir.join("ticket-held"),
+                "ticket client never acquired",
             );
 
-            std::fs::write(state_dir.join("successor-release"), "").unwrap();
-            let (holder_lines, holder_code) = collect_script(holder);
-            assert_eq!(holder_code, Some(0), "lines: {holder_lines:?}");
-            let (observer_lines, observer_code) = collect_script(observer);
-            assert_eq!(observer_code, Some(0), "lines: {observer_lines:?}");
+            let legacy_source = legacy_lock_holder_script("legacy-held", "legacy-release");
+            let legacy = spawn_script_source(&["shutdown"], None, home.path(), &legacy_source);
+            std::thread::sleep(Duration::from_millis(250));
+            assert!(
+                !state_dir.join("legacy-held").exists(),
+                "legacy client overlapped a live ticket holder"
+            );
+
+            std::fs::write(state_dir.join("ticket-release"), "").unwrap();
+            let (lines, code) = collect_script(ticket);
+            assert_eq!(code, Some(0), "lines: {lines:?}");
+            wait_for_path(
+                &state_dir.join("legacy-held"),
+                "legacy client never acquired",
+            );
+            std::fs::write(state_dir.join("legacy-release"), "").unwrap();
+            assert_eq!(legacy.wait_with_output().unwrap().status.code(), Some(0));
         }
 
         #[test]
@@ -1347,11 +1401,22 @@ fi
             let bin = tempfile::tempdir().unwrap();
             let goose = write_noisy_goose_shim(bin.path());
             let goose_arg = b64_arg(&goose.to_string_lossy());
-            let log_path = home.path().join(".state/berd/remote/goose-serve.log");
+            let state_dir = home.path().join(".state/berd/remote");
+            let log_path = state_dir.join("goose-serve.log");
             std::fs::create_dir_all(log_path.parent().unwrap()).unwrap();
             std::fs::write(&log_path, b"!").unwrap();
 
-            let (lines, code) = run_script(&["ensure", "-", &goose_arg], None, home.path());
+            let instrumented_script = BOOTSTRAP_SCRIPT.replace(
+                "      if ! tail -c \"$LOG_RETAIN_BYTES\" \"$writer_log\" >\"$writer_tmp\" 2>/dev/null; then",
+                "      printf x >>\"$STATE_DIR/log-rotations\"\n      if ! tail -c \"$LOG_RETAIN_BYTES\" \"$writer_log\" >\"$writer_tmp\" 2>/dev/null; then",
+            );
+            assert_ne!(instrumented_script, BOOTSTRAP_SCRIPT);
+            let (lines, code) = collect_script(spawn_script_source(
+                &["ensure", "-", &goose_arg],
+                None,
+                home.path(),
+                &instrumented_script,
+            ));
             assert_eq!(code, Some(0), "lines: {lines:?}");
             let mut log_len = 0;
             let mut retained_ids = Vec::new();
@@ -1379,9 +1444,20 @@ fi
                 "bounded writer did not retain complete sequence records"
             );
             assert_eq!(retained_ids.last(), Some(&79_999));
+            let first_gap = retained_ids
+                .windows(2)
+                .find(|pair| pair[1] != pair[0] + 1)
+                .map(|pair| (pair[0], pair[1]));
             assert!(
-                retained_ids.windows(2).all(|pair| pair[1] == pair[0] + 1),
-                "bounded writer dropped a sequence record"
+                first_gap.is_none(),
+                "bounded writer dropped a sequence record at {first_gap:?}"
+            );
+            let rotations = std::fs::read(state_dir.join("log-rotations"))
+                .map(|bytes| bytes.len())
+                .unwrap_or(0);
+            assert!(
+                rotations <= 2,
+                "5 MiB of output triggered {rotations} full-tail rewrites"
             );
 
             let (_, code) = run_script(&["shutdown"], None, home.path());
@@ -1421,6 +1497,38 @@ fi
                 "producer did not finish its no-newline burst"
             );
             assert!(std::fs::metadata(&log_path).unwrap().len() <= 4 * 1024 * 1024);
+
+            let (_, code) = run_script(&["shutdown"], None, home.path());
+            assert_eq!(code, Some(0));
+        }
+
+        #[test]
+        fn daemon_log_publishes_a_short_diagnostic_while_producer_is_alive() {
+            if !python3_available() {
+                eprintln!("skipping: python3 unavailable for the goose serve shim");
+                return;
+            }
+            let home = tempfile::tempdir().unwrap();
+            let bin = tempfile::tempdir().unwrap();
+            let goose = write_diagnostic_goose_shim(bin.path());
+            let goose_arg = b64_arg(&goose.to_string_lossy());
+
+            let (lines, code) = run_script(&["ensure", "-", &goose_arg], None, home.path());
+            assert_eq!(code, Some(0), "lines: {lines:?}");
+            let log_path = home.path().join(".state/berd/remote/goose-serve.log");
+            let mut visible = false;
+            for _ in 0..100 {
+                let contents = std::fs::read_to_string(&log_path).unwrap_or_default();
+                if contents.contains("IMPORTANT-STARTUP-DIAGNOSTIC") {
+                    visible = true;
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                visible,
+                "live producer's startup diagnostic stayed buffered"
+            );
 
             let (_, code) = run_script(&["shutdown"], None, home.path());
             assert_eq!(code, Some(0));

--- a/src-tauri/src/services/remote_backend/daemon.rs
+++ b/src-tauri/src/services/remote_backend/daemon.rs
@@ -1260,6 +1260,49 @@ fi
         }
 
         #[test]
+        fn legacy_reclaimer_does_not_claim_a_live_successor_generation() {
+            let home = tempfile::tempdir().unwrap();
+            let state_dir = home.path().join(".state/berd/remote");
+            let lock_dir = state_dir.join("daemon.lock");
+            std::fs::create_dir_all(&lock_dir).unwrap();
+            std::fs::write(lock_dir.join("owner"), "999999 invalid-identity").unwrap();
+
+            let paused_script = BOOTSTRAP_SCRIPT.replace(
+                "        legacy_guard=\"$LEGACY_LOCK_DIR/.berd-reclaim.$NONCE.$$.$compat_attempt\"",
+                "        : > \"$STATE_DIR/reclaim-paused\"\n        while [ ! -f \"$STATE_DIR/reclaim-continue\" ]; do sleep 0.01; done\n        legacy_guard=\"$LEGACY_LOCK_DIR/.berd-reclaim.$NONCE.$$.$compat_attempt\"",
+            );
+            assert_ne!(paused_script, BOOTSTRAP_SCRIPT);
+            let reclaimer = spawn_script_source(&["shutdown"], None, home.path(), &paused_script);
+            wait_for_path(
+                &state_dir.join("reclaim-paused"),
+                "reclaimer never paused before generation claim",
+            );
+
+            std::fs::remove_file(lock_dir.join("owner")).unwrap();
+            std::fs::remove_dir(&lock_dir).unwrap();
+            let successor_source = legacy_lock_holder_script("successor-held", "successor-release");
+            let successor =
+                spawn_script_source(&["shutdown"], None, home.path(), &successor_source);
+            wait_for_path(
+                &state_dir.join("successor-held"),
+                "live successor never acquired legacy lock",
+            );
+
+            std::fs::write(state_dir.join("reclaim-continue"), "").unwrap();
+            std::thread::sleep(Duration::from_millis(250));
+            assert!(
+                lock_dir.join("owner").exists(),
+                "successor owner was reclaimed"
+            );
+
+            std::fs::write(state_dir.join("successor-release"), "").unwrap();
+            assert_eq!(successor.wait_with_output().unwrap().status.code(), Some(0));
+            let (lines, code) = collect_script(reclaimer);
+            assert_eq!(code, Some(0), "lines: {lines:?}");
+            assert!(lines.iter().any(|line| line == "STOPPED"));
+        }
+
+        #[test]
         fn legacy_holder_blocks_ticket_client_until_release() {
             let home = tempfile::tempdir().unwrap();
             let state_dir = home.path().join(".state/berd/remote");

--- a/src-tauri/src/services/remote_backend/daemon.rs
+++ b/src-tauri/src/services/remote_backend/daemon.rs
@@ -760,6 +760,15 @@ mod tests {
             path_override: Option<&str>,
             home: &std::path::Path,
         ) -> std::process::Child {
+            spawn_script_source(args, path_override, home, BOOTSTRAP_SCRIPT)
+        }
+
+        fn spawn_script_source(
+            args: &[&str],
+            path_override: Option<&str>,
+            home: &std::path::Path,
+            script: &str,
+        ) -> std::process::Child {
             let nonce = "berd-test-nonce";
             let mut command = StdCommand::new("bash");
             command
@@ -781,7 +790,7 @@ mod tests {
                 .stdin
                 .take()
                 .unwrap()
-                .write_all(BOOTSTRAP_SCRIPT.as_bytes())
+                .write_all(script.as_bytes())
                 .unwrap();
             child
         }
@@ -1141,6 +1150,57 @@ fi
             assert_eq!(code, Some(0), "lines: {lines:?}");
             assert!(lines.iter().any(|line| line == "STOPPED"));
             assert!(!lock_dir.exists(), "partial lock generation survived");
+        }
+
+        #[test]
+        fn a_crash_after_reclaim_does_not_block_future_daemon_operations() {
+            let home = tempfile::tempdir().unwrap();
+            let state_dir = home.path().join(".state/berd/remote");
+            let lock_dir = state_dir.join("daemon.lock");
+            std::fs::create_dir_all(&lock_dir).unwrap();
+            std::fs::write(lock_dir.join("owner"), "999999 invalid-identity").unwrap();
+
+            // Pause a test-only copy immediately after its atomic claim. The
+            // production script contains no pause hook; replacing this exact
+            // cleanup statement lets the test kill the real shell at the
+            // otherwise tiny rename-to-delete boundary deterministically.
+            let paused_marker = state_dir.join("reclaim-paused");
+            let paused_script = BOOTSTRAP_SCRIPT.replace(
+                "    rm -rf -- \"$claimed_lock\"",
+                "    : > \"$STATE_DIR/reclaim-paused\"\n    while [ ! -f \"$STATE_DIR/reclaim-continue\" ]; do sleep 0.01; done\n    rm -rf -- \"$claimed_lock\"",
+            );
+            assert_ne!(paused_script, BOOTSTRAP_SCRIPT);
+            let mut reclaimer =
+                spawn_script_source(&["shutdown"], None, home.path(), &paused_script);
+            for _ in 0..500 {
+                if paused_marker.exists() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            assert!(
+                paused_marker.exists(),
+                "reclaimer never claimed the stale lock"
+            );
+            assert!(StdCommand::new("kill")
+                .arg("-KILL")
+                .arg(reclaimer.id().to_string())
+                .status()
+                .unwrap()
+                .success());
+            assert_eq!(reclaimer.wait().unwrap().code(), None);
+            assert!(
+                !lock_dir.exists(),
+                "claimed generation returned to lock path"
+            );
+
+            // Also leave the ownerless mutex used by the previous
+            // implementation. Neither crash artifact may participate in the
+            // new acquisition protocol.
+            std::fs::create_dir(state_dir.join("daemon.lock.reclaim")).unwrap();
+            let (lines, code) = run_script(&["shutdown"], None, home.path());
+            assert_eq!(code, Some(0), "lines: {lines:?}");
+            assert!(lines.iter().any(|line| line == "STOPPED"));
         }
 
         #[test]

--- a/src-tauri/src/services/remote_backend/mod.rs
+++ b/src-tauri/src/services/remote_backend/mod.rs
@@ -118,6 +118,9 @@ struct HostSlot {
 
 struct SlotShared {
     state: RemoteBackendState,
+    /// Set before an inactive slot leaves the registry. Connect attempts that
+    /// already retained its Arc must observe this tombstone after admission.
+    forgotten: bool,
     /// Monotonic ownership token: each successful establish bumps it, and a
     /// supervisor only acts while its own generation is current. Explicit
     /// disconnects bump it to strand any racing supervisor.
@@ -141,6 +144,7 @@ impl RemoteBackendRegistry {
                 connect_lock: tokio::sync::Mutex::new(()),
                 shared: Mutex::new(SlotShared {
                     state: RemoteBackendState::Disconnected,
+                    forgotten: false,
                     generation: 0,
                     daemon: None,
                     local_port: None,
@@ -173,19 +177,34 @@ impl RemoteBackendRegistry {
     /// Remove an inactive host slot from the registry. The exact key is used
     /// deliberately so malformed inputs from a failed connect can still be
     /// forgotten instead of having to pass host parsing again.
-    pub fn forget(&self, key: &str) -> bool {
-        let mut slots = self.slots.lock().expect("remote backend registry poisoned");
-        let Some(slot) = slots.get(key) else {
+    pub async fn forget(&self, key: &str) -> bool {
+        let Some(slot) = self.existing_slot(key) else {
             return true;
         };
-        let forgettable = matches!(
-            slot.shared.lock().expect("slot poisoned").state,
-            RemoteBackendState::Disconnected | RemoteBackendState::Failed { .. }
-        );
-        if forgettable {
-            slots.remove(key);
+
+        // Serialize with every establish/reconnect owner. A connect may have
+        // retained this Arc before waiting on the lock, so removal also leaves
+        // a tombstone and advances its generation for that admitted waiter.
+        let _guard = slot.connect_lock.lock().await;
+        let mut slots = self.slots.lock().expect("remote backend registry poisoned");
+        let Some(registered) = slots.get(key) else {
+            return true;
+        };
+        if !Arc::ptr_eq(registered, &slot) {
+            return false;
         }
-        forgettable
+        let mut shared = slot.shared.lock().expect("slot poisoned");
+        if !matches!(
+            shared.state,
+            RemoteBackendState::Disconnected | RemoteBackendState::Failed { .. }
+        ) {
+            return false;
+        }
+        shared.forgotten = true;
+        shared.generation += 1;
+        drop(shared);
+        slots.remove(key);
+        true
     }
 
     /// Best-effort synchronous tunnel teardown for app exit. Daemons are left
@@ -368,6 +387,11 @@ pub async fn connect(
 
     {
         let mut shared = slot.shared.lock().expect("slot poisoned");
+        if shared.forgotten {
+            return Err(RemoteBackendError::internal(
+                "remote connection attempt was superseded",
+            ));
+        }
         if let Some(existing) = cached_connection(&shared, goose_path.as_deref()) {
             return Ok(existing);
         }
@@ -746,6 +770,7 @@ mod tests {
                 http_base_url: "http://127.0.0.1:5000".to_string(),
                 local_port: 5000,
             },
+            forgotten: false,
             generation: 1,
             daemon: Some(RemoteDaemonInfo {
                 pid: 10,
@@ -855,8 +880,8 @@ mod tests {
         assert_eq!(snapshot[0].host, "devbox");
     }
 
-    #[test]
-    fn forget_removes_inactive_slot_by_its_exact_key() {
+    #[tokio::test]
+    async fn forget_removes_inactive_slot_by_its_exact_key() {
         let registry = RemoteBackendRegistry::default();
         let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
         let slot = registry.slot(&spec);
@@ -864,18 +889,33 @@ mod tests {
             error: RemoteBackendError::internal("failed"),
         };
 
-        assert!(registry.forget("devbox"));
+        assert!(registry.forget("devbox").await);
         assert!(registry.snapshot().is_empty());
     }
 
-    #[test]
-    fn forget_preserves_active_slot() {
+    #[tokio::test]
+    async fn forget_preserves_active_slot() {
         let registry = RemoteBackendRegistry::default();
         let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
         let slot = registry.slot(&spec);
         slot.shared.lock().expect("slot poisoned").state = RemoteBackendState::Connecting;
 
-        assert!(!registry.forget("devbox"));
+        assert!(!registry.forget("devbox").await);
         assert_eq!(registry.snapshot().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pending_connect_observes_tombstone_after_forget() {
+        let registry = RemoteBackendRegistry::default();
+        let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
+        let admitted = registry.slot(&spec);
+
+        assert!(registry.forget("devbox").await);
+        let _guard = admitted.connect_lock.lock().await;
+        assert!(admitted.shared.lock().expect("slot poisoned").forgotten);
+
+        let replacement = registry.slot(&spec);
+        assert!(!Arc::ptr_eq(&admitted, &replacement));
+        assert!(!replacement.shared.lock().expect("slot poisoned").forgotten);
     }
 }

--- a/src-tauri/src/services/remote_backend/mod.rs
+++ b/src-tauri/src/services/remote_backend/mod.rs
@@ -84,6 +84,8 @@ pub enum RemoteBackendState {
 #[serde(rename_all = "camelCase")]
 pub struct RemoteBackendStatus {
     pub host: String,
+    pub incarnation: String,
+    pub generation: u64,
     #[serde(flatten)]
     pub state: RemoteBackendState,
 }
@@ -97,6 +99,9 @@ pub struct RemoteBackendConnection {
     pub local_port: u16,
     pub goose_version: String,
     pub daemon_reused: bool,
+    /// Unique identity for this registry slot. A forgotten host receives a
+    /// new incarnation even when its per-slot generation restarts.
+    pub incarnation: String,
     /// Slot generation that owns this tunnel. Callers use it to invalidate
     /// only the connection they established, never a newer replacement.
     pub generation: u64,
@@ -110,6 +115,7 @@ pub struct RemoteBackendRegistry {
 struct HostSlot {
     key: String,
     spec: RemoteHostSpec,
+    incarnation: String,
     /// Serializes establish attempts (user connects and supervisor
     /// reconnects) per host.
     connect_lock: tokio::sync::Mutex<()>,
@@ -141,6 +147,7 @@ impl RemoteBackendRegistry {
             Arc::new(HostSlot {
                 key: spec.key(),
                 spec: spec.clone(),
+                incarnation: uuid::Uuid::new_v4().to_string(),
                 connect_lock: tokio::sync::Mutex::new(()),
                 shared: Mutex::new(SlotShared {
                     state: RemoteBackendState::Disconnected,
@@ -167,9 +174,14 @@ impl RemoteBackendRegistry {
         let slots = self.slots.lock().expect("remote backend registry poisoned");
         slots
             .values()
-            .map(|slot| RemoteBackendStatus {
-                host: slot.key.clone(),
-                state: slot.shared.lock().expect("slot poisoned").state.clone(),
+            .map(|slot| {
+                let shared = slot.shared.lock().expect("slot poisoned");
+                RemoteBackendStatus {
+                    host: slot.key.clone(),
+                    incarnation: slot.incarnation.clone(),
+                    generation: shared.generation,
+                    state: shared.state.clone(),
+                }
             })
             .collect()
     }
@@ -182,9 +194,22 @@ impl RemoteBackendRegistry {
             return true;
         };
 
-        // Serialize with every establish/reconnect owner. A connect may have
-        // retained this Arc before waiting on the lock, so removal also leaves
-        // a tombstone and advances its generation for that admitted waiter.
+        // Invalidate queued connection admission before waiting on the lock.
+        // A current establish already holding the lock publishes Connecting,
+        // so only an inactive slot can reach this point; a waiter that retained
+        // the Arc must observe the tombstone when it eventually acquires.
+        {
+            let mut shared = slot.shared.lock().expect("slot poisoned");
+            if !matches!(
+                shared.state,
+                RemoteBackendState::Disconnected | RemoteBackendState::Failed { .. }
+            ) {
+                return false;
+            }
+            shared.forgotten = true;
+            shared.generation += 1;
+        }
+
         let _guard = slot.connect_lock.lock().await;
         let mut slots = self.slots.lock().expect("remote backend registry poisoned");
         let Some(registered) = slots.get(key) else {
@@ -193,16 +218,6 @@ impl RemoteBackendRegistry {
         if !Arc::ptr_eq(registered, &slot) {
             return false;
         }
-        let mut shared = slot.shared.lock().expect("slot poisoned");
-        if !matches!(
-            shared.state,
-            RemoteBackendState::Disconnected | RemoteBackendState::Failed { .. }
-        ) {
-            return false;
-        }
-        shared.forgotten = true;
-        shared.generation += 1;
-        drop(shared);
         slots.remove(key);
         true
     }
@@ -245,11 +260,12 @@ fn kill_tunnel_pid(pid: u32) {
 }
 
 fn set_state(app: &AppHandle, slot: &HostSlot, state: RemoteBackendState) {
-    {
+    let generation = {
         let mut shared = slot.shared.lock().expect("slot poisoned");
         shared.state = state.clone();
-    }
-    emit_status(app, &slot.key, &state);
+        shared.generation
+    };
+    emit_status(app, slot, generation, &state);
 }
 
 fn update_state_if_current(
@@ -277,13 +293,15 @@ fn set_state_if_current(
     if !update_state_if_current(&mut shared, generation, state.clone()) {
         return false;
     }
-    emit_status(app, &slot.key, &state);
+    emit_status(app, slot, generation, &state);
     true
 }
 
-fn emit_status(app: &AppHandle, host: &str, state: &RemoteBackendState) {
+fn emit_status(app: &AppHandle, slot: &HostSlot, generation: u64, state: &RemoteBackendState) {
     let payload = RemoteBackendStatus {
-        host: host.to_string(),
+        host: slot.key.clone(),
+        incarnation: slot.incarnation.clone(),
+        generation,
         state: state.clone(),
     };
     if let Err(error) = app.emit(REMOTE_BACKEND_STATUS_EVENT, &payload) {
@@ -318,7 +336,10 @@ fn extra_serve_args() -> Vec<String> {
     }
 }
 
-fn connection_from_shared(shared: &SlotShared) -> Option<RemoteBackendConnection> {
+fn connection_from_shared(
+    shared: &SlotShared,
+    incarnation: &str,
+) -> Option<RemoteBackendConnection> {
     let daemon = shared.daemon.as_ref()?;
     let local_port = shared.local_port?;
     if let RemoteBackendState::Ready {
@@ -334,6 +355,7 @@ fn connection_from_shared(shared: &SlotShared) -> Option<RemoteBackendConnection
             local_port,
             goose_version: daemon.goose_version.clone(),
             daemon_reused: daemon.reused,
+            incarnation: incarnation.to_string(),
             generation: shared.generation,
         })
     } else {
@@ -347,11 +369,24 @@ fn connection_from_shared(shared: &SlotShared) -> Option<RemoteBackendConnection
 fn cached_connection(
     shared: &SlotShared,
     requested_goose_path: Option<&str>,
+    incarnation: &str,
 ) -> Option<RemoteBackendConnection> {
     if shared.goose_path.as_deref() != requested_goose_path {
         return None;
     }
-    connection_from_shared(shared)
+    connection_from_shared(shared, incarnation)
+}
+
+async fn acquire_connect_admission(
+    slot: &HostSlot,
+) -> Result<tokio::sync::MutexGuard<'_, ()>, RemoteBackendError> {
+    let guard = slot.connect_lock.lock().await;
+    if slot.shared.lock().expect("slot poisoned").forgotten {
+        return Err(RemoteBackendError::internal(
+            "remote connection attempt was superseded",
+        ));
+    }
+    Ok(guard)
 }
 
 fn advance_generation_if_current(shared: &mut SlotShared, expected: u64) -> Option<u64> {
@@ -383,16 +418,19 @@ pub async fn connect(
     let goose_path = goose_path.map(daemon::normalize_goose_path).transpose()?;
     let slot = registry.slot(&spec);
 
-    let _guard = slot.connect_lock.lock().await;
+    let _guard = acquire_connect_admission(&slot).await?;
 
     {
         let mut shared = slot.shared.lock().expect("slot poisoned");
+        // Forget can tombstone an inactive slot after this connect acquires
+        // admission but before it publishes Connecting.
         if shared.forgotten {
             return Err(RemoteBackendError::internal(
                 "remote connection attempt was superseded",
             ));
         }
-        if let Some(existing) = cached_connection(&shared, goose_path.as_deref()) {
+        if let Some(existing) = cached_connection(&shared, goose_path.as_deref(), &slot.incarnation)
+        {
             return Ok(existing);
         }
         if shared.goose_path.as_deref() != goose_path.as_deref() {
@@ -502,7 +540,7 @@ async fn establish(
         let _ = tunnel.child.wait().await;
         return Ok(None);
     };
-    emit_status(app, &slot.key, &state);
+    emit_status(app, slot, generation, &state);
 
     let connection = RemoteBackendConnection {
         ws_url,
@@ -511,6 +549,7 @@ async fn establish(
         local_port,
         goose_version: daemon_info.goose_version.clone(),
         daemon_reused: daemon_info.reused,
+        incarnation: slot.incarnation.clone(),
         generation,
     };
 
@@ -756,10 +795,14 @@ mod tests {
     fn status_payload_flattens_state() {
         let status = RemoteBackendStatus {
             host: "devbox".to_string(),
+            incarnation: "slot-1".to_string(),
+            generation: 7,
             state: RemoteBackendState::Connecting,
         };
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["host"], "devbox");
+        assert_eq!(json["incarnation"], "slot-1");
+        assert_eq!(json["generation"], 7);
         assert_eq!(json["state"], "connecting");
     }
 
@@ -788,10 +831,11 @@ mod tests {
 
     #[test]
     fn cached_connection_is_reused_for_the_same_goose_path() {
-        assert!(cached_connection(&ready_shared(None), None).is_some());
+        assert!(cached_connection(&ready_shared(None), None, "slot-1").is_some());
         assert!(cached_connection(
             &ready_shared(Some("/opt/goose/bin/goose")),
-            Some("/opt/goose/bin/goose")
+            Some("/opt/goose/bin/goose"),
+            "slot-1"
         )
         .is_some());
     }
@@ -800,11 +844,18 @@ mod tests {
     fn cached_connection_is_refused_for_a_different_goose_path() {
         // Adding, removing, or swapping an override all force a fresh connect
         // because the bootstrap restarts the remote daemon.
-        assert!(cached_connection(&ready_shared(None), Some("/opt/goose/bin/goose")).is_none());
-        assert!(cached_connection(&ready_shared(Some("/opt/goose/bin/goose")), None).is_none());
+        assert!(
+            cached_connection(&ready_shared(None), Some("/opt/goose/bin/goose"), "slot-1")
+                .is_none()
+        );
+        assert!(
+            cached_connection(&ready_shared(Some("/opt/goose/bin/goose")), None, "slot-1")
+                .is_none()
+        );
         assert!(cached_connection(
             &ready_shared(Some("/opt/goose/bin/goose")),
-            Some("~/src/goose/target/release/goose")
+            Some("~/src/goose/target/release/goose"),
+            "slot-1"
         )
         .is_none());
     }
@@ -813,7 +864,7 @@ mod tests {
     fn cached_connection_is_none_while_not_ready() {
         let mut shared = ready_shared(None);
         shared.state = RemoteBackendState::Connecting;
-        assert!(cached_connection(&shared, None).is_none());
+        assert!(cached_connection(&shared, None, "slot-1").is_none());
     }
 
     #[test]
@@ -905,14 +956,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_connect_observes_tombstone_after_forget() {
-        let registry = RemoteBackendRegistry::default();
+    async fn pending_connect_is_superseded_before_establishment_after_forget() {
+        let registry = Arc::new(RemoteBackendRegistry::default());
         let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
         let admitted = registry.slot(&spec);
+        let held = admitted.connect_lock.lock().await;
 
-        assert!(registry.forget("devbox").await);
-        let _guard = admitted.connect_lock.lock().await;
+        let side_effect_reached = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let connect_slot = Arc::clone(&admitted);
+        let connect_side_effect = Arc::clone(&side_effect_reached);
+        let pending_connect = tokio::spawn(async move {
+            let admission = acquire_connect_admission(&connect_slot).await;
+            if admission.is_ok() {
+                connect_side_effect.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+            admission.map(|_| ())
+        });
+        tokio::task::yield_now().await;
+
+        let forget_registry = Arc::clone(&registry);
+        let forgetting = tokio::spawn(async move { forget_registry.forget("devbox").await });
+        for _ in 0..100 {
+            if admitted.shared.lock().expect("slot poisoned").forgotten {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
         assert!(admitted.shared.lock().expect("slot poisoned").forgotten);
+
+        drop(held);
+        let connect_error = pending_connect.await.unwrap().unwrap_err();
+        assert_eq!(
+            connect_error.message,
+            "remote connection attempt was superseded"
+        );
+        assert!(!side_effect_reached.load(std::sync::atomic::Ordering::SeqCst));
+        assert!(forgetting.await.unwrap());
+        assert!(registry.snapshot().is_empty());
 
         let replacement = registry.slot(&spec);
         assert!(!Arc::ptr_eq(&admitted, &replacement));

--- a/src-tauri/src/services/remote_backend/mod.rs
+++ b/src-tauri/src/services/remote_backend/mod.rs
@@ -720,6 +720,20 @@ pub fn disconnect_generation(
     true
 }
 
+fn validate_shutdown_generation(
+    slot: &HostSlot,
+    expected_generation: Option<u64>,
+) -> Result<(), RemoteBackendError> {
+    let shared = slot.shared.lock().expect("slot poisoned");
+    if expected_generation.is_some_and(|expected| shared.generation != expected) {
+        return Err(RemoteBackendError::new(
+            RemoteBackendErrorKind::DaemonChanged,
+            "Remote backend changed before shutdown completed",
+        ));
+    }
+    Ok(())
+}
+
 /// Stop the remote daemon, then drop the tunnel.
 pub async fn shutdown(
     app: &AppHandle,
@@ -733,18 +747,19 @@ pub async fn shutdown(
     let slot = registry.slot(&spec);
     let shell_env = dir_env::capture_home_interactive_env().await;
 
-    // Wait out any in-flight establish, then invalidate its supervisor and
-    // drop its tunnel before touching the daemon. A new connect cannot start
-    // until shutdown releases this lock, so ensure_daemon cannot recreate the
-    // daemon after shutdown_daemon stops it.
+    // Wait out any in-flight establish and validate the local owner before
+    // touching either resource. Keep the tunnel intact until remote shutdown
+    // succeeds: a daemon identity mismatch must not leave a dead local path
+    // represented by the still-current Ready state.
     let _guard = slot.connect_lock.lock().await;
+    validate_shutdown_generation(&slot, expected_generation)?;
+    daemon::shutdown_daemon(&spec, &shell_env, expected_instance_token).await?;
     if !disconnect_generation(app, registry, &spec.key(), expected_generation) {
         return Err(RemoteBackendError::new(
             RemoteBackendErrorKind::DaemonChanged,
             "Remote backend changed before shutdown completed",
         ));
     }
-    daemon::shutdown_daemon(&spec, &shell_env, expected_instance_token).await?;
     record_diagnostic(DiagnosticLevel::Info, "daemon_shutdown", &spec.key(), None);
     Ok(())
 }
@@ -926,6 +941,25 @@ mod tests {
             },
         ));
         assert!(matches!(shared.state, RemoteBackendState::Disconnected));
+    }
+
+    #[test]
+    fn shutdown_generation_mismatch_preserves_the_ready_tunnel() {
+        let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
+        let slot = HostSlot {
+            key: spec.key(),
+            spec,
+            incarnation: "slot-1".to_string(),
+            connect_lock: tokio::sync::Mutex::new(()),
+            shared: Mutex::new(ready_shared(None)),
+        };
+
+        let error = validate_shutdown_generation(&slot, Some(2)).unwrap_err();
+        assert_eq!(error.kind, RemoteBackendErrorKind::DaemonChanged);
+        let shared = slot.shared.lock().expect("slot poisoned");
+        assert_eq!(shared.generation, 1);
+        assert_eq!(shared.tunnel_pid, Some(99));
+        assert!(matches!(shared.state, RemoteBackendState::Ready { .. }));
     }
 
     #[test]

--- a/src-tauri/src/services/remote_backend/mod.rs
+++ b/src-tauri/src/services/remote_backend/mod.rs
@@ -170,6 +170,24 @@ impl RemoteBackendRegistry {
             .collect()
     }
 
+    /// Remove an inactive host slot from the registry. The exact key is used
+    /// deliberately so malformed inputs from a failed connect can still be
+    /// forgotten instead of having to pass host parsing again.
+    pub fn forget(&self, key: &str) -> bool {
+        let mut slots = self.slots.lock().expect("remote backend registry poisoned");
+        let Some(slot) = slots.get(key) else {
+            return true;
+        };
+        let forgettable = matches!(
+            slot.shared.lock().expect("slot poisoned").state,
+            RemoteBackendState::Disconnected | RemoteBackendState::Failed { .. }
+        );
+        if forgettable {
+            slots.remove(key);
+        }
+        forgettable
+    }
+
     /// Best-effort synchronous tunnel teardown for app exit. Daemons are left
     /// running deliberately: surviving the client is the feature.
     pub fn kill_all_tunnels(&self) {
@@ -835,5 +853,29 @@ mod tests {
         let snapshot = registry.snapshot();
         assert_eq!(snapshot.len(), 1);
         assert_eq!(snapshot[0].host, "devbox");
+    }
+
+    #[test]
+    fn forget_removes_inactive_slot_by_its_exact_key() {
+        let registry = RemoteBackendRegistry::default();
+        let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
+        let slot = registry.slot(&spec);
+        slot.shared.lock().expect("slot poisoned").state = RemoteBackendState::Failed {
+            error: RemoteBackendError::internal("failed"),
+        };
+
+        assert!(registry.forget("devbox"));
+        assert!(registry.snapshot().is_empty());
+    }
+
+    #[test]
+    fn forget_preserves_active_slot() {
+        let registry = RemoteBackendRegistry::default();
+        let spec = RemoteHostSpec::parse("devbox", &[]).unwrap();
+        let slot = registry.slot(&spec);
+        slot.shared.lock().expect("slot poisoned").state = RemoteBackendState::Connecting;
+
+        assert!(!registry.forget("devbox"));
+        assert_eq!(registry.snapshot().len(), 1);
     }
 }

--- a/src-tauri/src/services/remote_backend/mod.rs
+++ b/src-tauri/src/services/remote_backend/mod.rs
@@ -681,11 +681,6 @@ fn spawn_supervisor(
     });
 }
 
-/// Kill the tunnel; the remote daemon keeps running.
-pub fn disconnect(app: &AppHandle, registry: &RemoteBackendRegistry, host_input: &str) {
-    disconnect_generation(app, registry, host_input, None);
-}
-
 /// Disconnect only when `expected_generation` still owns the host slot. This
 /// lets an initializer clean up work superseded while it was awaiting without
 /// tearing down a newer connection that won the race.
@@ -703,7 +698,7 @@ pub fn disconnect_generation(
     let Some(slot) = registry.existing_slot(&host_key) else {
         return false;
     };
-    {
+    let disconnected_generation = {
         let mut shared = slot.shared.lock().expect("slot poisoned");
         if expected_generation.is_some_and(|expected| shared.generation != expected) {
             return false;
@@ -713,8 +708,14 @@ pub fn disconnect_generation(
             kill_tunnel_pid(pid);
         }
         shared.local_port = None;
-    }
-    set_state(app, &slot, RemoteBackendState::Disconnected);
+        shared.generation
+    };
+    set_state_if_current(
+        app,
+        &slot,
+        disconnected_generation,
+        RemoteBackendState::Disconnected,
+    );
     record_diagnostic(DiagnosticLevel::Info, "disconnected", &host_key, None);
     true
 }
@@ -725,6 +726,7 @@ pub async fn shutdown(
     registry: &RemoteBackendRegistry,
     host_input: &str,
     expected_instance_token: Option<&str>,
+    expected_generation: Option<u64>,
 ) -> Result<(), RemoteBackendError> {
     let aliases = ssh_config::load_ssh_config_hosts();
     let spec = RemoteHostSpec::parse(host_input, &aliases)?;
@@ -736,7 +738,12 @@ pub async fn shutdown(
     // until shutdown releases this lock, so ensure_daemon cannot recreate the
     // daemon after shutdown_daemon stops it.
     let _guard = slot.connect_lock.lock().await;
-    disconnect(app, registry, &spec.key());
+    if !disconnect_generation(app, registry, &spec.key(), expected_generation) {
+        return Err(RemoteBackendError::new(
+            RemoteBackendErrorKind::DaemonChanged,
+            "Remote backend changed before shutdown completed",
+        ));
+    }
     daemon::shutdown_daemon(&spec, &shell_env, expected_instance_token).await?;
     record_diagnostic(DiagnosticLevel::Info, "daemon_shutdown", &spec.key(), None);
     Ok(())

--- a/src-tauri/src/services/remote_backend/remote_daemon.sh
+++ b/src-tauri/src/services/remote_backend/remote_daemon.sh
@@ -208,9 +208,22 @@ acquire_legacy_compat_lock() {
       # A mkdir winner publishes its owner immediately. Repeated observations
       # distinguish that window from a process that died before publication.
       if [ "$stale_observations" -ge 20 ]; then
-        legacy_claim="$STATE_DIR/.daemon.lock.legacy.$NONCE.$$.$compat_attempt"
-        if mv "$LEGACY_LOCK_DIR" "$legacy_claim" 2>/dev/null; then
-          rm -rf -- "$legacy_claim"
+        # Pin the directory generation before acting on it. Older clients
+        # release with rmdir, so this guard prevents the observed directory
+        # from disappearing and a live successor reusing the shared pathname.
+        # If replacement won before the guard, the owner recheck detects it.
+        legacy_guard="$LEGACY_LOCK_DIR/.berd-reclaim.$NONCE.$$.$compat_attempt"
+        if mkdir "$legacy_guard" 2>/dev/null; then
+          if lock_owner_is_current "$LEGACY_LOCK_OWNER"; then
+            rmdir "$legacy_guard" 2>/dev/null || true
+          else
+            legacy_claim="$STATE_DIR/.daemon.lock.legacy.$NONCE.$$.$compat_attempt"
+            if mv "$LEGACY_LOCK_DIR" "$legacy_claim" 2>/dev/null; then
+              rm -rf -- "$legacy_claim"
+            else
+              rmdir "$legacy_guard" 2>/dev/null || true
+            fi
+          fi
         fi
         stale_observations=0
       fi

--- a/src-tauri/src/services/remote_backend/remote_daemon.sh
+++ b/src-tauri/src/services/remote_backend/remote_daemon.sh
@@ -45,8 +45,7 @@ LEGACY_LOCK_OWNER="$LEGACY_LOCK_DIR/owner"
 RECORD_FORMAT="v4"
 LOG_MAX_BYTES=$((4 * 1024 * 1024))
 LOG_RETAIN_BYTES=$((2 * 1024 * 1024))
-LOG_READ_BLOCK_BYTES=$((64 * 1024))
-LOG_READ_BLOCK_COUNT=64
+LOG_SEGMENT_BYTES=$((LOG_RETAIN_BYTES - 64 * 1024))
 
 emit() { printf '%s %s\n' "$NONCE" "$*"; }
 
@@ -119,11 +118,18 @@ lock_owner_is_current() {
 }
 
 release_daemon_lock() {
-  [ "${lock_held:-0}" = "1" ] || return 0
+  if [ "${compat_lock_held:-0}" = "1" ] &&
+    IFS= read -r current_compat_owner <"$LEGACY_LOCK_OWNER" 2>/dev/null &&
+    [ "$current_compat_owner" = "$our_lock_owner" ]; then
+    rm -f "$LEGACY_LOCK_OWNER"
+    rmdir "$LEGACY_LOCK_DIR" 2>/dev/null || true
+  fi
+  compat_lock_held=0
   if IFS= read -r current_lock_owner <"$our_ticket/owner" 2>/dev/null &&
     [ "$current_lock_owner" = "$our_lock_owner" ]; then
     rm -rf -- "$our_ticket"
   fi
+  [ -z "${pending_ticket:-}" ] || rm -rf -- "$pending_ticket"
   lock_held=0
 }
 
@@ -163,19 +169,56 @@ cleanup_daemon_mutation() {
   release_daemon_lock
 }
 
-# A pre-ticket script may have crashed while holding daemon.lock. Migrating
-# that one legacy path is safe for the ticket protocol because new owners never
-# reuse it; even a delayed legacy reclaimer cannot touch a ticket generation.
-clear_stale_legacy_lock() {
-  [ -d "$LEGACY_LOCK_DIR" ] || return 0
-  if lock_owner_is_current "$LEGACY_LOCK_OWNER"; then
-    return 1
-  fi
-  legacy_claim="$STATE_DIR/.daemon.lock.legacy.$NONCE.$$"
-  if mv "$LEGACY_LOCK_DIR" "$legacy_claim" 2>/dev/null; then
-    rm -rf -- "$legacy_claim"
-  fi
-  [ ! -d "$LEGACY_LOCK_DIR" ]
+# Ticket clients also hold daemon.lock for the full mutation. Older Berd
+# clients know only this path, so retaining it as a compatibility gate makes
+# mixed-version rollouts mutually exclusive in both acquisition orders. The
+# ticket remains the generation-safe ordering protocol for current clients.
+acquire_legacy_compat_lock() {
+  compat_attempt=0
+  stale_observations=0
+  while [ "$compat_attempt" -lt 1200 ]; do
+    compat_attempt=$((compat_attempt + 1))
+    if mkdir "$LEGACY_LOCK_DIR" 2>/dev/null; then
+      compat_owner_tmp="$LEGACY_LOCK_DIR/.owner.$$"
+      if ! printf '%s\n' "$our_lock_owner" >"$compat_owner_tmp" ||
+        ! mv -f "$compat_owner_tmp" "$LEGACY_LOCK_OWNER"; then
+        rm -f "$compat_owner_tmp"
+        rmdir "$LEGACY_LOCK_DIR" 2>/dev/null || true
+        stale_observations=0
+        sleep 0.01
+        continue
+      fi
+      # Let an observer that saw the directory before owner publication finish
+      # its claim, then prove this exact generation still occupies the path.
+      sleep 0.01
+      if ! IFS= read -r current_compat_owner <"$LEGACY_LOCK_OWNER" 2>/dev/null ||
+        [ "$current_compat_owner" != "$our_lock_owner" ]; then
+        stale_observations=0
+        sleep 0.01
+        continue
+      fi
+      compat_lock_held=1
+      return 0
+    fi
+
+    if lock_owner_is_current "$LEGACY_LOCK_OWNER"; then
+      stale_observations=0
+    else
+      stale_observations=$((stale_observations + 1))
+      # A mkdir winner publishes its owner immediately. Repeated observations
+      # distinguish that window from a process that died before publication.
+      if [ "$stale_observations" -ge 20 ]; then
+        legacy_claim="$STATE_DIR/.daemon.lock.legacy.$NONCE.$$.$compat_attempt"
+        if mv "$LEGACY_LOCK_DIR" "$legacy_claim" 2>/dev/null; then
+          rm -rf -- "$legacy_claim"
+        fi
+        stale_observations=0
+      fi
+    fi
+    sleep 0.1
+  done
+  emit "ERR state-dir"
+  exit 46
 }
 
 # Each invocation owns a path that is never reused (`NONCE` is a UUID). Stale
@@ -192,6 +235,7 @@ acquire_daemon_lock() {
   }
 
   lock_held=0
+  compat_lock_held=0
   our_ticket=""
   pending_ticket=""
   uncommitted_pid=""
@@ -212,17 +256,6 @@ acquire_daemon_lock() {
     exit 46
   }
   our_lock_owner="$$ $(b64 "$our_identity")"
-
-  legacy_attempt=0
-  while [ -d "$LEGACY_LOCK_DIR" ] && [ "$legacy_attempt" -lt 1200 ]; do
-    legacy_attempt=$((legacy_attempt + 1))
-    clear_stale_legacy_lock || true
-    [ ! -d "$LEGACY_LOCK_DIR" ] || sleep 0.1
-  done
-  if [ -d "$LEGACY_LOCK_DIR" ]; then
-    emit "ERR state-dir"
-    exit 46
-  fi
 
   our_ticket_id="$NONCE.$$"
   pending_ticket="$LOCK_ROOT/.pending.$our_ticket_id"
@@ -299,6 +332,7 @@ acquire_daemon_lock() {
       fi
     done
     if [ "$ticket_blocked" = "0" ]; then
+      acquire_legacy_compat_lock
       lock_held=1
       return 0
     fi
@@ -379,58 +413,52 @@ trim_log_if_needed() {
   fi
 }
 
-# `dd` performs many pipe reads per invocation, so a multi-megabyte pre-bind
-# burst is drained without a process per small FIFO read. Every consumed byte
-# first lands in the chunk file; rotation then carries that complete chunk into
-# the bounded tail, avoiding the userspace read-ahead loss caused by killing a
-# writer at RLIMIT_FSIZE.
+# `tee` writes every partial pipe read to its named output (the visible log)
+# before stdout. `head` closes that stdout counter after a roughly 2 MiB
+# segment, ending this tee only after the same bytes are visible. The 64 KiB reserve
+# covers the final in-flight pipe read, so a segment starting from the retained
+# 2 MiB tail cannot exceed the 4 MiB cap. Rotation happens per segment rather
+# than per small FIFO read.
 bounded_log_writer() {
   writer_log="$1"
-  writer_chunk="$STATE_DIR/.goose-serve.log.chunk.$$"
   writer_tmp="$STATE_DIR/.goose-serve.log.rotate.$$"
-  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 143' TERM
-  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 129' HUP
-  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 130' INT
+  writer_head_pid=""
+  # Preserve the Goose FIFO before backgrounding each counter pipeline;
+  # non-interactive Bash otherwise redirects an asynchronous stdin to null.
+  exec 3<&0
+  trap 'kill -TERM "$writer_head_pid" 2>/dev/null || true; wait "$writer_head_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 143' TERM
+  trap 'kill -TERM "$writer_head_pid" 2>/dev/null || true; wait "$writer_head_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 129' HUP
+  trap 'kill -TERM "$writer_head_pid" 2>/dev/null || true; wait "$writer_head_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 130' INT
 
   while :; do
-    rm -f "$writer_chunk"
-    dd bs="$LOG_READ_BLOCK_BYTES" count="$LOG_READ_BLOCK_COUNT" of="$writer_chunk" 2>/dev/null || true
-    chunk_bytes="$(wc -c <"$writer_chunk" 2>/dev/null | tr -d ' ')"
-    case "$chunk_bytes" in
-    '' | *[!0-9]*) chunk_bytes=0 ;;
-    esac
-    [ "$chunk_bytes" -gt 0 ] || break
-
     writer_bytes="$(wc -c <"$writer_log" 2>/dev/null | tr -d ' ')"
     case "$writer_bytes" in
     '' | *[!0-9]*) writer_bytes=0 ;;
     esac
-    if [ "$chunk_bytes" -ge "$LOG_MAX_BYTES" ]; then
-      if ! tail -c "$LOG_MAX_BYTES" "$writer_chunk" >"$writer_tmp" 2>/dev/null; then
+    if [ "$writer_bytes" -gt "$LOG_RETAIN_BYTES" ]; then
+      if ! tail -c "$LOG_RETAIN_BYTES" "$writer_log" >"$writer_tmp" 2>/dev/null; then
         rm -f "$writer_tmp"
         break
       fi
-    elif [ $((writer_bytes + chunk_bytes)) -le "$LOG_MAX_BYTES" ]; then
-      cat "$writer_chunk" >>"$writer_log"
-      continue
-    else
-      carry_bytes=$((LOG_MAX_BYTES - chunk_bytes))
-      if ! tail -c "$carry_bytes" "$writer_log" >"$writer_tmp" 2>/dev/null; then
+      if ! mv -f "$writer_tmp" "$writer_log"; then
         rm -f "$writer_tmp"
         break
       fi
-      if ! cat "$writer_chunk" >>"$writer_tmp"; then
-        rm -f "$writer_tmp"
-        break
-      fi
+      writer_bytes="$LOG_RETAIN_BYTES"
     fi
-    if ! mv -f "$writer_tmp" "$writer_log"; then
-      rm -f "$writer_tmp"
-      break
-    fi
+
+    tee -a "$writer_log" <&3 2>/dev/null | head -c "$LOG_SEGMENT_BYTES" >/dev/null 2>&1 &
+    writer_head_pid=$!
+    wait "$writer_head_pid" 2>/dev/null || true
+    writer_head_pid=""
+    writer_after="$(wc -c <"$writer_log" 2>/dev/null | tr -d ' ')"
+    case "$writer_after" in
+    '' | *[!0-9]*) writer_after="$writer_bytes" ;;
+    esac
+    [ "$writer_after" -gt "$writer_bytes" ] || break
   done
   trim_log_if_needed "$writer_log"
-  rm -f "$writer_chunk" "$writer_tmp"
+  rm -f "$writer_tmp"
 }
 
 # Confirms the PID is still the exact process that wrote this record. `kill -0`

--- a/src-tauri/src/services/remote_backend/remote_daemon.sh
+++ b/src-tauri/src/services/remote_backend/remote_daemon.sh
@@ -39,12 +39,14 @@ GOOSE_ARG="${4:--}"
 STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/berd/remote"
 RECORD="$STATE_DIR/daemon.record"
 LOG="$STATE_DIR/goose-serve.log"
-LOCK_DIR="$STATE_DIR/daemon.lock"
-LOCK_OWNER="$LOCK_DIR/owner"
+LOCK_ROOT="$STATE_DIR/daemon.locks"
+LEGACY_LOCK_DIR="$STATE_DIR/daemon.lock"
+LEGACY_LOCK_OWNER="$LEGACY_LOCK_DIR/owner"
 RECORD_FORMAT="v4"
 LOG_MAX_BYTES=$((4 * 1024 * 1024))
 LOG_RETAIN_BYTES=$((2 * 1024 * 1024))
-LOG_MAX_KIB=$((LOG_MAX_BYTES / 1024))
+LOG_READ_BLOCK_BYTES=$((64 * 1024))
+LOG_READ_BLOCK_COUNT=64
 
 emit() { printf '%s %s\n' "$NONCE" "$*"; }
 
@@ -104,7 +106,8 @@ process_identity() {
 }
 
 lock_owner_is_current() {
-  IFS=' ' read -r lock_pid lock_b64identity lock_extra <"$LOCK_OWNER" 2>/dev/null || return 1
+  owner_path="$1"
+  IFS=' ' read -r lock_pid lock_b64identity lock_extra <"$owner_path" 2>/dev/null || return 1
   case "$lock_pid" in
   '' | *[!0-9]*) return 1 ;;
   esac
@@ -117,10 +120,9 @@ lock_owner_is_current() {
 
 release_daemon_lock() {
   [ "${lock_held:-0}" = "1" ] || return 0
-  if IFS= read -r current_lock_owner <"$LOCK_OWNER" 2>/dev/null &&
+  if IFS= read -r current_lock_owner <"$our_ticket/owner" 2>/dev/null &&
     [ "$current_lock_owner" = "$our_lock_owner" ]; then
-    rm -f "$LOCK_OWNER"
-    rmdir "$LOCK_DIR" 2>/dev/null || true
+    rm -rf -- "$our_ticket"
   fi
   lock_held=0
 }
@@ -161,36 +163,37 @@ cleanup_daemon_mutation() {
   release_daemon_lock
 }
 
-# Atomically move one observed stale lock generation out of the acquisition
-# path before deleting it. There is deliberately no second mutex: a crash after
-# the rename can leave only a uniquely named cleanup artifact, which cannot
-# prevent a future operation from acquiring daemon.lock. Concurrent observers
-# can claim at most the generation present when their rename executes, and
-# cleanup is confined to that exact claimed path.
-reclaim_stale_daemon_lock() {
-  if lock_owner_is_current; then
+# A pre-ticket script may have crashed while holding daemon.lock. Migrating
+# that one legacy path is safe for the ticket protocol because new owners never
+# reuse it; even a delayed legacy reclaimer cannot touch a ticket generation.
+clear_stale_legacy_lock() {
+  [ -d "$LEGACY_LOCK_DIR" ] || return 0
+  if lock_owner_is_current "$LEGACY_LOCK_OWNER"; then
     return 1
   fi
-
-  claimed_lock="$STATE_DIR/.daemon.lock.reclaimed.$$.$lock_attempt"
-  if mv "$LOCK_DIR" "$claimed_lock" 2>/dev/null; then
-    rm -rf -- "$claimed_lock"
-    return 0
+  legacy_claim="$STATE_DIR/.daemon.lock.legacy.$NONCE.$$"
+  if mv "$LEGACY_LOCK_DIR" "$legacy_claim" 2>/dev/null; then
+    rm -rf -- "$legacy_claim"
   fi
-  return 1
+  [ ! -d "$LEGACY_LOCK_DIR" ]
 }
 
-# `mkdir` is the portable cross-process atomic primitive available on both
-# Linux and macOS remotes. The lock covers every daemon.record read/mutation,
-# including shutdown from another Berd client using the same remote account.
+# Each invocation owns a path that is never reused (`NONCE` is a UUID). Stale
+# cleanup therefore removes the exact generation whose owner was inspected,
+# never a successor at a shared pathname. A Lamport bakery ticket orders
+# simultaneous contenders without introducing another reclaimable mutex: a
+# process first publishes `choosing`, then a number, and may enter only after
+# every live lower `(number, ticket-id)` pair has departed.
 acquire_daemon_lock() {
   umask 077
-  mkdir -p "$STATE_DIR" || {
+  mkdir -p "$STATE_DIR" "$LOCK_ROOT" || {
     emit "ERR state-dir"
     exit 46
   }
 
   lock_held=0
+  our_ticket=""
+  pending_ticket=""
   uncommitted_pid=""
   uncommitted_logger_pid=""
   uncommitted_log_pipe=""
@@ -198,61 +201,111 @@ acquire_daemon_lock() {
   trap 'exit 129' HUP
   trap 'exit 130' INT
   trap 'exit 143' TERM
-  stale_observations=0
+  case "$NONCE" in
+  '' | *[!A-Za-z0-9._-]*)
+    emit "ERR state-dir"
+    exit 46
+    ;;
+  esac
+  our_identity="$(process_identity "$$")" || {
+    emit "ERR state-dir"
+    exit 46
+  }
+  our_lock_owner="$$ $(b64 "$our_identity")"
+
+  legacy_attempt=0
+  while [ -d "$LEGACY_LOCK_DIR" ] && [ "$legacy_attempt" -lt 1200 ]; do
+    legacy_attempt=$((legacy_attempt + 1))
+    clear_stale_legacy_lock || true
+    [ ! -d "$LEGACY_LOCK_DIR" ] || sleep 0.1
+  done
+  if [ -d "$LEGACY_LOCK_DIR" ]; then
+    emit "ERR state-dir"
+    exit 46
+  fi
+
+  our_ticket_id="$NONCE.$$"
+  pending_ticket="$LOCK_ROOT/.pending.$our_ticket_id"
+  our_ticket="$LOCK_ROOT/ticket.$our_ticket_id"
+  rm -rf -- "$pending_ticket"
+  if ! mkdir "$pending_ticket" 2>/dev/null ||
+    ! printf '%s\n' "$our_lock_owner" >"$pending_ticket/owner" ||
+    ! : >"$pending_ticket/choosing" ||
+    ! mv "$pending_ticket" "$our_ticket" 2>/dev/null; then
+    rm -rf -- "$pending_ticket"
+    emit "ERR state-dir"
+    exit 46
+  fi
+
+  max_ticket_number=0
+  for observed_ticket in "$LOCK_ROOT"/ticket.*; do
+    [ -d "$observed_ticket" ] || continue
+    if ! lock_owner_is_current "$observed_ticket/owner"; then
+      rm -rf -- "$observed_ticket"
+      continue
+    fi
+    if IFS= read -r observed_number <"$observed_ticket/number" 2>/dev/null; then
+      case "$observed_number" in
+      '' | *[!0-9]*) ;;
+      *)
+        if [ "$observed_number" -gt "$max_ticket_number" ]; then
+          max_ticket_number="$observed_number"
+        fi
+        ;;
+      esac
+    fi
+  done
+  our_ticket_number=$((max_ticket_number + 1))
+  if ! printf '%s\n' "$our_ticket_number" >"$our_ticket/.number.$$" ||
+    ! mv "$our_ticket/.number.$$" "$our_ticket/number" 2>/dev/null ||
+    ! rm -f "$our_ticket/choosing"; then
+    rm -rf -- "$our_ticket"
+    emit "ERR state-dir"
+    exit 46
+  fi
+
   lock_attempt=0
   # A lock holder can spend about 80 seconds across five readiness attempts
   # and bounded cleanup. Wait longer than that critical section so a healthy
   # concurrent ensure cannot be mistaken for a wedged state-dir operation.
   while [ "$lock_attempt" -lt 1200 ]; do
     lock_attempt=$((lock_attempt + 1))
-    if mkdir "$LOCK_DIR" 2>/dev/null; then
-      our_identity="$(process_identity "$$")" || {
-        rmdir "$LOCK_DIR" 2>/dev/null || true
-        emit "ERR state-dir"
-        exit 46
-      }
-      our_lock_owner="$$ $(b64 "$our_identity")"
-      lock_owner_tmp="$LOCK_DIR/.owner.$$"
-      if ! printf '%s\n' "$our_lock_owner" >"$lock_owner_tmp" ||
-        ! mv -f "$lock_owner_tmp" "$LOCK_OWNER"; then
-        rm -f "$lock_owner_tmp"
-        rmdir "$LOCK_DIR" 2>/dev/null || true
-        # A concurrent stale observer may have claimed the generation between
-        # mkdir and owner publication. Nothing was committed under this lock;
-        # retry against the current path instead of turning the benign race
-        # into a state-dir failure.
-        stale_observations=0
-        sleep 0.01
+    ticket_blocked=0
+    for observed_ticket in "$LOCK_ROOT"/ticket.*; do
+      [ -d "$observed_ticket" ] || continue
+      [ "$observed_ticket" != "$our_ticket" ] || continue
+      if ! lock_owner_is_current "$observed_ticket/owner"; then
+        rm -rf -- "$observed_ticket"
         continue
       fi
-      # Give a reclaimer that performed its final stale check before owner
-      # publication a chance to complete its atomic rename, then prove our
-      # owner is still published at the acquisition path before proceeding.
-      sleep 0.01
-      if ! IFS= read -r current_lock_owner <"$LOCK_OWNER" 2>/dev/null ||
-        [ "$current_lock_owner" != "$our_lock_owner" ]; then
-        stale_observations=0
-        sleep 0.01
+      if [ -e "$observed_ticket/choosing" ]; then
+        ticket_blocked=1
         continue
       fi
+      if ! IFS= read -r observed_number <"$observed_ticket/number" 2>/dev/null; then
+        ticket_blocked=1
+        continue
+      fi
+      case "$observed_number" in
+      '' | *[!0-9]*)
+        ticket_blocked=1
+        continue
+        ;;
+      esac
+      observed_id="${observed_ticket##*/ticket.}"
+      if [ "$observed_number" -lt "$our_ticket_number" ] ||
+        { [ "$observed_number" -eq "$our_ticket_number" ] && [[ "$observed_id" < "$our_ticket_id" ]]; }; then
+        ticket_blocked=1
+      fi
+    done
+    if [ "$ticket_blocked" = "0" ]; then
       lock_held=1
       return 0
-    fi
-
-    if lock_owner_is_current; then
-      stale_observations=0
-    else
-      stale_observations=$((stale_observations + 1))
-      # Allow the mkdir winner time to publish its owner before treating a
-      # missing/malformed owner as stale after an interrupted invocation.
-      if [ "$stale_observations" -ge 20 ]; then
-        reclaim_stale_daemon_lock || true
-        stale_observations=0
-      fi
     fi
     sleep 0.1
   done
 
+  rm -rf -- "$our_ticket"
   emit "ERR state-dir"
   exit 46
 }
@@ -326,45 +379,58 @@ trim_log_if_needed() {
   fi
 }
 
-# `cat` is the only process on the FIFO read path, so even a multi-megabyte
-# pre-bind burst drains at native pipe speed. The kernel file-size limit stops
-# that writer exactly at 4 MiB; after retaining the final 2 MiB, a fresh cat
-# resumes from the still-open FIFO. This gives a hard on-disk cap without a
-# process-heavy per-chunk shell loop or polling race.
+# `dd` performs many pipe reads per invocation, so a multi-megabyte pre-bind
+# burst is drained without a process per small FIFO read. Every consumed byte
+# first lands in the chunk file; rotation then carries that complete chunk into
+# the bounded tail, avoiding the userspace read-ahead loss caused by killing a
+# writer at RLIMIT_FSIZE.
 bounded_log_writer() {
   writer_log="$1"
+  writer_chunk="$STATE_DIR/.goose-serve.log.chunk.$$"
   writer_tmp="$STATE_DIR/.goose-serve.log.rotate.$$"
-  # Preserve the FIFO on a non-stdin descriptor before starting cat
-  # asynchronously; non-interactive Bash redirects a background command's
-  # implicit stdin to /dev/null.
-  exec 3<&0
-  writer_cat_pid=""
-  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 143' TERM
-  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 129' HUP
-  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 130' INT
+  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 143' TERM
+  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 129' HUP
+  trap 'rm -f "$writer_chunk" "$writer_tmp"; exit 130' INT
 
   while :; do
-    (ulimit -S -f "$LOG_MAX_KIB" && exec cat <&3 >>"$writer_log") 2>/dev/null &
-    writer_cat_pid=$!
-    if wait "$writer_cat_pid" 2>/dev/null; then
-      break
-    fi
+    rm -f "$writer_chunk"
+    dd bs="$LOG_READ_BLOCK_BYTES" count="$LOG_READ_BLOCK_COUNT" of="$writer_chunk" 2>/dev/null || true
+    chunk_bytes="$(wc -c <"$writer_chunk" 2>/dev/null | tr -d ' ')"
+    case "$chunk_bytes" in
+    '' | *[!0-9]*) chunk_bytes=0 ;;
+    esac
+    [ "$chunk_bytes" -gt 0 ] || break
+
     writer_bytes="$(wc -c <"$writer_log" 2>/dev/null | tr -d ' ')"
     case "$writer_bytes" in
     '' | *[!0-9]*) writer_bytes=0 ;;
     esac
-    if [ "$writer_bytes" -lt "$LOG_MAX_BYTES" ]; then
-      break
-    fi
-    if tail -c "$LOG_RETAIN_BYTES" "$writer_log" >"$writer_tmp" 2>/dev/null; then
-      mv -f "$writer_tmp" "$writer_log"
+    if [ "$chunk_bytes" -ge "$LOG_MAX_BYTES" ]; then
+      if ! tail -c "$LOG_MAX_BYTES" "$writer_chunk" >"$writer_tmp" 2>/dev/null; then
+        rm -f "$writer_tmp"
+        break
+      fi
+    elif [ $((writer_bytes + chunk_bytes)) -le "$LOG_MAX_BYTES" ]; then
+      cat "$writer_chunk" >>"$writer_log"
+      continue
     else
+      carry_bytes=$((LOG_MAX_BYTES - chunk_bytes))
+      if ! tail -c "$carry_bytes" "$writer_log" >"$writer_tmp" 2>/dev/null; then
+        rm -f "$writer_tmp"
+        break
+      fi
+      if ! cat "$writer_chunk" >>"$writer_tmp"; then
+        rm -f "$writer_tmp"
+        break
+      fi
+    fi
+    if ! mv -f "$writer_tmp" "$writer_log"; then
       rm -f "$writer_tmp"
       break
     fi
   done
   trim_log_if_needed "$writer_log"
-  rm -f "$writer_tmp"
+  rm -f "$writer_chunk" "$writer_tmp"
 }
 
 # Confirms the PID is still the exact process that wrote this record. `kill -0`

--- a/src-tauri/src/services/remote_backend/remote_daemon.sh
+++ b/src-tauri/src/services/remote_backend/remote_daemon.sh
@@ -41,11 +41,10 @@ RECORD="$STATE_DIR/daemon.record"
 LOG="$STATE_DIR/goose-serve.log"
 LOCK_DIR="$STATE_DIR/daemon.lock"
 LOCK_OWNER="$LOCK_DIR/owner"
-LOCK_RECLAIM_DIR="$STATE_DIR/daemon.lock.reclaim"
 RECORD_FORMAT="v4"
 LOG_MAX_BYTES=$((4 * 1024 * 1024))
 LOG_RETAIN_BYTES=$((2 * 1024 * 1024))
-LOG_WRITE_CHUNK_BYTES=$((64 * 1024))
+LOG_MAX_KIB=$((LOG_MAX_BYTES / 1024))
 
 emit() { printf '%s %s\n' "$NONCE" "$*"; }
 
@@ -126,12 +125,6 @@ release_daemon_lock() {
   lock_held=0
 }
 
-release_reclaim_lock() {
-  [ "${reclaim_held:-0}" = "1" ] || return 0
-  rmdir "$LOCK_RECLAIM_DIR" 2>/dev/null || true
-  reclaim_held=0
-}
-
 terminate_uncommitted_daemon() {
   case "${uncommitted_pid:-}" in
   '' | *[!0-9]*) ;;
@@ -166,31 +159,25 @@ terminate_uncommitted_daemon() {
 cleanup_daemon_mutation() {
   terminate_uncommitted_daemon
   release_daemon_lock
-  release_reclaim_lock
 }
 
-# Claim one stale lock generation before deleting it. The separate reclaim
-# mutex serializes observers: after its final owner re-check, no peer can
-# remove the old directory and let a new generation appear before this process
-# atomically renames it. Once renamed, cleanup is confined to the claimed path,
-# so partial `.owner.*` publications are removed without touching a successor.
+# Atomically move one observed stale lock generation out of the acquisition
+# path before deleting it. There is deliberately no second mutex: a crash after
+# the rename can leave only a uniquely named cleanup artifact, which cannot
+# prevent a future operation from acquiring daemon.lock. Concurrent observers
+# can claim at most the generation present when their rename executes, and
+# cleanup is confined to that exact claimed path.
 reclaim_stale_daemon_lock() {
-  if ! mkdir "$LOCK_RECLAIM_DIR" 2>/dev/null; then
-    return 1
-  fi
-  reclaim_held=1
-
   if lock_owner_is_current; then
-    release_reclaim_lock
     return 1
   fi
 
   claimed_lock="$STATE_DIR/.daemon.lock.reclaimed.$$.$lock_attempt"
   if mv "$LOCK_DIR" "$claimed_lock" 2>/dev/null; then
     rm -rf -- "$claimed_lock"
+    return 0
   fi
-  release_reclaim_lock
-  return 0
+  return 1
 }
 
 # `mkdir` is the portable cross-process atomic primitive available on both
@@ -204,7 +191,6 @@ acquire_daemon_lock() {
   }
 
   lock_held=0
-  reclaim_held=0
   uncommitted_pid=""
   uncommitted_logger_pid=""
   uncommitted_log_pipe=""
@@ -231,8 +217,23 @@ acquire_daemon_lock() {
         ! mv -f "$lock_owner_tmp" "$LOCK_OWNER"; then
         rm -f "$lock_owner_tmp"
         rmdir "$LOCK_DIR" 2>/dev/null || true
-        emit "ERR state-dir"
-        exit 46
+        # A concurrent stale observer may have claimed the generation between
+        # mkdir and owner publication. Nothing was committed under this lock;
+        # retry against the current path instead of turning the benign race
+        # into a state-dir failure.
+        stale_observations=0
+        sleep 0.01
+        continue
+      fi
+      # Give a reclaimer that performed its final stale check before owner
+      # publication a chance to complete its atomic rename, then prove our
+      # owner is still published at the acquisition path before proceeding.
+      sleep 0.01
+      if ! IFS= read -r current_lock_owner <"$LOCK_OWNER" 2>/dev/null ||
+        [ "$current_lock_owner" != "$our_lock_owner" ]; then
+        stale_observations=0
+        sleep 0.01
+        continue
       fi
       lock_held=1
       return 0
@@ -325,45 +326,45 @@ trim_log_if_needed() {
   fi
 }
 
-prepare_log_for_append() {
-  append_log="$1"
-  append_bytes="$2"
-  [ -f "$append_log" ] || return 0
-  current_bytes="$(wc -c <"$append_log" 2>/dev/null | tr -d ' ')"
-  case "$current_bytes" in
-  '' | *[!0-9]*) return 0 ;;
-  esac
-  if [ $((current_bytes + append_bytes)) -gt "$LOG_MAX_BYTES" ]; then
-    log_tmp="$STATE_DIR/.goose-serve.log.$$"
-    if tail -c "$LOG_RETAIN_BYTES" "$append_log" >"$log_tmp" 2>/dev/null; then
-      mv -f "$log_tmp" "$append_log"
-    else
-      rm -f "$log_tmp"
-    fi
-  fi
-}
-
-# Consume fixed-size byte chunks rather than newline records. This bounds shell
-# memory for a huge line and continues rotating a producer that never emits a
-# newline. Each append reopens the path so atomic trims take effect.
+# `cat` is the only process on the FIFO read path, so even a multi-megabyte
+# pre-bind burst drains at native pipe speed. The kernel file-size limit stops
+# that writer exactly at 4 MiB; after retaining the final 2 MiB, a fresh cat
+# resumes from the still-open FIFO. This gives a hard on-disk cap without a
+# process-heavy per-chunk shell loop or polling race.
 bounded_log_writer() {
   writer_log="$1"
-  writer_chunk="$STATE_DIR/.goose-serve.log.chunk.$$"
+  writer_tmp="$STATE_DIR/.goose-serve.log.rotate.$$"
+  # Preserve the FIFO on a non-stdin descriptor before starting cat
+  # asynchronously; non-interactive Bash redirects a background command's
+  # implicit stdin to /dev/null.
+  exec 3<&0
+  writer_cat_pid=""
+  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 143' TERM
+  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 129' HUP
+  trap 'kill -TERM "$writer_cat_pid" 2>/dev/null || true; wait "$writer_cat_pid" 2>/dev/null || true; rm -f "$writer_tmp"; exit 130' INT
+
   while :; do
-    rm -f "$writer_chunk"
-    dd bs="$LOG_WRITE_CHUNK_BYTES" count=1 of="$writer_chunk" 2>/dev/null || true
-    writer_bytes="$(wc -c <"$writer_chunk" 2>/dev/null | tr -d ' ')"
+    (ulimit -S -f "$LOG_MAX_KIB" && exec cat <&3 >>"$writer_log") 2>/dev/null &
+    writer_cat_pid=$!
+    if wait "$writer_cat_pid" 2>/dev/null; then
+      break
+    fi
+    writer_bytes="$(wc -c <"$writer_log" 2>/dev/null | tr -d ' ')"
     case "$writer_bytes" in
     '' | *[!0-9]*) writer_bytes=0 ;;
     esac
-    if [ "$writer_bytes" -eq 0 ]; then
-      rm -f "$writer_chunk"
+    if [ "$writer_bytes" -lt "$LOG_MAX_BYTES" ]; then
       break
     fi
-    prepare_log_for_append "$writer_log" "$writer_bytes"
-    cat "$writer_chunk" >>"$writer_log"
+    if tail -c "$LOG_RETAIN_BYTES" "$writer_log" >"$writer_tmp" 2>/dev/null; then
+      mv -f "$writer_tmp" "$writer_log"
+    else
+      rm -f "$writer_tmp"
+      break
+    fi
   done
-  rm -f "$writer_chunk"
+  trim_log_if_needed "$writer_log"
+  rm -f "$writer_tmp"
 }
 
 # Confirms the PID is still the exact process that wrote this record. `kill -0`

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -361,7 +361,10 @@ describe("disconnect and shutdownHost", () => {
 
     await useRemoteHostStore.getState().disconnect("devbox");
 
-    expect(mocks.disconnectRemoteHost).toHaveBeenCalledWith("devbox");
+    expect(mocks.disconnectRemoteHost).toHaveBeenCalledWith(
+      "devbox",
+      backendIdentity.generation,
+    );
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
       ...backendIdentity,
       state: "disconnected",
@@ -376,7 +379,11 @@ describe("disconnect and shutdownHost", () => {
 
     await useRemoteHostStore.getState().shutdownHost("devbox");
 
-    expect(mocks.shutdownRemoteHost).toHaveBeenCalledWith("devbox");
+    expect(mocks.shutdownRemoteHost).toHaveBeenCalledWith(
+      "devbox",
+      undefined,
+      backendIdentity.generation,
+    );
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
       ...backendIdentity,
       state: "disconnected",
@@ -393,7 +400,74 @@ describe("disconnect and shutdownHost", () => {
     expect(mocks.shutdownRemoteHost).toHaveBeenCalledWith(
       "devbox",
       "opaque-generation",
+      undefined,
     );
+  });
+
+  it("does not publish a stale disconnect completion", async () => {
+    let resolveDisconnect: () => void = () => {};
+    mocks.disconnectRemoteHost.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDisconnect = resolve;
+        }),
+    );
+    useRemoteHostStore.setState({
+      lifecycleByHost: { devbox: 1 },
+      statusByHost: { devbox: { ...backendIdentity, state: "ready" } },
+    });
+
+    const pending = useRemoteHostStore.getState().disconnect("devbox");
+    useRemoteHostStore.setState({
+      lifecycleByHost: { devbox: 2 },
+      statusByHost: {
+        devbox: { incarnation: "slot-2", generation: 2, state: "ready" },
+      },
+    });
+    resolveDisconnect();
+    await pending;
+
+    expect(mocks.disconnectRemoteHost).toHaveBeenCalledWith("devbox", 1);
+    expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      incarnation: "slot-2",
+      generation: 2,
+      state: "ready",
+    });
+  });
+
+  it("does not publish a stale shutdown completion", async () => {
+    let resolveShutdown: () => void = () => {};
+    mocks.shutdownRemoteHost.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveShutdown = resolve;
+        }),
+    );
+    useRemoteHostStore.setState({
+      lifecycleByHost: { devbox: 1 },
+      statusByHost: { devbox: { ...backendIdentity, state: "ready" } },
+    });
+
+    const pending = useRemoteHostStore.getState().shutdownHost("devbox");
+    useRemoteHostStore.setState({
+      lifecycleByHost: { devbox: 2 },
+      statusByHost: {
+        devbox: { incarnation: "slot-2", generation: 2, state: "ready" },
+      },
+    });
+    resolveShutdown();
+    await pending;
+
+    expect(mocks.shutdownRemoteHost).toHaveBeenCalledWith(
+      "devbox",
+      undefined,
+      1,
+    );
+    expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      incarnation: "slot-2",
+      generation: 2,
+      state: "ready",
+    });
   });
 });
 
@@ -659,7 +733,7 @@ describe("manual host persistence", () => {
     expect(useRemoteHostStore.getState().manualHosts).toEqual(["adhoc.blox"]);
   });
 
-  it("forgets a broken host and clears all of its local state", async () => {
+  it("forgets a broken host while preserving reusable preferences", async () => {
     const host = "ssh broken.blox";
     useRemoteHostStore.setState({
       manualHosts: [host, "keep.blox"],
@@ -699,12 +773,12 @@ describe("manual host persistence", () => {
     expect(state.doctorByHost).not.toHaveProperty(host);
     expect(state.doctorPendingByHost).not.toHaveProperty(host);
     expect(state.doctorErrorByHost).not.toHaveProperty(host);
-    expect(state.recentDirsByHost).not.toHaveProperty(host);
-    expect(state.goosePathByHost).not.toHaveProperty(host);
+    expect(state.recentDirsByHost[host]).toEqual(["~/src"]);
+    expect(state.goosePathByHost[host]).toBe("~/bin/goose");
     expect(state.forgottenHosts[host]).toBe(true);
     expect(loadPersistedManualHosts()).toEqual(["keep.blox"]);
-    expect(loadPersistedRecentDirs()).toEqual({});
-    expect(loadPersistedGoosePaths()).toEqual({});
+    expect(loadPersistedRecentDirs()).toEqual({ [host]: ["~/src"] });
+    expect(loadPersistedGoosePaths()).toEqual({ [host]: "~/bin/goose" });
   });
 
   it("keeps local state when the backend refuses to forget an active host", async () => {

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   RemoteBackendConnection,
+  RemoteBackendSnapshotEntry,
   RemoteToolProbe,
 } from "@/shared/api/remoteHosts";
 
@@ -53,6 +54,10 @@ function resetStore(): void {
     doctorByHost: {},
     doctorPendingByHost: {},
     doctorErrorByHost: {},
+    forgottenHosts: {},
+    lifecycleByHost: {},
+    forgetPendingByHost: {},
+    forgetErrorByHost: {},
     recentDirsByHost: {},
     goosePathByHost: {},
   });
@@ -134,6 +139,56 @@ describe("syncBackendSnapshot", () => {
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
       state: "ready",
     });
+  });
+
+  it("does not restore a forgotten host from an older in-flight snapshot", async () => {
+    const host = "broken.blox";
+    let resolveSnapshot: (snapshot: RemoteBackendSnapshotEntry[]) => void =
+      () => {};
+    mocks.listRemoteBackends.mockImplementation(
+      () =>
+        new Promise<RemoteBackendSnapshotEntry[]>((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+    useRemoteHostStore.setState({
+      statusByHost: { [host]: { state: "failed" } },
+    });
+
+    const syncing = useRemoteHostStore.getState().syncBackendSnapshot();
+    await useRemoteHostStore.getState().forgetHost(host);
+    resolveSnapshot([{ host, state: "failed" }]);
+    await syncing;
+
+    expect(useRemoteHostStore.getState().statusByHost).not.toHaveProperty(host);
+    expect(useRemoteHostStore.getState().forgottenHosts[host]).toBe(true);
+  });
+
+  it("rejects a pre-forget snapshot after an intentional reconnect", async () => {
+    const host = "broken.blox";
+    let resolveSnapshot: (snapshot: RemoteBackendSnapshotEntry[]) => void =
+      () => {};
+    mocks.listRemoteBackends.mockImplementation(
+      () =>
+        new Promise<RemoteBackendSnapshotEntry[]>((resolve) => {
+          resolveSnapshot = resolve;
+        }),
+    );
+    mocks.connectRemoteHost.mockResolvedValue(connection);
+    useRemoteHostStore.setState({
+      statusByHost: { [host]: { state: "failed" } },
+    });
+
+    const syncing = useRemoteHostStore.getState().syncBackendSnapshot();
+    await useRemoteHostStore.getState().forgetHost(host);
+    await useRemoteHostStore.getState().ensureHostConnected(host);
+    resolveSnapshot([{ host, state: "disconnected" }]);
+    await syncing;
+
+    expect(useRemoteHostStore.getState().statusByHost[host]).toEqual({
+      state: "ready",
+    });
+    expect(useRemoteHostStore.getState().forgottenHosts[host]).toBeUndefined();
   });
 });
 
@@ -554,6 +609,7 @@ describe("manual host persistence", () => {
     expect(state.doctorErrorByHost).not.toHaveProperty(host);
     expect(state.recentDirsByHost).not.toHaveProperty(host);
     expect(state.goosePathByHost).not.toHaveProperty(host);
+    expect(state.forgottenHosts[host]).toBe(true);
     expect(loadPersistedManualHosts()).toEqual(["keep.blox"]);
     expect(loadPersistedRecentDirs()).toEqual({});
     expect(loadPersistedGoosePaths()).toEqual({});
@@ -574,6 +630,70 @@ describe("manual host persistence", () => {
     expect(useRemoteHostStore.getState().statusByHost).toHaveProperty(
       "adhoc.blox",
     );
+    expect(
+      useRemoteHostStore.getState().forgetPendingByHost["adhoc.blox"],
+    ).toBe(false);
+    expect(
+      useRemoteHostStore.getState().forgetErrorByHost["adhoc.blox"],
+    ).toEqual({ kind: "internal", message: "active" });
+  });
+
+  it("ignores late status events until an intentional reconnect", async () => {
+    const host = "broken.blox";
+    useRemoteHostStore.setState({
+      statusByHost: { [host]: { state: "failed" } },
+    });
+
+    await useRemoteHostStore.getState().forgetHost(host);
+    useRemoteHostStore.getState().applyStatusEvent({
+      host,
+      state: "disconnected",
+    });
+    expect(useRemoteHostStore.getState().statusByHost).not.toHaveProperty(host);
+
+    mocks.connectRemoteHost.mockResolvedValue(connection);
+    await useRemoteHostStore.getState().ensureHostConnected(host);
+    useRemoteHostStore.getState().applyStatusEvent({
+      host,
+      state: "reconnecting",
+      attempt: 1,
+    });
+    expect(useRemoteHostStore.getState().statusByHost[host]).toEqual({
+      state: "reconnecting",
+      attempt: 1,
+    });
+  });
+
+  it("exposes forget pending and failure state and deduplicates submissions", async () => {
+    const host = "broken.blox";
+    let rejectForget: (error: unknown) => void = () => {};
+    mocks.forgetRemoteHost.mockImplementation(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectForget = reject;
+        }),
+    );
+    useRemoteHostStore.setState({
+      statusByHost: { [host]: { state: "failed" } },
+    });
+
+    const first = useRemoteHostStore.getState().forgetHost(host);
+    const firstResult = expect(first).rejects.toEqual({
+      kind: "internal",
+      message: "still connecting",
+    });
+    expect(useRemoteHostStore.getState().forgetPendingByHost[host]).toBe(true);
+    const duplicate = useRemoteHostStore.getState().forgetHost(host);
+    expect(mocks.forgetRemoteHost).toHaveBeenCalledTimes(1);
+
+    rejectForget({ kind: "internal", message: "still connecting" });
+    await firstResult;
+    await duplicate;
+    expect(useRemoteHostStore.getState().forgetPendingByHost[host]).toBe(false);
+    expect(useRemoteHostStore.getState().forgetErrorByHost[host]).toEqual({
+      kind: "internal",
+      message: "still connecting",
+    });
   });
 
   it("tolerates corrupted storage when loading manual hosts", () => {

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -390,6 +390,26 @@ describe("disconnect and shutdownHost", () => {
     });
   });
 
+  it("keeps an authoritative ready state when shutdown rejects before tunnel teardown", async () => {
+    const daemonChanged = {
+      kind: "daemon-changed",
+      message: "remote daemon changed",
+    };
+    mocks.shutdownRemoteHost.mockRejectedValue(daemonChanged);
+    useRemoteHostStore
+      .getState()
+      .applyStatusEvent({ host: "devbox", ...backendIdentity, state: "ready" });
+
+    await expect(
+      useRemoteHostStore.getState().shutdownHost("devbox"),
+    ).rejects.toBe(daemonChanged);
+
+    expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
+      state: "ready",
+    });
+  });
+
   it("passes a conflict generation token to shutdown", async () => {
     mocks.shutdownRemoteHost.mockResolvedValue(undefined);
 
@@ -779,6 +799,43 @@ describe("manual host persistence", () => {
     expect(loadPersistedManualHosts()).toEqual(["keep.blox"]);
     expect(loadPersistedRecentDirs()).toEqual({ [host]: ["~/src"] });
     expect(loadPersistedGoosePaths()).toEqual({ [host]: "~/bin/goose" });
+  });
+
+  it("does not let a late Forget completion erase a newer connection", async () => {
+    const host = "adhoc.blox";
+    let resolveForget: () => void = () => {};
+    mocks.forgetRemoteHost.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveForget = resolve;
+        }),
+    );
+    useRemoteHostStore.setState({
+      lifecycleByHost: { [host]: 1 },
+      manualHosts: [host],
+      statusByHost: { [host]: { ...backendIdentity, state: "disconnected" } },
+    });
+
+    const forgetting = useRemoteHostStore.getState().forgetHost(host);
+    const replacement = {
+      ...connection,
+      incarnation: "slot-replacement",
+      generation: 7,
+    };
+    mocks.connectRemoteHost.mockResolvedValue(replacement);
+    await useRemoteHostStore.getState().ensureHostConnected(host);
+    resolveForget();
+    await forgetting;
+
+    const state = useRemoteHostStore.getState();
+    expect(state.statusByHost[host]).toEqual({
+      state: "ready",
+      incarnation: replacement.incarnation,
+      generation: replacement.generation,
+    });
+    expect(state.manualHosts).toContain(host);
+    expect(state.forgottenHosts[host]).toBeUndefined();
+    expect(state.forgetPendingByHost[host]).toBeUndefined();
   });
 
   it("keeps local state when the backend refuses to forget an active host", async () => {

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   listSshConfigHosts: vi.fn(),
   connectRemoteHost: vi.fn(),
   disconnectRemoteHost: vi.fn(),
+  forgetRemoteHost: vi.fn(),
   shutdownRemoteHost: vi.fn(),
   listRemoteBackends: vi.fn(),
   checkRemoteHost: vi.fn(),
@@ -61,6 +62,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
   resetStore();
+  mocks.forgetRemoteHost.mockResolvedValue(undefined);
 });
 
 describe("applyStatusEvent", () => {
@@ -510,14 +512,68 @@ describe("manual host persistence", () => {
     expect(useRemoteHostStore.getState().manualHosts).toEqual(["adhoc.blox"]);
   });
 
-  it("forgets a manual host and persists the removal", async () => {
-    mocks.connectRemoteHost.mockResolvedValue(connection);
-    await useRemoteHostStore.getState().ensureHostConnected("adhoc.blox");
+  it("forgets a broken host and clears all of its local state", async () => {
+    const host = "ssh broken.blox";
+    useRemoteHostStore.setState({
+      manualHosts: [host, "keep.blox"],
+      statusByHost: {
+        [host]: {
+          state: "failed",
+          error: { kind: "invalid-host", message: "invalid host" },
+        },
+      },
+      doctorByHost: { [host]: [] },
+      doctorPendingByHost: { [host]: false },
+      doctorErrorByHost: {
+        [host]: { kind: "invalid-host", message: "invalid host" },
+      },
+      recentDirsByHost: { [host]: ["~/src"] },
+      goosePathByHost: { [host]: "~/bin/goose" },
+    });
+    window.localStorage.setItem(
+      REMOTE_HOST_MANUAL_HOSTS_STORAGE_KEY,
+      JSON.stringify([host, "keep.blox"]),
+    );
+    window.localStorage.setItem(
+      REMOTE_HOST_RECENT_DIRS_STORAGE_KEY,
+      JSON.stringify({ [host]: ["~/src"] }),
+    );
+    window.localStorage.setItem(
+      REMOTE_HOST_GOOSE_PATH_STORAGE_KEY,
+      JSON.stringify({ [host]: "~/bin/goose" }),
+    );
 
-    useRemoteHostStore.getState().removeManualHost("adhoc.blox");
+    await useRemoteHostStore.getState().forgetHost(host);
 
-    expect(useRemoteHostStore.getState().manualHosts).toEqual([]);
-    expect(loadPersistedManualHosts()).toEqual([]);
+    expect(mocks.forgetRemoteHost).toHaveBeenCalledWith(host);
+    const state = useRemoteHostStore.getState();
+    expect(state.manualHosts).toEqual(["keep.blox"]);
+    expect(state.statusByHost).not.toHaveProperty(host);
+    expect(state.doctorByHost).not.toHaveProperty(host);
+    expect(state.doctorPendingByHost).not.toHaveProperty(host);
+    expect(state.doctorErrorByHost).not.toHaveProperty(host);
+    expect(state.recentDirsByHost).not.toHaveProperty(host);
+    expect(state.goosePathByHost).not.toHaveProperty(host);
+    expect(loadPersistedManualHosts()).toEqual(["keep.blox"]);
+    expect(loadPersistedRecentDirs()).toEqual({});
+    expect(loadPersistedGoosePaths()).toEqual({});
+  });
+
+  it("keeps local state when the backend refuses to forget an active host", async () => {
+    mocks.forgetRemoteHost.mockRejectedValueOnce(new Error("active"));
+    useRemoteHostStore.setState({
+      manualHosts: ["adhoc.blox"],
+      statusByHost: { "adhoc.blox": { state: "ready" } },
+    });
+
+    await expect(
+      useRemoteHostStore.getState().forgetHost("adhoc.blox"),
+    ).rejects.toThrow("active");
+
+    expect(useRemoteHostStore.getState().manualHosts).toEqual(["adhoc.blox"]);
+    expect(useRemoteHostStore.getState().statusByHost).toHaveProperty(
+      "adhoc.blox",
+    );
   });
 
   it("tolerates corrupted storage when loading manual hosts", () => {

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -43,7 +43,13 @@ const connection: RemoteBackendConnection = {
   localPort: 4001,
   gooseVersion: "1.2.3",
   daemonReused: false,
+  incarnation: "slot-1",
   generation: 1,
+};
+
+const backendIdentity = {
+  incarnation: connection.incarnation,
+  generation: connection.generation,
 };
 
 function resetStore(): void {
@@ -56,6 +62,8 @@ function resetStore(): void {
     doctorErrorByHost: {},
     forgottenHosts: {},
     lifecycleByHost: {},
+    connectPendingLifecycleByHost: {},
+    retiredIncarnationsByHost: {},
     forgetPendingByHost: {},
     forgetErrorByHost: {},
     recentDirsByHost: {},
@@ -74,11 +82,13 @@ describe("applyStatusEvent", () => {
   it("updates statusByHost from status events", () => {
     useRemoteHostStore.getState().applyStatusEvent({
       host: "devbox",
+      ...backendIdentity,
       state: "reconnecting",
       attempt: 2,
     });
 
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "reconnecting",
       attempt: 2,
     });
@@ -87,6 +97,7 @@ describe("applyStatusEvent", () => {
   it("clears a previous error when a ready event arrives", () => {
     useRemoteHostStore.getState().applyStatusEvent({
       host: "devbox",
+      ...backendIdentity,
       state: "failed",
       error: { kind: "host-unreachable", message: "no route" },
     });
@@ -96,12 +107,14 @@ describe("applyStatusEvent", () => {
 
     useRemoteHostStore.getState().applyStatusEvent({
       host: "devbox",
+      ...backendIdentity,
       state: "ready",
       wsUrl: connection.wsUrl,
       localPort: connection.localPort,
     });
 
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "ready",
     });
   });
@@ -110,9 +123,11 @@ describe("applyStatusEvent", () => {
 describe("syncBackendSnapshot", () => {
   it("copies snapshot entries into statusByHost", async () => {
     mocks.listRemoteBackends.mockResolvedValue([
-      { host: "devbox", state: "ready" },
+      { host: "devbox", ...backendIdentity, state: "ready" },
       {
         host: "broken",
+        incarnation: "broken-slot",
+        generation: 3,
         state: "failed",
         error: { kind: "auth-failed", message: "denied" },
       },
@@ -121,8 +136,13 @@ describe("syncBackendSnapshot", () => {
     await useRemoteHostStore.getState().syncBackendSnapshot();
 
     const { statusByHost } = useRemoteHostStore.getState();
-    expect(statusByHost.devbox).toEqual({ state: "ready" });
+    expect(statusByHost.devbox).toEqual({
+      ...backendIdentity,
+      state: "ready",
+    });
     expect(statusByHost.broken).toEqual({
+      incarnation: "broken-slot",
+      generation: 3,
       state: "failed",
       error: { kind: "auth-failed", message: "denied" },
     });
@@ -131,12 +151,13 @@ describe("syncBackendSnapshot", () => {
   it("keeps the previous statuses when the snapshot fails", async () => {
     useRemoteHostStore
       .getState()
-      .applyStatusEvent({ host: "devbox", state: "ready" });
+      .applyStatusEvent({ host: "devbox", ...backendIdentity, state: "ready" });
     mocks.listRemoteBackends.mockRejectedValue(new Error("ipc down"));
 
     await useRemoteHostStore.getState().syncBackendSnapshot();
 
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "ready",
     });
   });
@@ -152,12 +173,12 @@ describe("syncBackendSnapshot", () => {
         }),
     );
     useRemoteHostStore.setState({
-      statusByHost: { [host]: { state: "failed" } },
+      statusByHost: { [host]: { ...backendIdentity, state: "failed" } },
     });
 
     const syncing = useRemoteHostStore.getState().syncBackendSnapshot();
     await useRemoteHostStore.getState().forgetHost(host);
-    resolveSnapshot([{ host, state: "failed" }]);
+    resolveSnapshot([{ host, ...backendIdentity, state: "failed" }]);
     await syncing;
 
     expect(useRemoteHostStore.getState().statusByHost).not.toHaveProperty(host);
@@ -174,18 +195,24 @@ describe("syncBackendSnapshot", () => {
           resolveSnapshot = resolve;
         }),
     );
-    mocks.connectRemoteHost.mockResolvedValue(connection);
+    const replacementConnection = {
+      ...connection,
+      incarnation: "slot-2",
+    };
+    mocks.connectRemoteHost.mockResolvedValue(replacementConnection);
     useRemoteHostStore.setState({
-      statusByHost: { [host]: { state: "failed" } },
+      statusByHost: { [host]: { ...backendIdentity, state: "failed" } },
     });
 
     const syncing = useRemoteHostStore.getState().syncBackendSnapshot();
     await useRemoteHostStore.getState().forgetHost(host);
     await useRemoteHostStore.getState().ensureHostConnected(host);
-    resolveSnapshot([{ host, state: "disconnected" }]);
+    resolveSnapshot([{ host, ...backendIdentity, state: "disconnected" }]);
     await syncing;
 
     expect(useRemoteHostStore.getState().statusByHost[host]).toEqual({
+      incarnation: replacementConnection.incarnation,
+      generation: replacementConnection.generation,
       state: "ready",
     });
     expect(useRemoteHostStore.getState().forgottenHosts[host]).toBeUndefined();
@@ -217,7 +244,7 @@ describe("ensureHostConnected", () => {
   it("resolves without invoking connect when the host is already ready", async () => {
     useRemoteHostStore
       .getState()
-      .applyStatusEvent({ host: "devbox", state: "ready" });
+      .applyStatusEvent({ host: "devbox", ...backendIdentity, state: "ready" });
 
     await useRemoteHostStore.getState().ensureHostConnected("devbox");
 
@@ -243,8 +270,58 @@ describe("ensureHostConnected", () => {
 
     expect(mocks.connectRemoteHost).toHaveBeenCalledWith("devbox");
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "ready",
     });
+  });
+
+  it("keeps the newest connection when two lifecycles complete out of order", async () => {
+    const resolvers: Array<(value: RemoteBackendConnection) => void> = [];
+    mocks.connectRemoteHost.mockImplementation(
+      () =>
+        new Promise<RemoteBackendConnection>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const older = useRemoteHostStore.getState().ensureHostConnected("devbox");
+    const newer = useRemoteHostStore.getState().ensureHostConnected("devbox");
+    const newestConnection = {
+      ...connection,
+      incarnation: "slot-new",
+      generation: 4,
+    };
+    resolvers[1]?.(newestConnection);
+    await newer;
+    resolvers[0]?.({ ...connection, incarnation: "slot-old", generation: 9 });
+    await older;
+
+    expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      state: "ready",
+      incarnation: newestConnection.incarnation,
+      generation: newestConnection.generation,
+    });
+  });
+
+  it("does not publish a connection that completes after Forget", async () => {
+    const host = "forgotten.blox";
+    let resolveConnect: (value: RemoteBackendConnection) => void = () => {};
+    mocks.connectRemoteHost.mockImplementation(
+      () =>
+        new Promise<RemoteBackendConnection>((resolve) => {
+          resolveConnect = resolve;
+        }),
+    );
+
+    const pending = useRemoteHostStore.getState().ensureHostConnected(host);
+    await useRemoteHostStore.getState().forgetHost(host);
+    resolveConnect(connection);
+    await pending;
+
+    const state = useRemoteHostStore.getState();
+    expect(state.statusByHost).not.toHaveProperty(host);
+    expect(state.manualHosts).not.toContain(host);
+    expect(state.forgottenHosts[host]).toBe(true);
   });
 
   it("marks the host failed with the typed error and rethrows", async () => {
@@ -280,12 +357,13 @@ describe("disconnect and shutdownHost", () => {
     mocks.disconnectRemoteHost.mockResolvedValue(undefined);
     useRemoteHostStore
       .getState()
-      .applyStatusEvent({ host: "devbox", state: "ready" });
+      .applyStatusEvent({ host: "devbox", ...backendIdentity, state: "ready" });
 
     await useRemoteHostStore.getState().disconnect("devbox");
 
     expect(mocks.disconnectRemoteHost).toHaveBeenCalledWith("devbox");
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "disconnected",
     });
   });
@@ -294,12 +372,13 @@ describe("disconnect and shutdownHost", () => {
     mocks.shutdownRemoteHost.mockResolvedValue(undefined);
     useRemoteHostStore
       .getState()
-      .applyStatusEvent({ host: "devbox", state: "ready" });
+      .applyStatusEvent({ host: "devbox", ...backendIdentity, state: "ready" });
 
     await useRemoteHostStore.getState().shutdownHost("devbox");
 
     expect(mocks.shutdownRemoteHost).toHaveBeenCalledWith("devbox");
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "disconnected",
     });
   });
@@ -497,14 +576,19 @@ describe("initRemoteHostStore", () => {
   it("subscribes to status events, seeds state, and returns unsubscribe", async () => {
     const unlisten = vi.fn();
     let statusHandler:
-      | ((payload: { host: string; state: string }) => void)
+      | ((payload: {
+          host: string;
+          incarnation: string;
+          generation: number;
+          state: string;
+        }) => void)
       | undefined;
     mocks.listenRemoteBackendStatus.mockImplementation((handler) => {
       statusHandler = handler;
       return Promise.resolve(unlisten);
     });
     mocks.listRemoteBackends.mockResolvedValue([
-      { host: "devbox", state: "ready" },
+      { host: "devbox", ...backendIdentity, state: "ready" },
     ]);
     mocks.listSshConfigHosts.mockResolvedValue(["devbox"]);
 
@@ -512,11 +596,19 @@ describe("initRemoteHostStore", () => {
 
     expect(useRemoteHostStore.getState().configHosts).toEqual(["devbox"]);
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
       state: "ready",
     });
 
-    statusHandler?.({ host: "devbox", state: "reconnecting" });
+    statusHandler?.({
+      host: "devbox",
+      ...backendIdentity,
+      generation: backendIdentity.generation + 1,
+      state: "reconnecting",
+    });
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
+      ...backendIdentity,
+      generation: backendIdentity.generation + 1,
       state: "reconnecting",
     });
 
@@ -641,26 +733,61 @@ describe("manual host persistence", () => {
   it("ignores late status events until an intentional reconnect", async () => {
     const host = "broken.blox";
     useRemoteHostStore.setState({
-      statusByHost: { [host]: { state: "failed" } },
+      statusByHost: { [host]: { ...backendIdentity, state: "failed" } },
     });
 
     await useRemoteHostStore.getState().forgetHost(host);
     useRemoteHostStore.getState().applyStatusEvent({
       host,
+      ...backendIdentity,
       state: "disconnected",
     });
     expect(useRemoteHostStore.getState().statusByHost).not.toHaveProperty(host);
 
-    mocks.connectRemoteHost.mockResolvedValue(connection);
+    const replacementConnection = {
+      ...connection,
+      incarnation: "slot-2",
+    };
+    mocks.connectRemoteHost.mockResolvedValue(replacementConnection);
     await useRemoteHostStore.getState().ensureHostConnected(host);
     useRemoteHostStore.getState().applyStatusEvent({
       host,
+      incarnation: "slot-2",
+      generation: 2,
       state: "reconnecting",
       attempt: 1,
     });
     expect(useRemoteHostStore.getState().statusByHost[host]).toEqual({
+      incarnation: "slot-2",
+      generation: 2,
       state: "reconnecting",
       attempt: 1,
+    });
+  });
+
+  it("ignores a retired incarnation after a replacement reconnects", async () => {
+    const host = "broken.blox";
+    useRemoteHostStore.setState({
+      statusByHost: { [host]: { ...backendIdentity, state: "failed" } },
+    });
+    await useRemoteHostStore.getState().forgetHost(host);
+    mocks.connectRemoteHost.mockResolvedValue({
+      ...connection,
+      incarnation: "slot-2",
+    });
+    await useRemoteHostStore.getState().ensureHostConnected(host);
+
+    useRemoteHostStore.getState().applyStatusEvent({
+      host,
+      incarnation: connection.incarnation,
+      generation: 99,
+      state: "disconnected",
+    });
+
+    expect(useRemoteHostStore.getState().statusByHost[host]).toEqual({
+      state: "ready",
+      incarnation: "slot-2",
+      generation: connection.generation,
     });
   });
 

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -456,6 +456,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
 
   forgetHost: async (host) => {
     if (get().forgetPendingByHost[host]) return;
+    const admittedLifecycle = get().lifecycleByHost[host] ?? 0;
     set((state) => ({
       forgetPendingByHost: {
         ...state.forgetPendingByHost,
@@ -469,19 +470,29 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
     try {
       await forgetRemoteHost(host);
     } catch (error) {
-      set((state) => ({
-        forgetPendingByHost: {
+      set((state) => {
+        const forgetPendingByHost = {
           ...state.forgetPendingByHost,
           [host]: false,
-        },
-        forgetErrorByHost: {
-          ...state.forgetErrorByHost,
-          [host]: toRemoteBackendError(error),
-        },
-      }));
+        };
+        const forgetErrorByHost = { ...state.forgetErrorByHost };
+        if ((state.lifecycleByHost[host] ?? 0) === admittedLifecycle) {
+          forgetErrorByHost[host] = toRemoteBackendError(error);
+        } else {
+          delete forgetErrorByHost[host];
+        }
+        return { forgetPendingByHost, forgetErrorByHost };
+      });
       throw error;
     }
     set((state) => {
+      const forgetPendingByHost = { ...state.forgetPendingByHost };
+      delete forgetPendingByHost[host];
+      if ((state.lifecycleByHost[host] ?? 0) !== admittedLifecycle) {
+        // A newer explicit Connect owns this row. The old Forget result may
+        // clear its own pending marker, but must not erase the replacement.
+        return { forgetPendingByHost };
+      }
       const manualHosts = state.manualHosts.filter(
         (candidate) => candidate !== host,
       );
@@ -496,7 +507,6 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       const retiredIncarnationsByHost = {
         ...state.retiredIncarnationsByHost,
       };
-      const forgetPendingByHost = { ...state.forgetPendingByHost };
       const forgetErrorByHost = { ...state.forgetErrorByHost };
       const forgottenIncarnation = statusByHost[host]?.incarnation;
       if (forgottenIncarnation) {
@@ -511,7 +521,6 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       delete doctorByHost[host];
       delete doctorPendingByHost[host];
       delete doctorErrorByHost[host];
-      delete forgetPendingByHost[host];
       delete forgetErrorByHost[host];
       delete connectPendingLifecycleByHost[host];
       persistManualHosts(manualHosts);

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -383,27 +383,53 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   },
 
   disconnect: async (host) => {
-    await disconnectRemoteHost(host);
-    set((state) => ({
-      statusByHost: {
-        ...state.statusByHost,
-        [host]: { ...state.statusByHost[host], state: "disconnected" },
-      },
-    }));
+    const admitted = get();
+    const admittedLifecycle = admitted.lifecycleByHost[host] ?? 0;
+    const admittedStatus = admitted.statusByHost[host];
+    await disconnectRemoteHost(host, admittedStatus?.generation);
+    set((state) => {
+      const currentStatus = state.statusByHost[host];
+      if (
+        (state.lifecycleByHost[host] ?? 0) !== admittedLifecycle ||
+        currentStatus?.incarnation !== admittedStatus?.incarnation ||
+        currentStatus?.generation !== admittedStatus?.generation
+      ) {
+        return state;
+      }
+      return {
+        statusByHost: {
+          ...state.statusByHost,
+          [host]: { ...currentStatus, state: "disconnected" },
+        },
+      };
+    });
   },
 
   shutdownHost: async (host, expectedInstanceToken) => {
-    if (expectedInstanceToken) {
-      await shutdownRemoteHost(host, expectedInstanceToken);
-    } else {
-      await shutdownRemoteHost(host);
-    }
-    set((state) => ({
-      statusByHost: {
-        ...state.statusByHost,
-        [host]: { ...state.statusByHost[host], state: "disconnected" },
-      },
-    }));
+    const admitted = get();
+    const admittedLifecycle = admitted.lifecycleByHost[host] ?? 0;
+    const admittedStatus = admitted.statusByHost[host];
+    await shutdownRemoteHost(
+      host,
+      expectedInstanceToken,
+      admittedStatus?.generation,
+    );
+    set((state) => {
+      const currentStatus = state.statusByHost[host];
+      if (
+        (state.lifecycleByHost[host] ?? 0) !== admittedLifecycle ||
+        currentStatus?.incarnation !== admittedStatus?.incarnation ||
+        currentStatus?.generation !== admittedStatus?.generation
+      ) {
+        return state;
+      }
+      return {
+        statusByHost: {
+          ...state.statusByHost,
+          [host]: { ...currentStatus, state: "disconnected" },
+        },
+      };
+    });
   },
 
   runDoctor: async (host) => {
@@ -463,8 +489,6 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       const doctorByHost = { ...state.doctorByHost };
       const doctorPendingByHost = { ...state.doctorPendingByHost };
       const doctorErrorByHost = { ...state.doctorErrorByHost };
-      const recentDirsByHost = { ...state.recentDirsByHost };
-      const goosePathByHost = { ...state.goosePathByHost };
       const forgottenHosts = { ...state.forgottenHosts, [host]: true as const };
       const connectPendingLifecycleByHost = {
         ...state.connectPendingLifecycleByHost,
@@ -487,14 +511,10 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       delete doctorByHost[host];
       delete doctorPendingByHost[host];
       delete doctorErrorByHost[host];
-      delete recentDirsByHost[host];
-      delete goosePathByHost[host];
       delete forgetPendingByHost[host];
       delete forgetErrorByHost[host];
       delete connectPendingLifecycleByHost[host];
       persistManualHosts(manualHosts);
-      persistRecentDirs(recentDirsByHost);
-      persistGoosePaths(goosePathByHost);
       return {
         manualHosts,
         statusByHost,
@@ -510,8 +530,6 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         retiredIncarnationsByHost,
         forgetPendingByHost,
         forgetErrorByHost,
-        recentDirsByHost,
-        goosePathByHost,
       };
     });
   },

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -8,6 +8,7 @@ import {
   checkRemoteHost,
   connectRemoteHost,
   disconnectRemoteHost,
+  forgetRemoteHost,
   isRemoteBackendError,
   listenRemoteBackendStatus,
   listRemoteBackends,
@@ -138,7 +139,7 @@ export interface RemoteHostStore {
   shutdownHost: (host: string, expectedInstanceToken?: string) => Promise<void>;
   runDoctor: (host: string) => Promise<void>;
   recordRecentDir: (host: string, dir: string) => void;
-  removeManualHost: (host: string) => void;
+  forgetHost: (host: string) => Promise<void>;
   /**
    * Set (or clear, with `null`) the goose binary a host's remote backend
    * should run. Returns false for a path the remote script could not resolve.
@@ -290,14 +291,36 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
     }
   },
 
-  removeManualHost: (host) => {
+  forgetHost: async (host) => {
+    await forgetRemoteHost(host);
     set((state) => {
-      if (!state.manualHosts.includes(host)) return state;
       const manualHosts = state.manualHosts.filter(
         (candidate) => candidate !== host,
       );
+      const statusByHost = { ...state.statusByHost };
+      const doctorByHost = { ...state.doctorByHost };
+      const doctorPendingByHost = { ...state.doctorPendingByHost };
+      const doctorErrorByHost = { ...state.doctorErrorByHost };
+      const recentDirsByHost = { ...state.recentDirsByHost };
+      const goosePathByHost = { ...state.goosePathByHost };
+      delete statusByHost[host];
+      delete doctorByHost[host];
+      delete doctorPendingByHost[host];
+      delete doctorErrorByHost[host];
+      delete recentDirsByHost[host];
+      delete goosePathByHost[host];
       persistManualHosts(manualHosts);
-      return { manualHosts };
+      persistRecentDirs(recentDirsByHost);
+      persistGoosePaths(goosePathByHost);
+      return {
+        manualHosts,
+        statusByHost,
+        doctorByHost,
+        doctorPendingByHost,
+        doctorErrorByHost,
+        recentDirsByHost,
+        goosePathByHost,
+      };
     });
   },
 

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -126,6 +126,12 @@ export interface RemoteHostStore {
   doctorByHost: Record<string, RemoteToolProbe[] | undefined>;
   doctorPendingByHost: Record<string, boolean>;
   doctorErrorByHost: Record<string, RemoteBackendErrorLike | undefined>;
+  /** Successful Forget tombstones, cleared only by an explicit new connect. */
+  forgottenHosts: Record<string, true>;
+  /** Monotonic local lifecycle used to reject snapshots admitted before a change. */
+  lifecycleByHost: Record<string, number>;
+  forgetPendingByHost: Record<string, boolean>;
+  forgetErrorByHost: Record<string, RemoteBackendErrorLike | undefined>;
   recentDirsByHost: Record<string, string[]>;
   /** Per-host goose binary override; absent means the remote login PATH. */
   goosePathByHost: Record<string, string>;
@@ -155,6 +161,10 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   doctorByHost: {},
   doctorPendingByHost: {},
   doctorErrorByHost: {},
+  forgottenHosts: {},
+  lifecycleByHost: {},
+  forgetPendingByHost: {},
+  forgetErrorByHost: {},
   recentDirsByHost: loadPersistedRecentDirs(),
   goosePathByHost: loadPersistedGoosePaths(),
 
@@ -169,11 +179,21 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   },
 
   syncBackendSnapshot: async () => {
+    // Keep the lifecycle object from admission time. Store updates replace it,
+    // so a Forget or explicit reconnect while IPC is in flight is observable.
+    const lifecycleAtStart = get().lifecycleByHost;
     try {
       const snapshot = await listRemoteBackends();
       set((state) => {
         const statusByHost = { ...state.statusByHost };
         for (const entry of snapshot) {
+          if (
+            state.forgottenHosts[entry.host] ||
+            (state.lifecycleByHost[entry.host] ?? 0) !==
+              (lifecycleAtStart[entry.host] ?? 0)
+          ) {
+            continue;
+          }
           statusByHost[entry.host] = {
             state: entry.state,
             ...(entry.attempt !== undefined ? { attempt: entry.attempt } : {}),
@@ -188,31 +208,54 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   },
 
   applyStatusEvent: (payload) => {
-    set((state) => ({
-      statusByHost: {
-        ...state.statusByHost,
-        [payload.host]: {
-          state: payload.state,
-          ...(payload.attempt !== undefined
-            ? { attempt: payload.attempt }
-            : {}),
-          ...(payload.error ? { error: payload.error } : {}),
+    set((state) => {
+      if (state.forgottenHosts[payload.host]) return state;
+      return {
+        statusByHost: {
+          ...state.statusByHost,
+          [payload.host]: {
+            state: payload.state,
+            ...(payload.attempt !== undefined
+              ? { attempt: payload.attempt }
+              : {}),
+            ...(payload.error ? { error: payload.error } : {}),
+          },
         },
-      },
-    }));
+      };
+    });
   },
 
   ensureHostConnected: async (host) => {
-    if (get().statusByHost[host]?.state === "ready") return;
+    const current = get();
+    if (
+      current.statusByHost[host]?.state === "ready" &&
+      !current.forgottenHosts[host]
+    ) {
+      return;
+    }
 
-    // Optimistic: the Rust side serializes concurrent connects per host and
-    // emits status events, but reflect intent immediately in the UI.
-    set((state) => ({
-      statusByHost: {
-        ...state.statusByHost,
-        [host]: { state: "connecting" },
-      },
-    }));
+    // An explicit connection starts a new local lifecycle. This is the only
+    // operation that clears a successful Forget tombstone.
+    set((state) => {
+      const forgottenHosts = { ...state.forgottenHosts };
+      const forgetErrorByHost = { ...state.forgetErrorByHost };
+      delete forgottenHosts[host];
+      delete forgetErrorByHost[host];
+      return {
+        forgottenHosts,
+        forgetErrorByHost,
+        lifecycleByHost: {
+          ...state.lifecycleByHost,
+          [host]: (state.lifecycleByHost[host] ?? 0) + 1,
+        },
+        // Optimistic: Rust serializes concurrent connects per host, but the UI
+        // should reflect the user's new lifecycle immediately.
+        statusByHost: {
+          ...state.statusByHost,
+          [host]: { state: "connecting" },
+        },
+      };
+    });
     try {
       await connectRemoteHost(host);
       set((state) => {
@@ -292,7 +335,32 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   },
 
   forgetHost: async (host) => {
-    await forgetRemoteHost(host);
+    if (get().forgetPendingByHost[host]) return;
+    set((state) => ({
+      forgetPendingByHost: {
+        ...state.forgetPendingByHost,
+        [host]: true,
+      },
+      forgetErrorByHost: {
+        ...state.forgetErrorByHost,
+        [host]: undefined,
+      },
+    }));
+    try {
+      await forgetRemoteHost(host);
+    } catch (error) {
+      set((state) => ({
+        forgetPendingByHost: {
+          ...state.forgetPendingByHost,
+          [host]: false,
+        },
+        forgetErrorByHost: {
+          ...state.forgetErrorByHost,
+          [host]: toRemoteBackendError(error),
+        },
+      }));
+      throw error;
+    }
     set((state) => {
       const manualHosts = state.manualHosts.filter(
         (candidate) => candidate !== host,
@@ -303,12 +371,17 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       const doctorErrorByHost = { ...state.doctorErrorByHost };
       const recentDirsByHost = { ...state.recentDirsByHost };
       const goosePathByHost = { ...state.goosePathByHost };
+      const forgottenHosts = { ...state.forgottenHosts, [host]: true as const };
+      const forgetPendingByHost = { ...state.forgetPendingByHost };
+      const forgetErrorByHost = { ...state.forgetErrorByHost };
       delete statusByHost[host];
       delete doctorByHost[host];
       delete doctorPendingByHost[host];
       delete doctorErrorByHost[host];
       delete recentDirsByHost[host];
       delete goosePathByHost[host];
+      delete forgetPendingByHost[host];
+      delete forgetErrorByHost[host];
       persistManualHosts(manualHosts);
       persistRecentDirs(recentDirsByHost);
       persistGoosePaths(goosePathByHost);
@@ -318,6 +391,13 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         doctorByHost,
         doctorPendingByHost,
         doctorErrorByHost,
+        forgottenHosts,
+        lifecycleByHost: {
+          ...state.lifecycleByHost,
+          [host]: (state.lifecycleByHost[host] ?? 0) + 1,
+        },
+        forgetPendingByHost,
+        forgetErrorByHost,
         recentDirsByHost,
         goosePathByHost,
       };

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -15,6 +15,7 @@ import {
   listSshConfigHosts,
   shutdownRemoteHost,
   type RemoteBackendErrorLike,
+  type RemoteBackendSnapshotEntry,
   type RemoteBackendState,
   type RemoteBackendStatusPayload,
   type RemoteToolProbe,
@@ -27,11 +28,39 @@ export const REMOTE_HOST_MANUAL_HOSTS_STORAGE_KEY =
 
 const MAX_RECENT_DIRS_PER_HOST = 8;
 const MAX_MANUAL_HOSTS = 16;
+const MAX_RETIRED_INCARNATIONS_PER_HOST = 8;
 
 export interface RemoteHostStatus {
   state: RemoteBackendState;
+  incarnation?: string;
+  generation?: number;
   attempt?: number;
   error?: RemoteBackendErrorLike;
+}
+
+function backendStatus(
+  payload: RemoteBackendStatusPayload | RemoteBackendSnapshotEntry,
+): RemoteHostStatus {
+  return {
+    state: payload.state,
+    incarnation: payload.incarnation,
+    generation: payload.generation,
+    ...(payload.attempt !== undefined ? { attempt: payload.attempt } : {}),
+    ...(payload.error ? { error: payload.error } : {}),
+  };
+}
+
+function acceptsBackendStatus(
+  current: RemoteHostStatus | undefined,
+  retiredIncarnations: string[] | undefined,
+  payload: RemoteBackendStatusPayload | RemoteBackendSnapshotEntry,
+): boolean {
+  if (retiredIncarnations?.includes(payload.incarnation)) return false;
+  if (!current?.incarnation) return true;
+  return (
+    current.incarnation === payload.incarnation &&
+    (current.generation ?? 0) <= payload.generation
+  );
 }
 
 function toRemoteBackendError(error: unknown): RemoteBackendErrorLike {
@@ -130,6 +159,10 @@ export interface RemoteHostStore {
   forgottenHosts: Record<string, true>;
   /** Monotonic local lifecycle used to reject snapshots admitted before a change. */
   lifecycleByHost: Record<string, number>;
+  /** Explicit connect lifecycle currently awaiting its backend result. */
+  connectPendingLifecycleByHost: Record<string, number>;
+  /** Forgotten backend slot identities that must never be admitted again. */
+  retiredIncarnationsByHost: Record<string, string[]>;
   forgetPendingByHost: Record<string, boolean>;
   forgetErrorByHost: Record<string, RemoteBackendErrorLike | undefined>;
   recentDirsByHost: Record<string, string[]>;
@@ -163,6 +196,8 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   doctorErrorByHost: {},
   forgottenHosts: {},
   lifecycleByHost: {},
+  connectPendingLifecycleByHost: {},
+  retiredIncarnationsByHost: {},
   forgetPendingByHost: {},
   forgetErrorByHost: {},
   recentDirsByHost: loadPersistedRecentDirs(),
@@ -189,16 +224,18 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         for (const entry of snapshot) {
           if (
             state.forgottenHosts[entry.host] ||
+            state.connectPendingLifecycleByHost[entry.host] !== undefined ||
             (state.lifecycleByHost[entry.host] ?? 0) !==
-              (lifecycleAtStart[entry.host] ?? 0)
+              (lifecycleAtStart[entry.host] ?? 0) ||
+            !acceptsBackendStatus(
+              statusByHost[entry.host],
+              state.retiredIncarnationsByHost[entry.host],
+              entry,
+            )
           ) {
             continue;
           }
-          statusByHost[entry.host] = {
-            state: entry.state,
-            ...(entry.attempt !== undefined ? { attempt: entry.attempt } : {}),
-            ...(entry.error ? { error: entry.error } : {}),
-          };
+          statusByHost[entry.host] = backendStatus(entry);
         }
         return { statusByHost };
       });
@@ -209,17 +246,21 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
 
   applyStatusEvent: (payload) => {
     set((state) => {
-      if (state.forgottenHosts[payload.host]) return state;
+      if (
+        state.forgottenHosts[payload.host] ||
+        state.connectPendingLifecycleByHost[payload.host] !== undefined ||
+        !acceptsBackendStatus(
+          state.statusByHost[payload.host],
+          state.retiredIncarnationsByHost[payload.host],
+          payload,
+        )
+      ) {
+        return state;
+      }
       return {
         statusByHost: {
           ...state.statusByHost,
-          [payload.host]: {
-            state: payload.state,
-            ...(payload.attempt !== undefined
-              ? { attempt: payload.attempt }
-              : {}),
-            ...(payload.error ? { error: payload.error } : {}),
-          },
+          [payload.host]: backendStatus(payload),
         },
       };
     });
@@ -236,9 +277,11 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
 
     // An explicit connection starts a new local lifecycle. This is the only
     // operation that clears a successful Forget tombstone.
+    const lifecycle = (current.lifecycleByHost[host] ?? 0) + 1;
     set((state) => {
       const forgottenHosts = { ...state.forgottenHosts };
       const forgetErrorByHost = { ...state.forgetErrorByHost };
+      const currentStatus = state.statusByHost[host];
       delete forgottenHosts[host];
       delete forgetErrorByHost[host];
       return {
@@ -246,19 +289,38 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         forgetErrorByHost,
         lifecycleByHost: {
           ...state.lifecycleByHost,
-          [host]: (state.lifecycleByHost[host] ?? 0) + 1,
+          [host]: lifecycle,
+        },
+        connectPendingLifecycleByHost: {
+          ...state.connectPendingLifecycleByHost,
+          [host]: lifecycle,
         },
         // Optimistic: Rust serializes concurrent connects per host, but the UI
         // should reflect the user's new lifecycle immediately.
         statusByHost: {
           ...state.statusByHost,
-          [host]: { state: "connecting" },
+          [host]: {
+            state: "connecting",
+            ...(currentStatus?.incarnation
+              ? {
+                  incarnation: currentStatus.incarnation,
+                  generation: currentStatus.generation,
+                }
+              : {}),
+          },
         },
       };
     });
     try {
-      await connectRemoteHost(host);
+      const connection = await connectRemoteHost(host);
       set((state) => {
+        if (
+          state.forgottenHosts[host] ||
+          state.lifecycleByHost[host] !== lifecycle ||
+          state.connectPendingLifecycleByHost[host] !== lifecycle
+        ) {
+          return state;
+        }
         // A host that connected but isn't in ~/.ssh/config was typed in
         // manually; remember it across restarts.
         const isKnown =
@@ -269,21 +331,53 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         if (!isKnown) {
           persistManualHosts(manualHosts);
         }
+        const connectPendingLifecycleByHost = {
+          ...state.connectPendingLifecycleByHost,
+        };
+        delete connectPendingLifecycleByHost[host];
         return {
           manualHosts,
+          connectPendingLifecycleByHost,
           statusByHost: {
             ...state.statusByHost,
-            [host]: { state: "ready" },
+            [host]: {
+              state: "ready",
+              incarnation: connection.incarnation,
+              generation: connection.generation,
+            },
           },
         };
       });
     } catch (error) {
-      set((state) => ({
-        statusByHost: {
-          ...state.statusByHost,
-          [host]: { state: "failed", error: toRemoteBackendError(error) },
-        },
-      }));
+      set((state) => {
+        if (
+          state.forgottenHosts[host] ||
+          state.lifecycleByHost[host] !== lifecycle ||
+          state.connectPendingLifecycleByHost[host] !== lifecycle
+        ) {
+          return state;
+        }
+        const connectPendingLifecycleByHost = {
+          ...state.connectPendingLifecycleByHost,
+        };
+        delete connectPendingLifecycleByHost[host];
+        return {
+          connectPendingLifecycleByHost,
+          statusByHost: {
+            ...state.statusByHost,
+            [host]: {
+              state: "failed",
+              ...(state.statusByHost[host]?.incarnation
+                ? {
+                    incarnation: state.statusByHost[host].incarnation,
+                    generation: state.statusByHost[host].generation,
+                  }
+                : {}),
+              error: toRemoteBackendError(error),
+            },
+          },
+        };
+      });
       throw error;
     }
   },
@@ -293,7 +387,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
     set((state) => ({
       statusByHost: {
         ...state.statusByHost,
-        [host]: { state: "disconnected" },
+        [host]: { ...state.statusByHost[host], state: "disconnected" },
       },
     }));
   },
@@ -307,7 +401,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
     set((state) => ({
       statusByHost: {
         ...state.statusByHost,
-        [host]: { state: "disconnected" },
+        [host]: { ...state.statusByHost[host], state: "disconnected" },
       },
     }));
   },
@@ -372,8 +466,23 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       const recentDirsByHost = { ...state.recentDirsByHost };
       const goosePathByHost = { ...state.goosePathByHost };
       const forgottenHosts = { ...state.forgottenHosts, [host]: true as const };
+      const connectPendingLifecycleByHost = {
+        ...state.connectPendingLifecycleByHost,
+      };
+      const retiredIncarnationsByHost = {
+        ...state.retiredIncarnationsByHost,
+      };
       const forgetPendingByHost = { ...state.forgetPendingByHost };
       const forgetErrorByHost = { ...state.forgetErrorByHost };
+      const forgottenIncarnation = statusByHost[host]?.incarnation;
+      if (forgottenIncarnation) {
+        retiredIncarnationsByHost[host] = [
+          forgottenIncarnation,
+          ...(retiredIncarnationsByHost[host] ?? []).filter(
+            (candidate) => candidate !== forgottenIncarnation,
+          ),
+        ].slice(0, MAX_RETIRED_INCARNATIONS_PER_HOST);
+      }
       delete statusByHost[host];
       delete doctorByHost[host];
       delete doctorPendingByHost[host];
@@ -382,6 +491,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       delete goosePathByHost[host];
       delete forgetPendingByHost[host];
       delete forgetErrorByHost[host];
+      delete connectPendingLifecycleByHost[host];
       persistManualHosts(manualHosts);
       persistRecentDirs(recentDirsByHost);
       persistGoosePaths(goosePathByHost);
@@ -396,6 +506,8 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
           ...state.lifecycleByHost,
           [host]: (state.lifecycleByHost[host] ?? 0) + 1,
         },
+        connectPendingLifecycleByHost,
+        retiredIncarnationsByHost,
         forgetPendingByHost,
         forgetErrorByHost,
         recentDirsByHost,

--- a/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
+++ b/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
@@ -199,6 +199,12 @@ function RemoteHostRow({
     state.configHosts.includes(host),
   );
   const forgetHost = useRemoteHostStore((state) => state.forgetHost);
+  const forgetPending = useRemoteHostStore(
+    (state) => state.forgetPendingByHost[host] === true,
+  );
+  const forgetError = useRemoteHostStore(
+    (state) => state.forgetErrorByHost[host],
+  );
 
   const state = status?.state ?? "disconnected";
   const isConnected = state === "ready" || state === "reconnecting";
@@ -285,17 +291,25 @@ function RemoteHostRow({
               type="button"
               variant="ghost"
               size="sm"
+              disabled={forgetPending}
               onClick={() => {
                 void forgetHost(host).catch(() => {});
               }}
             >
-              {t("remoteHosts.actions.forget")}
+              {forgetPending
+                ? t("remoteHosts.actions.forgetting")
+                : t("remoteHosts.actions.forget")}
             </Button>
           ) : null}
         </div>
       }
       details={
         <div className="space-y-3">
+          {forgetError ? (
+            <p className="text-xs text-destructive" role="alert">
+              {t("remoteHosts.forget.error")}
+            </p>
+          ) : null}
           {showDoctor ? (
             <DoctorReport
               probes={probes}

--- a/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
+++ b/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
@@ -291,14 +291,15 @@ function RemoteHostRow({
               type="button"
               variant="ghost"
               size="sm"
-              disabled={forgetPending}
+              feedbackState={forgetPending ? "loading" : "idle"}
+              loadingLabel={t("remoteHosts.actions.forgetting")}
+              loadingVisual="text"
+              preserveWidth
               onClick={() => {
                 void forgetHost(host).catch(() => {});
               }}
             >
-              {forgetPending
-                ? t("remoteHosts.actions.forgetting")
-                : t("remoteHosts.actions.forget")}
+              {t("remoteHosts.actions.forget")}
             </Button>
           ) : null}
         </div>

--- a/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
+++ b/src/features/remoteHosts/ui/RemoteHostsSettings.tsx
@@ -195,12 +195,10 @@ function RemoteHostRow({
   );
   const disconnect = useRemoteHostStore((state) => state.disconnect);
   const runDoctor = useRemoteHostStore((state) => state.runDoctor);
-  const isManualHost = useRemoteHostStore((state) =>
-    state.manualHosts.includes(host),
+  const isConfigHost = useRemoteHostStore((state) =>
+    state.configHosts.includes(host),
   );
-  const removeManualHost = useRemoteHostStore(
-    (state) => state.removeManualHost,
-  );
+  const forgetHost = useRemoteHostStore((state) => state.forgetHost);
 
   const state = status?.state ?? "disconnected";
   const isConnected = state === "ready" || state === "reconnecting";
@@ -282,12 +280,14 @@ function RemoteHostRow({
           >
             {t("remoteHosts.actions.check")}
           </Button>
-          {isManualHost && !isConnected ? (
+          {!isConfigHost && (state === "failed" || state === "disconnected") ? (
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              onClick={() => removeManualHost(host)}
+              onClick={() => {
+                void forgetHost(host).catch(() => {});
+              }}
             >
               {t("remoteHosts.actions.forget")}
             </Button>

--- a/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
+++ b/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
@@ -32,6 +32,10 @@ function baseState() {
     doctorByHost: {},
     doctorPendingByHost: {},
     doctorErrorByHost: {},
+    forgottenHosts: {},
+    lifecycleByHost: {},
+    forgetPendingByHost: {},
+    forgetErrorByHost: {},
     recentDirsByHost: {},
     goosePathByHost: {} as Record<string, string>,
     ensureHostConnected,
@@ -123,6 +127,54 @@ describe("RemoteHostsSettings", () => {
     );
 
     expect(forgetHost).toHaveBeenCalledWith(host);
+  });
+
+  it("disables Forget while pending", () => {
+    const host = "broken.blox";
+    seedStore({
+      statusByHost: { [host]: { state: "failed" } },
+      forgetPendingByHost: { [host]: true },
+    });
+    renderWithProviders(<RemoteHostsSettings />);
+
+    expect(
+      screen.getByRole("button", {
+        name: enSettings.remoteHosts.actions.forgetting,
+      }),
+    ).toBeDisabled();
+  });
+
+  it("keeps the row and explains a rejected Forget", async () => {
+    const user = userEvent.setup();
+    const host = "broken.blox";
+    forgetHost.mockImplementationOnce(async () => {
+      useRemoteHostStore.setState((state) => ({
+        forgetPendingByHost: {
+          ...state.forgetPendingByHost,
+          [host]: false,
+        },
+        forgetErrorByHost: {
+          ...state.forgetErrorByHost,
+          [host]: { kind: "internal", message: "still connecting" },
+        },
+      }));
+      throw new Error("still connecting");
+    });
+    seedStore({
+      statusByHost: { [host]: { state: "failed" } },
+    });
+    renderWithProviders(<RemoteHostsSettings />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: enSettings.remoteHosts.actions.forget,
+      }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      enSettings.remoteHosts.forget.error,
+    );
+    expect(screen.getByText(host)).toBeInTheDocument();
   });
 
   it("does not offer Forget for an ssh-config host", () => {

--- a/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
+++ b/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
@@ -17,6 +17,7 @@ const shutdownHost = vi.fn(async () => {});
 const runDoctor = vi.fn(async () => {});
 const refreshConfigHosts = vi.fn(async () => {});
 const syncBackendSnapshot = vi.fn(async () => {});
+const forgetHost = vi.fn(async () => {});
 const setGoosePath = vi.fn((_host: string, _path: string | null) => true);
 
 function seedStore(overrides?: Partial<ReturnType<typeof baseState>>) {
@@ -26,6 +27,7 @@ function seedStore(overrides?: Partial<ReturnType<typeof baseState>>) {
 function baseState() {
   return {
     configHosts: [] as string[],
+    manualHosts: [] as string[],
     statusByHost: {},
     doctorByHost: {},
     doctorPendingByHost: {},
@@ -38,6 +40,7 @@ function baseState() {
     runDoctor,
     refreshConfigHosts,
     syncBackendSnapshot,
+    forgetHost,
     setGoosePath,
   };
 }
@@ -95,6 +98,45 @@ describe("RemoteHostsSettings", () => {
     });
     renderWithProviders(<RemoteHostsSettings />);
     expect(screen.getByText("user@adhoc")).toBeInTheDocument();
+  });
+
+  it("can forget a failed free-form host", async () => {
+    const user = userEvent.setup();
+    const host = "ssh broken.blox";
+    seedStore({
+      statusByHost: {
+        [host]: {
+          state: "failed",
+          error: {
+            kind: "invalid-host",
+            message: "host must not contain whitespace or control characters",
+          },
+        },
+      },
+    });
+    renderWithProviders(<RemoteHostsSettings />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: enSettings.remoteHosts.actions.forget,
+      }),
+    );
+
+    expect(forgetHost).toHaveBeenCalledWith(host);
+  });
+
+  it("does not offer Forget for an ssh-config host", () => {
+    seedStore({
+      configHosts: ["configured"],
+      statusByHost: { configured: { state: "failed" } },
+    });
+    renderWithProviders(<RemoteHostsSettings />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: enSettings.remoteHosts.actions.forget,
+      }),
+    ).not.toBeInTheDocument();
   });
 
   it("connects a disconnected host via the row's Connect button", async () => {

--- a/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
+++ b/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/render";
@@ -137,11 +137,17 @@ describe("RemoteHostsSettings", () => {
     });
     renderWithProviders(<RemoteHostsSettings />);
 
+    const button = screen.getByRole("button", {
+      name: enSettings.remoteHosts.actions.forgetting,
+    });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("data-feedback-state", "loading");
+    expect(button).toHaveAttribute("aria-busy", "true");
     expect(
-      screen.getByRole("button", {
-        name: enSettings.remoteHosts.actions.forgetting,
-      }),
-    ).toBeDisabled();
+      within(button)
+        .getAllByText(enSettings.remoteHosts.actions.forget)
+        .every((label) => label.getAttribute("aria-hidden") === "true"),
+    ).toBe(true);
   });
 
   it("keeps the row and explains a rejected Forget", async () => {

--- a/src/shared/api/__tests__/remoteHosts.test.ts
+++ b/src/shared/api/__tests__/remoteHosts.test.ts
@@ -102,11 +102,12 @@ describe("remote host goose binary override", () => {
   });
 
   it("scopes a confirmed takeover to the inspected daemon instance", async () => {
-    await shutdownRemoteHost("devbox", "instance-token");
+    await shutdownRemoteHost("devbox", "instance-token", 7);
 
     expect(mockedInvoke).toHaveBeenCalledWith("remote_backend_shutdown", {
       host: "devbox",
       expectedInstanceToken: "instance-token",
+      expectedGeneration: 7,
     });
   });
 });

--- a/src/shared/api/remoteHosts.ts
+++ b/src/shared/api/remoteHosts.ts
@@ -138,10 +138,12 @@ export async function forgetRemoteHost(host: string): Promise<void> {
 export async function shutdownRemoteHost(
   host: string,
   expectedInstanceToken?: string,
+  expectedGeneration?: number,
 ): Promise<void> {
   await invoke("remote_backend_shutdown", {
     host,
     expectedInstanceToken: expectedInstanceToken ?? null,
+    expectedGeneration: expectedGeneration ?? null,
   });
 }
 

--- a/src/shared/api/remoteHosts.ts
+++ b/src/shared/api/remoteHosts.ts
@@ -37,6 +37,7 @@ export interface RemoteBackendConnection {
   localPort: number;
   gooseVersion: string;
   daemonReused: boolean;
+  incarnation: string;
   generation: number;
 }
 
@@ -53,6 +54,8 @@ export const REMOTE_BACKEND_STATUS_EVENT = "berd:remote-backend-status";
 
 export interface RemoteBackendStatusPayload {
   host: string;
+  incarnation: string;
+  generation: number;
   state: RemoteBackendState;
   wsUrl?: string;
   httpBaseUrl?: string;
@@ -64,6 +67,8 @@ export interface RemoteBackendStatusPayload {
 /** One entry from the `list_remote_backends` snapshot. */
 export interface RemoteBackendSnapshotEntry {
   host: string;
+  incarnation: string;
+  generation: number;
   state: RemoteBackendState;
   wsUrl?: string;
   httpBaseUrl?: string;

--- a/src/shared/api/remoteHosts.ts
+++ b/src/shared/api/remoteHosts.ts
@@ -124,6 +124,11 @@ export async function disconnectRemoteHost(
   });
 }
 
+/** Remove an inactive host from the backend registry. */
+export async function forgetRemoteHost(host: string): Promise<void> {
+  await invoke("remote_backend_forget", { host });
+}
+
 /** Stop the remote daemon on `host` and tear down the tunnel. */
 export async function shutdownRemoteHost(
   host: string,

--- a/src/shared/i18n/locales/en/settings.json
+++ b/src/shared/i18n/locales/en/settings.json
@@ -700,6 +700,7 @@
       "connect": "Connect",
       "disconnect": "Disconnect",
       "forget": "Forget",
+      "forgetting": "Forgetting...",
       "shutdown": "Stop remote backend",
       "takeover": "Stop and reconnect"
     },
@@ -721,6 +722,9 @@
       "notFound": "Not found"
     },
     "empty": "No hosts found in ~/.ssh/config.",
+    "forget": {
+      "error": "Couldn't forget this host. Disconnect it or wait for the current connection attempt to finish, then try again."
+    },
     "gooseBinary": {
       "clear": "Clear",
       "hint": "Overrides the PATH lookup for goose on this host. Changing it restarts the remote backend on the next connect.",


### PR DESCRIPTION
**Category:** fix
**User Impact:** Remote SSH sessions recover reliably after interrupted cleanup, tolerate noisy startup logs, and let users remove broken ad-hoc hosts.
**Problem:** A crashed stale-lock reclaimer could block every future remote daemon operation, the chunked logger could backpressure Goose before it bound its port, and failed free-form hosts could become permanent settings rows. **Solution:** Reclaim lock generations atomically, drain startup logs through a native-speed bounded reader, and provide a terminal-state Forget operation that clears both backend and persisted UI state.

<details>
<summary>File changes</summary>

**src-tauri/src/commands/remote_backend.rs**
Exposes the inactive-host forget operation to the renderer.

**src-tauri/src/lib.rs**
Registers the new remote backend command.

**src-tauri/src/services/remote_backend/daemon.rs**
Adds deterministic kill-during-reclaim coverage and preserves the bounded-tail and 5 MiB pre-bind startup regressions.

**src-tauri/src/services/remote_backend/mod.rs**
Removes inactive host slots without allowing active connections to be orphaned, with focused registry tests.

**src-tauri/src/services/remote_backend/remote_daemon.sh**
Reclaims stale lock generations with one atomic rename and replaces the process-heavy chunk logger with a native-speed bounded FIFO reader.

**src/features/remoteHosts/stores/remoteHostStore.test.ts**
Covers complete cleanup of a broken host and preservation of local state when the backend rejects an active-host removal.

**src/features/remoteHosts/stores/remoteHostStore.ts**
Forgets backend state plus all persisted per-host metadata, including diagnostics, recent directories, and Goose overrides.

**src/features/remoteHosts/ui/RemoteHostsSettings.tsx**
Shows Forget for failed or disconnected ad-hoc hosts while leaving SSH-config hosts managed by SSH config.

**src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx**
Regresses the invalid free-form host case and verifies SSH-config hosts do not expose Forget.

**src/shared/api/remoteHosts.ts**
Adds the typed renderer wrapper for forgetting an inactive backend.

</details>


<img width="1211" height="768" alt="image" src="https://github.com/user-attachments/assets/7b6d86af-0ed0-48a8-9c2e-35585933429c" />
