### PR TITLE
harden Realtime voice lifecycle transitions

### DIFF
--- a/src-tauri/crates/berd-voice/PROTOCOL.md
+++ b/src-tauri/crates/berd-voice/PROTOCOL.md
@@ -50,8 +50,8 @@ initial policy; a host-specific `auto` mode must be resolved before the request:
 {"type":"hello","id":1,"input_during_tts":"allow_barge_in"}
 ```
 
-The response uses `protocol:4` as a fixed wire-integrity marker, not a
-negotiated mode:
+The response uses `protocol:4` as the exact session message-set version. The
+parent must reject a version it does not support:
 
 ```json
 {"type":"ready","id":1,"protocol":4,"session":{"tts":{"revision":1,"backend":"siri","voice":"Aaron","language":"en-US","rate":1.0},"input_during_tts":{"revision":1,"policy":"allow_barge_in"}}}

--- a/src-tauri/crates/berd-voice/PROTOCOL.md
+++ b/src-tauri/crates/berd-voice/PROTOCOL.md
@@ -190,6 +190,7 @@ it never admits a replacement while old host audio may still be active.
 audio acknowledgements listed above
 {"type":"query_state","id":u64,"after":u64}
 {"type":"cancel","id":u64}
+{"type":"cancel_speech","id":u64,"speech_id":u64}
 {"type":"shutdown"}
 ```
 
@@ -319,6 +320,10 @@ cancellation and shutdown terminals.
 targets the originating `prepare_speak.id`. `cancel_result` is emitted first. A
 live held target then emits `not_admitted(cancelled)`; a live admitted target
 then emits `speech_interrupted`. `spoken_through_utf8` is Berd Voice's conservative UTF-8 byte boundary through the last fully played word; hosts may use it to distinguish the estimated spoken prefix from the unspoken suffix without recreating delivery policy. Repeated or unknown cancellation is stale.
+`cancel_speech.speech_id` targets active output directly, including autonomous
+Spokesperson output that has no originating `prepare_speak`. Its correlated
+`cancel_result` names that speech ID and is emitted before Berd Voice requests
+the host's quiescent `audio_cancelled` barrier.
 Every speech event carries the originating prepare ID. `speech_started` appears
 only after the first PCM Chunk is accepted by the host, and exactly one terminal
 message follows every admission.

--- a/src-tauri/crates/berd-voice/PROTOCOL.md
+++ b/src-tauri/crates/berd-voice/PROTOCOL.md
@@ -50,11 +50,11 @@ initial policy; a host-specific `auto` mode must be resolved before the request:
 {"type":"hello","id":1,"input_during_tts":"allow_barge_in"}
 ```
 
-The response uses `protocol:3` as a fixed wire-integrity marker, not a
+The response uses `protocol:4` as a fixed wire-integrity marker, not a
 negotiated mode:
 
 ```json
-{"type":"ready","id":1,"protocol":3,"session":{"tts":{"revision":1,"backend":"siri","voice":"Aaron","language":"en-US","rate":1.0},"input_during_tts":{"revision":1,"policy":"allow_barge_in"}}}
+{"type":"ready","id":1,"protocol":4,"session":{"tts":{"revision":1,"backend":"siri","voice":"Aaron","language":"en-US","rate":1.0},"input_during_tts":{"revision":1,"policy":"allow_barge_in"}}}
 ```
 
 The `session.tts` object is the authoritative, sanitized TTS configuration.
