### PR TITLE
add SSH environments from the composer

### DIFF
--- a/src/features/chat/ui/AddRemoteHostDialog.tsx
+++ b/src/features/chat/ui/AddRemoteHostDialog.tsx
@@ -64,10 +64,14 @@ export function AddRemoteHostDialog({
     setPending(true);
     const attempt = ++attemptRef.current;
     try {
-      const accepted = await useRemoteHostStore
+      const outcome = await useRemoteHostStore
         .getState()
         .ensureHostConnected(host);
-      if (attemptRef.current !== attempt || !accepted) return;
+      if (attemptRef.current !== attempt) return;
+      if (outcome === "superseded") {
+        setError(t("toolbar.remoteHost.add.superseded"));
+        return;
+      }
       onConnected(host);
       handleOpenChange(false);
     } catch (connectionError) {

--- a/src/features/chat/ui/AddRemoteHostDialog.tsx
+++ b/src/features/chat/ui/AddRemoteHostDialog.tsx
@@ -1,0 +1,132 @@
+import { useState, type FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
+import { isRemoteBackendError } from "@/shared/api/remoteHosts";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import { Label } from "@/shared/ui/label";
+
+interface AddRemoteHostDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConnected: (host: string) => void;
+}
+
+export function AddRemoteHostDialog({
+  open,
+  onOpenChange,
+  onConnected,
+}: AddRemoteHostDialogProps) {
+  const { t } = useTranslation("chat");
+  const [hostDraft, setHostDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && pending) return;
+    onOpenChange(nextOpen);
+    if (!nextOpen) {
+      setHostDraft("");
+      setError(null);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (pending) return;
+
+    const host = hostDraft.trim();
+    if (!host) {
+      setError(t("toolbar.remoteHost.add.emptyHost"));
+      return;
+    }
+
+    setError(null);
+    setPending(true);
+    try {
+      await useRemoteHostStore.getState().ensureHostConnected(host);
+      onConnected(host);
+      onOpenChange(false);
+      setHostDraft("");
+    } catch (connectionError) {
+      setError(
+        isRemoteBackendError(connectionError)
+          ? connectionError.message
+          : String(connectionError),
+      );
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        size="md"
+        closeLabel={t("toolbar.remoteHost.add.close")}
+        showCloseButton={!pending}
+      >
+        <form className="contents" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.remoteHost.add.title")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.remoteHost.add.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="add-ssh-environment-host">
+              {t("toolbar.remoteHost.add.hostLabel")}
+            </Label>
+            <Input
+              id="add-ssh-environment-host"
+              value={hostDraft}
+              placeholder={t("toolbar.remoteHost.add.hostPlaceholder")}
+              disabled={pending}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? "add-ssh-environment-error" : undefined}
+              onChange={(event) => {
+                setHostDraft(event.target.value);
+                if (error) setError(null);
+              }}
+            />
+            {error ? (
+              <p
+                id="add-ssh-environment-error"
+                className="text-sm text-destructive"
+                role="alert"
+              >
+                {error}
+              </p>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={pending}
+              onClick={() => handleOpenChange(false)}
+            >
+              {t("toolbar.remoteHost.add.cancel")}
+            </Button>
+            <Button
+              type="submit"
+              feedbackState={pending ? "loading" : "idle"}
+              loadingLabel={t("toolbar.remoteHost.status.connecting")}
+              preserveWidth
+            >
+              {t("toolbar.remoteHost.add.connect")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/chat/ui/AddRemoteHostDialog.tsx
+++ b/src/features/chat/ui/AddRemoteHostDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 import { isRemoteBackendError } from "@/shared/api/remoteHosts";
@@ -29,13 +29,24 @@ export function AddRemoteHostDialog({
   const [hostDraft, setHostDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const attemptRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      attemptRef.current += 1;
+    },
+    [],
+  );
 
   const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && pending) return;
     onOpenChange(nextOpen);
     if (!nextOpen) {
+      // The backend connection may still finish, but closing the dialog must
+      // keep that late result from changing the composer's selected host.
+      attemptRef.current += 1;
       setHostDraft("");
       setError(null);
+      setPending(false);
     }
   };
 
@@ -51,29 +62,29 @@ export function AddRemoteHostDialog({
 
     setError(null);
     setPending(true);
+    const attempt = ++attemptRef.current;
     try {
       await useRemoteHostStore.getState().ensureHostConnected(host);
+      if (attemptRef.current !== attempt) return;
       onConnected(host);
-      onOpenChange(false);
-      setHostDraft("");
+      handleOpenChange(false);
     } catch (connectionError) {
+      if (attemptRef.current !== attempt) return;
       setError(
         isRemoteBackendError(connectionError)
           ? connectionError.message
           : String(connectionError),
       );
     } finally {
-      setPending(false);
+      if (attemptRef.current === attempt) {
+        setPending(false);
+      }
     }
   };
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        size="md"
-        closeLabel={t("toolbar.remoteHost.add.close")}
-        showCloseButton={!pending}
-      >
+      <DialogContent size="md" closeLabel={t("toolbar.remoteHost.add.close")}>
         <form className="contents" onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>{t("toolbar.remoteHost.add.title")}</DialogTitle>
@@ -111,7 +122,6 @@ export function AddRemoteHostDialog({
             <Button
               type="button"
               variant="outline"
-              disabled={pending}
               onClick={() => handleOpenChange(false)}
             >
               {t("toolbar.remoteHost.add.cancel")}

--- a/src/features/chat/ui/AddRemoteHostDialog.tsx
+++ b/src/features/chat/ui/AddRemoteHostDialog.tsx
@@ -64,8 +64,10 @@ export function AddRemoteHostDialog({
     setPending(true);
     const attempt = ++attemptRef.current;
     try {
-      await useRemoteHostStore.getState().ensureHostConnected(host);
-      if (attemptRef.current !== attempt) return;
+      const accepted = await useRemoteHostStore
+        .getState()
+        .ensureHostConnected(host);
+      if (attemptRef.current !== attempt || !accepted) return;
       onConnected(host);
       handleOpenChange(false);
     } catch (connectionError) {

--- a/src/features/chat/ui/RemoteHostSelector.tsx
+++ b/src/features/chat/ui/RemoteHostSelector.tsx
@@ -1,5 +1,7 @@
-import { Laptop, Server } from "lucide-react";
+import { useState } from "react";
+import { Laptop, Plus, Server } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { AddRemoteHostDialog } from "./AddRemoteHostDialog";
 import {
   ChatInputSelector,
   type ChatInputSelectorItem,
@@ -7,6 +9,7 @@ import {
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 
 const LOCAL_HOST_VALUE = "__local__";
+const ADD_HOST_VALUE = "__add_ssh_environment__";
 
 interface RemoteHostSelectorProps {
   selectedHost?: string | null;
@@ -33,6 +36,7 @@ export function RemoteHostSelector({
   modal,
 }: RemoteHostSelectorProps) {
   const { t } = useTranslation("chat");
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
   const configHosts = useRemoteHostStore((state) => state.configHosts);
   const manualHosts = useRemoteHostStore((state) => state.manualHosts);
   const statusByHost = useRemoteHostStore((state) => state.statusByHost);
@@ -65,6 +69,10 @@ export function RemoteHostSelector({
   }));
 
   const handleValueChange = (value: string) => {
+    if (value === ADD_HOST_VALUE) {
+      setAddDialogOpen(true);
+      return;
+    }
     onHostChange?.(value === LOCAL_HOST_VALUE ? null : value);
   };
 
@@ -77,52 +85,72 @@ export function RemoteHostSelector({
   };
 
   return (
-    <ChatInputSelector
-      ariaLabel={t("toolbar.remoteHost.selectHost")}
-      value={selectedHost ?? LOCAL_HOST_VALUE}
-      triggerLabel={selectedHost ?? t("toolbar.remoteHost.thisComputer")}
-      triggerTitle={
-        selectedHost
-          ? t("toolbar.remoteHost.remoteTriggerTitle", { host: selectedHost })
-          : t("toolbar.remoteHost.localTriggerTitle")
-      }
-      icon={
-        selectedHost ? (
-          <Server className="size-4" />
-        ) : (
-          <Laptop className="size-4" />
-        )
-      }
-      open={open}
-      onOpenChange={handleOpenChange}
-      onRequestComposerFocus={onRequestComposerFocus}
-      triggerIconOnly={triggerIconOnly}
-      triggerVariant="toolbar"
-      menuLabel={t("toolbar.remoteHost.chooseHost")}
-      contentWidth="wide"
-      disabled={disabled}
-      modal={modal}
-      sections={[
-        {
-          items: [
-            {
-              value: LOCAL_HOST_VALUE,
-              label: t("toolbar.remoteHost.thisComputer"),
-              description: t("toolbar.remoteHost.thisComputerDescription"),
-              icon: <Laptop className="size-4 text-foreground" />,
-            },
-          ],
-        },
-        ...(hostItems.length > 0
-          ? [
+    <>
+      <ChatInputSelector
+        ariaLabel={t("toolbar.remoteHost.selectHost")}
+        value={selectedHost ?? LOCAL_HOST_VALUE}
+        triggerLabel={selectedHost ?? t("toolbar.remoteHost.thisComputer")}
+        triggerTitle={
+          selectedHost
+            ? t("toolbar.remoteHost.remoteTriggerTitle", {
+                host: selectedHost,
+              })
+            : t("toolbar.remoteHost.localTriggerTitle")
+        }
+        icon={
+          selectedHost ? (
+            <Server className="size-4" />
+          ) : (
+            <Laptop className="size-4" />
+          )
+        }
+        open={open}
+        onOpenChange={handleOpenChange}
+        onRequestComposerFocus={onRequestComposerFocus}
+        triggerIconOnly={triggerIconOnly}
+        triggerVariant="toolbar"
+        menuLabel={t("toolbar.remoteHost.chooseHost")}
+        contentWidth="wide"
+        disabled={disabled}
+        modal={modal}
+        sections={[
+          {
+            items: [
               {
-                label: t("toolbar.remoteHost.sshHosts"),
-                items: hostItems,
+                value: LOCAL_HOST_VALUE,
+                label: t("toolbar.remoteHost.thisComputer"),
+                description: t("toolbar.remoteHost.thisComputerDescription"),
+                icon: <Laptop className="size-4 text-foreground" />,
               },
-            ]
-          : []),
-      ]}
-      onValueChange={handleValueChange}
-    />
+            ],
+          },
+          ...(hostItems.length > 0
+            ? [
+                {
+                  label: t("toolbar.remoteHost.sshHosts"),
+                  items: hostItems,
+                },
+              ]
+            : []),
+          {
+            items: [
+              {
+                value: ADD_HOST_VALUE,
+                label: t("toolbar.remoteHost.add.action"),
+                icon: <Plus className="size-4 text-foreground" />,
+              },
+            ],
+          },
+        ]}
+        onValueChange={handleValueChange}
+        preservesExternalFocus={(value) => value === ADD_HOST_VALUE}
+      />
+
+      <AddRemoteHostDialog
+        open={addDialogOpen}
+        onOpenChange={setAddDialogOpen}
+        onConnected={(host) => onHostChange?.(host)}
+      />
+    </>
   );
 }

--- a/src/features/chat/ui/RemoteHostSelector.tsx
+++ b/src/features/chat/ui/RemoteHostSelector.tsx
@@ -8,8 +8,13 @@ import {
 } from "./ChatInputSelector";
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 
-const LOCAL_HOST_VALUE = "__local__";
-const ADD_HOST_VALUE = "__add_ssh_environment__";
+const LOCAL_HOST_VALUE = "action:local";
+const ADD_HOST_VALUE = "action:add-ssh-environment";
+const HOST_VALUE_PREFIX = "host:";
+
+function hostValue(host: string): string {
+  return `${HOST_VALUE_PREFIX}${host}`;
+}
 
 interface RemoteHostSelectorProps {
   selectedHost?: string | null;
@@ -62,7 +67,7 @@ export function RemoteHostSelector({
   };
 
   const hostItems: ChatInputSelectorItem[] = listedHosts.map((host) => ({
-    value: host,
+    value: hostValue(host),
     label: host,
     description: statusDescription(host),
     icon: <Server className="size-4 text-foreground" />,
@@ -73,7 +78,13 @@ export function RemoteHostSelector({
       setAddDialogOpen(true);
       return;
     }
-    onHostChange?.(value === LOCAL_HOST_VALUE ? null : value);
+    if (value === LOCAL_HOST_VALUE) {
+      onHostChange?.(null);
+      return;
+    }
+    if (value.startsWith(HOST_VALUE_PREFIX)) {
+      onHostChange?.(value.slice(HOST_VALUE_PREFIX.length));
+    }
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -88,7 +99,7 @@ export function RemoteHostSelector({
     <>
       <ChatInputSelector
         ariaLabel={t("toolbar.remoteHost.selectHost")}
-        value={selectedHost ?? LOCAL_HOST_VALUE}
+        value={selectedHost ? hostValue(selectedHost) : LOCAL_HOST_VALUE}
         triggerLabel={selectedHost ?? t("toolbar.remoteHost.thisComputer")}
         triggerTitle={
           selectedHost

--- a/src/features/chat/ui/__tests__/RemoteHostConnectionBanner.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostConnectionBanner.test.tsx
@@ -78,6 +78,7 @@ describe("RemoteHostConnectionBanner", () => {
   it("reconnects the host and reloads the session transcript", async () => {
     const ensureHostConnected = vi.fn(async () => {
       setHostState("ready");
+      return true;
     });
     const original = useRemoteHostStore.getState().ensureHostConnected;
     useRemoteHostStore.setState({ ensureHostConnected });

--- a/src/features/chat/ui/__tests__/RemoteHostConnectionBanner.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostConnectionBanner.test.tsx
@@ -78,7 +78,7 @@ describe("RemoteHostConnectionBanner", () => {
   it("reconnects the host and reloads the session transcript", async () => {
     const ensureHostConnected = vi.fn(async () => {
       setHostState("ready");
-      return true;
+      return "connected" as const;
     });
     const original = useRemoteHostStore.getState().ensureHostConnected;
     useRemoteHostStore.setState({ ensureHostConnected });

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -1,14 +1,15 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RemoteHostSelector } from "../RemoteHostSelector";
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 
 const mockListSshConfigHosts = vi.fn();
+const mockConnectRemoteHost = vi.fn();
 
 vi.mock("@/shared/api/remoteHosts", () => ({
   listSshConfigHosts: (...args: unknown[]) => mockListSshConfigHosts(...args),
-  connectRemoteHost: vi.fn(),
+  connectRemoteHost: (...args: unknown[]) => mockConnectRemoteHost(...args),
   disconnectRemoteHost: vi.fn(),
   shutdownRemoteHost: vi.fn(),
   listRemoteBackends: vi.fn().mockResolvedValue([]),
@@ -23,9 +24,13 @@ describe("RemoteHostSelector", () => {
     // Opening the selector refreshes hosts from the SSH config, so the mock
     // must agree with the seeded store state.
     mockListSshConfigHosts.mockReset().mockResolvedValue(["devbox", "gpu-box"]);
+    mockConnectRemoteHost.mockReset().mockResolvedValue(undefined);
     useRemoteHostStore.setState({
       configHosts: ["devbox", "gpu-box"],
+      manualHosts: [],
       statusByHost: { devbox: { state: "ready" } },
+      forgottenHosts: {},
+      lifecycleByHost: {},
     });
   });
 
@@ -80,6 +85,69 @@ describe("RemoteHostSelector", () => {
 
     expect(
       screen.getByRole("menuitem", { name: /devbox/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("offers an add SSH environment action even when no hosts are configured", async () => {
+    mockListSshConfigHosts.mockResolvedValue([]);
+    useRemoteHostStore.setState({ configHosts: [], statusByHost: {} });
+    const user = userEvent.setup();
+    render(<RemoteHostSelector selectedHost={null} onHostChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+
+    expect(
+      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("connects and selects a host added from the environment dialog", async () => {
+    const user = userEvent.setup();
+    const onHostChange = vi.fn();
+    render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+    );
+    await user.type(screen.getByRole("textbox", { name: /ssh host/i }), "blox");
+    await user.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    await waitFor(() => {
+      expect(mockConnectRemoteHost).toHaveBeenCalledWith("blox");
+      expect(onHostChange).toHaveBeenCalledWith("blox");
+    });
+    expect(
+      screen.queryByRole("dialog", { name: /add ssh environment/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the add dialog open with feedback when connecting fails", async () => {
+    mockConnectRemoteHost.mockRejectedValue(new Error("SSH host unavailable"));
+    const user = userEvent.setup();
+    const onHostChange = vi.fn();
+    render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /ssh host/i }),
+      "offline-box",
+    );
+    await user.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "SSH host unavailable",
+    );
+    expect(onHostChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: /add ssh environment/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -180,4 +180,45 @@ describe("RemoteHostSelector", () => {
       screen.getByRole("dialog", { name: /add ssh environment/i }),
     ).toBeInTheDocument();
   });
+
+  it("dismisses a pending connection and ignores its late success", async () => {
+    let resolveConnection: (value: {
+      incarnation: string;
+      generation: number;
+    }) => void = () => {};
+    mockConnectRemoteHost.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveConnection = resolve;
+        }),
+    );
+    const user = userEvent.setup();
+    const onHostChange = vi.fn();
+    render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /ssh host/i }),
+      "slow-box",
+    );
+    await user.click(screen.getByRole("button", { name: /^connect$/i }));
+    await user.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(
+      screen.queryByRole("dialog", { name: /add ssh environment/i }),
+    ).not.toBeInTheDocument();
+
+    resolveConnection({ incarnation: "slot-slow", generation: 1 });
+    await waitFor(() => {
+      expect(
+        useRemoteHostStore.getState().statusByHost["slow-box"]?.state,
+      ).toBe("ready");
+    });
+    expect(onHostChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -221,4 +221,56 @@ describe("RemoteHostSelector", () => {
     });
     expect(onHostChange).not.toHaveBeenCalled();
   });
+
+  it("does not select a connection lifecycle superseded while the dialog waits", async () => {
+    const resolvers: Array<
+      (value: { incarnation: string; generation: number }) => void
+    > = [];
+    mockConnectRemoteHost.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const user = userEvent.setup();
+    const onHostChange = vi.fn();
+    render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /ssh host/i }),
+      "superseded-box",
+    );
+    await user.click(screen.getByRole("button", { name: /^connect$/i }));
+
+    const replacement = useRemoteHostStore
+      .getState()
+      .ensureHostConnected("superseded-box");
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+    resolvers[1]?.({ incarnation: "slot-new", generation: 2 });
+    await expect(replacement).resolves.toBe(true);
+    resolvers[0]?.({ incarnation: "slot-old", generation: 1 });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^connect$/i }),
+      ).not.toBeDisabled();
+    });
+    expect(onHostChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: /add ssh environment/i }),
+    ).toBeInTheDocument();
+    expect(
+      useRemoteHostStore.getState().statusByHost["superseded-box"],
+    ).toEqual({
+      state: "ready",
+      incarnation: "slot-new",
+      generation: 2,
+    });
+  });
 });

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -245,7 +245,7 @@ describe("RemoteHostSelector", () => {
       .ensureHostConnected("superseded-box");
     await waitFor(() => expect(resolvers).toHaveLength(2));
     resolvers[1]?.({ incarnation: "slot-new", generation: 2 });
-    await expect(replacement).resolves.toBe(true);
+    await expect(replacement).resolves.toBe("connected");
     resolvers[0]?.({ incarnation: "slot-old", generation: 1 });
 
     await waitFor(() => {
@@ -257,6 +257,11 @@ describe("RemoteHostSelector", () => {
     expect(
       screen.getByRole("dialog", { name: /add ssh host/i }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This SSH connection changed while connecting. Try again or cancel.",
+    );
+    expect(screen.getByRole("button", { name: /^connect$/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeEnabled();
     expect(
       useRemoteHostStore.getState().statusByHost["superseded-box"],
     ).toEqual({

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -118,7 +118,7 @@ describe("RemoteHostSelector", () => {
     ).toBeInTheDocument();
   });
 
-  it("offers an add SSH environment action even when no hosts are configured", async () => {
+  it("offers an add SSH host action even when no hosts are configured", async () => {
     mockListSshConfigHosts.mockResolvedValue([]);
     useRemoteHostStore.setState({ configHosts: [], statusByHost: {} });
     const user = userEvent.setup();
@@ -127,7 +127,7 @@ describe("RemoteHostSelector", () => {
     await user.click(screen.getByRole("button", { name: /select computer/i }));
 
     expect(
-      screen.getByRole("menuitem", { name: /add ssh environment/i }),
+      screen.getByRole("menuitem", { name: /add ssh host/i }),
     ).toBeInTheDocument();
   });
 
@@ -139,9 +139,7 @@ describe("RemoteHostSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /select computer/i }));
-    await user.click(
-      screen.getByRole("menuitem", { name: /add ssh environment/i }),
-    );
+    await user.click(screen.getByRole("menuitem", { name: /add ssh host/i }));
     await user.type(screen.getByRole("textbox", { name: /ssh host/i }), "blox");
     await user.click(screen.getByRole("button", { name: /^connect$/i }));
 
@@ -150,7 +148,7 @@ describe("RemoteHostSelector", () => {
       expect(onHostChange).toHaveBeenCalledWith("blox");
     });
     expect(
-      screen.queryByRole("dialog", { name: /add ssh environment/i }),
+      screen.queryByRole("dialog", { name: /add ssh host/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -163,9 +161,7 @@ describe("RemoteHostSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /select computer/i }));
-    await user.click(
-      screen.getByRole("menuitem", { name: /add ssh environment/i }),
-    );
+    await user.click(screen.getByRole("menuitem", { name: /add ssh host/i }));
     await user.type(
       screen.getByRole("textbox", { name: /ssh host/i }),
       "offline-box",
@@ -177,7 +173,7 @@ describe("RemoteHostSelector", () => {
     );
     expect(onHostChange).not.toHaveBeenCalled();
     expect(
-      screen.getByRole("dialog", { name: /add ssh environment/i }),
+      screen.getByRole("dialog", { name: /add ssh host/i }),
     ).toBeInTheDocument();
   });
 
@@ -199,9 +195,7 @@ describe("RemoteHostSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /select computer/i }));
-    await user.click(
-      screen.getByRole("menuitem", { name: /add ssh environment/i }),
-    );
+    await user.click(screen.getByRole("menuitem", { name: /add ssh host/i }));
     await user.type(
       screen.getByRole("textbox", { name: /ssh host/i }),
       "slow-box",
@@ -210,7 +204,7 @@ describe("RemoteHostSelector", () => {
     await user.click(screen.getByRole("button", { name: /^cancel$/i }));
 
     expect(
-      screen.queryByRole("dialog", { name: /add ssh environment/i }),
+      screen.queryByRole("dialog", { name: /add ssh host/i }),
     ).not.toBeInTheDocument();
 
     resolveConnection({ incarnation: "slot-slow", generation: 1 });
@@ -239,9 +233,7 @@ describe("RemoteHostSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /select computer/i }));
-    await user.click(
-      screen.getByRole("menuitem", { name: /add ssh environment/i }),
-    );
+    await user.click(screen.getByRole("menuitem", { name: /add ssh host/i }));
     await user.type(
       screen.getByRole("textbox", { name: /ssh host/i }),
       "superseded-box",
@@ -263,7 +255,7 @@ describe("RemoteHostSelector", () => {
     });
     expect(onHostChange).not.toHaveBeenCalled();
     expect(
-      screen.getByRole("dialog", { name: /add ssh environment/i }),
+      screen.getByRole("dialog", { name: /add ssh host/i }),
     ).toBeInTheDocument();
     expect(
       useRemoteHostStore.getState().statusByHost["superseded-box"],

--- a/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
+++ b/src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx
@@ -24,7 +24,10 @@ describe("RemoteHostSelector", () => {
     // Opening the selector refreshes hosts from the SSH config, so the mock
     // must agree with the seeded store state.
     mockListSshConfigHosts.mockReset().mockResolvedValue(["devbox", "gpu-box"]);
-    mockConnectRemoteHost.mockReset().mockResolvedValue(undefined);
+    mockConnectRemoteHost.mockReset().mockResolvedValue({
+      incarnation: "slot-1",
+      generation: 1,
+    });
     useRemoteHostStore.setState({
       configHosts: ["devbox", "gpu-box"],
       manualHosts: [],
@@ -73,6 +76,33 @@ describe("RemoteHostSelector", () => {
     await user.click(screen.getByRole("button", { name: /select computer/i }));
     await user.click(screen.getByRole("menuitem", { name: /this computer/i }));
     expect(onHostChange).toHaveBeenCalledWith(null);
+  });
+
+  it("treats aliases matching the former action sentinels as SSH hosts", async () => {
+    const aliases = ["__local__", "__add_ssh_environment__"];
+    mockListSshConfigHosts.mockResolvedValue(aliases);
+    useRemoteHostStore.setState({ configHosts: aliases });
+    const user = userEvent.setup();
+    const onHostChange = vi.fn();
+    const { unmount } = render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(screen.getByRole("menuitem", { name: "__local__" }));
+    expect(onHostChange).toHaveBeenLastCalledWith("__local__");
+    unmount();
+
+    onHostChange.mockClear();
+    render(
+      <RemoteHostSelector selectedHost={null} onHostChange={onHostChange} />,
+    );
+    await user.click(screen.getByRole("button", { name: /select computer/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: "__add_ssh_environment__" }),
+    );
+    expect(onHostChange).toHaveBeenLastCalledWith("__add_ssh_environment__");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("still lists a selected host that is missing from the SSH config", async () => {

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -738,6 +738,31 @@ describe("manual host persistence", () => {
     expect(loadPersistedManualHosts()).toEqual(["adhoc.blox"]);
   });
 
+  it("retains concurrent already-ready manual hosts in state and storage", async () => {
+    useRemoteHostStore.setState({
+      statusByHost: {
+        "alpha.blox": { ...backendIdentity, state: "ready" },
+        "beta.blox": {
+          incarnation: "slot-beta",
+          generation: 2,
+          state: "ready",
+        },
+      },
+    });
+
+    const accepted = await Promise.all([
+      useRemoteHostStore.getState().ensureHostConnected("alpha.blox"),
+      useRemoteHostStore.getState().ensureHostConnected("beta.blox"),
+    ]);
+
+    expect(accepted).toEqual([true, true]);
+    expect(useRemoteHostStore.getState().manualHosts).toEqual([
+      "beta.blox",
+      "alpha.blox",
+    ]);
+    expect(loadPersistedManualHosts()).toEqual(["beta.blox", "alpha.blox"]);
+  });
+
   it("does not record ssh-config hosts as manual", async () => {
     mocks.connectRemoteHost.mockResolvedValue(connection);
     useRemoteHostStore.setState({ configHosts: ["configured"] });

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -251,6 +251,23 @@ describe("ensureHostConnected", () => {
     expect(mocks.connectRemoteHost).not.toHaveBeenCalled();
   });
 
+  it("remembers a manually entered host when its backend is already ready", async () => {
+    useRemoteHostStore.setState({ configHosts: ["configured"] });
+    useRemoteHostStore.getState().applyStatusEvent({
+      host: "workstation.blox",
+      ...backendIdentity,
+      state: "ready",
+    });
+
+    await useRemoteHostStore.getState().ensureHostConnected("workstation.blox");
+
+    expect(mocks.connectRemoteHost).not.toHaveBeenCalled();
+    expect(useRemoteHostStore.getState().manualHosts).toEqual([
+      "workstation.blox",
+    ]);
+    expect(loadPersistedManualHosts()).toEqual(["workstation.blox"]);
+  });
+
   it("connects and marks the host ready", async () => {
     let resolveConnect: (value: RemoteBackendConnection) => void = () => {};
     mocks.connectRemoteHost.mockImplementation(

--- a/src/features/remoteHosts/stores/remoteHostStore.test.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.test.ts
@@ -309,9 +309,9 @@ describe("ensureHostConnected", () => {
       generation: 4,
     };
     resolvers[1]?.(newestConnection);
-    await newer;
+    await expect(newer).resolves.toBe("connected");
     resolvers[0]?.({ ...connection, incarnation: "slot-old", generation: 9 });
-    await older;
+    await expect(older).resolves.toBe("superseded");
 
     expect(useRemoteHostStore.getState().statusByHost.devbox).toEqual({
       state: "ready",
@@ -755,7 +755,7 @@ describe("manual host persistence", () => {
       useRemoteHostStore.getState().ensureHostConnected("beta.blox"),
     ]);
 
-    expect(accepted).toEqual([true, true]);
+    expect(accepted).toEqual(["connected", "connected"]);
     expect(useRemoteHostStore.getState().manualHosts).toEqual([
       "beta.blox",
       "alpha.blox",

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -38,6 +38,8 @@ export interface RemoteHostStatus {
   error?: RemoteBackendErrorLike;
 }
 
+export type RemoteHostConnectOutcome = "connected" | "superseded";
+
 function backendStatus(
   payload: RemoteBackendStatusPayload | RemoteBackendSnapshotEntry,
 ): RemoteHostStatus {
@@ -174,7 +176,7 @@ export interface RemoteHostStore {
   syncBackendSnapshot: () => Promise<void>;
   applyStatusEvent: (payload: RemoteBackendStatusPayload) => void;
   /** Connect the host and report whether this exact lifecycle became current. */
-  ensureHostConnected: (host: string) => Promise<boolean>;
+  ensureHostConnected: (host: string) => Promise<RemoteHostConnectOutcome>;
   disconnect: (host: string) => Promise<void>;
   shutdownHost: (host: string, expectedInstanceToken?: string) => Promise<void>;
   runDoctor: (host: string) => Promise<void>;
@@ -298,7 +300,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         persistManualHosts(manualHosts);
         return { manualHosts };
       });
-      if (accepted) return true;
+      if (accepted) return "connected";
       current = get();
     }
 
@@ -377,7 +379,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
           },
         };
       });
-      return accepted;
+      return accepted ? "connected" : "superseded";
     } catch (error) {
       let accepted = false;
       set((state) => {
@@ -410,7 +412,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
           },
         };
       });
-      if (!accepted) return false;
+      if (!accepted) return "superseded";
       throw error;
     }
   },

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -272,6 +272,20 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       current.statusByHost[host]?.state === "ready" &&
       !current.forgottenHosts[host]
     ) {
+      // A manually entered host can already be ready when it was restored
+      // from the backend snapshot. Remember it even though no new connect is
+      // required, otherwise it disappears from the selector after restart.
+      if (
+        !current.configHosts.includes(host) &&
+        !current.manualHosts.includes(host)
+      ) {
+        const manualHosts = [host, ...current.manualHosts].slice(
+          0,
+          MAX_MANUAL_HOSTS,
+        );
+        persistManualHosts(manualHosts);
+        set({ manualHosts });
+      }
       return;
     }
 

--- a/src/features/remoteHosts/stores/remoteHostStore.ts
+++ b/src/features/remoteHosts/stores/remoteHostStore.ts
@@ -173,7 +173,8 @@ export interface RemoteHostStore {
   refreshConfigHosts: () => Promise<void>;
   syncBackendSnapshot: () => Promise<void>;
   applyStatusEvent: (payload: RemoteBackendStatusPayload) => void;
-  ensureHostConnected: (host: string) => Promise<void>;
+  /** Connect the host and report whether this exact lifecycle became current. */
+  ensureHostConnected: (host: string) => Promise<boolean>;
   disconnect: (host: string) => Promise<void>;
   shutdownHost: (host: string, expectedInstanceToken?: string) => Promise<void>;
   runDoctor: (host: string) => Promise<void>;
@@ -267,7 +268,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
   },
 
   ensureHostConnected: async (host) => {
-    const current = get();
+    let current = get();
     if (
       current.statusByHost[host]?.state === "ready" &&
       !current.forgottenHosts[host]
@@ -275,18 +276,30 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
       // A manually entered host can already be ready when it was restored
       // from the backend snapshot. Remember it even though no new connect is
       // required, otherwise it disappears from the selector after restart.
-      if (
-        !current.configHosts.includes(host) &&
-        !current.manualHosts.includes(host)
-      ) {
-        const manualHosts = [host, ...current.manualHosts].slice(
+      let accepted = false;
+      set((state) => {
+        if (
+          state.statusByHost[host]?.state !== "ready" ||
+          state.forgottenHosts[host]
+        ) {
+          return state;
+        }
+        accepted = true;
+        if (
+          state.configHosts.includes(host) ||
+          state.manualHosts.includes(host)
+        ) {
+          return state;
+        }
+        const manualHosts = [host, ...state.manualHosts].slice(
           0,
           MAX_MANUAL_HOSTS,
         );
         persistManualHosts(manualHosts);
-        set({ manualHosts });
-      }
-      return;
+        return { manualHosts };
+      });
+      if (accepted) return true;
+      current = get();
     }
 
     // An explicit connection starts a new local lifecycle. This is the only
@@ -327,6 +340,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
     });
     try {
       const connection = await connectRemoteHost(host);
+      let accepted = false;
       set((state) => {
         if (
           state.forgottenHosts[host] ||
@@ -335,6 +349,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         ) {
           return state;
         }
+        accepted = true;
         // A host that connected but isn't in ~/.ssh/config was typed in
         // manually; remember it across restarts.
         const isKnown =
@@ -362,7 +377,9 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
           },
         };
       });
+      return accepted;
     } catch (error) {
+      let accepted = false;
       set((state) => {
         if (
           state.forgottenHosts[host] ||
@@ -371,6 +388,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
         ) {
           return state;
         }
+        accepted = true;
         const connectPendingLifecycleByHost = {
           ...state.connectPendingLifecycleByHost,
         };
@@ -392,6 +410,7 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
           },
         };
       });
+      if (!accepted) return false;
       throw error;
     }
   },
@@ -602,7 +621,10 @@ export const useRemoteHostStore = create<RemoteHostStore>((set, get) => ({
  * action for callers outside React (e.g. session routing in chat).
  */
 export function ensureHostConnected(host: string): Promise<void> {
-  return useRemoteHostStore.getState().ensureHostConnected(host);
+  return useRemoteHostStore
+    .getState()
+    .ensureHostConnected(host)
+    .then(() => undefined);
 }
 
 let remoteHostStoreInitStarted = false;

--- a/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
+++ b/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
@@ -11,7 +11,7 @@ import {
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 import { RemoteHostsSettings } from "../RemoteHostsSettings";
 
-const ensureHostConnected = vi.fn(async () => true);
+const ensureHostConnected = vi.fn(async () => "connected" as const);
 const disconnect = vi.fn(async () => {});
 const shutdownHost = vi.fn(async () => {});
 const runDoctor = vi.fn(async () => {});

--- a/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
+++ b/src/features/remoteHosts/ui/__tests__/RemoteHostsSettings.test.tsx
@@ -11,7 +11,7 @@ import {
 import { useRemoteHostStore } from "@/features/remoteHosts/stores/remoteHostStore";
 import { RemoteHostsSettings } from "../RemoteHostsSettings";
 
-const ensureHostConnected = vi.fn(async () => {});
+const ensureHostConnected = vi.fn(async () => true);
 const disconnect = vi.fn(async () => {});
 const shutdownHost = vi.fn(async () => {});
 const runDoctor = vi.fn(async () => {});

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -536,6 +536,17 @@
       "thisComputer": "This computer",
       "thisComputerDescription": "Run the session locally",
       "sshHosts": "SSH hosts",
+      "add": {
+        "action": "Add SSH environment",
+        "title": "Add SSH environment",
+        "description": "Connect using an SSH config alias or a user@host address.",
+        "hostLabel": "SSH host",
+        "hostPlaceholder": "user@host",
+        "emptyHost": "Enter an SSH host.",
+        "cancel": "Cancel",
+        "connect": "Connect",
+        "close": "Close add SSH environment dialog"
+      },
       "localTriggerTitle": "Runs on this computer",
       "remoteTriggerTitle": "Runs on {{host}} over SSH",
       "missingDirectory": "Choose a folder on the remote host before sending",

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -543,6 +543,7 @@
         "hostLabel": "SSH host",
         "hostPlaceholder": "user@host",
         "emptyHost": "Enter an SSH host.",
+        "superseded": "This SSH connection changed while connecting. Try again or cancel.",
         "cancel": "Cancel",
         "connect": "Connect",
         "close": "Close add SSH host dialog"

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -537,15 +537,15 @@
       "thisComputerDescription": "Run the session locally",
       "sshHosts": "SSH hosts",
       "add": {
-        "action": "Add SSH environment",
-        "title": "Add SSH environment",
+        "action": "Add SSH host",
+        "title": "Add SSH host",
         "description": "Connect using an SSH config alias or a user@host address.",
         "hostLabel": "SSH host",
         "hostPlaceholder": "user@host",
         "emptyHost": "Enter an SSH host.",
         "cancel": "Cancel",
         "connect": "Connect",
-        "close": "Close add SSH environment dialog"
+        "close": "Close add SSH host dialog"
       },
       "localTriggerTitle": "Runs on this computer",
       "remoteTriggerTitle": "Runs on {{host}} over SSH",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can add and select a new SSH environment directly from the chat composer.

**Problem:** The environment picker only lists SSH hosts Berd already knows about, so adding a new host requires leaving the chat flow and finding the remote-host settings. **Solution:** Add a separated “Add SSH environment” action that opens an accessible connection dialog, accepts an SSH config alias or `user@host`, selects the environment after a successful connection, and keeps loading and error feedback in context. This PR is stacked on #269 and should merge after it.

<details>
<summary>File changes</summary>

**src/features/chat/ui/AddRemoteHostDialog.tsx**
Adds the focused connection dialog, including validation, pending-state protection, backend error feedback, and selection after a successful connection.

**src/features/chat/ui/RemoteHostSelector.tsx**
Adds the separated “Add SSH environment” menu action and preserves focus while transitioning from the environment menu into the dialog.

**src/features/chat/ui/__tests__/RemoteHostSelector.test.tsx**
Covers the empty-host menu, successful add-and-select flow, and retained dialog feedback when connection fails.

**src/shared/i18n/locales/en/chat.json**
Adds localized copy and accessible labels for the new environment action and dialog.

</details>
