### PR TITLE
Handle unavailable remote sessions gracefully

### DIFF
--- a/playwright.table-overflow.config.ts
+++ b/playwright.table-overflow.config.ts
@@ -7,7 +7,10 @@ import { defineConfig, devices } from "@playwright/test";
  */
 export default defineConfig({
   testDir: "./tests/e2e",
-  testMatch: ["**/table-overflow.spec.ts"],
+  testMatch: [
+    "**/table-overflow.spec.ts",
+    "**/remote-session-unavailable.spec.ts",
+  ],
   timeout: 30_000,
   retries: 0,
   workers: 1,

--- a/src/features/chat/hooks/useSessionAddressedComposerAdmission.test.tsx
+++ b/src/features/chat/hooks/useSessionAddressedComposerAdmission.test.tsx
@@ -34,6 +34,20 @@ function derive(
 }
 
 describe("session-addressed composer admission", () => {
+  it("blocks a missing remote session even when its transcript remains cached", () => {
+    const { result } = renderHook(() =>
+      useSessionAddressedComposerAdmission({
+        sessionId: session.id,
+        sessionSnapshot: {
+          ...session,
+          remoteHost: "remote-server",
+          remoteSessionUnavailable: true,
+        },
+      }),
+    );
+    expect(result.current.blocked).toBe(true);
+    expect(result.current.readOnlyReason).toBeTruthy();
+  });
   beforeEach(() => {
     useSecurityConfirmationStore.setState({
       pendingBySessionId: {},

--- a/src/features/chat/hooks/useSessionAddressedComposerAdmission.ts
+++ b/src/features/chat/hooks/useSessionAddressedComposerAdmission.ts
@@ -90,6 +90,9 @@ export function useSessionAddressedComposerAdmission({
   );
   const readOnlyReason =
     assertedReadOnlyReason ??
+    ((sessionSnapshot ?? storedSession)?.remoteSessionUnavailable
+      ? t("remoteSessionUnavailable.description")
+      : undefined) ??
     (openInSessionWindow ? t("sessionWindow.readOnlyStatus") : undefined);
 
   return deriveSessionAddressedComposerAdmission({

--- a/src/features/chat/lib/__tests__/sessionActivation.test.ts
+++ b/src/features/chat/lib/__tests__/sessionActivation.test.ts
@@ -1148,6 +1148,33 @@ describe("loadSessionMessages", () => {
   });
 
   describe("remote sessions", () => {
+    it.each([
+      false,
+      true,
+    ])("handles missing remote sessions with an optional memory cache (%s)", async (cached) => {
+      seedSession(
+        {
+          id: "remote-gone",
+          remoteHost: "devbox",
+          workingDir: "/remote/project",
+        },
+        { replay: false },
+      );
+      const messages = cached ? [replayUserMessage()] : [];
+      useChatStore.getState().setMessages("remote-gone", messages);
+      acpLoadSession.mockRejectedValue(new Error("Session not found: old-id"));
+      await expect(
+        loadSessionMessages("remote-gone", { force: true }),
+      ).resolves.toBe(false);
+      expect(messagesFor("remote-gone")).toEqual(messages);
+      expect(
+        useChatSessionStore.getState().getSession("remote-gone")
+          ?.remoteSessionUnavailable,
+      ).toBe(true);
+      acpLoadSession.mockClear();
+      await expect(loadSessionMessages("remote-gone")).resolves.toBe(false);
+      expect(acpLoadSession).not.toHaveBeenCalled();
+    });
     it("passes the remote workingDir through verbatim and skips local checks", async () => {
       seedSession({
         id: "s-remote",
@@ -1174,7 +1201,7 @@ describe("loadSessionMessages", () => {
       expect(ensureRemoteHostConnected).not.toHaveBeenCalled();
     });
 
-    it("surfaces a failed host connection as the standard load failure", async () => {
+    it("leaves failed host connections to the reconnect banner", async () => {
       ensureRemoteHostConnected.mockRejectedValue(
         new Error("ssh tunnel failed"),
       );
@@ -1190,9 +1217,11 @@ describe("loadSessionMessages", () => {
       await expect(loadSessionMessages("s-remote-down")).resolves.toBe(false);
 
       expect(acpLoadSession).not.toHaveBeenCalled();
-      const error = notificationFromLastMessage("s-remote-down");
-      expect(error.notificationType).toBe("error");
-      expect(error.text).toBe("ssh tunnel failed");
+      expect(messagesFor("s-remote-down")).toEqual([]);
+      expect(
+        useChatSessionStore.getState().getSession("s-remote-down")
+          ?.remoteSessionUnavailable,
+      ).toBeUndefined();
       expect(
         useChatStore.getState().loadingSessionIds.has("s-remote-down"),
       ).toBe(false);

--- a/src/features/chat/lib/queuedMessageAttemptOwnership.ts
+++ b/src/features/chat/lib/queuedMessageAttemptOwnership.ts
@@ -19,7 +19,8 @@ export function isQueuedMessageTargetAttemptable(
     // against it reaches the backend with an id it never created. Hold the
     // head instead; promotion clears `creationState` and swaps in the backend
     // id, which notifies the session store and wakes every drain.
-    session?.creationState == null
+    session?.creationState == null &&
+    !session?.remoteSessionUnavailable
   );
 }
 

--- a/src/features/chat/lib/queuedSessionSend.ts
+++ b/src/features/chat/lib/queuedSessionSend.ts
@@ -122,7 +122,10 @@ export async function acquireExistingSessionForBackgroundSend(
   const sessionBeforeHydration = useChatSessionStore
     .getState()
     .getSession(sessionId);
-  if (!sessionBeforeHydration) {
+  if (
+    !sessionBeforeHydration ||
+    sessionBeforeHydration.remoteSessionUnavailable
+  ) {
     return { status: "session-missing" } as const;
   }
   // Backend creation is still in flight (or has failed), so this id is a

--- a/src/features/chat/lib/sessionActivation.ts
+++ b/src/features/chat/lib/sessionActivation.ts
@@ -20,7 +20,10 @@ import {
 import { resolveSessionArtifactCwd } from "@/shared/artifacts/sessionArtifactLocation";
 import { perfLog } from "@/shared/lib/perfLog";
 import { isDefaultChatTitle } from "@/features/chat/lib/sessionTitle";
-import { formatAcpErrorMessage } from "@/shared/api/acpErrors";
+import {
+  formatAcpErrorMessage,
+  isAcpSessionNotFoundError,
+} from "@/shared/api/acpErrors";
 import { i18n } from "@/shared/i18n";
 import {
   createSystemNotificationMessage,
@@ -252,6 +255,13 @@ export async function loadSessionMessagesAndPrepare(
         prepareWorkingDir: workingDir,
       });
     } catch (error) {
+      if (session?.remoteHost && isAcpSessionNotFoundError(error)) {
+        useChatSessionStore
+          .getState()
+          .patchSession(sessionId, { remoteSessionUnavailable: true });
+        useChatStore.getState().setError(sessionId, null);
+        return false;
+      }
       console.warn("Failed to prepare loaded session selection:", error);
     }
   }
@@ -292,6 +302,12 @@ async function performSessionMessagesLoad(
   sessionId: string,
   options: LoadSessionMessagesOptions,
 ): Promise<boolean> {
+  if (
+    useChatSessionStore.getState().getSession(sessionId)
+      ?.remoteSessionUnavailable
+  ) {
+    return false;
+  }
   const sid = sessionId.slice(0, 8);
   const existingMsgs = useChatStore.getState().messagesBySession[sessionId];
   if (!options.force && hasConversationMessages(existingMsgs)) {
@@ -331,6 +347,7 @@ async function performSessionMessagesLoad(
   const t0 = performance.now();
   perfLog(`[perf:load] ${sid} start`);
   useChatStore.getState().setSessionLoading(sessionId, true);
+  let connectingRemoteHost = false;
   try {
     const [
       { acpGetSessionInfo, acpLoadSession },
@@ -391,9 +408,10 @@ async function performSessionMessagesLoad(
     const { workingDir, missingCwdWarning } =
       await resolveWorkingDirForSessionLoad(session, project);
     if (session && isRemoteSession(session) && session.remoteHost) {
-      // A failed connect throws into the shared catch below, which surfaces
-      // the standard session-load-failed notification for this session.
+      // The connection banner owns failed connections and reconnect actions.
+      connectingRemoteHost = true;
       await ensureRemoteHostConnected(session.remoteHost);
+      connectingRemoteHost = false;
     }
     const loadedSelection = await acpLoadSession(sessionId, workingDir);
     const loadedTarget = loadedSelection
@@ -500,6 +518,13 @@ async function performSessionMessagesLoad(
       sessionId,
       loaderNoticeMessageId(sessionId, "error"),
     );
+    if (connectingRemoteHost) return false;
+    if (sessionAtRequest?.remoteHost && isAcpSessionNotFoundError(err)) {
+      sessionStore.patchSession(sessionId, { remoteSessionUnavailable: true });
+      // Preserve cached messages; the unavailable banner replaces the raw error.
+      chatStore.setError(sessionId, null);
+      return false;
+    }
     chatStore.addMessage(sessionId, {
       ...createSystemNotificationMessage(errorMessage, "error"),
       id: loaderNoticeMessageId(sessionId, "error"),

--- a/src/features/chat/stores/chatSessionStore.ts
+++ b/src/features/chat/stores/chatSessionStore.ts
@@ -89,6 +89,8 @@ export interface ChatSession {
   creationState?: "pending" | "failed";
   creationError?: string;
   pinnedLoadState?: "loading" | "failed";
+  /** Transient UI state; not a durable history or remote identity record. */
+  remoteSessionUnavailable?: boolean;
   clientSessionId?: string;
   intent?: "build-agent" | null;
   agentBuilderOpen?: boolean;

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -112,7 +112,7 @@ interface ChatViewProps {
 }
 
 export function ChatView({
-  sessionId,
+  sessionId: requestedSessionId,
   activeSession,
   readOnlyStatus: assertedReadOnlyStatus,
   onCreatePersona,
@@ -129,7 +129,7 @@ export function ChatView({
   onAgentBuilderCompleted,
 }: ChatViewProps) {
   const { t } = useTranslation("chat");
-  const targetSessionId = activeSession?.id ?? sessionId;
+  const targetSessionId = activeSession?.id ?? requestedSessionId;
   const storedSession = useChatSessionStore(
     (state) =>
       state.sessions?.find((session) => session.id === targetSessionId) ?? null,
@@ -137,7 +137,10 @@ export function ChatView({
   // Resolve the entire snapshot, not individual flags from different revisions.
   // The controller and queue also read the current store record for this id.
   const selectedSession = storedSession ?? activeSession ?? null;
-  const selectedSessionId = selectedSession?.id ?? sessionId;
+  // All session-addressed children, including security, voice and terminal,
+  // must follow the selected replacement rather than the stale requested id.
+  const sessionId = selectedSession?.id ?? requestedSessionId;
+  const selectedSessionId = sessionId;
   const remoteSessionUnavailable = Boolean(
     selectedSession?.remoteSessionUnavailable,
   );

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { ChatSearchBar } from "./ChatSearchBar";
 import { ChatTranscriptSurface } from "./ChatTranscriptSurface";
 import { RemoteHostConnectionBanner } from "./RemoteHostConnectionBanner";
+import { RemoteSessionUnavailableNotice } from "./RemoteSessionUnavailableNotice";
 import { LoadingBerd } from "./LoadingBerd";
 import { ChatRightRail } from "./ChatRightRail";
 import {
@@ -113,7 +114,7 @@ interface ChatViewProps {
 export function ChatView({
   sessionId,
   activeSession,
-  readOnlyStatus,
+  readOnlyStatus: assertedReadOnlyStatus,
   onCreatePersona,
   onCreateProject,
   onOpenProjectSettings,
@@ -128,6 +129,18 @@ export function ChatView({
   onAgentBuilderCompleted,
 }: ChatViewProps) {
   const { t } = useTranslation("chat");
+  const remoteSessionUnavailable = useChatSessionStore(
+    (state) =>
+      state.sessions?.find((session) => session.id === sessionId)
+        ?.remoteSessionUnavailable ??
+      activeSession?.remoteSessionUnavailable ??
+      false,
+  );
+  const readOnlyStatus =
+    assertedReadOnlyStatus ??
+    (remoteSessionUnavailable
+      ? t("remoteSessionUnavailable.description")
+      : undefined);
   useRegisterSecurityConfirmationSurface(sessionId);
   const mountStart = useRef(performance.now());
   const terminalRootRef = useRef<HTMLDivElement | null>(null);
@@ -673,7 +686,8 @@ export function ChatView({
 
   // The composer is owned by the timeline so it stays mounted across loading,
   // empty, and populated states without losing focus or draft text.
-  const footerStatus = composerHandoffActive ? null : readOnlyStatus ? (
+  const hideFooterStatus = composerHandoffActive || remoteSessionUnavailable;
+  const footerStatus = hideFooterStatus ? null : readOnlyStatus ? (
     <div
       className={cn(
         "chat-response-status-enter flex h-8 items-center gap-2 px-3 text-sm",
@@ -724,9 +738,11 @@ export function ChatView({
           composerHandoffActive && "invisible pointer-events-none",
         )}
       >
-        {sessionIsRemote &&
-        effectiveSession?.remoteHost &&
-        !effectiveSession.creationState ? (
+        {remoteSessionUnavailable ? (
+          <RemoteSessionUnavailableNotice />
+        ) : sessionIsRemote &&
+          effectiveSession?.remoteHost &&
+          !effectiveSession.creationState ? (
           <RemoteHostConnectionBanner
             host={effectiveSession.remoteHost}
             sessionId={effectiveSession.id}

--- a/src/features/chat/ui/ChatView.tsx
+++ b/src/features/chat/ui/ChatView.tsx
@@ -129,19 +129,24 @@ export function ChatView({
   onAgentBuilderCompleted,
 }: ChatViewProps) {
   const { t } = useTranslation("chat");
-  const remoteSessionUnavailable = useChatSessionStore(
+  const targetSessionId = activeSession?.id ?? sessionId;
+  const storedSession = useChatSessionStore(
     (state) =>
-      state.sessions?.find((session) => session.id === sessionId)
-        ?.remoteSessionUnavailable ??
-      activeSession?.remoteSessionUnavailable ??
-      false,
+      state.sessions?.find((session) => session.id === targetSessionId) ?? null,
+  );
+  // Resolve the entire snapshot, not individual flags from different revisions.
+  // The controller and queue also read the current store record for this id.
+  const selectedSession = storedSession ?? activeSession ?? null;
+  const selectedSessionId = selectedSession?.id ?? sessionId;
+  const remoteSessionUnavailable = Boolean(
+    selectedSession?.remoteSessionUnavailable,
   );
   const readOnlyStatus =
     assertedReadOnlyStatus ??
     (remoteSessionUnavailable
       ? t("remoteSessionUnavailable.description")
       : undefined);
-  useRegisterSecurityConfirmationSurface(sessionId);
+  useRegisterSecurityConfirmationSurface(selectedSessionId);
   const mountStart = useRef(performance.now());
   const terminalRootRef = useRef<HTMLDivElement | null>(null);
   const chatColumnRef = useRef<HTMLDivElement | null>(null);
@@ -160,8 +165,8 @@ export function ChatView({
   const composerBinding = useConversationComposerBinding({
     target: {
       kind: "existingSession",
-      sessionId,
-      sessionSnapshot: activeSession,
+      sessionId: selectedSessionId,
+      sessionSnapshot: selectedSession,
       readOnlyReason: readOnlyStatus,
     },
     onCreatePersonaRequested: onCreatePersona,
@@ -217,10 +222,9 @@ export function ChatView({
     sessionId,
   ]);
   const workspaceRepository = useWorkspaceRepository();
-  const effectiveSession = controller.session ?? activeSession ?? null;
-  // The effective session identity: during session replacement or
-  // reconciliation the requested sessionId can briefly disagree with the
-  // snapshot the controller serves. Every artifact-store read/write and
+  const effectiveSession = selectedSession;
+  // During replacement the supplied snapshot can already have the new id.
+  // The composer/controller target and every artifact-store read/write and
   // every layout decision derived from viewer state must use THIS id, so
   // the panel, the policy provider, and the width math all describe the
   // same store entry. (Audited: all useOpenArtifact call sites in ChatView.)

--- a/src/features/chat/ui/RemoteSessionUnavailableNotice.tsx
+++ b/src/features/chat/ui/RemoteSessionUnavailableNotice.tsx
@@ -1,0 +1,14 @@
+import { useTranslation } from "react-i18next";
+import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
+
+export function RemoteSessionUnavailableNotice() {
+  const { t } = useTranslation("chat");
+  return (
+    <Alert role="status" className="mb-2">
+      <AlertTitle>{t("remoteSessionUnavailable.title")}</AlertTitle>
+      <AlertDescription>
+        {t("remoteSessionUnavailable.description")}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/features/chat/ui/RemoteSessionUnavailableNotice.tsx
+++ b/src/features/chat/ui/RemoteSessionUnavailableNotice.tsx
@@ -5,7 +5,7 @@ export function RemoteSessionUnavailableNotice() {
   const { t } = useTranslation("chat");
   return (
     <Alert role="status" className="mb-2">
-      <AlertTitle>{t("remoteSessionUnavailable.title")}</AlertTitle>
+      <AlertTitle wrap>{t("remoteSessionUnavailable.title")}</AlertTitle>
       <AlertDescription>
         {t("remoteSessionUnavailable.description")}
       </AlertDescription>

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -736,6 +736,31 @@ describe("ChatView MCP app messaging", () => {
     expect(timelineProps.rendererPolicy).toBe("auto");
   });
 
+  it("shows an unavailable state without restore actions or activity signaling", () => {
+    render(
+      <ChatView
+        sessionId="session-1"
+        activeSession={{
+          ...chatSessionWithWorkingDir("/remote/project"),
+          remoteHost: "remote-server",
+          remoteSessionUnavailable: true,
+        }}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "remoteSessionUnavailable.title",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "remoteSessionUnavailable.description",
+    );
+    expect(mocks.useChatSessionController).toHaveBeenLastCalledWith(
+      expect.objectContaining({ readOnly: true }),
+    );
+    expect(
+      screen.queryByRole("button", { name: /restore|copy/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not pass fork-from-message in read-only mode", () => {
     render(
       <ChatView

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -20,8 +20,11 @@ import { useSecurityConfirmationStore } from "@/features/security/stores/securit
 import { DEFAULT_RUNTIME_CONFIG } from "@/shared/runtime-config/schema";
 import { useRuntimeConfigStore } from "@/shared/runtime-config/runtimeConfigStore";
 import { ChatView } from "../ChatView";
+import { isQueuedMessageTargetAttemptable } from "../../lib/queuedMessageAttemptOwnership";
+import type { QueuedMessageRecord } from "../../stores/chatStore";
 
 const mocks = vi.hoisted(() => ({
+  sessions: [] as ChatSession[],
   messageTimelineSpy: vi.fn(),
   chatInputSpy: vi.fn(),
   chatRightRailSpy: vi.fn(),
@@ -324,6 +327,7 @@ vi.mock("../../hooks/useChatSessionController", () => ({
 vi.mock("../../stores/chatSessionStore", () => ({
   useChatSessionStore: (selector: (state: unknown) => unknown) =>
     selector({
+      sessions: mocks.sessions,
       activeWorkspaceBySession: mocks.activeWorkspaceBySession,
       isRightRailOpen: mocks.isRightRailOpen,
       setRightRailOpen: mocks.setRightRailOpen,
@@ -444,6 +448,7 @@ describe("ChatView MCP app messaging", () => {
   });
 
   beforeEach(() => {
+    mocks.sessions = [];
     mocks.messageTimelineSpy.mockClear();
     mocks.chatInputSpy.mockClear();
     mocks.chatRightRailSpy.mockClear();
@@ -591,7 +596,7 @@ describe("ChatView MCP app messaging", () => {
     expect(screen.getAllByTestId("artifact-policy-provider")).toHaveLength(1);
   });
 
-  it("keys the artifact policy provider by the controller's effective session, not the requested id", () => {
+  it("keys the artifact policy provider by the selected replacement session, not the requested id", () => {
     // During session replacement/reconciliation the requested sessionId can
     // briefly disagree with the session snapshot the controller serves. The
     // provider governs filesystem policy and viewer-store identity for its
@@ -616,7 +621,10 @@ describe("ChatView MCP app messaging", () => {
     render(
       <ChatView
         sessionId="session-requested"
-        activeSession={chatSessionWithWorkingDir("/tmp/project")}
+        activeSession={{
+          ...chatSessionWithWorkingDir("/tmp/project"),
+          id: "session-effective",
+        }}
       />,
     );
 
@@ -659,7 +667,10 @@ describe("ChatView MCP app messaging", () => {
     const { unmount } = render(
       <ChatView
         sessionId="session-requested"
-        activeSession={chatSessionWithWorkingDir("/tmp/project")}
+        activeSession={{
+          ...chatSessionWithWorkingDir("/tmp/project"),
+          id: "session-effective",
+        }}
       />,
     );
 
@@ -682,7 +693,10 @@ describe("ChatView MCP app messaging", () => {
     render(
       <ChatView
         sessionId="session-requested"
-        activeSession={chatSessionWithWorkingDir("/tmp/project")}
+        activeSession={{
+          ...chatSessionWithWorkingDir("/tmp/project"),
+          id: "session-effective",
+        }}
       />,
     );
     const chatColumnAfter = document.querySelector(
@@ -759,6 +773,62 @@ describe("ChatView MCP app messaging", () => {
     expect(
       screen.queryByRole("button", { name: /restore|copy/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it.each([
+    [true, false],
+    [false, false],
+    [true, true],
+    [false, true],
+  ])("uses the current whole session (unavailable=%s, replacement=%s)", (unavailable, replacement) => {
+    const current: ChatSession = {
+      ...chatSessionWithWorkingDir("/remote/current"),
+      id: replacement ? "replacement-session" : "session-1",
+      remoteHost: "remote-server",
+      executionTarget: {
+        harnessId: "goose",
+        modelProviderId: "openai",
+        modelId: "test-model",
+        modelName: "Test model",
+      },
+      ...(unavailable ? { remoteSessionUnavailable: true } : {}),
+    };
+    mocks.sessions = replacement
+      ? [
+          {
+            ...current,
+            id: "session-1",
+            remoteSessionUnavailable: !unavailable,
+          },
+          current,
+        ]
+      : [current];
+    mocks.useChatSessionController.mockReturnValue({
+      ...mocks.useChatSessionController(),
+      session: current,
+    });
+    render(
+      <ChatView
+        sessionId="session-1"
+        activeSession={{ ...current, remoteSessionUnavailable: !unavailable }}
+      />,
+    );
+    expect(Boolean(screen.queryByText("remoteSessionUnavailable.title"))).toBe(
+      unavailable,
+    );
+    expect(mocks.useChatSessionController).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionId: current.id, readOnly: unavailable }),
+    );
+    expect(
+      isQueuedMessageTargetAttemptable(
+        { kind: "transport-ready", editing: false } as QueuedMessageRecord,
+        current,
+      ),
+    ).toBe(!unavailable);
+    expect(screen.getByTestId("artifact-viewer-panel")).toHaveAttribute(
+      "data-session-id",
+      current.id,
+    );
   });
 
   it("does not pass fork-from-message in read-only mode", () => {

--- a/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
+++ b/src/features/chat/ui/__tests__/ChatView.mcpApp.test.tsx
@@ -897,6 +897,61 @@ describe("ChatView MCP app messaging", () => {
     expect(chatInputProps.className).toBeUndefined();
   });
 
+  it("shows and resolves security confirmation for the selected replacement", () => {
+    const replacement = {
+      ...chatSessionWithWorkingDir("/remote/project"),
+      id: "replacement",
+    };
+    const resolve = vi.fn();
+    mocks.sessions = [replacement];
+    useSecurityConfirmationStore.setState({
+      pendingBySessionId: {
+        replacement: [
+          {
+            request: {
+              sessionId: "replacement",
+              options: [
+                { optionId: "allow", kind: "allow_once", name: "Allow" },
+              ],
+            } as never,
+            title: "Replacement confirmation",
+            command: null,
+            alertText: "Replacement alert",
+            resolve,
+            inferredExplanation: { status: "idle" },
+          },
+        ],
+      },
+    });
+    render(<ChatView sessionId="old-session" activeSession={replacement} />);
+    expect(screen.getByText("Replacement alert")).toBeInTheDocument();
+    expect(
+      useSecurityConfirmationStore.getState().mountedSurfaceCountBySessionId
+        .replacement,
+    ).toBe(1);
+    expect(
+      useSecurityConfirmationStore.getState().mountedSurfaceCountBySessionId[
+        "old-session"
+      ],
+    ).toBeUndefined();
+    expect(
+      mocks.chatInputSpy.mock.calls
+        .at(-1)?.[0]
+        .composerActions.onSend("blocked"),
+    ).toBe(false);
+    fireEvent.click(
+      screen.getByRole("button", { name: "securityConfirmation.allow" }),
+    );
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(
+      useSecurityConfirmationStore.getState().pendingBySessionId.replacement ??
+        [],
+    ).toHaveLength(0);
+    expect(
+      mocks.chatInputSpy.mock.calls.at(-1)?.[0].composerActions.onSend("ready"),
+    ).toBe(true);
+  });
+
   it("blocks and hides composer, queue, MCP, and voice delivery while security confirmation is pending", () => {
     const sendDeferredAnyway = vi.fn();
     mocks.useChatSessionController.mockReturnValue({

--- a/src/shared/api/acpErrors.ts
+++ b/src/shared/api/acpErrors.ts
@@ -19,6 +19,11 @@ function getErrorMessage(error: unknown): string {
   return "";
 }
 
+/** Match Goose's missing-session detail, not unrelated missing resources. */
+export function isAcpSessionNotFoundError(error: unknown): boolean {
+  return /^Session not found:\s*\S+/i.test(formatAcpErrorMessage(error, ""));
+}
+
 function stringifyData(data: unknown): string {
   try {
     return JSON.stringify(data);

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -1,7 +1,7 @@
 {
   "remoteSessionUnavailable": {
     "title": "This session is no longer available",
-    "description": "This chat is no longer available on the remote host. Any messages still cached in this app are shown here. Start a new chat to continue."
+    "description": "This chat is no longer available on the remote host. Any messages still available are shown above, but may disappear when you restart Berd. Save any important information before closing the app. Start a new chat to continue."
   },
   "attachments": {
     "alt": "Attachment {{index}}",

--- a/src/shared/i18n/locales/en/chat.json
+++ b/src/shared/i18n/locales/en/chat.json
@@ -1,4 +1,8 @@
 {
+  "remoteSessionUnavailable": {
+    "title": "This session is no longer available",
+    "description": "This chat is no longer available on the remote host. Any messages still cached in this app are shown here. Start a new chat to continue."
+  },
   "attachments": {
     "alt": "Attachment {{index}}",
     "chooseFilesDialogTitle": "Choose files to attach",

--- a/src/shared/i18n/locales/es/chat.json
+++ b/src/shared/i18n/locales/es/chat.json
@@ -1,7 +1,7 @@
 {
   "remoteSessionUnavailable": {
     "title": "Esta sesión ya no está disponible",
-    "description": "Este chat ya no está disponible en el servidor remoto. Aquí se muestran los mensajes que siguen en la caché de esta aplicación. Inicia un chat nuevo para continuar."
+    "description": "Este chat ya no está disponible en el servidor remoto. Los mensajes que siguen disponibles se muestran arriba, pero pueden desaparecer al reiniciar Berd. Guarda la información importante antes de cerrar la aplicación. Inicia un chat nuevo para continuar."
   },
   "attachments": {
     "alt": "Adjunto {{index}}",

--- a/src/shared/i18n/locales/es/chat.json
+++ b/src/shared/i18n/locales/es/chat.json
@@ -1,4 +1,8 @@
 {
+  "remoteSessionUnavailable": {
+    "title": "Esta sesión ya no está disponible",
+    "description": "Este chat ya no está disponible en el servidor remoto. Aquí se muestran los mensajes que siguen en la caché de esta aplicación. Inicia un chat nuevo para continuar."
+  },
   "attachments": {
     "alt": "Adjunto {{index}}",
     "chooseFilesDialogTitle": "Elegir archivos para adjuntar",

--- a/src/shared/ui/alert.tsx
+++ b/src/shared/ui/alert.tsx
@@ -42,7 +42,14 @@ function Alert({
   );
 }
 
-function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+function AlertTitle({
+  className,
+  wrap = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  /** Keep important or localized titles fully visible at constrained widths. */
+  wrap?: boolean;
+}) {
   return (
     <div
       {...getDesignSystemMetadata({
@@ -53,7 +60,8 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
       })}
       data-slot="alert-title"
       className={cn(
-        "font-display col-start-2 line-clamp-1 min-h-4 font-semibold tracking-[-0.01em]",
+        "font-display col-start-2 min-h-4 font-semibold tracking-[-0.01em]",
+        wrap ? "min-w-0 break-words" : "line-clamp-1",
         className,
       )}
       {...props}

--- a/tests/e2e/remote-session-unavailable.spec.ts
+++ b/tests/e2e/remote-session-unavailable.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+import { createServer, type ViteDevServer } from "vite";
+
+let server: ViteDevServer;
+let url: string;
+test.beforeAll(async () => {
+  server = await createServer({
+    server: { host: "127.0.0.1", port: 0, open: false },
+    plugins: [
+      {
+        name: "unavailable-session-fixture",
+        configureServer(vite) {
+          vite.middlewares.use("/unavailable-session", async (_req, res) => {
+            res.setHeader("Content-Type", "text/html");
+            res.end(
+              await vite.transformIndexHtml(
+                "/unavailable-session",
+                `
+            <!doctype html><html lang="en"><body><main id="root" style="max-width:640px;margin:80px auto;padding:16px"></main>
+            <script type="module">
+              import React from 'react';
+              import { createRoot } from 'react-dom/client';
+              import { RemoteSessionUnavailableNotice } from '/src/features/chat/ui/RemoteSessionUnavailableNotice.tsx';
+              import { i18n } from '/src/shared/i18n/index.ts';
+              import '/src/shared/styles/globals.css';
+              await i18n.changeLanguage(new URLSearchParams(location.search).get('lang') || 'en');
+              await i18n.loadNamespaces('chat');
+              createRoot(document.getElementById('root')).render(React.createElement(RemoteSessionUnavailableNotice));
+            </script></body></html>`,
+              ),
+            );
+          });
+        },
+      },
+    ],
+  });
+  await server.listen();
+  url = `${server.resolvedUrls?.local[0]}unavailable-session`;
+});
+test.afterAll(async () => {
+  await server?.close();
+});
+
+test("unavailable notice stays readable without recovery actions", async ({
+  page,
+}, testInfo) => {
+  for (const lang of ["en", "es"]) {
+    await page.goto(`${url}?lang=${lang}`);
+    const notice = page.getByRole("status");
+    await expect(notice).toContainText(
+      lang === "en"
+        ? "This session is no longer available"
+        : "Esta sesión ya no está disponible",
+    );
+    await expect(notice.getByRole("button")).toHaveCount(0);
+    for (const width of [360, 800]) {
+      await page.setViewportSize({ width, height: 400 });
+      expect(
+        await notice.evaluate((el) => el.scrollWidth <= el.clientWidth),
+      ).toBe(true);
+    }
+    if (lang === "en")
+      await notice.screenshot({
+        path: testInfo.outputPath("remote-session-unavailable-en.png"),
+      });
+  }
+});

--- a/tests/e2e/remote-session-unavailable.spec.ts
+++ b/tests/e2e/remote-session-unavailable.spec.ts
@@ -53,6 +53,14 @@ test("unavailable notice stays readable without recovery actions", async ({
         : "Esta sesión ya no está disponible",
     );
     await expect(notice.getByRole("button")).toHaveCount(0);
+    await expect(notice).toContainText(
+      lang === "en" ? "shown above" : "se muestran arriba",
+    );
+    await expect(notice).toContainText(
+      lang === "en"
+        ? "may disappear when you restart Berd"
+        : "pueden desaparecer al reiniciar Berd",
+    );
     for (const width of [360, 800]) {
       await page.setViewportSize({ width, height: 400 });
       expect(

--- a/tests/e2e/remote-session-unavailable.spec.ts
+++ b/tests/e2e/remote-session-unavailable.spec.ts
@@ -25,6 +25,10 @@ test.beforeAll(async () => {
               import '/src/shared/styles/globals.css';
               await i18n.changeLanguage(new URLSearchParams(location.search).get('lang') || 'en');
               await i18n.loadNamespaces('chat');
+              if (new URLSearchParams(location.search).has('longTitle')) {
+                i18n.addResource('es', 'chat', 'remoteSessionUnavailable.title', 'Esta sesión remota ya no está disponible y no puedes continuar enviando mensajes en este chat');
+                document.documentElement.style.fontSize = '32px';
+              }
               createRoot(document.getElementById('root')).render(React.createElement(RemoteSessionUnavailableNotice));
             </script></body></html>`,
               ),
@@ -36,6 +40,30 @@ test.beforeAll(async () => {
   });
   await server.listen();
   url = `${server.resolvedUrls?.local[0]}unavailable-session`;
+});
+
+test("long translated title reflows with enlarged text", async ({ page }) => {
+  await page.setViewportSize({ width: 360, height: 800 });
+  await page.goto(`${url}?lang=es&longTitle=1`);
+  const title = page.locator('[data-slot="alert-title"]');
+  await expect(title).toHaveText(
+    "Esta sesión remota ya no está disponible y no puedes continuar enviando mensajes en este chat",
+  );
+  const dimensions = await title.evaluate((el) => ({
+    height: el.clientHeight,
+    contentHeight: el.scrollHeight,
+    width: el.clientWidth,
+    contentWidth: el.scrollWidth,
+    lineHeight: Number.parseFloat(getComputedStyle(el).lineHeight),
+  }));
+  expect(dimensions.height).toBeGreaterThan(dimensions.lineHeight);
+  expect(dimensions.contentHeight).toBeLessThanOrEqual(dimensions.height);
+  expect(dimensions.contentWidth).toBeLessThanOrEqual(dimensions.width);
+  expect(
+    await page
+      .getByRole("status")
+      .evaluate((el) => el.scrollWidth <= el.clientWidth),
+  ).toBe(true);
 });
 test.afterAll(async () => {
   await server?.close();


### PR DESCRIPTION
## Summary

Show a friendly, read-only notice when a remote session no longer exists, instead of displaying the raw `Session not found` error.

- Preserve messages already in the in-memory cache; handle an empty cache too.
- Keep failed host connections on the existing reconnect path.
- Block sending and queue dispatch to a known missing session. Users can start a new chat with the existing controls.

No durable history, restoration, native storage changes, or Goose API changes. Cached messages are not guaranteed to survive restarting Berd.

## Validation

- `just check`, `just tauri-check`, and `just clippy`
- Full unit suite: 7,703 passed, 1 skipped
- Final focused load/composer/view tests: 122 passed
- Browser check of the production notice in English and Spanish at 360px and 800px; English screenshot visually checked

Follows `LAWS/CHAT.md`: missing sessions cannot dispatch queued prompts, and prompts are not moved to another chat.

## Screenshot

Updated English notice screenshot is ready for upload. The image below belongs to the superseded proposal, not the current UI.

<details>
<summary>Previous proposal — retained for reference</summary>

<img width="3036" height="1976" alt="Superseded durable-history proposal" src="https://github.com/user-attachments/assets/195e56e2-51b6-4456-998e-992276ab63fd" />

</details>

<img width="608" height="108" alt="image" src="https://github.com/user-attachments/assets/21fc50d2-3401-404e-a2c1-139ba305497d" />

