### PR TITLE
feat: complete Pi support with onboarding and one-click install

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "doctor"
 version = "0.1.0"
-source = "git+https://github.com/block/builderbot?rev=73ff9a0521dcc784c9514911a655187e5dd3b6ca#73ff9a0521dcc784c9514911a655187e5dd3b6ca"
+source = "git+https://github.com/block/builderbot?rev=3fb5fa839c4fbfd5edaa118042c2c8bfed845e7a#3fb5fa839c4fbfd5edaa118042c2c8bfed845e7a"
 dependencies = [
  "dirs",
  "futures",
@@ -2809,7 +2809,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry 0.6.1",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4343,7 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6710,7 +6710,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tracing",
  "url",
- "windows-registry 0.5.3",
+ "windows-registry",
  "windows-result 0.3.4",
 ]
 
@@ -7031,7 +7031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8451,17 +8451,6 @@ dependencies = [
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,7 +37,7 @@ berd-voice = { path = "crates/berd-voice", features = ["static"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 dunce = "1"
-doctor = { git = "https://github.com/block/builderbot", rev = "73ff9a0521dcc784c9514911a655187e5dd3b6ca" }
+doctor = { git = "https://github.com/block/builderbot", rev = "3fb5fa839c4fbfd5edaa118042c2c8bfed845e7a" }
 etcetera = "0.11.0"
 flate2 = "1"
 tempfile = "3"

--- a/src/features/onboarding/model/catalog.test.ts
+++ b/src/features/onboarding/model/catalog.test.ts
@@ -37,6 +37,7 @@ describe("onboarding catalog", () => {
       "copilot-acp",
       "amp-acp",
       "cursor-agent",
+      "pi-acp",
     ]);
   });
 });

--- a/src/features/onboarding/model/catalog.ts
+++ b/src/features/onboarding/model/catalog.ts
@@ -102,6 +102,7 @@ export const CURATED_HARNESS_IDS = [
   "copilot-acp",
   "amp-acp",
   "cursor-agent",
+  "pi-acp",
 ] as const;
 
 export type CuratedHarnessId = (typeof CURATED_HARNESS_IDS)[number];

--- a/src/features/onboarding/ui/HarnessStep.tsx
+++ b/src/features/onboarding/ui/HarnessStep.tsx
@@ -14,6 +14,7 @@ const PROVIDER_ICON_SIZES: Record<CuratedHarnessId, string> = {
   "copilot-acp": "size-[100px]",
   "amp-acp": "size-[92px]",
   "cursor-agent": "size-[90px]",
+  "pi-acp": "size-[92px]",
 };
 
 interface HarnessStepProps {

--- a/src/features/providers/curatedProviders.ts
+++ b/src/features/providers/curatedProviders.ts
@@ -89,7 +89,7 @@ export const CURATED_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     binaryName: "pi-acp",
     group: "default",
     aliases: ["pi-acp", "pi"],
-    supportsInstall: false,
+    supportsInstall: true,
     supportsAuth: false,
     supportsAuthStatus: false,
   },


### PR DESCRIPTION
## Context
PR #285 shipped Pi as a curated agent but deferred onboarding selection and one-click install. The builderbot doctor crate now provides Pi install commands, so Berd can complete support.

## Summary
- Flip `supportsInstall` to `true` for the `pi-acp` provider.
- Add `pi-acp` to onboarding `CURATED_HARNESS_IDS` and its icon size.
- Pin the `doctor` crate to block/builderbot#941's merged rev.
- Update the onboarding catalog test for the new harness id.

## Dependencies
None. block/berd#285 and block/builderbot#941 are merged; the doctor rev pins the latter's final SHA.
