### PR TITLE
fix(voice): defer OpenAI Keychain access

### DIFF
--- a/src-tauri/src/commands/openai_voice_credentials.rs
+++ b/src-tauri/src/commands/openai_voice_credentials.rs
@@ -2,7 +2,6 @@
 
 const KEYCHAIN_SERVICE: &str = "berd-openai-voice";
 const KEYCHAIN_ACCOUNT: &str = "api-key";
-const LEGACY_TTS_KEYCHAIN_ACCOUNT: &str = "tts-api-key";
 
 #[derive(Clone, Copy)]
 pub(crate) enum OpenAiVoiceCredential {
@@ -59,45 +58,19 @@ fn clear_account(account: &str) -> Result<(), String> {
     }
 }
 
-fn canonical_mutation_with_legacy_cleanup<T>(
-    canonical_mutation: impl FnOnce() -> Result<T, String>,
-    legacy_cleanup: impl FnOnce() -> Result<(), String>,
-) -> Result<T, String> {
-    let value = canonical_mutation()?;
-    if let Err(error) = legacy_cleanup() {
-        log::warn!("Could not remove Berd's legacy OpenAI voice credential: {error}");
-    }
-    Ok(value)
-}
-
 pub(crate) fn read(credential: OpenAiVoiceCredential) -> Result<Option<String>, String> {
-    if let Some(api_key) = read_account(credential.account())? {
-        return Ok(Some(api_key));
-    }
-    let Some(api_key) = read_account(LEGACY_TTS_KEYCHAIN_ACCOUNT)? else {
-        return Ok(None);
-    };
-    store(credential, &api_key)?;
-    Ok(Some(api_key))
+    read_account(credential.account())
 }
 
 pub(crate) fn store(credential: OpenAiVoiceCredential, api_key: &str) -> Result<(), String> {
     let entry = entry(credential.account())?;
-    canonical_mutation_with_legacy_cleanup(
-        || {
-            entry
-                .set_password(api_key)
-                .map_err(|error| format!("Could not save Berd's OpenAI voice credential: {error}"))
-        },
-        || clear_account(LEGACY_TTS_KEYCHAIN_ACCOUNT),
-    )
+    entry
+        .set_password(api_key)
+        .map_err(|error| format!("Could not save Berd's OpenAI voice credential: {error}"))
 }
 
 pub(crate) fn clear(credential: OpenAiVoiceCredential) -> Result<(), String> {
-    canonical_mutation_with_legacy_cleanup(
-        || clear_account(credential.account()),
-        || clear_account(LEGACY_TTS_KEYCHAIN_ACCOUNT),
-    )
+    clear_account(credential.account())
 }
 
 pub(crate) fn require(credential: OpenAiVoiceCredential) -> Result<String, String> {
@@ -107,36 +80,10 @@ pub(crate) fn require(credential: OpenAiVoiceCredential) -> Result<String, Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
-
     #[test]
     fn speech_services_use_the_shared_voice_keychain_account() {
         assert_eq!(OpenAiVoiceCredential::SpeechToText.account(), "api-key");
         assert_eq!(OpenAiVoiceCredential::TextToSpeech.account(), "api-key");
         assert_eq!(OpenAiVoiceCredential::Realtime.account(), "api-key");
-    }
-
-    #[test]
-    fn legacy_cleanup_failure_does_not_change_canonical_mutation_result() {
-        let credential = RefCell::new(None);
-        let save = canonical_mutation_with_legacy_cleanup(
-            || {
-                credential.replace(Some("shared-key"));
-                Ok(())
-            },
-            || Err("legacy cleanup failed".to_string()),
-        );
-        assert_eq!(save, Ok(()));
-        assert_eq!(*credential.borrow(), Some("shared-key"));
-
-        let clear = canonical_mutation_with_legacy_cleanup(
-            || {
-                credential.replace(None);
-                Ok(())
-            },
-            || Err("legacy cleanup failed".to_string()),
-        );
-        assert_eq!(clear, Ok(()));
-        assert_eq!(*credential.borrow(), None);
     }
 }

