### PR TITLE
chore: validate DCO sign-offs before commit

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,11 @@
 # Equivalent of the aaif-goose/goose Husky hooks, using lefthook.
 # See: https://github.com/evilmartians/lefthook
 
+commit-msg:
+  commands:
+    dco-signoff:
+      run: node ./scripts/validate-dco-signoff.mjs "{1}"
+
 pre-commit:
   commands:
     biome-format:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "biome format --write .",
     "preview": "vite preview",
     "tauri": "tauri",
-    "test": "vitest run",
+    "test": "vitest run && node --test scripts/dco-signoff.test.mjs",
     "test:release-scripts": "vitest run --config vitest.release-scripts.config.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/dco-signoff.test.mjs
+++ b/scripts/dco-signoff.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+const validator = new URL("./validate-dco-signoff.mjs", import.meta.url)
+  .pathname;
+
+function run(
+  message,
+  author = { name: "Ada Lovelace", email: "ada@example.com" },
+) {
+  const repo = mkdtempSync(join(tmpdir(), "berd-dco-"));
+  execFileSync("git", ["init", "--quiet", repo]);
+  execFileSync("git", ["-C", repo, "config", "user.name", author.name]);
+  execFileSync("git", ["-C", repo, "config", "user.email", author.email]);
+  const messagePath = join(repo, "COMMIT_EDITMSG");
+  writeFileSync(messagePath, message);
+  return spawnSync("node", [validator, messagePath], {
+    cwd: repo,
+    encoding: "utf8",
+  });
+}
+
+test("accepts an author-matching sign-off", () => {
+  const result = run(
+    "Subject\n\nSigned-off-by: Ada Lovelace <ada@example.com>\n",
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
+test("rejects a missing sign-off with remediation", () => {
+  const result = run("Subject\n");
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Signed-off-by: Ada Lovelace <ada@example\.com>/);
+  assert.match(result.stderr, /git commit --signoff/);
+});
+
+test("rejects a sign-off from someone other than the author", () => {
+  const result = run(
+    "Subject\n\nSigned-off-by: Grace Hopper <grace@example.com>\n",
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Signed-off-by: Ada Lovelace <ada@example\.com>/);
+});
+
+test("honors the effective author identity", () => {
+  const result = run(
+    "Subject\n\nSigned-off-by: Zoë Agent <zoe@example.com>\n",
+    { name: "Zoë Agent", email: "zoe@example.com" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+});

--- a/scripts/dco-signoff.test.mjs
+++ b/scripts/dco-signoff.test.mjs
@@ -3,10 +3,12 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-const validator = new URL("./validate-dco-signoff.mjs", import.meta.url)
-  .pathname;
+const validator = fileURLToPath(
+  new URL("./validate-dco-signoff.mjs", import.meta.url),
+);
 
 function run(
   message,
@@ -21,6 +23,11 @@ function run(
   return spawnSync("node", [validator, messagePath], {
     cwd: repo,
     encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: author.name,
+      GIT_AUTHOR_EMAIL: author.email,
+    },
   });
 }
 

--- a/scripts/validate-dco-signoff.mjs
+++ b/scripts/validate-dco-signoff.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function authorIdentity() {
+  const ident = git("var", "GIT_AUTHOR_IDENT");
+  const match = ident.match(/^(.* <[^<>]+>) \d+ [+-]\d{4}$/);
+  if (!match) {
+    throw new Error(`could not parse Git author identity: ${ident}`);
+  }
+  return match[1];
+}
+
+function signedOffByIdentities(messagePath) {
+  const trailers = git("interpret-trailers", "--parse", "--", messagePath);
+  return trailers
+    .split("\n")
+    .map((line) => line.match(/^Signed-off-by:\s*(.+)$/i)?.[1].trim())
+    .filter(Boolean);
+}
+
+const messagePath = process.argv[2];
+if (!messagePath) {
+  console.error("usage: validate-dco-signoff.mjs <commit-message-file>");
+  process.exit(2);
+}
+
+try {
+  const author = authorIdentity();
+  if (!signedOffByIdentities(messagePath).includes(author)) {
+    console.error(
+      `DCO sign-off required: add exactly "Signed-off-by: ${author}".`,
+    );
+    console.error(
+      "Retry the commit with `git commit --signoff` or add that trailer in your commit editor.",
+    );
+    process.exit(1);
+  }
+} catch (error) {
+  console.error(`Unable to validate DCO sign-off: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

Adds a Lefthook `commit-msg` check that requires a `Signed-off-by` trailer matching Git's effective author identity. Commits without the matching DCO certification fail locally with the exact trailer to add and guidance to retry with `git commit --signoff`. CI remains the authoritative backstop.

### Related issue

None found.

### Testing

- `just check`
- `node --test scripts/dco-signoff.test.mjs`
- Exercised the installed Lefthook command with missing, mismatched, and author-matching sign-offs.

## Reviewer-reproducible examples

After `just setup`, create temporary commit messages and run the hook directly:

```bash
tmp=$(mktemp -d)
printf 'Subject\n' > "$tmp/missing"
lefthook run commit-msg --force -- "$tmp/missing"
```

The command fails and prints the effective author's exact required trailer plus `git commit --signoff` remediation. Then:

```bash
author=$(git var GIT_AUTHOR_IDENT | sed -E 's/ ([0-9]+) ([+-][0-9]{4})$//')
printf 'Subject\n\nSigned-off-by: %s\n' "$author" > "$tmp/valid"
lefthook run commit-msg --force -- "$tmp/valid"
```

The command succeeds.
