### PR TITLE
chore: bump Goose for GPT-6 Astra

### DIFF
--- a/goose-backend.lock.json
+++ b/goose-backend.lock.json
@@ -1,7 +1,7 @@
 {
   "repo": "https://github.com/aaif-goose/goose.git",
   "ref": "main",
-  "commit": "b9b671c6c3f6a019530698773af2354afece3756",
+  "commit": "5e90925962f05acf8e255032de44d16c4a7768a2",
   "package": "goose-cli",
   "bin": "goose"
 }


### PR DESCRIPTION
## Summary

Berd's pinned Goose backend predates GPT-6 Astra support. Astra model-service requests can therefore use Chat Completions, which rejects tool calls when reasoning is enabled.

This bumps Goose from `b9b671c6c` to `5e9092596`. The new pin routes Astra through the Responses API and includes its 1,050,000-token context window and 128,000-token output limit.

### Related issue

Upstream fix: https://github.com/aaif-goose/goose/pull/11869

### Testing

- Built the pinned Goose binary with `GOOSE_DEV_MODE=required ./scripts/ensure-local-goose.sh --print-bin`.
- Ran `just check` successfully.
- Pre-push `fmt-check`, `tauri-check`, `clippy`, and frontend checks passed.
- End-to-end Astra verification remains for the author in local Berd.

Generated with Goose
