### PR TITLE
fix: ignore transient Cargo target directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 
 # Rust/Tauri build artifacts
 **/target/
+src-tauri/target*/
 
 # Environment files
 .env

--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,7 @@
     "ignoreUnknown": false,
     "includes": [
       "**",
+      "!src-tauri/target*",
       "!.pnpm-store",
       "!sdk/src/generated",
       "!src-tauri/gen",


### PR DESCRIPTION
## Summary

Berd runs repository-wide Biome formatting in parallel with Cargo checks. On a cold checkout, Cargo can create and remove a temporary `src-tauri/targetXXXXXX` directory while Biome traverses it, causing the pre-push hook to fail with `internalError/io`.

Ignore `src-tauri/target*` in Git and Biome so formatters never traverse stable or transient Rust build output.

### Testing

Created a synthetic `src-tauri/targetAb12Cd/async-git-probe.js` and confirmed Git ignores it and `biome format . --verbose` does not enumerate it. The frontend and Rust formatting checks pass.