@@ -316,13 +316,15 @@ cancellation and shutdown terminals.
 {"type":"fatal","message":string}
 ```
 
-`query_state.after` is an exclusive token cutoff; `0` requests all. `cancel.id`
-targets the originating `prepare_speak.id`. `cancel_result` is emitted first. A
+`query_state.after` is an exclusive token cutoff; `0` requests all. Message `id`
+always correlates a result with its parent request; `cancel` uses the originating
+`prepare_speak.id` as that request ID. `cancel_result` is emitted first. A
 live held target then emits `not_admitted(cancelled)`; a live admitted target
 then emits `speech_interrupted`. `spoken_through_utf8` is Berd Voice's conservative UTF-8 byte boundary through the last fully played word; hosts may use it to distinguish the estimated spoken prefix from the unspoken suffix without recreating delivery policy. Repeated or unknown cancellation is stale.
 `cancel_speech.speech_id` targets active output directly, including autonomous
 Spokesperson output that has no originating `prepare_speak`. Its correlated
-`cancel_result` names that speech ID and is emitted before Berd Voice requests
+`cancel_result.id` echoes the `cancel_speech.id`, while `cancel_result.speech_id`
+names the targeted speech. The result is emitted before Berd Voice requests
 the host's quiescent `audio_cancelled` barrier.
 Every speech event carries the originating prepare ID. `speech_started` appears
 only after the first PCM Chunk is accepted by the host, and exactly one terminal

--- a/src-tauri/crates/berd-voice/src/main.rs
+++ b/src-tauri/crates/berd-voice/src/main.rs
@@ -1869,6 +1869,9 @@ fn run_session(config: SessionConfig, pcm_output_fd: RawFd) -> Result<(), String
             Input::Request(SessionRequest::Cancel { id }) => {
                 handle_cancel(id, &mut held, &mut core, &mut active, &mut writer)?;
             }
+            Input::Request(SessionRequest::CancelSpeech { id, speech_id }) => {
+                handle_cancel_speech(id, speech_id, &mut core, &mut active, &mut writer)?;
+            }
         }
     }
 }
@@ -3795,6 +3798,27 @@ fn run_expert_spokesperson_session(
                             spoken_through_utf8: 0,
                         },
                     )?;
+                }
+            }
+            Input::Request(SessionRequest::CancelSpeech { id, speech_id }) => {
+                let outcome = if active
+                    .as_ref()
+                    .is_some_and(|playback| playback.speech_id == speech_id)
+                {
+                    CancelOutcome::Cancelled
+                } else {
+                    CancelOutcome::Stale
+                };
+                write_message(
+                    &mut writer,
+                    &SessionMessage::CancelResult {
+                        id,
+                        outcome,
+                        speech_id: Some(speech_id),
+                    },
+                )?;
+                if outcome == CancelOutcome::Cancelled {
+                    cancel_live_playback(&mut active);
                 }
             }
             Input::Request(SessionRequest::SetInputMuted { id, active: muted }) => {
@@ -6225,6 +6249,35 @@ fn handle_cancel(
     Ok(())
 }
 
+fn handle_cancel_speech(
+    id: u64,
+    speech_id: u64,
+    core: &mut SessionCore,
+    active: &mut Option<ActivePlayback>,
+    writer: &mut impl Write,
+) -> Result<(), String> {
+    let outcome = if active
+        .as_ref()
+        .is_some_and(|current| current.speech_id == speech_id)
+    {
+        CancelOutcome::Cancelled
+    } else {
+        CancelOutcome::Stale
+    };
+    write_message(
+        writer,
+        &SessionMessage::CancelResult {
+            id,
+            outcome,
+            speech_id: Some(speech_id),
+        },
+    )?;
+    if outcome == CancelOutcome::Cancelled {
+        interrupt_active(core, active, writer)?;
+    }
+    Ok(())
+}
+
 fn abort_active(active: &Option<ActivePlayback>) {
     if let Some(flag) = active.as_ref().and_then(|current| current.active.as_ref()) {
         flag.store(false, Ordering::SeqCst);
@@ -6450,7 +6503,8 @@ fn validate_request(request: SessionRequest) -> Result<SessionRequest, String> {
         | SessionRequest::QueryState { id, .. }
         | SessionRequest::DismissHandoffs { id, .. }
         | SessionRequest::CompleteExpertTurn { id, .. }
-        | SessionRequest::Cancel { id } => Some(*id),
+        | SessionRequest::Cancel { id }
+        | SessionRequest::CancelSpeech { id, .. } => Some(*id),
         SessionRequest::SetPaused { .. }
         | SessionRequest::AudioBeginAccepted { .. }
         | SessionRequest::AudioBeginFailed { .. }
@@ -6501,6 +6555,9 @@ fn validate_request(request: SessionRequest) -> Result<SessionRequest, String> {
             }
         }
         SessionRequest::OutputReady { speech_id: 0, .. } => {
+            return Err("speech id must be positive".into())
+        }
+        SessionRequest::CancelSpeech { speech_id: 0, .. } => {
             return Err("speech id must be positive".into())
         }
         SessionRequest::SetTtsSettings {
@@ -9788,6 +9845,44 @@ mod tests {
                 json!({"type":"cancel_result","id":7,"outcome":"cancelled","speech_id":1}),
                 json!({"type":"speech_interrupted","id":7,"speech_id":1,"spoken_through_utf8":0}),
                 json!({"type":"cancel_result","id":7,"outcome":"stale","speech_id":null}),
+            ]
+        );
+    }
+
+    #[test]
+    fn speech_targeted_cancel_orders_result_before_terminal() {
+        let mut core = SessionCore::default();
+        let PrepareOutcome::Admitted {
+            speech_id, text, ..
+        } = core.prepare(PrepareRequest {
+            id: 7,
+            acknowledgement: None,
+            text: "reply".into(),
+        })
+        else {
+            panic!("test speech must be admitted")
+        };
+        let mut active = Some(ActivePlayback {
+            prepare_id: 7,
+            speech_id,
+            text,
+            output: None,
+            active: None,
+            ready_deadline: Instant::now() + Duration::from_secs(2),
+            assistant_activity: None,
+            input_during_tts: test_input_policy(),
+            tts: test_tts_lease(),
+            suspension_requested: false,
+        });
+        let mut output = Vec::new();
+
+        handle_cancel_speech(9, speech_id, &mut core, &mut active, &mut output).unwrap();
+
+        assert_eq!(
+            messages(&output),
+            [
+                json!({"type":"cancel_result","id":9,"outcome":"cancelled","speech_id":1}),
+                json!({"type":"speech_interrupted","id":7,"speech_id":1,"spoken_through_utf8":0}),
             ]
         );
     }

--- a/src-tauri/crates/berd-voice/src/main.rs
+++ b/src-tauri/crates/berd-voice/src/main.rs
@@ -65,7 +65,8 @@ use session_audio::{
     AUDIO_CANCELLED,
 };
 
-const WIRE_MARKER: u32 = 4;
+const SESSION_PROTOCOL_VERSION: u32 = 4;
+const INPUT_FRAME_MARKER: u8 = 3;
 const MAX_LINE_BYTES: usize = 1024 * 1024;
 const FRAME_MAGIC: [u8; 2] = *b"BV";
 const JSON_FRAME_KIND: u8 = 1;
@@ -1484,7 +1485,7 @@ fn run_session(config: SessionConfig, pcm_output_fd: RawFd) -> Result<(), String
                     &mut writer,
                     &SessionMessage::Ready {
                         id,
-                        protocol: WIRE_MARKER,
+                        protocol: SESSION_PROTOCOL_VERSION,
                         session,
                     },
                 )?;
@@ -3447,7 +3448,7 @@ fn run_expert_spokesperson_session(
                     &mut writer,
                     &SessionMessage::Ready {
                         id,
-                        protocol: WIRE_MARKER,
+                        protocol: SESSION_PROTOCOL_VERSION,
                         session: snapshot,
                     },
                 )?;
@@ -6449,7 +6450,7 @@ fn decode_framed_input(reader: &mut impl Read, header: [u8; FRAME_HEADER_BYTES])
     if header[..2] != FRAME_MAGIC {
         return Input::Invalid("invalid session frame magic".into());
     }
-    if header[2] != WIRE_MARKER as u8 {
+    if header[2] != INPUT_FRAME_MARKER {
         return Input::Invalid(format!("invalid session frame marker: {}", header[2]));
     }
     let kind = header[3];
@@ -8119,7 +8120,7 @@ mod tests {
         };
         let ready = serde_json::to_string(&SessionMessage::Ready {
             id: 1,
-            protocol: WIRE_MARKER,
+            protocol: SESSION_PROTOCOL_VERSION,
             session: VoiceSessionSnapshot {
                 tts: snapshot.clone(),
                 input_during_tts: test_input_policy(),
@@ -9420,7 +9421,7 @@ mod tests {
     }
 
     fn framed(kind: u8, payload: &[u8]) -> Vec<u8> {
-        let mut frame = Vec::from([b'B', b'V', WIRE_MARKER as u8, kind]);
+        let mut frame = Vec::from([b'B', b'V', INPUT_FRAME_MARKER, kind]);
         frame.extend_from_slice(&(payload.len() as u32).to_le_bytes());
         frame.extend_from_slice(payload);
         frame
@@ -9477,7 +9478,7 @@ mod tests {
             (JSON_FRAME_KIND, MAX_LINE_BYTES + 1, "request exceeds 1 MiB"),
             (PCM_FRAME_KIND, PCM_FRAME_BYTES - 1, "PCM frame has"),
         ] {
-            let mut header = Vec::from([b'B', b'V', WIRE_MARKER as u8, kind]);
+            let mut header = Vec::from([b'B', b'V', INPUT_FRAME_MARKER, kind]);
             header.extend_from_slice(&(length as u32).to_le_bytes());
             let (control_sender, control_receiver) = mpsc::channel();
             let (pcm_sender, _pcm_receiver) = mpsc::sync_channel(1);

--- a/src-tauri/crates/berd-voice/src/main.rs
+++ b/src-tauri/crates/berd-voice/src/main.rs
@@ -65,7 +65,7 @@ use session_audio::{
     AUDIO_CANCELLED,
 };
 
-const WIRE_MARKER: u32 = 3;
+const WIRE_MARKER: u32 = 4;
 const MAX_LINE_BYTES: usize = 1024 * 1024;
 const FRAME_MAGIC: [u8; 2] = *b"BV";
 const JSON_FRAME_KIND: u8 = 1;
@@ -1940,8 +1940,7 @@ fn activate_spokesperson_voice_update(
         .replace(activated.runtime)
         .expect("initialized runtime");
     *runtime_events = Some(activated.events);
-    // Shutdown waits for provider events; keep draining microphone input meanwhile.
-    drop(old_runtime);
+    old_runtime.retire_in_background();
     for frame in activated.held_input {
         runtime
             .as_ref()

--- a/src-tauri/crates/berd-voice/src/main.rs
+++ b/src-tauri/crates/berd-voice/src/main.rs
@@ -1937,7 +1937,8 @@ fn activate_spokesperson_voice_update(
         .replace(activated.runtime)
         .expect("initialized runtime");
     *runtime_events = Some(activated.events);
-    old_runtime.finish()?;
+    // Shutdown waits for provider events; keep draining microphone input meanwhile.
+    drop(old_runtime);
     for frame in activated.held_input {
         runtime
             .as_ref()

--- a/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
+++ b/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
@@ -1135,6 +1135,35 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    #[test]
+    fn retiring_runtime_does_not_wait_for_worker_shutdown() {
+        let (commands, mut requests) = tokio::sync::mpsc::unbounded_channel();
+        let (audio, _audio_rx) = tokio::sync::mpsc::channel(1);
+        let (release, wait) = std::sync::mpsc::channel();
+        let (retired, retirement) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            assert!(matches!(
+                requests.blocking_recv(),
+                Some(super::SpokespersonCommand::Shutdown)
+            ));
+            wait.recv().unwrap();
+        });
+        let runtime = super::OpenAiSpokespersonRuntime {
+            commands,
+            audio,
+            worker: Some(worker),
+        };
+        let caller = std::thread::spawn(move || {
+            drop(runtime);
+            retired.send(()).unwrap();
+        });
+        let result = retirement.recv_timeout(Duration::from_secs(2));
+        // Always release the worker, including when the nonblocking assertion fails.
+        release.send(()).unwrap();
+        caller.join().unwrap();
+        result.expect("runtime retirement blocked on provider shutdown");
+    }
+
     use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
     use futures_util::{SinkExt, StreamExt};
     use serde_json::{json, Value};

--- a/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
+++ b/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
@@ -392,8 +392,8 @@ impl OpenAiSpokespersonRuntime {
     }
 
     fn begin_background_retirement(&mut self) {
-        let _ = self.commands.send(SpokespersonCommand::Shutdown);
         if let Some(worker) = self.worker.take() {
+            let _ = self.commands.send(SpokespersonCommand::Shutdown);
             reap_spokesperson_worker(worker, self.audio.clone());
         }
     }
@@ -1149,12 +1149,14 @@ mod tests {
         let (audio, _audio_rx) = tokio::sync::mpsc::channel(1);
         let (release, wait) = std::sync::mpsc::channel();
         let (retired, retirement) = std::sync::mpsc::channel();
+        let (observed, observation) = std::sync::mpsc::channel();
         let worker = std::thread::spawn(move || {
             assert!(matches!(
                 requests.blocking_recv(),
                 Some(super::SpokespersonCommand::Shutdown)
             ));
             wait.recv().unwrap();
+            observed.send(requests.try_recv()).unwrap();
         });
         let runtime = super::OpenAiSpokespersonRuntime {
             commands,
@@ -1170,6 +1172,11 @@ mod tests {
         release.send(()).unwrap();
         caller.join().unwrap();
         result.expect("runtime retirement blocked on provider shutdown");
+        assert!(matches!(
+            observation.recv_timeout(Duration::from_secs(2)).unwrap(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty
+                | tokio::sync::mpsc::error::TryRecvError::Disconnected)
+        ));
     }
 
     use base64::{engine::general_purpose::STANDARD as BASE64, Engine};

--- a/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
+++ b/src-tauri/crates/berd-voice/src/openai_spokesperson.rs
@@ -386,14 +386,22 @@ impl OpenAiSpokespersonRuntime {
             .join()
             .map_err(|_| "Spokesperson runtime panicked".to_string())
     }
-}
 
-impl Drop for OpenAiSpokespersonRuntime {
-    fn drop(&mut self) {
+    pub fn retire_in_background(mut self) {
+        self.begin_background_retirement();
+    }
+
+    fn begin_background_retirement(&mut self) {
         let _ = self.commands.send(SpokespersonCommand::Shutdown);
         if let Some(worker) = self.worker.take() {
             reap_spokesperson_worker(worker, self.audio.clone());
         }
+    }
+}
+
+impl Drop for OpenAiSpokespersonRuntime {
+    fn drop(&mut self) {
+        self.begin_background_retirement();
     }
 }
 
@@ -1136,7 +1144,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn retiring_runtime_does_not_wait_for_worker_shutdown() {
+    fn background_retirement_does_not_wait_for_worker_shutdown() {
         let (commands, mut requests) = tokio::sync::mpsc::unbounded_channel();
         let (audio, _audio_rx) = tokio::sync::mpsc::channel(1);
         let (release, wait) = std::sync::mpsc::channel();
@@ -1154,7 +1162,7 @@ mod tests {
             worker: Some(worker),
         };
         let caller = std::thread::spawn(move || {
-            drop(runtime);
+            runtime.retire_in_background();
             retired.send(()).unwrap();
         });
         let result = retirement.recv_timeout(Duration::from_secs(2));

--- a/src-tauri/crates/berd-voice/src/protocol.rs
+++ b/src-tauri/crates/berd-voice/src/protocol.rs
@@ -101,6 +101,10 @@ pub enum SessionRequest {
     Cancel {
         id: u64,
     },
+    CancelSpeech {
+        id: u64,
+        speech_id: u64,
+    },
     Shutdown,
 }
 
@@ -365,6 +369,16 @@ mod tests {
                 id: 8,
                 expected_revision: 1,
                 policy: InputDuringTtsPolicy::SuppressInput,
+            }
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionRequest>(
+                r#"{"type":"cancel_speech","id":9,"speech_id":12}"#
+            )
+            .unwrap(),
+            SessionRequest::CancelSpeech {
+                id: 9,
+                speech_id: 12,
             }
         );
         assert_eq!(

--- a/src-tauri/crates/berd-voice/src/protocol.rs
+++ b/src-tauri/crates/berd-voice/src/protocol.rs
@@ -341,7 +341,7 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&SessionMessage::Ready {
                 id: 4,
-                protocol: 3,
+                protocol: 4,
                 session: VoiceSessionSnapshot {
                     tts: TtsConfigurationSnapshot {
                         revision: 1,
@@ -358,7 +358,7 @@ mod tests {
                 },
             })
             .unwrap(),
-            r#"{"type":"ready","id":4,"protocol":3,"session":{"tts":{"revision":1,"backend":"openai","model":"gpt-4o-mini-tts","voice":"marin","rate":1.0},"input_during_tts":{"revision":1,"policy":"allow_barge_in"}}}"#
+            r#"{"type":"ready","id":4,"protocol":4,"session":{"tts":{"revision":1,"backend":"openai","model":"gpt-4o-mini-tts","voice":"marin","rate":1.0},"input_during_tts":{"revision":1,"policy":"allow_barge_in"}}}"#
         );
         assert_eq!(
             serde_json::from_str::<SessionRequest>(

--- a/src-tauri/crates/berd-voice/src/realtime_host.rs
+++ b/src-tauri/crates/berd-voice/src/realtime_host.rs
@@ -866,7 +866,8 @@ fn activate_managed_update(
     let report_settings = matches!(activated.purpose, VoiceUpdatePurpose::Settings);
     let old_runtime = std::mem::replace(runtime, activated.runtime);
     *events = activated.events;
-    old_runtime.finish()?;
+    // Shutdown waits for provider events; keep draining microphone input meanwhile.
+    drop(old_runtime);
     for frame in activated.held_input {
         runtime
             .send(SpokespersonCommand::InputPcm48Khz(

--- a/src-tauri/crates/berd-voice/src/realtime_host.rs
+++ b/src-tauri/crates/berd-voice/src/realtime_host.rs
@@ -866,8 +866,7 @@ fn activate_managed_update(
     let report_settings = matches!(activated.purpose, VoiceUpdatePurpose::Settings);
     let old_runtime = std::mem::replace(runtime, activated.runtime);
     *events = activated.events;
-    // Shutdown waits for provider events; keep draining microphone input meanwhile.
-    drop(old_runtime);
+    old_runtime.retire_in_background();
     for frame in activated.held_input {
         runtime
             .send(SpokespersonCommand::InputPcm48Khz(

--- a/src-tauri/crates/berd-voice/src/session_audio.rs
+++ b/src-tauri/crates/berd-voice/src/session_audio.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use berd_voice::{PcmAudioOutput, TtsPcmSpec};
 
 pub const AUDIO_FRAME_MAGIC: [u8; 2] = *b"BA";
-pub const AUDIO_FRAME_MARKER: u8 = 4;
+pub const AUDIO_FRAME_MARKER: u8 = 3;
 pub const AUDIO_BEGIN_KIND: u8 = 1;
 pub const AUDIO_CHUNK_KIND: u8 = 2;
 pub const AUDIO_END_KIND: u8 = 3;

--- a/src-tauri/crates/berd-voice/src/session_audio.rs
+++ b/src-tauri/crates/berd-voice/src/session_audio.rs
@@ -570,10 +570,37 @@ impl RemotePcmAudioOutput {
             {
                 return Ok(false)
             }
-            _ => {
-                return Err(
-                    "audio host acknowledgement is stale, out of order, or impossible".into(),
-                )
+            invalid => {
+                let received = match invalid {
+                    AudioHostAck::BeginAccepted => "BeginAccepted".into(),
+                    AudioHostAck::BeginFailed { played_frames, .. } => {
+                        format!("BeginFailed({played_frames})")
+                    }
+                    AudioHostAck::ChunkAccepted { sequence } => {
+                        format!("ChunkAccepted({sequence})")
+                    }
+                    AudioHostAck::Played { played_frames } => format!("Played({played_frames})"),
+                    AudioHostAck::Suspended { played_frames } => {
+                        format!("Suspended({played_frames})")
+                    }
+                    AudioHostAck::Resumed { played_frames } => format!("Resumed({played_frames})"),
+                    AudioHostAck::Drained {
+                        sequence,
+                        played_frames,
+                    } => format!("Drained({sequence}, {played_frames})"),
+                    AudioHostAck::Failed { played_frames, .. } => {
+                        format!("Failed({played_frames})")
+                    }
+                    AudioHostAck::Cancelled { played_frames } => {
+                        format!("Cancelled({played_frames})")
+                    }
+                };
+                return Err(format!(
+                    "audio host acknowledgement is stale, out of order, or impossible: received={received} phase={:?} suspension={:?} played={} accepted={} total={} pending={:?}",
+                    state.phase, state.suspension,
+                    state.played_frames, state.accepted_frames, state.total_frames,
+                    state.pending_sequence,
+                ));
             }
         }
         self.changed.notify_all();
@@ -1365,12 +1392,10 @@ mod tests {
                 message: "route failed".into(),
             })
             .unwrap();
-        assert_eq!(
-            output
-                .handle_ack(AudioHostAck::Suspended { played_frames: 0 })
-                .unwrap_err(),
-            "audio host acknowledgement is stale, out of order, or impossible"
-        );
+        assert!(output
+            .handle_ack(AudioHostAck::Suspended { played_frames: 0 })
+            .unwrap_err()
+            .starts_with("audio host acknowledgement is stale, out of order, or impossible"));
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/session_audio.rs
+++ b/src-tauri/crates/berd-voice/src/session_audio.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use berd_voice::{PcmAudioOutput, TtsPcmSpec};
 
 pub const AUDIO_FRAME_MAGIC: [u8; 2] = *b"BA";
-pub const AUDIO_FRAME_MARKER: u8 = 3;
+pub const AUDIO_FRAME_MARKER: u8 = 4;
 pub const AUDIO_BEGIN_KIND: u8 = 1;
 pub const AUDIO_CHUNK_KIND: u8 = 2;
 pub const AUDIO_END_KIND: u8 = 3;
@@ -571,32 +571,8 @@ impl RemotePcmAudioOutput {
                 return Ok(false)
             }
             invalid => {
-                let received = match invalid {
-                    AudioHostAck::BeginAccepted => "BeginAccepted".into(),
-                    AudioHostAck::BeginFailed { played_frames, .. } => {
-                        format!("BeginFailed({played_frames})")
-                    }
-                    AudioHostAck::ChunkAccepted { sequence } => {
-                        format!("ChunkAccepted({sequence})")
-                    }
-                    AudioHostAck::Played { played_frames } => format!("Played({played_frames})"),
-                    AudioHostAck::Suspended { played_frames } => {
-                        format!("Suspended({played_frames})")
-                    }
-                    AudioHostAck::Resumed { played_frames } => format!("Resumed({played_frames})"),
-                    AudioHostAck::Drained {
-                        sequence,
-                        played_frames,
-                    } => format!("Drained({sequence}, {played_frames})"),
-                    AudioHostAck::Failed { played_frames, .. } => {
-                        format!("Failed({played_frames})")
-                    }
-                    AudioHostAck::Cancelled { played_frames } => {
-                        format!("Cancelled({played_frames})")
-                    }
-                };
                 return Err(format!(
-                    "audio host acknowledgement is stale, out of order, or impossible: received={received} phase={:?} suspension={:?} played={} accepted={} total={} pending={:?}",
+                    "audio host acknowledgement is stale, out of order, or impossible: received={invalid:?} phase={:?} suspension={:?} played={} accepted={} total={} pending={:?}",
                     state.phase, state.suspension,
                     state.played_frames, state.accepted_frames, state.total_frames,
                     state.pending_sequence,

--- a/src-tauri/crates/berd-voice/tests/session_protocol.rs
+++ b/src-tauri/crates/berd-voice/tests/session_protocol.rs
@@ -34,13 +34,18 @@ struct ExpertSpokespersonTestSession {
     audio_host: Option<std::thread::JoinHandle<()>>,
 }
 
+struct AudioCancellationGate {
+    observed: mpsc::SyncSender<()>,
+    release: mpsc::Receiver<()>,
+}
+
 impl ExpertSpokespersonTestSession {
     fn start(endpoint: String) -> Self {
         Self::start_with_renew_after(endpoint, None)
     }
 
     fn start_with_renew_after(endpoint: String, renew_after_ms: Option<u64>) -> Self {
-        Self::start_with_options(endpoint, renew_after_ms, None, None)
+        Self::start_with_options(endpoint, renew_after_ms, None, None, None)
     }
 
     fn start_with_options(
@@ -48,6 +53,7 @@ impl ExpertSpokespersonTestSession {
         renew_after_ms: Option<u64>,
         played_frame_limit: Option<u64>,
         played_ready: Option<mpsc::SyncSender<()>>,
+        cancellation_gate: Option<AudioCancellationGate>,
     ) -> Self {
         let (mut command, _pcm, audio_host) = session_command();
         if let Some(renew_after_ms) = renew_after_ms {
@@ -78,6 +84,7 @@ impl ExpertSpokespersonTestSession {
             Arc::clone(&stdin),
             played_frame_limit,
             played_ready,
+            cancellation_gate,
         );
         let mut session = Self {
             child,
@@ -285,7 +292,7 @@ fn spawn_audio_host(
     reader: UnixStream,
     stdin: Arc<Mutex<std::process::ChildStdin>>,
 ) -> std::thread::JoinHandle<()> {
-    spawn_audio_host_with_played_limit(reader, stdin, None, None)
+    spawn_audio_host_with_played_limit(reader, stdin, None, None, None)
 }
 
 fn spawn_audio_host_with_played_limit(
@@ -293,6 +300,7 @@ fn spawn_audio_host_with_played_limit(
     stdin: Arc<Mutex<std::process::ChildStdin>>,
     played_frame_limit: Option<u64>,
     mut played_ready: Option<mpsc::SyncSender<()>>,
+    mut cancellation_gate: Option<AudioCancellationGate>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
         let mut current = None::<(u64, u64, u64)>;
@@ -361,6 +369,10 @@ fn spawn_audio_host_with_played_limit(
                         .map_or(0, |state| {
                             played_frame_limit.map_or(state.2, |limit| state.2.min(limit))
                         });
+                    if let Some(gate) = cancellation_gate.take() {
+                        let _ = gate.observed.send(());
+                        gate.release.recv().unwrap();
+                    }
                     json!({"type":"audio_cancelled","speech_id":speech_id,"played_frames":played_frames})
                 }
                 kind => panic!("unknown audio record kind {kind}"),
@@ -564,6 +576,7 @@ fn expert_spokesperson_renews_before_provider_expiry_without_changing_settings()
         Some(1_000),
         Some(12_000),
         Some(audio_ready_tx),
+        None,
     );
     audio_ready_rx.recv_timeout(Duration::from_secs(2)).unwrap();
     release_speech_tx.send(()).unwrap();
@@ -812,6 +825,176 @@ fn active_spokesperson_disconnect_is_specific_terminal_and_does_not_replay() {
 }
 
 #[test]
+fn autonomous_spokesperson_cancel_is_correlated_before_audio_cancellation_and_then_stale() {
+    let (endpoint_tx, endpoint_rx) = mpsc::sync_channel(1);
+    let (cancel_observed_tx, cancel_observed_rx) = mpsc::sync_channel(1);
+    let (release_cancel_tx, release_cancel_rx) = mpsc::sync_channel(1);
+    let (played_tx, played_rx) = mpsc::sync_channel(1);
+    let (finish_provider_tx, finish_provider_rx) = mpsc::sync_channel(1);
+    let (provider_terminal_tx, provider_terminal_rx) = mpsc::sync_channel(1);
+    let server = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async move {
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                endpoint_tx
+                    .send(format!("ws://{}/", listener.local_addr().unwrap()))
+                    .unwrap();
+                let (stream, _) = listener.accept().await.unwrap();
+                let mut socket = accept_async(stream).await.unwrap();
+                let update = receive_realtime_json(&mut socket).await;
+                acknowledge_realtime_session(&mut socket, &update).await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({"type":"input_audio_buffer.speech_started","item_id":"user-autonomous"}),
+                )
+                .await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({"type":"input_audio_buffer.speech_stopped","item_id":"user-autonomous"}),
+                )
+                .await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({
+                        "type":"conversation.item.input_audio_transcription.completed",
+                        "item_id":"user-autonomous",
+                        "transcript":"Say something on your own."
+                    }),
+                )
+                .await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({"type":"response.created","response":{"id":"response-autonomous"}}),
+                )
+                .await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({
+                        "type":"response.output_audio.delta",
+                        "response_id":"response-autonomous",
+                        "item_id":"assistant-autonomous",
+                        "output_index":0,
+                        "content_index":0,
+                        "delta":BASE64.encode(vec![0_u8; 24_000])
+                    }),
+                )
+                .await;
+                send_realtime_json(
+                    &mut socket,
+                    json!({
+                        "type":"response.output_audio_transcript.done",
+                        "response_id":"response-autonomous",
+                        "item_id":"assistant-autonomous",
+                        "output_index":0,
+                        "content_index":0,
+                        "transcript":"This autonomous response is interrupted."
+                    }),
+                )
+                .await;
+                tokio::task::spawn_blocking(move || finish_provider_rx.recv().unwrap())
+                    .await
+                    .unwrap();
+                send_realtime_json(
+                    &mut socket,
+                    json!({
+                        "type":"response.done",
+                        "response":{"id":"response-autonomous","status":"cancelled"}
+                    }),
+                )
+                .await;
+                provider_terminal_tx.send(()).unwrap();
+                let _ = socket.next().await;
+            });
+    });
+    let endpoint = endpoint_rx.recv().unwrap();
+    let mut session = ExpertSpokespersonTestSession::start_with_options(
+        endpoint,
+        None,
+        Some(1_000),
+        Some(played_tx),
+        Some(AudioCancellationGate {
+            observed: cancel_observed_tx,
+            release: release_cancel_rx,
+        }),
+    );
+    let started = loop {
+        let message = session.recv(Duration::from_secs(2));
+        if message["type"] == "spokesperson_speech" {
+            break message;
+        }
+        assert_ne!(message["type"], "fatal");
+    };
+    let speech_id = started["speech_id"].as_u64().unwrap();
+    played_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("autonomous playback should be live before cancellation");
+
+    session.send(json!({"type":"cancel_speech","id":2,"speech_id":speech_id}));
+    let cancelled = session.recv(Duration::from_secs(2));
+    assert_eq!(cancelled["type"], "cancel_result");
+    assert_eq!(cancelled["id"], 2);
+    assert_eq!(cancelled["speech_id"], speech_id);
+    assert_eq!(cancelled["outcome"], "cancelled");
+    finish_provider_tx.send(()).unwrap();
+    cancel_observed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("audio cancellation should begin after the correlated result");
+    release_cancel_tx.send(()).unwrap();
+    provider_terminal_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("provider should end the cancelled response");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let mut after_cancel = Vec::new();
+    let interrupted = loop {
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .unwrap_or_else(|| panic!("interrupted transcript was not emitted: {after_cancel:?}"));
+        let message = session
+            .output
+            .recv_timeout(remaining)
+            .unwrap_or_else(|error| {
+                panic!("interrupted transcript was not emitted ({error}): {after_cancel:?}")
+            });
+        if message["type"] == "live_event" && message["origin"] == "spokesperson" {
+            break message;
+        }
+        assert_ne!(message["type"], "fatal", "unexpected fatal: {message}");
+        after_cancel.push(message);
+    };
+    assert_eq!(interrupted["type"], "live_event");
+    assert_eq!(interrupted["origin"], "spokesperson");
+    assert!(interrupted["text"]
+        .as_str()
+        .unwrap()
+        .contains("Spokesperson said (interrupted; best effort)"));
+
+    for (id, stale_speech_id) in [(3, speech_id), (4, speech_id + 1)] {
+        session.send(json!({
+            "type":"cancel_speech",
+            "id":id,
+            "speech_id":stale_speech_id
+        }));
+        let stale = loop {
+            let message = session.recv(Duration::from_secs(2));
+            if message["type"] == "cancel_result" {
+                break message;
+            }
+            assert_ne!(message["type"], "fatal", "unexpected fatal: {message}");
+        };
+        assert_eq!(stale["type"], "cancel_result");
+        assert_eq!(stale["id"], id);
+        assert_eq!(stale["speech_id"], stale_speech_id);
+        assert_eq!(stale["outcome"], "stale");
+    }
+    session.shutdown();
+    server.join().unwrap();
+}
+
+#[test]
 fn one_realtime_response_with_two_audio_parts_completes_without_identity_failure() {
     let (endpoint_tx, endpoint_rx) = mpsc::sync_channel(1);
     let (played_tx, played_rx) = mpsc::sync_channel(1);
@@ -905,6 +1088,7 @@ fn one_realtime_response_with_two_audio_parts_completes_without_identity_failure
         None,
         Some(16_384),
         Some(played_tx),
+        None,
     );
     session.send(json!({
         "type":"prepare_speak",

--- a/src-tauri/crates/berd-voice/tests/session_protocol.rs
+++ b/src-tauri/crates/berd-voice/tests/session_protocol.rs
@@ -13,6 +13,8 @@ use serde_json::{json, Value};
 use tokio::net::TcpListener;
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 
+const FRAME_MARKER: u8 = 3;
+
 struct ChildGuard(Option<Child>);
 
 impl Drop for ChildGuard {
@@ -152,7 +154,7 @@ impl ExpertSpokespersonTestSession {
 fn write_session_json(writer: &mut impl Write, value: &Value) {
     let payload = serde_json::to_vec(value).unwrap();
     writer.write_all(b"BV").unwrap();
-    writer.write_all(&[4, 1]).unwrap();
+    writer.write_all(&[FRAME_MARKER, 1]).unwrap();
     writer
         .write_all(&(payload.len() as u32).to_le_bytes())
         .unwrap();
@@ -161,7 +163,7 @@ fn write_session_json(writer: &mut impl Write, value: &Value) {
 
 fn write_session_pcm(writer: &mut impl Write, value: f32) {
     writer.write_all(b"BV").unwrap();
-    writer.write_all(&[4, 2]).unwrap();
+    writer.write_all(&[FRAME_MARKER, 2]).unwrap();
     writer.write_all(&(960_u32 * 4).to_le_bytes()).unwrap();
     for _ in 0..960 {
         writer.write_all(&value.to_le_bytes()).unwrap();
@@ -302,7 +304,7 @@ fn spawn_audio_host_with_played_limit(
                 Err(error) => panic!("audio pipe read failed: {error}"),
             }
             assert_eq!(&header[..2], b"BA");
-            assert_eq!(header[2], 4);
+            assert_eq!(header[2], FRAME_MARKER);
             let length = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
             let mut payload = vec![0_u8; length];
             reader.read_exact(&mut payload).unwrap();

--- a/src-tauri/crates/berd-voice/tests/session_protocol.rs
+++ b/src-tauri/crates/berd-voice/tests/session_protocol.rs
@@ -152,7 +152,7 @@ impl ExpertSpokespersonTestSession {
 fn write_session_json(writer: &mut impl Write, value: &Value) {
     let payload = serde_json::to_vec(value).unwrap();
     writer.write_all(b"BV").unwrap();
-    writer.write_all(&[3, 1]).unwrap();
+    writer.write_all(&[4, 1]).unwrap();
     writer
         .write_all(&(payload.len() as u32).to_le_bytes())
         .unwrap();
@@ -161,7 +161,7 @@ fn write_session_json(writer: &mut impl Write, value: &Value) {
 
 fn write_session_pcm(writer: &mut impl Write, value: f32) {
     writer.write_all(b"BV").unwrap();
-    writer.write_all(&[3, 2]).unwrap();
+    writer.write_all(&[4, 2]).unwrap();
     writer.write_all(&(960_u32 * 4).to_le_bytes()).unwrap();
     for _ in 0..960 {
         writer.write_all(&value.to_le_bytes()).unwrap();
@@ -302,7 +302,7 @@ fn spawn_audio_host_with_played_limit(
                 Err(error) => panic!("audio pipe read failed: {error}"),
             }
             assert_eq!(&header[..2], b"BA");
-            assert_eq!(header[2], 3);
+            assert_eq!(header[2], 4);
             let length = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
             let mut payload = vec![0_u8; length];
             reader.read_exact(&mut payload).unwrap();
@@ -2324,7 +2324,7 @@ fn siri_session_reaches_ready_without_openai_credentials() {
     stdin.flush().unwrap();
     let ready = receive();
     assert_eq!(ready["type"], "ready");
-    assert_eq!(ready["protocol"], 3);
+    assert_eq!(ready["protocol"], 4);
     assert_eq!(ready["session"]["tts"]["backend"], "siri");
     assert_eq!(ready["session"]["tts"]["voice"], voice);
     assert_eq!(ready["session"]["tts"]["language"], language);

--- a/src-tauri/src/commands/voice_buddy.rs
+++ b/src-tauri/src/commands/voice_buddy.rs
@@ -780,26 +780,28 @@ pub async fn stop_voice_conversation_from_buddy(
 }
 
 #[tauri::command]
-pub fn start_openai_realtime_voice_controls(
+pub async fn start_openai_realtime_voice_controls(
     app: AppHandle,
     window: WebviewWindow,
     state: tauri::State<'_, RealtimeVoiceControlsState>,
     native_state: tauri::State<'_, NativeVoiceState>,
+    capture: tauri::State<'_, VoiceCaptureState>,
     session_id: String,
 ) -> Result<RealtimeVoiceControlsStatus, String> {
     if window.label() == WINDOW_LABEL {
         return Err("Floating controls cannot own a Realtime voice conversation.".to_string());
     }
-    if native_state.active_session_target().is_some() {
-        return Err("A chained voice conversation is already active.".to_string());
-    }
     let owner_window_label = window.label().to_string();
-    let revision = state.begin(session_id.clone(), owner_window_label.clone())?;
-    if let Err(error) = install_realtime(&app, &owner_window_label, revision) {
-        let _ = state.finish(&session_id, revision);
-        return Err(error);
-    }
-    Ok(state.status())
+    native_state
+        .stop_active_then(&app, capture.inner(), || {
+            let revision = state.begin(session_id.clone(), owner_window_label.clone())?;
+            if let Err(error) = install_realtime(&app, &owner_window_label, revision) {
+                let _ = state.finish(&session_id, revision);
+                return Err(error);
+            }
+            Ok(state.status())
+        })
+        .await
 }
 
 #[tauri::command]


### PR DESCRIPTION
**Category:** fix
**User Impact:** Live voice conversations avoid blocking during runtime replacement, switch from chained mode into Expert and Spokesperson mode cleanly, and cancel autonomous speech through one authoritative Berd Voice lifecycle.

**Problem:** Replacing an active Realtime runtime could block the control path; starting Expert and Spokesperson controls raced an active chained conversation; and VCCLI had no speech-targeted protocol operation for coordinating autonomous playback cancellation with Berd Voice.
**Solution:** Retire replaced runtimes asynchronously, serialize chained shutdown before installing Realtime controls, and add the protocol-v4 `cancel_speech` request whose result is ordered before the terminal audio event. Invalid playback acknowledgements also include state-rich diagnostics.

<details>
<summary>File changes</summary>

**src-tauri/crates/berd-voice/**
Adds non-blocking runtime retirement, authoritative speech-targeted cancellation, protocol-v4 documentation and fixtures, and focused lifecycle tests.

**src-tauri/src/commands/voice_buddy.rs**
Serializes chained-session shutdown before Expert and Spokesperson controls start.

</details>

### Validation

- 262 Berd Voice unit tests
- 23 session-protocol integration tests
- Focused runtime-retirement and speech-cancellation ordering tests
- Expert and Spokesperson live voice/rate-change integration test
- `cargo clippy -p berd-voice -- -D warnings`
- Full pre-push frontend formatting/checks, Tauri checks, and Clippy
