### PR TITLE
fix(voice): preserve first streamed TTS phrase

### DIFF
--- a/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatStore } from "../../stores/chatStore";
@@ -464,10 +464,12 @@ describe("useChat", () => {
       firstPromptDeferred.resolve();
       await firstSendPromise;
     });
-    expect(
-      useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
-        ?.completionStatus,
-    ).toBe("completed");
+    await waitFor(() =>
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
+          ?.completionStatus,
+      ).toBe("completed"),
+    );
     expect(
       useChatStore.getState().messagesBySession["session-1"]?.[3]?.metadata
         ?.completionStatus,
@@ -515,10 +517,12 @@ describe("useChat", () => {
       cancelDeferred.resolve(false);
       await cancelDeferred.promise;
     });
-    expect(
-      useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
-        ?.completionStatus,
-    ).toBe("completed");
+    await waitFor(() =>
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
+          ?.completionStatus,
+      ).toBe("completed"),
+    );
   });
 
   it("completes the settled assistant when cancellation rejects", async () => {
@@ -562,10 +566,12 @@ describe("useChat", () => {
       }
       await Promise.resolve();
     });
-    expect(
-      useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
-        ?.completionStatus,
-    ).toBe("completed");
+    await waitFor(() =>
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
+          ?.completionStatus,
+      ).toBe("completed"),
+    );
   });
 
   it("marks the streaming assistant completed when the prompt settles", async () => {
@@ -593,10 +599,12 @@ describe("useChat", () => {
       await sendPromise;
     });
 
-    expect(
-      useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
-        ?.completionStatus,
-    ).toBe("completed");
+    await waitFor(() =>
+      expect(
+        useChatStore.getState().messagesBySession["session-1"]?.[1]?.metadata
+          ?.completionStatus,
+      ).toBe("completed"),
+    );
   });
 
   it("preserves a newer assistant when the final flush changes prompt ownership", async () => {
@@ -639,13 +647,19 @@ describe("useChat", () => {
       await sendPromise;
     });
 
+    await waitFor(() =>
+      expect(
+        useChatStore
+          .getState()
+          .messagesBySession["session-1"].find(
+            (message) => message.id === "assistant-1",
+          ),
+      ).toMatchObject({
+        content: [{ type: "text", text: "final text" }],
+        metadata: { completionStatus: "completed" },
+      }),
+    );
     const messages = useChatStore.getState().messagesBySession["session-1"];
-    expect(
-      messages.find((message) => message.id === "assistant-1"),
-    ).toMatchObject({
-      content: [{ type: "text", text: "final text" }],
-      metadata: { completionStatus: "completed" },
-    });
     expect(
       messages.find((message) => message.id === "assistant-2")?.metadata
         ?.completionStatus,
@@ -682,9 +696,11 @@ describe("useChat", () => {
       await sendPromise;
     });
 
-    const runtime = useChatStore.getState().getSessionRuntime("session-1");
-    expect(runtime.activeRunId).toBeNull();
-    expect(runtime.isRunCancellationPending).toBe(false);
+    await waitFor(() => {
+      const runtime = useChatStore.getState().getSessionRuntime("session-1");
+      expect(runtime.activeRunId).toBeNull();
+      expect(runtime.isRunCancellationPending).toBe(false);
+    });
   });
 
   it("does not mark a newer follow-up idle when the stopped prompt settles", async () => {
@@ -938,9 +954,11 @@ describe("useChat", () => {
       await secondSendPromise;
     });
 
-    runtime = useChatStore.getState().getSessionRuntime("session-1");
-    expect(runtime.activeRunId).toBeNull();
-    expect(runtime.isRunCancellationPending).toBe(false);
+    await waitFor(() => {
+      runtime = useChatStore.getState().getSessionRuntime("session-1");
+      expect(runtime.activeRunId).toBeNull();
+      expect(runtime.isRunCancellationPending).toBe(false);
+    });
   });
 
   it("keeps cancellation pending after stopping a streaming run without active run metadata", async () => {

--- a/src/features/chat/lib/sendCore.test.ts
+++ b/src/features/chat/lib/sendCore.test.ts
@@ -65,6 +65,42 @@ describe("dispatchPrompt pre-commit rejection", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("applies the final ACP update before marking the response complete", async () => {
+    mocks.acpSendMessage.mockImplementationOnce(
+      (
+        sessionId: string,
+        _prompt: string,
+        options: { onPromptDispatching(): void },
+      ) => {
+        options.onPromptDispatching();
+        const store = useChatStore.getState();
+        store.addMessage(sessionId, {
+          id: "assistant-1",
+          role: "assistant",
+          created: Date.now(),
+          content: [{ type: "text", text: "N" }],
+          metadata: { completionStatus: "inProgress" },
+        });
+        store.setStreamingMessageId(sessionId, "assistant-1");
+        window.setTimeout(() => {
+          useChatStore
+            .getState()
+            .appendStreamingText(sessionId, "assistant-1", "ora arrived.");
+        }, 0);
+        return Promise.resolve();
+      },
+    );
+
+    await dispatchPrompt("session-1", "Tell me a story", {});
+
+    expect(
+      useChatStore.getState().messagesBySession["session-1"]?.at(-1),
+    ).toMatchObject({
+      content: [{ type: "text", text: "Nora arrived." }],
+      metadata: { completionStatus: "completed" },
+    });
+  });
+
   it("preserves the complete newer-owner runtime on ownership loss", async () => {
     let newerOwnerRuntime: SessionChatRuntime | undefined;
     mocks.acpSendMessage.mockImplementationOnce(

--- a/src/features/chat/lib/sendCore.ts
+++ b/src/features/chat/lib/sendCore.ts
@@ -215,7 +215,7 @@ async function recoverMissingMasterTranscript(
   }
 }
 
-async function settleMasterTranscriptDelivery(
+async function settlePromptTranscriptDelivery(
   sessionId: string,
 ): Promise<void> {
   if (useChatStore.getState().loadingSessionIds.has(sessionId)) {
@@ -229,7 +229,7 @@ async function settleMasterTranscriptDelivery(
   }
   // ACP may resolve session/prompt immediately before dispatching the final
   // session/update already read from the same transport. Yield one macrotask
-  // so transcript recovery sees that last visible text block.
+  // so completion observers and transcript recovery see that last text block.
   // Keep ownership through new-session hydration as well: a late live chunk
   // routed after ownership is released looks like replay and can be discarded
   // by the hydration snapshot that is finishing at the same boundary.
@@ -425,7 +425,7 @@ export async function dispatchPrompt(
     ) {
       return;
     }
-    await settleMasterTranscriptDelivery(sessionId);
+    await settlePromptTranscriptDelivery(sessionId);
     if (
       assistantTextBeforeTurn &&
       !finalMasterTextSince(sessionId, assistantTextBeforeTurn)
@@ -550,6 +550,7 @@ export async function dispatchPrompt(
       );
     }
 
+    await settlePromptTranscriptDelivery(sessionId);
     finishPromptSuccessfully();
     try {
       await completeRealtimeTurnIfActive(acpPrompt);

--- a/src/features/chat/lib/sendCore.ts
+++ b/src/features/chat/lib/sendCore.ts
@@ -414,6 +414,11 @@ export async function dispatchPrompt(
     }
   };
 
+  const finishPromptAfterTranscriptSettles = async () => {
+    await settlePromptTranscriptDelivery(sessionId);
+    finishPromptSuccessfully();
+  };
+
   const completeRealtimeTurnIfActive = async (prompt: string) => {
     const shouldCoordinateAtCompletion =
       shouldCoordinateRealtime ||
@@ -425,7 +430,6 @@ export async function dispatchPrompt(
     ) {
       return;
     }
-    await settlePromptTranscriptDelivery(sessionId);
     if (
       assistantTextBeforeTurn &&
       !finalMasterTextSince(sessionId, assistantTextBeforeTurn)
@@ -550,8 +554,7 @@ export async function dispatchPrompt(
       );
     }
 
-    await settlePromptTranscriptDelivery(sessionId);
-    finishPromptSuccessfully();
+    await finishPromptAfterTranscriptSettles();
     try {
       await completeRealtimeTurnIfActive(acpPrompt);
     } catch (error) {
@@ -563,7 +566,7 @@ export async function dispatchPrompt(
       userMessageMetadata?.origin === "voice_conversation" &&
       isVoiceConversationEmptyResponse(formatAcpErrorMessage(err));
     if (isVoiceConversationNoop) {
-      finishPromptSuccessfully();
+      await finishPromptAfterTranscriptSettles();
       try {
         await completeRealtimeTurnIfActive(dispatchedPrompt);
       } catch (error) {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -737,6 +737,32 @@ describe("native assistant speech stream", () => {
     ).toMatchObject({ speech: { status: "spoken" } });
   });
 
+  it("includes a final queued text delta before finishing streamed speech", async () => {
+    startNativeAssistantSpeech("session-1", vi.fn());
+    useChatStore
+      .getState()
+      .setMessages("session-1", [assistant([{ type: "text", text: "N" }])]);
+    window.setTimeout(() => {
+      useChatStore
+        .getState()
+        .appendStreamingText("session-1", "assistant-1", "ora arrived.");
+    }, 0);
+    useChatStore
+      .getState()
+      .setMessages("session-1", [
+        assistant([{ type: "text", text: "N" }], "completed"),
+      ]);
+
+    await vi.waitFor(() => expect(mocks.finish).toHaveBeenCalledTimes(1));
+
+    expect(mocks.append.mock.calls.map(([, text]) => text).join("")).toBe(
+      "Nora arrived.",
+    );
+    expect(mocks.finish.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mocks.append.mock.invocationCallOrder.at(-1) ?? 0,
+    );
+  });
+
   it("serializes terminal idle behind the speaking activity report", async () => {
     let finishSpeakingReport: (() => void) | undefined;
     mocks.setAssistantSpeaking.mockImplementation(

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts
@@ -737,30 +737,28 @@ describe("native assistant speech stream", () => {
     ).toMatchObject({ speech: { status: "spoken" } });
   });
 
-  it("includes a final queued text delta before finishing streamed speech", async () => {
+  it("does not flush the first text chunk when a tool preceded it", async () => {
     startNativeAssistantSpeech("session-1", vi.fn());
+    const toolRequest = {
+      type: "toolRequest" as const,
+      id: "tool-1",
+      name: "todo_write",
+      arguments: {},
+      status: "completed" as const,
+    };
     useChatStore
       .getState()
-      .setMessages("session-1", [assistant([{ type: "text", text: "N" }])]);
-    window.setTimeout(() => {
-      useChatStore
-        .getState()
-        .appendStreamingText("session-1", "assistant-1", "ora arrived.");
-    }, 0);
+      .setMessages("session-1", [assistant([toolRequest])]);
     useChatStore
       .getState()
       .setMessages("session-1", [
-        assistant([{ type: "text", text: "N" }], "completed"),
+        assistant([toolRequest, { type: "text", text: "Mara" }]),
       ]);
 
-    await vi.waitFor(() => expect(mocks.finish).toHaveBeenCalledTimes(1));
-
-    expect(mocks.append.mock.calls.map(([, text]) => text).join("")).toBe(
-      "Nora arrived.",
+    await vi.waitFor(() =>
+      expect(mocks.append).toHaveBeenCalledWith(expect.any(String), "Mara"),
     );
-    expect(mocks.finish.mock.invocationCallOrder[0]).toBeGreaterThan(
-      mocks.append.mock.invocationCallOrder.at(-1) ?? 0,
-    );
+    expect(mocks.flush).not.toHaveBeenCalled();
   });
 
   it("serializes terminal idle behind the speaking activity report", async () => {

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -1486,7 +1486,7 @@ export function startNativeAssistantSpeech(
       ).length;
       const priorToolCount = toolCountByMessage.get(message.id) ?? 0;
       const crossedToolBoundary = toolCount > priorToolCount;
-      const completed =
+      const completionPending =
         message.metadata?.completionStatus === "completed" &&
         !handledCompletionMessages.has(message.id);
       let textOrdinal = 0;
@@ -1645,7 +1645,9 @@ export function startNativeAssistantSpeech(
         interruptedMessages.has(message.id) ||
         invalidatedMessages.has(message.id);
       toolCountByMessage.set(message.id, toolCount);
-      let completionHandled = completed && messageCannotSpeak;
+      const completionHandled =
+        completionPending &&
+        (messageCannotSpeak || Boolean(utteranceOwnsMessage));
       if (
         crossedToolBoundary &&
         utterance &&
@@ -1660,12 +1662,11 @@ export function startNativeAssistantSpeech(
         );
       }
       if (
-        completed &&
+        completionPending &&
         utterance &&
         utteranceOwnsMessage &&
         !utterance.nativeStartQueued
       ) {
-        completionHandled = true;
         for (const target of utterance.targets) {
           heldSpeech?.targets.delete(targetKey(target));
         }
@@ -1675,12 +1676,11 @@ export function startNativeAssistantSpeech(
         }
         activeUtterance = null;
       } else if (
-        completed &&
+        completionPending &&
         utterance &&
         utteranceOwnsMessage &&
         !utterance.finishing
       ) {
-        completionHandled = true;
         utterance.finishing = true;
         queueStreamCommand(
           utterance,

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -1008,8 +1008,6 @@ export function startNativeAssistantSpeech(
   const transcriptReferenceByKey = new Map<string, VoiceTranscriptReference>();
   const invalidatedMessages = new Set<string>();
   const completedMessages = new Set<string>();
-  const completionReadyMessages = new Set<string>();
-  const completionTimers = new Map<string, number>();
   const interruptedMessages = new Set<string>();
   const failedMessages = new Set<string>();
   const interruptionCauseByMessage = new Map<string, InterruptionCause>();
@@ -1054,6 +1052,11 @@ export function startNativeAssistantSpeech(
   let pendingUserRecognitionSegment = false;
   let recognitionSegmentTimer: number | null = null;
   let heldReleaseTimer: number | null = null;
+  let pendingCompletionConfirmation: {
+    messageId: string;
+    timer: number;
+    ready: boolean;
+  } | null = null;
 
   const cacheCausalTranscriptKeys = (
     messages: ReturnType<
@@ -1646,11 +1649,11 @@ export function startNativeAssistantSpeech(
         failedMessages.has(message.id) ||
         interruptedMessages.has(message.id) ||
         invalidatedMessages.has(message.id);
+      const completionReady =
+        pendingCompletionConfirmation?.messageId === message.id &&
+        pendingCompletionConfirmation.ready;
       if (utteranceOwnsMessage || messageCannotSpeak) {
         toolCountByMessage.set(message.id, toolCount);
-        if (completed && messageCannotSpeak) {
-          completedMessages.add(message.id);
-        }
       }
       if (
         crossedToolBoundary &&
@@ -1671,7 +1674,6 @@ export function startNativeAssistantSpeech(
         utteranceOwnsMessage &&
         !utterance.nativeStartQueued
       ) {
-        completedMessages.add(message.id);
         for (const target of utterance.targets) {
           heldSpeech?.targets.delete(targetKey(target));
         }
@@ -1680,9 +1682,7 @@ export function startNativeAssistantSpeech(
           heldReleaseReady = false;
         }
         activeUtterance = null;
-        continue;
-      }
-      if (
+      } else if (
         completed &&
         utterance &&
         utteranceOwnsMessage &&
@@ -1692,26 +1692,38 @@ export function startNativeAssistantSpeech(
         // session/update already read from the same transport. Confirm the
         // completion on the next macrotask so a trailing text delta is
         // appended before native TTS receives finish.
-        if (!completionReadyMessages.has(message.id)) {
-          if (!completionTimers.has(message.id)) {
-            const timer = window.setTimeout(() => {
-              completionTimers.delete(message.id);
-              if (activeGeneration !== generation) return;
-              completionReadyMessages.add(message.id);
+        if (!completionReady) {
+          if (pendingCompletionConfirmation?.messageId !== message.id) {
+            const pending = { messageId: message.id, timer: 0, ready: false };
+            pending.timer = window.setTimeout(() => {
+              if (
+                activeGeneration !== generation ||
+                pendingCompletionConfirmation !== pending
+              ) {
+                return;
+              }
+              pending.ready = true;
               inspect();
             }, 0);
-            completionTimers.set(message.id, timer);
+            pendingCompletionConfirmation = pending;
           }
           break;
         }
-        completionReadyMessages.delete(message.id);
-        completedMessages.add(message.id);
+        pendingCompletionConfirmation = null;
         utterance.finishing = true;
         queueStreamCommand(
           utterance,
           () => streamBackend.finish(utterance.id),
           onFailure,
         );
+      }
+      if (
+        completed &&
+        (messageCannotSpeak ||
+          (utteranceOwnsMessage &&
+            (!utterance?.nativeStartQueued || completionReady)))
+      ) {
+        completedMessages.add(message.id);
       }
     }
   };
@@ -1730,11 +1742,10 @@ export function startNativeAssistantSpeech(
   const unsubscribeChat = useChatStore.subscribe(inspect);
   stopSubscription = () => {
     unsubscribeChat();
-    for (const timer of completionTimers.values()) {
-      window.clearTimeout(timer);
+    if (pendingCompletionConfirmation) {
+      window.clearTimeout(pendingCompletionConfirmation.timer);
+      pendingCompletionConfirmation = null;
     }
-    completionTimers.clear();
-    completionReadyMessages.clear();
   };
   let reachedRunning =
     initialVoice.status.lifecycle === "running" &&

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -1008,6 +1008,8 @@ export function startNativeAssistantSpeech(
   const transcriptReferenceByKey = new Map<string, VoiceTranscriptReference>();
   const invalidatedMessages = new Set<string>();
   const completedMessages = new Set<string>();
+  const completionReadyMessages = new Set<string>();
+  const completionTimers = new Map<string, number>();
   const interruptedMessages = new Set<string>();
   const failedMessages = new Set<string>();
   const interruptionCauseByMessage = new Map<string, InterruptionCause>();
@@ -1646,7 +1648,9 @@ export function startNativeAssistantSpeech(
         invalidatedMessages.has(message.id);
       if (utteranceOwnsMessage || messageCannotSpeak) {
         toolCountByMessage.set(message.id, toolCount);
-        if (completed) completedMessages.add(message.id);
+        if (completed && messageCannotSpeak) {
+          completedMessages.add(message.id);
+        }
       }
       if (
         crossedToolBoundary &&
@@ -1667,6 +1671,7 @@ export function startNativeAssistantSpeech(
         utteranceOwnsMessage &&
         !utterance.nativeStartQueued
       ) {
+        completedMessages.add(message.id);
         for (const target of utterance.targets) {
           heldSpeech?.targets.delete(targetKey(target));
         }
@@ -1683,6 +1688,24 @@ export function startNativeAssistantSpeech(
         utteranceOwnsMessage &&
         !utterance.finishing
       ) {
+        // ACP can resolve session/prompt just before dispatching a final
+        // session/update already read from the same transport. Confirm the
+        // completion on the next macrotask so a trailing text delta is
+        // appended before native TTS receives finish.
+        if (!completionReadyMessages.has(message.id)) {
+          if (!completionTimers.has(message.id)) {
+            const timer = window.setTimeout(() => {
+              completionTimers.delete(message.id);
+              if (activeGeneration !== generation) return;
+              completionReadyMessages.add(message.id);
+              inspect();
+            }, 0);
+            completionTimers.set(message.id, timer);
+          }
+          break;
+        }
+        completionReadyMessages.delete(message.id);
+        completedMessages.add(message.id);
         utterance.finishing = true;
         queueStreamCommand(
           utterance,
@@ -1704,7 +1727,15 @@ export function startNativeAssistantSpeech(
     }
   };
 
-  stopSubscription = useChatStore.subscribe(inspect);
+  const unsubscribeChat = useChatStore.subscribe(inspect);
+  stopSubscription = () => {
+    unsubscribeChat();
+    for (const timer of completionTimers.values()) {
+      window.clearTimeout(timer);
+    }
+    completionTimers.clear();
+    completionReadyMessages.clear();
+  };
   let reachedRunning =
     initialVoice.status.lifecycle === "running" &&
     initialVoice.status.sessionId === sessionId;

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -1052,11 +1052,6 @@ export function startNativeAssistantSpeech(
   let pendingUserRecognitionSegment = false;
   let recognitionSegmentTimer: number | null = null;
   let heldReleaseTimer: number | null = null;
-  let pendingCompletionConfirmation: {
-    messageId: string;
-    timer: number;
-    ready: boolean;
-  } | null = null;
 
   const cacheCausalTranscriptKeys = (
     messages: ReturnType<
@@ -1649,11 +1644,9 @@ export function startNativeAssistantSpeech(
         failedMessages.has(message.id) ||
         interruptedMessages.has(message.id) ||
         invalidatedMessages.has(message.id);
-      const completionReady =
-        pendingCompletionConfirmation?.messageId === message.id &&
-        pendingCompletionConfirmation.ready;
-      if (utteranceOwnsMessage || messageCannotSpeak) {
-        toolCountByMessage.set(message.id, toolCount);
+      toolCountByMessage.set(message.id, toolCount);
+      if (completed && messageCannotSpeak) {
+        completedMessages.add(message.id);
       }
       if (
         crossedToolBoundary &&
@@ -1674,6 +1667,7 @@ export function startNativeAssistantSpeech(
         utteranceOwnsMessage &&
         !utterance.nativeStartQueued
       ) {
+        completedMessages.add(message.id);
         for (const target of utterance.targets) {
           heldSpeech?.targets.delete(targetKey(target));
         }
@@ -1682,48 +1676,21 @@ export function startNativeAssistantSpeech(
           heldReleaseReady = false;
         }
         activeUtterance = null;
-      } else if (
+        continue;
+      }
+      if (
         completed &&
         utterance &&
         utteranceOwnsMessage &&
         !utterance.finishing
       ) {
-        // ACP can resolve session/prompt just before dispatching a final
-        // session/update already read from the same transport. Confirm the
-        // completion on the next macrotask so a trailing text delta is
-        // appended before native TTS receives finish.
-        if (!completionReady) {
-          if (pendingCompletionConfirmation?.messageId !== message.id) {
-            const pending = { messageId: message.id, timer: 0, ready: false };
-            pending.timer = window.setTimeout(() => {
-              if (
-                activeGeneration !== generation ||
-                pendingCompletionConfirmation !== pending
-              ) {
-                return;
-              }
-              pending.ready = true;
-              inspect();
-            }, 0);
-            pendingCompletionConfirmation = pending;
-          }
-          break;
-        }
-        pendingCompletionConfirmation = null;
+        completedMessages.add(message.id);
         utterance.finishing = true;
         queueStreamCommand(
           utterance,
           () => streamBackend.finish(utterance.id),
           onFailure,
         );
-      }
-      if (
-        completed &&
-        (messageCannotSpeak ||
-          (utteranceOwnsMessage &&
-            (!utterance?.nativeStartQueued || completionReady)))
-      ) {
-        completedMessages.add(message.id);
       }
     }
   };
@@ -1739,14 +1706,7 @@ export function startNativeAssistantSpeech(
     }
   };
 
-  const unsubscribeChat = useChatStore.subscribe(inspect);
-  stopSubscription = () => {
-    unsubscribeChat();
-    if (pendingCompletionConfirmation) {
-      window.clearTimeout(pendingCompletionConfirmation.timer);
-      pendingCompletionConfirmation = null;
-    }
-  };
+  stopSubscription = useChatStore.subscribe(inspect);
   let reachedRunning =
     initialVoice.status.lifecycle === "running" &&
     initialVoice.status.sessionId === sessionId;

--- a/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
+++ b/src/features/voice-conversation/lib/nativeAssistantSpeech.ts
@@ -1007,7 +1007,7 @@ export function startNativeAssistantSpeech(
   const causalTranscriptKeyByMessage = new Map<string, string | null>();
   const transcriptReferenceByKey = new Map<string, VoiceTranscriptReference>();
   const invalidatedMessages = new Set<string>();
-  const completedMessages = new Set<string>();
+  const handledCompletionMessages = new Set<string>();
   const interruptedMessages = new Set<string>();
   const failedMessages = new Set<string>();
   const interruptionCauseByMessage = new Map<string, InterruptionCause>();
@@ -1033,7 +1033,7 @@ export function startNativeAssistantSpeech(
         .length,
     );
     if (message.metadata?.completionStatus === "completed") {
-      completedMessages.add(message.id);
+      handledCompletionMessages.add(message.id);
     }
     let textOrdinal = 0;
     for (const content of message.content) {
@@ -1219,7 +1219,7 @@ export function startNativeAssistantSpeech(
         targetKey(target),
         content.text.slice(0, safeLocalCutoff),
       );
-      completedMessages.delete(target.messageId);
+      handledCompletionMessages.delete(target.messageId);
     }
     resumableInterruption = null;
     interruptionReleaseReady = false;
@@ -1488,7 +1488,7 @@ export function startNativeAssistantSpeech(
       const crossedToolBoundary = toolCount > priorToolCount;
       const completed =
         message.metadata?.completionStatus === "completed" &&
-        !completedMessages.has(message.id);
+        !handledCompletionMessages.has(message.id);
       let textOrdinal = 0;
       for (const content of message.content) {
         if (content.type !== "text") continue;
@@ -1645,9 +1645,7 @@ export function startNativeAssistantSpeech(
         interruptedMessages.has(message.id) ||
         invalidatedMessages.has(message.id);
       toolCountByMessage.set(message.id, toolCount);
-      if (completed && messageCannotSpeak) {
-        completedMessages.add(message.id);
-      }
+      let completionHandled = completed && messageCannotSpeak;
       if (
         crossedToolBoundary &&
         utterance &&
@@ -1667,7 +1665,7 @@ export function startNativeAssistantSpeech(
         utteranceOwnsMessage &&
         !utterance.nativeStartQueued
       ) {
-        completedMessages.add(message.id);
+        completionHandled = true;
         for (const target of utterance.targets) {
           heldSpeech?.targets.delete(targetKey(target));
         }
@@ -1676,21 +1674,24 @@ export function startNativeAssistantSpeech(
           heldReleaseReady = false;
         }
         activeUtterance = null;
-        continue;
-      }
-      if (
+      } else if (
         completed &&
         utterance &&
         utteranceOwnsMessage &&
         !utterance.finishing
       ) {
-        completedMessages.add(message.id);
+        completionHandled = true;
         utterance.finishing = true;
         queueStreamCommand(
           utterance,
           () => streamBackend.finish(utterance.id),
           onFailure,
         );
+      }
+      // A completed tool-only message remains unhandled until later text can
+      // create an utterance for it.
+      if (completionHandled) {
+        handledCompletionMessages.add(message.id);
       }
     }
   };


### PR DESCRIPTION
**Category:** fix
**User Impact:** Streamed voice replies no longer pronounce an isolated first letter or word, pause, and then continue after the coding agent uses a tool or as its final ACP update settles.

**Problem:** Two ordering boundaries could split the opening phrase. Tool-only assistant phases were recorded only after they owned a speech utterance, so the first later text delta looked like a newly crossed tool boundary and was flushed alone. Separately, ACP may resolve a prompt just before dispatching its final already-read update, allowing completion observers to finish an incomplete fragment.

**Solution:** Record the observed tool count for every assistant message, while explicitly tracking only completion events already handled. At the producer boundary, keep prompt ownership for one event-loop turn before marking the response complete so the final ACP update reaches the transcript and shared TTS stream first. The fix applies to Siri, Pocket, and OpenAI TTS through the shared native speech path.

**Reviewer-reproducible examples:**
- `pnpm vitest run src/features/voice-conversation/lib/nativeAssistantSpeech.test.ts -t "does not flush the first text chunk when a tool preceded it"` simulates a completed tool-only phase followed by the first streamed word and verifies no standalone flush occurs.
- `pnpm vitest run src/features/chat/lib/sendCore.test.ts -t "applies the final ACP update before marking the response complete"` simulates prompt resolution immediately before a queued final text update and verifies the complete phrase is present before completion is published.