--- a/src/features/voice-conversation/api/openAiVoice.ts
+++ b/src/features/voice-conversation/api/openAiVoice.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { shareInFlight } from "@/shared/lib/shareInFlight";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type { VoiceDeliveryProgress } from "./pocketVoice";
 import type {
@@ -28,9 +29,9 @@ export interface OpenAiVoiceStreamEvent {
   delivery?: VoiceDeliveryProgress | null;
 }
 
-export function getOpenAiVoiceStatus(): Promise<OpenAiVoiceStatus> {
-  return invoke<OpenAiVoiceStatus>("get_openai_voice_status");
-}
+export const getOpenAiVoiceStatus = shareInFlight(
+  (): Promise<OpenAiVoiceStatus> => invoke("get_openai_voice_status"),
+);
 
 export function setOpenAiTtsApiKey(apiKey: string): Promise<void> {
   return invoke("set_openai_tts_api_key", { apiKey });

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
@@ -4,14 +4,16 @@ import type { OpenAiVoiceStatus } from "../api/openAiVoice";
 import { useOpenAiVoiceSetup } from "./useOpenAiVoiceSetup";
 
 const mocks = vi.hoisted(() => ({
-  getStatus: vi.fn<() => Promise<OpenAiVoiceStatus>>(),
+  getStatus:
+    vi.fn<(options?: { coalesce?: boolean }) => Promise<OpenAiVoiceStatus>>(),
   settingsChanged: null as (() => void) | null,
   finishListening: null as (() => void) | null,
   listenerError: null as Error | null,
 }));
 
 vi.mock("../api/openAiVoice", () => ({
-  getOpenAiVoiceStatus: () => mocks.getStatus(),
+  getOpenAiVoiceStatus: (options?: { coalesce?: boolean }) =>
+    mocks.getStatus(options),
   listenToOpenAiVoiceSettings: (listener: () => void) => {
     mocks.settingsChanged = listener;
     if (mocks.listenerError) return Promise.reject(mocks.listenerError);
@@ -66,6 +68,7 @@ describe("useOpenAiVoiceSetup", () => {
     await waitFor(() => expect(mocks.settingsChanged).not.toBeNull());
     act(() => mocks.finishListening?.());
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
+    expect(mocks.getStatus).toHaveBeenLastCalledWith({ coalesce: true });
 
     act(() => mocks.settingsChanged?.());
     refreshed.resolve(status(true));

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
@@ -6,7 +6,7 @@ import { useOpenAiVoiceSetup } from "./useOpenAiVoiceSetup";
 const mocks = vi.hoisted(() => ({
   getStatus:
     vi.fn<(options?: { coalesce?: boolean }) => Promise<OpenAiVoiceStatus>>(),
-  settingsChanged: null as (() => void) | null,
+  settingsChanged: null as ((event?: unknown) => void) | null,
   finishListening: null as (() => void) | null,
   listenerError: null as Error | null,
 }));
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../api/openAiVoice", () => ({
   getOpenAiVoiceStatus: (options?: { coalesce?: boolean }) =>
     mocks.getStatus(options),
-  listenToOpenAiVoiceSettings: (listener: () => void) => {
+  listenToOpenAiVoiceSettings: (listener: (event?: unknown) => void) => {
     mocks.settingsChanged = listener;
     if (mocks.listenerError) return Promise.reject(mocks.listenerError);
     return new Promise<() => void>((resolve) => {
@@ -70,7 +70,13 @@ describe("useOpenAiVoiceSetup", () => {
     await waitFor(() => expect(mocks.getStatus).toHaveBeenCalledTimes(1));
     expect(mocks.getStatus).toHaveBeenLastCalledWith({ coalesce: true });
 
-    act(() => mocks.settingsChanged?.());
+    act(() =>
+      mocks.settingsChanged?.({
+        event: "openai-voice:settings-changed",
+        id: 1,
+        payload: null,
+      }),
+    );
     expect(mocks.getStatus).toHaveBeenLastCalledWith(undefined);
     refreshed.resolve(status(true));
     await waitFor(() =>

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
@@ -127,7 +127,7 @@ describe("useOpenAiVoiceSetup", () => {
     expect(result.current.error).toBe("Keychain unavailable");
   });
 
-  it("does not expose cached readiness while disabled", async () => {
+  it("does not reuse cached readiness after being disabled", async () => {
     mocks.listenerError = new Error("listener unavailable");
     mocks.getStatus.mockResolvedValue(status(true));
     const { result, rerender } = renderHook(
@@ -141,5 +141,16 @@ describe("useOpenAiVoiceSetup", () => {
     rerender({ enabled: false });
 
     expect(result.current).toEqual({ status: null, error: null });
+
+    const reloaded = deferred<OpenAiVoiceStatus>();
+    mocks.getStatus.mockReturnValueOnce(reloaded.promise);
+    rerender({ enabled: true });
+
+    expect(result.current).toEqual({ status: null, error: null });
+
+    reloaded.resolve(status(false));
+    await waitFor(() =>
+      expect(result.current.status?.ttsConfigured).toBe(false),
+    );
   });
 });

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.test.tsx
@@ -71,6 +71,7 @@ describe("useOpenAiVoiceSetup", () => {
     expect(mocks.getStatus).toHaveBeenLastCalledWith({ coalesce: true });
 
     act(() => mocks.settingsChanged?.());
+    expect(mocks.getStatus).toHaveBeenLastCalledWith(undefined);
     refreshed.resolve(status(true));
     await waitFor(() =>
       expect(result.current.status?.sttConfigured).toBe(true),

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
@@ -10,7 +10,11 @@ export function useOpenAiVoiceSetup(enabled = true) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) {
+      setStatus(null);
+      setError(null);
+      return;
+    }
     let active = true;
     let refreshGeneration = 0;
     let unsubscribe: (() => void) | null = null;

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
@@ -16,7 +16,7 @@ export function useOpenAiVoiceSetup(enabled = true) {
     let unsubscribe: (() => void) | null = null;
     const refresh = () => {
       const generation = ++refreshGeneration;
-      void getOpenAiVoiceStatus().then(
+      void getOpenAiVoiceStatus({ coalesce: true }).then(
         (next) => {
           if (active && generation === refreshGeneration) {
             setStatus(next);

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
@@ -14,9 +14,9 @@ export function useOpenAiVoiceSetup(enabled = true) {
     let active = true;
     let refreshGeneration = 0;
     let unsubscribe: (() => void) | null = null;
-    const refresh = () => {
+    const refresh = (coalesce = false) => {
       const generation = ++refreshGeneration;
-      void getOpenAiVoiceStatus({ coalesce: true }).then(
+      void getOpenAiVoiceStatus(coalesce ? { coalesce: true } : undefined).then(
         (next) => {
           if (active && generation === refreshGeneration) {
             setStatus(next);
@@ -35,7 +35,7 @@ export function useOpenAiVoiceSetup(enabled = true) {
       (nextUnsubscribe) => {
         if (active) {
           unsubscribe = nextUnsubscribe;
-          refresh();
+          refresh(true);
         } else nextUnsubscribe();
       },
       () => {

--- a/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
+++ b/src/features/voice-conversation/hooks/useOpenAiVoiceSetup.ts
@@ -35,7 +35,7 @@ export function useOpenAiVoiceSetup(enabled = true) {
         },
       );
     };
-    void listenToOpenAiVoiceSettings(refresh).then(
+    void listenToOpenAiVoiceSettings(() => refresh()).then(
       (nextUnsubscribe) => {
         if (active) {
           unsubscribe = nextUnsubscribe;

--- a/src/features/voice-conversation/ui/VoiceSettings.test.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.test.tsx
@@ -51,6 +51,7 @@ const microphonePermissionState = vi.hoisted(() => ({
   openSettings: vi.fn(),
 }));
 const openAiStatusState = vi.hoisted(() => ({
+  enabled: null as boolean | null,
   current: {
     sttConfigured: true,
     ttsConfigured: true,
@@ -81,10 +82,13 @@ vi.mock("../api/openAiVoice", () => ({
   clearOpenAiTtsApiKey: openAiApiMocks.clearTtsApiKey,
 }));
 vi.mock("../hooks/useOpenAiVoiceSetup", () => ({
-  useOpenAiVoiceSetup: () => ({
-    status: openAiStatusState.current,
-    error: null,
-  }),
+  useOpenAiVoiceSetup: (enabled: boolean) => {
+    openAiStatusState.enabled = enabled;
+    return {
+      status: enabled ? openAiStatusState.current : null,
+      error: null,
+    };
+  },
 }));
 vi.mock("../hooks/usePocketVoiceSetup", () => ({
   usePocketVoiceSetup: () => setupState.current,
@@ -244,6 +248,28 @@ describe("VoiceSettings", () => {
     openAiApiMocks.clearTtsApiKey.mockClear();
     openAiApiMocks.setSttApiKey.mockClear();
     openAiApiMocks.clearSttApiKey.mockClear();
+  });
+
+  it("does not inspect OpenAI credentials for Apple speech input and output", () => {
+    inputState.backend = "macos";
+    outputState.backend = "siri";
+
+    renderWithProviders(<VoiceSettings />);
+
+    expect(openAiStatusState.enabled).toBe(false);
+  });
+
+  it.each([
+    ["openai", "siri"],
+    ["macos", "openai"],
+    ["openai", "openai"],
+  ] as const)("inspects OpenAI credentials for %s speech input and %s speech output", (inputBackend, outputBackend) => {
+    inputState.backend = inputBackend;
+    outputState.backend = outputBackend;
+
+    renderWithProviders(<VoiceSettings />);
+
+    expect(openAiStatusState.enabled).toBe(true);
   });
 
   it("renders independently selected OpenAI input and output settings", async () => {

--- a/src/features/voice-conversation/ui/VoiceSettings.test.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.test.tsx
@@ -19,7 +19,11 @@ if (!HTMLElement.prototype.scrollIntoView) {
   HTMLElement.prototype.scrollIntoView = () => {};
 }
 
-vi.mock("@/shared/lib/platform", () => ({ getPlatform: () => "mac" }));
+const platformState = vi.hoisted(() => ({ current: "mac" }));
+
+vi.mock("@/shared/lib/platform", () => ({
+  getPlatform: () => platformState.current,
+}));
 
 const setupState = vi.hoisted(() => ({
   current: null as PocketVoiceSetup | null,
@@ -62,6 +66,7 @@ const microphonePermissionState = vi.hoisted(() => ({
 }));
 const openAiStatusState = vi.hoisted(() => ({
   enabled: null as boolean | null,
+  loaded: true,
   current: {
     sttConfigured: true,
     ttsConfigured: true,
@@ -95,7 +100,8 @@ vi.mock("../hooks/useOpenAiVoiceSetup", () => ({
   useOpenAiVoiceSetup: (enabled: boolean) => {
     openAiStatusState.enabled = enabled;
     return {
-      status: enabled ? openAiStatusState.current : null,
+      status:
+        enabled && openAiStatusState.loaded ? openAiStatusState.current : null,
       error: null,
     };
   },
@@ -221,6 +227,8 @@ describe("VoiceSettings", () => {
     microphonePermissionState.openSettings.mockReset();
     inputState.backend = "parakeet";
     outputState.backend = "pocket";
+    platformState.current = "mac";
+    openAiStatusState.loaded = true;
     macSpeechSetupState.current = {
       status: {
         supported: false,
@@ -280,6 +288,32 @@ describe("VoiceSettings", () => {
 
     expect(
       screen.getByRole("option", { name: "OpenAI text-to-speech" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer OpenAI voice playback on unsupported platforms", async () => {
+    platformState.current = "linux";
+    setupState.current = setup(pocketStatus());
+    renderWithProviders(<VoiceSettings />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Speech output" }));
+
+    expect(
+      screen.queryByRole("option", { name: "OpenAI text-to-speech" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("waits for OpenAI credential status before showing readiness guidance", () => {
+    outputState.backend = "openai";
+    openAiStatusState.loaded = false;
+    setupState.current = setup(pocketStatus({ parakeetInstalled: true }));
+
+    renderWithProviders(<VoiceSettings />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Checking OpenAI voice settings…"),
     ).toBeInTheDocument();
   });
 

--- a/src/features/voice-conversation/ui/VoiceSettings.test.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.test.tsx
@@ -11,6 +11,16 @@ import type { VoiceInputBackend } from "../lib/voiceInputPreference";
 import type { VoiceOutputBackend } from "../lib/voiceOutputPreference";
 import { VoiceSettings } from "./VoiceSettings";
 
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false;
+}
+
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {};
+}
+
+vi.mock("@/shared/lib/platform", () => ({ getPlatform: () => "mac" }));
+
 const setupState = vi.hoisted(() => ({
   current: null as PocketVoiceSetup | null,
 }));
@@ -257,6 +267,20 @@ describe("VoiceSettings", () => {
     renderWithProviders(<VoiceSettings />);
 
     expect(openAiStatusState.enabled).toBe(false);
+  });
+
+  it("keeps OpenAI voice playback selectable without inspecting credentials", async () => {
+    setupState.current = setup(pocketStatus());
+    renderWithProviders(<VoiceSettings />);
+
+    expect(openAiStatusState.enabled).toBe(false);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("combobox", { name: "Speech output" }));
+
+    expect(
+      screen.getByRole("option", { name: "OpenAI text-to-speech" }),
+    ).toBeInTheDocument();
   });
 
   it.each([

--- a/src/features/voice-conversation/ui/VoiceSettings.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.tsx
@@ -95,16 +95,18 @@ export function VoiceSettings() {
   const { t } = useTranslation("settings");
   const setup = usePocketVoiceSetup();
   const macSpeechSetup = useMacSpeechSetup();
-  const { status: openAiStatus, error: openAiError } = useOpenAiVoiceSetup();
   const [openAiSpeed, setOpenAiSpeed] = useState(1);
   const [openAiSpeedError, setOpenAiSpeedError] = useState<string | null>(null);
-  useEffect(() => {
-    if (openAiStatus) setOpenAiSpeed(openAiStatus.playbackSpeed);
-  }, [openAiStatus]);
   const input = useVoiceInputPreference(
     isMacSpeechAvailable(macSpeechSetup.status, macSpeechSetup.loading),
   );
   const output = useVoiceOutputPreference();
+  const { status: openAiStatus, error: openAiError } = useOpenAiVoiceSetup(
+    input.backend === "openai" || output.backend === "openai",
+  );
+  useEffect(() => {
+    if (openAiStatus) setOpenAiSpeed(openAiStatus.playbackSpeed);
+  }, [openAiStatus]);
   const interruption = useVoiceInterruptionPreference();
   const mode = useVoiceConversationModePreference();
   const siriSetup = useSiriVoiceSetup(output.backend === "siri");

--- a/src/features/voice-conversation/ui/VoiceSettings.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.tsx
@@ -143,22 +143,27 @@ export function VoiceSettings() {
   const pocketStatusLoaded =
     (input.backend !== "parakeet" && output.backend !== "pocket") ||
     setup.status !== null;
-  const readinessKey = !pocketStatusLoaded
-    ? null
-    : !inputReady && output.backend === "siri" && !siriOutputLoaded
-      ? input.backend === "macos"
-        ? "voice.notReadyMacInput"
-        : "voice.notReadyInput"
-      : output.backend === "siri" && !siriOutputLoaded
-        ? null
-        : input.backend === null
+  const openAiStatusLoaded =
+    (input.backend !== "openai" && output.backend !== "openai") ||
+    openAiStatus !== null ||
+    openAiError !== null;
+  const readinessKey =
+    !pocketStatusLoaded || !openAiStatusLoaded
+      ? null
+      : !inputReady && output.backend === "siri" && !siriOutputLoaded
+        ? input.backend === "macos"
+          ? "voice.notReadyMacInput"
+          : "voice.notReadyInput"
+        : output.backend === "siri" && !siriOutputLoaded
           ? null
-          : readinessDescriptionKey(
-              inputReady,
-              outputReady,
-              output.backend,
-              input.backend,
-            );
+          : input.backend === null
+            ? null
+            : readinessDescriptionKey(
+                inputReady,
+                outputReady,
+                output.backend,
+                input.backend,
+              );
 
   return (
     <SettingsPage

--- a/src/features/voice-conversation/ui/VoiceSettings.tsx
+++ b/src/features/voice-conversation/ui/VoiceSettings.tsx
@@ -339,7 +339,7 @@ export function VoiceSettings() {
                     <SelectItem value="pocket">
                       {t("voice.backendPocket")}
                     </SelectItem>
-                    {openAiStatus?.ttsAvailable ? (
+                    {getPlatform() === "mac" ? (
                       <SelectItem value="openai">
                         {t("voice.backendOpenAiTts")}
                       </SelectItem>


### PR DESCRIPTION
## Summary

- Read the shared OpenAI voice credential only when the selected Voice settings need it, while keeping OpenAI TTS selectable before that read.
- Coalesce concurrent mount-time status requests and force fresh status reads after credential changes.
- Use only Berd’s shared `berd-openai-voice` / `api-key` credential, without legacy account lookup or migration.

## Reviewer-reproducible examples

- Open Voice settings with the default on-device chained configuration. Berd does not inspect the OpenAI Keychain credential.
- Select OpenAI transcription, OpenAI playback, or OpenAI Realtime. The corresponding settings load the shared credential status.
- Save or clear the shared key. Every mounted OpenAI voice surface refreshes to the new status, while simultaneous mount reads share one in-flight request.