### PR TITLE
fix(voice): speak streamed responses by paragraph

### DIFF
--- a/src-tauri/crates/berd-voice/src/lib.rs
+++ b/src-tauri/crates/berd-voice/src/lib.rs
@@ -55,4 +55,7 @@ pub use pocket::{
 #[cfg(target_os = "macos")]
 pub use siri::SiriTts;
 pub use synthesis::{synthesize_pcm16_wav, WavSynthesis, WavSynthesisError, WavSynthesisErrorKind};
-pub use tts::{OpenAiTts, PocketTtsBackend, TtsBackend, TtsOutcome, TtsPcmSpec, TtsSynthesisEvent};
+pub use tts::{
+    OpenAiTts, PocketTtsBackend, StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec,
+    TtsSynthesisEvent,
+};

--- a/src-tauri/crates/berd-voice/src/lib.rs
+++ b/src-tauri/crates/berd-voice/src/lib.rs
@@ -49,13 +49,13 @@ pub use outbound::{
 };
 pub use parakeet::ParakeetRecognizer;
 pub use pocket::{
-    load_pocket_voice_style, load_text_to_speech, load_voice_style, take_streaming_text_chunks,
-    PocketTts, StreamingTextChunks, VoiceStyle, SAMPLE_RATE,
+    load_pocket_voice_style, load_text_to_speech, load_voice_style, PocketTts, VoiceStyle,
+    SAMPLE_RATE,
 };
 #[cfg(target_os = "macos")]
 pub use siri::SiriTts;
 pub use synthesis::{synthesize_pcm16_wav, WavSynthesis, WavSynthesisError, WavSynthesisErrorKind};
 pub use tts::{
-    OpenAiTts, PocketTtsBackend, StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec,
-    TtsSynthesisEvent,
+    OpenAiTts, PocketTtsBackend, StreamingTextChunks, StreamingTtsText, TtsBackend, TtsOutcome,
+    TtsPcmSpec, TtsSynthesisEvent,
 };

--- a/src-tauri/crates/berd-voice/src/lib.rs
+++ b/src-tauri/crates/berd-voice/src/lib.rs
@@ -56,6 +56,6 @@ pub use pocket::{
 pub use siri::SiriTts;
 pub use synthesis::{synthesize_pcm16_wav, WavSynthesis, WavSynthesisError, WavSynthesisErrorKind};
 pub use tts::{
-    OpenAiTts, PocketTtsBackend, StreamingTextChunks, StreamingTtsText, TtsBackend, TtsOutcome,
-    TtsPcmSpec, TtsSynthesisEvent,
+    OpenAiTts, PocketTtsBackend, StreamingTextChunk, StreamingTextChunks, StreamingTtsText,
+    TtsBackend, TtsOutcome, TtsPcmSpec, TtsSynthesisEvent,
 };

--- a/src-tauri/crates/berd-voice/src/outbound.rs
+++ b/src-tauri/crates/berd-voice/src/outbound.rs
@@ -120,9 +120,7 @@ struct LedgerSegment {
     text: String,
     total_frames: u64,
     trailing_silence_frames: u64,
-    measured_trailing_quiet_frames: u64,
-    quiet_window_sum_squares: f64,
-    quiet_window_frames: usize,
+    trailing_quiet: TrailingQuietMeter,
     synthesis_complete: bool,
 }
 
@@ -130,6 +128,60 @@ struct LedgerSegment {
 // measurements while tolerating quiet nonzero padding from cloud synthesis.
 const QUIET_PCM_WINDOWS_PER_SECOND: usize = 200;
 const QUIET_PCM_RMS_THRESHOLD: f64 = 0.01;
+
+#[derive(Debug)]
+struct TrailingQuietMeter {
+    window_frames: usize,
+    measured_frames: u64,
+    window_sum_squares: f64,
+    buffered_frames: usize,
+}
+
+impl TrailingQuietMeter {
+    fn new(sample_rate: u32) -> Self {
+        Self {
+            window_frames: ((sample_rate as usize) / QUIET_PCM_WINDOWS_PER_SECOND).max(1),
+            measured_frames: 0,
+            window_sum_squares: 0.0,
+            buffered_frames: 0,
+        }
+    }
+
+    fn push(&mut self, samples: &[f32]) {
+        for sample in samples {
+            self.window_sum_squares += f64::from(*sample).powi(2);
+            self.buffered_frames += 1;
+            if self.buffered_frames == self.window_frames {
+                if self.buffered_window_is_quiet() {
+                    self.measured_frames = self
+                        .measured_frames
+                        .saturating_add(self.window_frames as u64);
+                } else {
+                    self.measured_frames = 0;
+                }
+                self.window_sum_squares = 0.0;
+                self.buffered_frames = 0;
+            }
+        }
+    }
+
+    fn measured_frames(&self) -> u64 {
+        if self.buffered_frames == 0 {
+            self.measured_frames
+        } else if self.buffered_window_is_quiet() {
+            self.measured_frames
+                .saturating_add(self.buffered_frames as u64)
+        } else {
+            0
+        }
+    }
+
+    fn buffered_window_is_quiet(&self) -> bool {
+        self.buffered_frames > 0
+            && (self.window_sum_squares / self.buffered_frames as f64).sqrt()
+                <= QUIET_PCM_RMS_THRESHOLD
+    }
+}
 
 impl DeliveryLedger {
     fn new(sample_rate: u32) -> Self {
@@ -144,9 +196,7 @@ impl DeliveryLedger {
             text,
             total_frames: 0,
             trailing_silence_frames: 0,
-            measured_trailing_quiet_frames: 0,
-            quiet_window_sum_squares: 0.0,
-            quiet_window_frames: 0,
+            trailing_quiet: TrailingQuietMeter::new(self.sample_rate),
             synthesis_complete: false,
         });
     }
@@ -154,23 +204,7 @@ impl DeliveryLedger {
     fn append_frames(&mut self, samples: &[f32]) {
         if let Some(segment) = self.segments.last_mut() {
             segment.total_frames = segment.total_frames.saturating_add(samples.len() as u64);
-            let window_frames = ((self.sample_rate as usize) / QUIET_PCM_WINDOWS_PER_SECOND).max(1);
-            for sample in samples {
-                segment.quiet_window_sum_squares += f64::from(*sample).powi(2);
-                segment.quiet_window_frames += 1;
-                if segment.quiet_window_frames == window_frames {
-                    let rms = (segment.quiet_window_sum_squares / window_frames as f64).sqrt();
-                    if rms.is_finite() && rms <= QUIET_PCM_RMS_THRESHOLD {
-                        segment.measured_trailing_quiet_frames = segment
-                            .measured_trailing_quiet_frames
-                            .saturating_add(window_frames as u64);
-                    } else {
-                        segment.measured_trailing_quiet_frames = 0;
-                    }
-                    segment.quiet_window_sum_squares = 0.0;
-                    segment.quiet_window_frames = 0;
-                }
-            }
+            segment.trailing_quiet.push(samples);
         }
     }
 
@@ -190,20 +224,11 @@ impl DeliveryLedger {
 
     fn missing_trailing_silence_frames(&self, target_frames: u64) -> u64 {
         self.segments.last().map_or(target_frames, |segment| {
-            let partial_window_is_quiet = segment.quiet_window_frames > 0
-                && (segment.quiet_window_sum_squares / segment.quiet_window_frames as f64).sqrt()
-                    <= QUIET_PCM_RMS_THRESHOLD;
-            let measured_trailing_quiet_frames = if partial_window_is_quiet {
-                segment
-                    .measured_trailing_quiet_frames
-                    .saturating_add(segment.quiet_window_frames as u64)
-            } else if segment.quiet_window_frames > 0 {
-                0
-            } else {
-                segment.measured_trailing_quiet_frames
-            };
             target_frames.saturating_sub(
-                measured_trailing_quiet_frames.saturating_add(segment.trailing_silence_frames),
+                segment
+                    .trailing_quiet
+                    .measured_frames()
+                    .saturating_add(segment.trailing_silence_frames),
             )
         })
     }
@@ -918,22 +943,20 @@ mod tests {
 
     #[test]
     fn silence_floor_counts_quiet_nonzero_provider_padding() {
-        let mut ledger = DeliveryLedger::new(1_000);
-        ledger.begin_segment("one".into());
-        ledger.append_frames(&[0.2; 5]);
-        ledger.append_frames(&[0.005; 10]);
+        let mut meter = TrailingQuietMeter::new(1_000);
+        meter.push(&[0.2; 5]);
+        meter.push(&[0.005; 10]);
 
-        assert_eq!(ledger.missing_trailing_silence_frames(10), 0);
+        assert_eq!(meter.measured_frames(), 10);
     }
 
     #[test]
     fn trailing_non_quiet_partial_window_resets_measured_padding() {
-        let mut ledger = DeliveryLedger::new(1_000);
-        ledger.begin_segment("one".into());
-        ledger.append_frames(&[0.0; 10]);
-        ledger.append_frames(&[0.5]);
+        let mut meter = TrailingQuietMeter::new(1_000);
+        meter.push(&[0.0; 10]);
+        meter.push(&[0.5]);
 
-        assert_eq!(ledger.missing_trailing_silence_frames(10), 10);
+        assert_eq!(meter.measured_frames(), 0);
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/outbound.rs
+++ b/src-tauri/crates/berd-voice/src/outbound.rs
@@ -124,8 +124,8 @@ struct LedgerSegment {
     synthesis_complete: bool,
 }
 
-// Five-millisecond windows at -40 dBFS match the empirical paragraph-gap
-// measurements while tolerating quiet nonzero padding from cloud synthesis.
+// Five-millisecond windows at -40 dBFS identify trailing quiet padding while
+// tolerating low-level nonzero output from cloud synthesis.
 const QUIET_PCM_WINDOWS_PER_SECOND: usize = 200;
 const QUIET_PCM_RMS_THRESHOLD: f64 = 0.01;
 

--- a/src-tauri/crates/berd-voice/src/outbound.rs
+++ b/src-tauri/crates/berd-voice/src/outbound.rs
@@ -120,8 +120,16 @@ struct LedgerSegment {
     text: String,
     total_frames: u64,
     trailing_silence_frames: u64,
+    measured_trailing_quiet_frames: u64,
+    quiet_window_sum_squares: f64,
+    quiet_window_frames: usize,
     synthesis_complete: bool,
 }
+
+// Five-millisecond windows at -40 dBFS match the empirical paragraph-gap
+// measurements while tolerating quiet nonzero padding from cloud synthesis.
+const QUIET_PCM_WINDOWS_PER_SECOND: usize = 200;
+const QUIET_PCM_RMS_THRESHOLD: f64 = 0.01;
 
 impl DeliveryLedger {
     fn new(sample_rate: u32) -> Self {
@@ -136,13 +144,33 @@ impl DeliveryLedger {
             text,
             total_frames: 0,
             trailing_silence_frames: 0,
+            measured_trailing_quiet_frames: 0,
+            quiet_window_sum_squares: 0.0,
+            quiet_window_frames: 0,
             synthesis_complete: false,
         });
     }
 
-    fn append_frames(&mut self, frames: usize) {
+    fn append_frames(&mut self, samples: &[f32]) {
         if let Some(segment) = self.segments.last_mut() {
-            segment.total_frames = segment.total_frames.saturating_add(frames as u64);
+            segment.total_frames = segment.total_frames.saturating_add(samples.len() as u64);
+            let window_frames = ((self.sample_rate as usize) / QUIET_PCM_WINDOWS_PER_SECOND).max(1);
+            for sample in samples {
+                segment.quiet_window_sum_squares += f64::from(*sample).powi(2);
+                segment.quiet_window_frames += 1;
+                if segment.quiet_window_frames == window_frames {
+                    let rms = (segment.quiet_window_sum_squares / window_frames as f64).sqrt();
+                    if rms.is_finite() && rms <= QUIET_PCM_RMS_THRESHOLD {
+                        segment.measured_trailing_quiet_frames = segment
+                            .measured_trailing_quiet_frames
+                            .saturating_add(window_frames as u64);
+                    } else {
+                        segment.measured_trailing_quiet_frames = 0;
+                    }
+                    segment.quiet_window_sum_squares = 0.0;
+                    segment.quiet_window_frames = 0;
+                }
+            }
         }
     }
 
@@ -158,6 +186,26 @@ impl DeliveryLedger {
                 .trailing_silence_frames
                 .saturating_add(frames as u64);
         }
+    }
+
+    fn missing_trailing_silence_frames(&self, target_frames: u64) -> u64 {
+        self.segments.last().map_or(target_frames, |segment| {
+            let partial_window_is_quiet = segment.quiet_window_frames > 0
+                && (segment.quiet_window_sum_squares / segment.quiet_window_frames as f64).sqrt()
+                    <= QUIET_PCM_RMS_THRESHOLD;
+            let measured_trailing_quiet_frames = if partial_window_is_quiet {
+                segment
+                    .measured_trailing_quiet_frames
+                    .saturating_add(segment.quiet_window_frames as u64)
+            } else if segment.quiet_window_frames > 0 {
+                0
+            } else {
+                segment.measured_trailing_quiet_frames
+            };
+            target_frames.saturating_sub(
+                measured_trailing_quiet_frames.saturating_add(segment.trailing_silence_frames),
+            )
+        })
     }
 
     fn snapshot(&self, played_frames: u64) -> DeliveryProgress {
@@ -271,7 +319,7 @@ impl<'a> OutboundPlayback<'a> {
                     return Ok(());
                 }
                 self.output.check_health()?;
-                self.ledger.append_frames(samples.len());
+                self.ledger.append_frames(samples);
                 if self.started {
                     before_write(false)?;
                     self.output.write(samples)?;
@@ -342,6 +390,20 @@ impl<'a> OutboundPlayback<'a> {
             .map_err(|message| self.fail(message))?;
         self.ledger.append_trailing_silence(frame_count);
         Ok(OutboundOutcome::Completed)
+    }
+
+    /// Ensures the preceding segment ends with at least `duration` of quiet
+    /// audio, counting both backend-provided trailing PCM and queued silence.
+    pub fn queue_inter_segment_silence_floor(
+        &mut self,
+        duration: Duration,
+    ) -> Result<OutboundOutcome, OutboundFailure> {
+        let target_frames =
+            (duration.as_secs_f64() * f64::from(self.ledger.sample_rate)).round() as u64;
+        let missing_frames = self.ledger.missing_trailing_silence_frames(target_frames);
+        let missing_duration =
+            Duration::from_secs_f64(missing_frames as f64 / f64::from(self.ledger.sample_rate));
+        self.queue_inter_segment_silence(missing_duration)
     }
 
     /// Converts a host-side setup failure into the same terminal, quiescent
@@ -796,6 +858,82 @@ mod tests {
 
         output.played.store(6, Ordering::SeqCst);
         assert_eq!(playback.snapshot().segments[1].played_frames, 1);
+    }
+
+    #[test]
+    fn silence_floor_counts_provider_padding_and_queues_only_the_deficit() {
+        let active = AtomicBool::new(true);
+        let output = FakeOutput::new(0);
+        let backend = FakeTts {
+            chunks: vec![vec![0.2, 0.2, 0.0, 0.0]],
+            cancel_after_first: false,
+        };
+        let mut playback = OutboundPlayback::new(&output, &active, 10, 0).unwrap();
+        playback
+            .synthesize_segment(
+                &backend,
+                "one",
+                &mut |_| Ok(()),
+                &mut || Ok(()),
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        playback
+            .queue_inter_segment_silence_floor(Duration::from_millis(500))
+            .unwrap();
+
+        assert_eq!(
+            output.writes.lock().unwrap().as_slice(),
+            &[vec![0.2, 0.2, 0.0, 0.0], vec![0.0, 0.0, 0.0]]
+        );
+    }
+
+    #[test]
+    fn silence_floor_does_not_extend_sufficient_provider_padding() {
+        let active = AtomicBool::new(true);
+        let output = FakeOutput::new(0);
+        let backend = FakeTts {
+            chunks: vec![vec![0.2, 0.2, 0.0, 0.0, 0.0]],
+            cancel_after_first: false,
+        };
+        let mut playback = OutboundPlayback::new(&output, &active, 10, 0).unwrap();
+        playback
+            .synthesize_segment(
+                &backend,
+                "one",
+                &mut |_| Ok(()),
+                &mut || Ok(()),
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        playback
+            .queue_inter_segment_silence_floor(Duration::from_millis(300))
+            .unwrap();
+
+        assert_eq!(
+            output.writes.lock().unwrap().as_slice(),
+            &[vec![0.2, 0.2, 0.0, 0.0, 0.0]]
+        );
+    }
+
+    #[test]
+    fn silence_floor_counts_quiet_nonzero_provider_padding() {
+        let mut ledger = DeliveryLedger::new(1_000);
+        ledger.begin_segment("one".into());
+        ledger.append_frames(&[0.2; 5]);
+        ledger.append_frames(&[0.005; 10]);
+
+        assert_eq!(ledger.missing_trailing_silence_frames(10), 0);
+    }
+
+    #[test]
+    fn trailing_non_quiet_partial_window_resets_measured_padding() {
+        let mut ledger = DeliveryLedger::new(1_000);
+        ledger.begin_segment("one".into());
+        ledger.append_frames(&[0.0; 10]);
+        ledger.append_frames(&[0.5]);
+
+        assert_eq!(ledger.missing_trailing_silence_frames(10), 10);
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/outbound.rs
+++ b/src-tauri/crates/berd-voice/src/outbound.rs
@@ -119,6 +119,7 @@ struct DeliveryLedger {
 struct LedgerSegment {
     text: String,
     total_frames: u64,
+    trailing_silence_frames: u64,
     synthesis_complete: bool,
 }
 
@@ -134,6 +135,7 @@ impl DeliveryLedger {
         self.segments.push(LedgerSegment {
             text,
             total_frames: 0,
+            trailing_silence_frames: 0,
             synthesis_complete: false,
         });
     }
@@ -150,6 +152,14 @@ impl DeliveryLedger {
         }
     }
 
+    fn append_trailing_silence(&mut self, frames: usize) {
+        if let Some(segment) = self.segments.last_mut() {
+            segment.trailing_silence_frames = segment
+                .trailing_silence_frames
+                .saturating_add(frames as u64);
+        }
+    }
+
     fn snapshot(&self, played_frames: u64) -> DeliveryProgress {
         let mut segment_start = 0_u64;
         let segments = self
@@ -159,7 +169,9 @@ impl DeliveryLedger {
                 let played_frames = played_frames
                     .saturating_sub(segment_start)
                     .min(segment.total_frames);
-                segment_start = segment_start.saturating_add(segment.total_frames);
+                segment_start = segment_start
+                    .saturating_add(segment.total_frames)
+                    .saturating_add(segment.trailing_silence_frames);
                 DeliverySegment {
                     text: segment.text.clone(),
                     played_frames,
@@ -300,6 +312,42 @@ impl<'a> OutboundPlayback<'a> {
             }
         }
         Ok(OutboundOutcome::Completed)
+    }
+
+    /// Queues silence after the most recently synthesized segment.
+    ///
+    /// The ledger treats the gap as playback time between text segments, so it
+    /// does not inflate either segment's spoken-text progress.
+    pub fn queue_inter_segment_silence(
+        &mut self,
+        duration: Duration,
+    ) -> Result<OutboundOutcome, OutboundFailure> {
+        self.ensure_live()?;
+        if !self.started || duration.is_zero() {
+            return Ok(OutboundOutcome::Completed);
+        }
+        if !self.active.load(Ordering::SeqCst) {
+            return self.interrupt();
+        }
+        let frame_count =
+            (duration.as_secs_f64() * f64::from(self.ledger.sample_rate)).round() as usize;
+        if frame_count == 0 {
+            return Ok(OutboundOutcome::Completed);
+        }
+        self.output
+            .check_health()
+            .map_err(|message| self.fail(message))?;
+        self.output
+            .write(&vec![0.0; frame_count])
+            .map_err(|message| self.fail(message))?;
+        self.ledger.append_trailing_silence(frame_count);
+        Ok(OutboundOutcome::Completed)
+    }
+
+    /// Converts a host-side setup failure into the same terminal, quiescent
+    /// failure contract used for synthesis and playback errors.
+    pub fn abort(&mut self, message: String) -> OutboundFailure {
+        self.fail(message)
     }
 
     pub fn finish(
@@ -704,6 +752,50 @@ mod tests {
             .segments
             .iter()
             .all(|segment| segment.synthesis_complete));
+    }
+
+    #[test]
+    fn inter_segment_silence_does_not_inflate_text_delivery() {
+        let active = AtomicBool::new(true);
+        let output = FakeOutput::new(0);
+        let backend = FakeTts {
+            chunks: vec![vec![0.1, 0.2, 0.3]],
+            cancel_after_first: false,
+        };
+        let mut playback = OutboundPlayback::new(&output, &active, 10, 0).unwrap();
+        playback
+            .synthesize_segment(
+                &backend,
+                "one",
+                &mut |_| Ok(()),
+                &mut || Ok(()),
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        playback
+            .queue_inter_segment_silence(Duration::from_millis(200))
+            .unwrap();
+        playback
+            .synthesize_segment(
+                &backend,
+                "two",
+                &mut |_| Ok(()),
+                &mut || Ok(()),
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            output.writes.lock().unwrap().as_slice(),
+            &[vec![0.1, 0.2, 0.3], vec![0.0, 0.0], vec![0.1, 0.2, 0.3]]
+        );
+        output.played.store(4, Ordering::SeqCst);
+        let snapshot = playback.snapshot();
+        assert_eq!(snapshot.segments[0].played_frames, 3);
+        assert_eq!(snapshot.segments[1].played_frames, 0);
+
+        output.played.store(6, Ordering::SeqCst);
+        assert_eq!(playback.snapshot().segments[1].played_frames, 1);
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/pocket.rs
+++ b/src-tauri/crates/berd-voice/src/pocket.rs
@@ -20,6 +20,8 @@ use std::sync::Mutex;
 
 use sherpa_onnx::Wave;
 
+use crate::tts::StreamingTextChunks;
+
 #[path = "pocket_april.rs"]
 mod pocket_april;
 use pocket_april::{prepare_april_prompt, AprilPocketTts};
@@ -28,20 +30,6 @@ use pocket_april::{prepare_april_prompt, AprilPocketTts};
 pub const SAMPLE_RATE: u32 = 24_000;
 
 const TTS_NUM_THREADS: usize = 1;
-
-/// Drain complete paragraphs from text that may still be growing.
-///
-/// The common policy keeps an incomplete paragraph intact until the stream is
-/// flushed. Backends with provider limits can apply a stricter splitter.
-pub fn take_streaming_text_chunks(text: &str, flush: bool) -> Result<StreamingTextChunks, String> {
-    let (ready, pending) = pocket_april::take_streaming_chunks_at_paragraph_boundaries(
-        text,
-        usize::MAX,
-        flush,
-        |_| Ok(0),
-    )?;
-    Ok(StreamingTextChunks { ready, pending })
-}
 
 thread_local! {
     static ACTIVE_SYNTHESIS_ENGINES: RefCell<Vec<usize>> = const { RefCell::new(Vec::new()) };
@@ -139,13 +127,6 @@ pub struct PocketTts {
     inner: Mutex<AprilPocketTts>,
 }
 
-/// Stable synthesis units drained from a growing assistant response.
-#[derive(Debug, PartialEq, Eq)]
-pub struct StreamingTextChunks {
-    pub ready: Vec<String>,
-    pub pending: String,
-}
-
 /// Load Berd's pinned April INT8 model.
 pub fn load_text_to_speech(model_dir: &str) -> Result<PocketTts, String> {
     let dir = Path::new(model_dir);
@@ -161,7 +142,7 @@ impl PocketTts {
     /// stays pending unless it exceeds Pocket's exact model token limit, when
     /// stable natural chunks are returned and the growing tail remains held.
     /// `flush` makes the tail ready at a response or tool boundary.
-    pub fn take_streaming_text_chunks(
+    pub(crate) fn take_streaming_text_chunks(
         &self,
         text: &str,
         flush: bool,

--- a/src-tauri/crates/berd-voice/src/pocket.rs
+++ b/src-tauri/crates/berd-voice/src/pocket.rs
@@ -29,29 +29,18 @@ pub const SAMPLE_RATE: u32 = 24_000;
 
 const TTS_NUM_THREADS: usize = 1;
 
-/// Drain stable, sentence-aware chunks from text that may still be growing.
+/// Drain complete paragraphs from text that may still be growing.
 ///
-/// This backend-neutral form uses a word-count budget. It lets system speech
-/// engines share Berd's first-sentence latency behavior without loading a
-/// Pocket model solely to segment text.
-pub fn take_streaming_text_chunks(
-    text: &str,
-    first_chunk_pending: bool,
-    flush: bool,
-) -> Result<StreamingTextChunks, String> {
-    let (ready, pending, first_chunk_pending) =
-        pocket_april::take_streaming_chunks_at_natural_boundaries(
-            text,
-            50,
-            first_chunk_pending,
-            flush,
-            |candidate| Ok(candidate.split_whitespace().count()),
-        )?;
-    Ok(StreamingTextChunks {
-        ready,
-        pending,
-        first_chunk_pending,
-    })
+/// The common policy keeps an incomplete paragraph intact until the stream is
+/// flushed. Backends with provider limits can apply a stricter splitter.
+pub fn take_streaming_text_chunks(text: &str, flush: bool) -> Result<StreamingTextChunks, String> {
+    let (ready, pending) = pocket_april::take_streaming_chunks_at_paragraph_boundaries(
+        text,
+        usize::MAX,
+        flush,
+        |_| Ok(0),
+    )?;
+    Ok(StreamingTextChunks { ready, pending })
 }
 
 thread_local! {
@@ -155,7 +144,6 @@ pub struct PocketTts {
 pub struct StreamingTextChunks {
     pub ready: Vec<String>,
     pub pending: String,
-    pub first_chunk_pending: bool,
 }
 
 /// Load Berd's pinned April INT8 model.
@@ -167,16 +155,15 @@ pub fn load_text_to_speech(model_dir: &str) -> Result<PocketTts, String> {
 }
 
 impl PocketTts {
-    /// Drain model-safe units from text that may still be growing.
+    /// Drain complete paragraphs and model-safe overflow from growing text.
     ///
-    /// The first complete sentence is made ready immediately. Later text stays
-    /// pending until it overflows the model's exact token limit, at which point
-    /// every stable natural chunk except the growing tail is returned. `flush`
-    /// makes the tail ready at a response or tool boundary.
+    /// Complete paragraphs become ready as a unit. An unfinished paragraph
+    /// stays pending unless it exceeds Pocket's exact model token limit, when
+    /// stable natural chunks are returned and the growing tail remains held.
+    /// `flush` makes the tail ready at a response or tool boundary.
     pub fn take_streaming_text_chunks(
         &self,
         text: &str,
-        first_chunk_pending: bool,
         flush: bool,
     ) -> Result<StreamingTextChunks, String> {
         self.reject_reentry()?;
@@ -184,13 +171,8 @@ impl PocketTts {
             .inner
             .lock()
             .map_err(|_| "Pocket TTS engine lock poisoned".to_string())?;
-        let (ready, pending, first_chunk_pending) =
-            engine.take_streaming_text_chunks(text, first_chunk_pending, flush)?;
-        Ok(StreamingTextChunks {
-            ready,
-            pending,
-            first_chunk_pending,
-        })
+        let (ready, pending) = engine.take_streaming_text_chunks(text, flush)?;
+        Ok(StreamingTextChunks { ready, pending })
     }
 
     /// Stream synthesis as PCM deltas become decoder-safe. `emit_frames` is

--- a/src-tauri/crates/berd-voice/src/pocket.rs
+++ b/src-tauri/crates/berd-voice/src/pocket.rs
@@ -152,8 +152,7 @@ impl PocketTts {
             .inner
             .lock()
             .map_err(|_| "Pocket TTS engine lock poisoned".to_string())?;
-        let (ready, pending) = engine.take_streaming_text_chunks(text, flush)?;
-        Ok(StreamingTextChunks { ready, pending })
+        engine.take_streaming_text_chunks(text, flush)
     }
 
     /// Stream synthesis as PCM deltas become decoder-safe. `emit_frames` is

--- a/src-tauri/crates/berd-voice/src/pocket_april.rs
+++ b/src-tauri/crates/berd-voice/src/pocket_april.rs
@@ -895,38 +895,18 @@ pub(crate) fn take_streaming_chunks_at_paragraph_boundaries<F>(
 where
     F: FnMut(&str) -> Result<usize, String>,
 {
-    let mut pending = text.trim_start().to_string();
+    let split = crate::tts::take_streaming_text_chunks(text, flush);
     let mut ready = Vec::new();
-
-    if pending.is_empty() {
-        return Ok((ready, pending));
-    }
-
-    while let Some(end) = first_stable_paragraph_end(&pending) {
-        let paragraph = pending[..end].to_string();
+    for paragraph in split.ready {
         ready.extend(split_at_natural_boundaries(
             &paragraph,
             max_tokens,
             &mut token_count,
         )?);
-        pending = pending[end..].trim_start().to_string();
     }
+    let mut pending = split.pending;
 
-    if pending.is_empty() {
-        return Ok((ready, pending));
-    }
-
-    if flush {
-        ready.extend(split_at_natural_boundaries(
-            &pending,
-            max_tokens,
-            &mut token_count,
-        )?);
-        pending.clear();
-        return Ok((ready, pending));
-    }
-
-    if token_count(&pending)? > max_tokens {
+    if !pending.is_empty() && token_count(&pending)? > max_tokens {
         let chunks = split_at_natural_boundaries(&pending, max_tokens, &mut token_count)?;
         if chunks.len() > 1 {
             let stable_count = chunks.len() - 1;
@@ -936,64 +916,6 @@ where
     }
 
     Ok((ready, pending))
-}
-
-fn first_stable_paragraph_end(text: &str) -> Option<usize> {
-    let mut saw_line_break = false;
-    for (offset, ch) in text.char_indices() {
-        if ch == '\n' {
-            if saw_line_break {
-                let separator_end = offset + ch.len_utf8();
-                let mut end = separator_end;
-                while text[end..].chars().next().is_some_and(char::is_whitespace) {
-                    end += text[end..]
-                        .chars()
-                        .next()
-                        .expect("checked above")
-                        .len_utf8();
-                }
-                if end == text.len() {
-                    return None;
-                }
-                if starts_markdown_list_item(text)
-                    && (starts_markdown_list_item(&text[end..])
-                        || next_block_is_indented(text, separator_end, end))
-                {
-                    saw_line_break = false;
-                    continue;
-                }
-                return Some(end);
-            }
-            saw_line_break = true;
-        } else if !ch.is_whitespace() {
-            saw_line_break = false;
-        }
-    }
-    None
-}
-
-fn next_block_is_indented(text: &str, separator_end: usize, content_start: usize) -> bool {
-    let line_start = text[separator_end..content_start]
-        .rfind('\n')
-        .map_or(separator_end, |offset| separator_end + offset + 1);
-    let indentation = &text[line_start..content_start];
-    indentation.contains('\t') || indentation.chars().filter(|ch| *ch == ' ').count() >= 2
-}
-
-fn starts_markdown_list_item(text: &str) -> bool {
-    let line = text.trim_start();
-    if line.starts_with("- ") || line.starts_with("* ") || line.starts_with("+ ") {
-        return true;
-    }
-    let marker_end = line
-        .char_indices()
-        .take_while(|(_, ch)| ch.is_ascii_digit())
-        .last()
-        .map(|(offset, ch)| offset + ch.len_utf8());
-    marker_end.is_some_and(|end| {
-        matches!(line[end..].chars().next(), Some('.' | ')'))
-            && line[end + 1..].starts_with(char::is_whitespace)
-    })
 }
 
 fn natural_boundary(candidate: &str, is_end_of_text: bool) -> TextBoundary {

--- a/src-tauri/crates/berd-voice/src/pocket_april.rs
+++ b/src-tauri/crates/berd-voice/src/pocket_april.rs
@@ -390,17 +390,12 @@ impl AprilPocketTts {
         text: &str,
         flush: bool,
     ) -> Result<crate::tts::StreamingTextChunks, String> {
-        split_streaming_text_for_pocket(
-            text,
-            self.bundle.max_token_per_chunk,
-            flush,
-            |candidate| {
-                let Some(prepared) = prepare_april_prompt(candidate) else {
-                    return Ok(0);
-                };
-                self.prepared_token_count(&prepared.text)
-            },
-        )
+        split_streaming_text_for_pocket(text, self.bundle.max_token_per_chunk, flush, |candidate| {
+            let Some(prepared) = prepare_april_prompt(candidate) else {
+                return Ok(0);
+            };
+            self.prepared_token_count(&prepared.text)
+        })
     }
 
     /// Return a fresh Flow LM state conditioned on the reference voice,
@@ -898,11 +893,7 @@ where
     let split = crate::tts::take_streaming_text_chunks(text, flush);
     let mut ready = Vec::new();
     for block in split.ready {
-        let pieces = split_at_natural_boundaries(
-            &block.text,
-            max_tokens,
-            &mut token_count,
-        )?;
+        let pieces = split_at_natural_boundaries(&block.text, max_tokens, &mut token_count)?;
         let last = pieces.len().saturating_sub(1);
         ready.extend(pieces.into_iter().enumerate().map(|(index, text)| {
             crate::tts::StreamingTextChunk {
@@ -918,13 +909,16 @@ where
         let chunks = split_at_natural_boundaries(&pending, max_tokens, &mut token_count)?;
         if chunks.len() > 1 {
             let stable_count = chunks.len() - 1;
-            ready.extend(chunks[..stable_count].iter().enumerate().map(
-                |(index, text)| crate::tts::StreamingTextChunk {
-                    text: text.clone(),
-                    starts_speech_block: index == 0,
-                    ends_speech_block: false,
-                },
-            ));
+            ready.extend(
+                chunks[..stable_count]
+                    .iter()
+                    .enumerate()
+                    .map(|(index, text)| crate::tts::StreamingTextChunk {
+                        text: text.clone(),
+                        starts_speech_block: index == 0,
+                        ends_speech_block: false,
+                    }),
+            );
             pending = chunks[stable_count].clone();
         }
     }

--- a/src-tauri/crates/berd-voice/src/pocket_april.rs
+++ b/src-tauri/crates/berd-voice/src/pocket_april.rs
@@ -380,24 +380,19 @@ impl AprilPocketTts {
         if self.prepared_token_count(&prepared.text)? <= self.bundle.max_token_per_chunk {
             return Ok(vec![prepared.text.clone()]);
         }
-        split_at_natural_boundaries(
-            &prepared.text,
-            self.bundle.max_token_per_chunk,
-            false,
-            |text| self.prepared_token_count(text),
-        )
+        split_at_natural_boundaries(&prepared.text, self.bundle.max_token_per_chunk, |text| {
+            self.prepared_token_count(text)
+        })
     }
 
     pub(crate) fn take_streaming_text_chunks(
         &mut self,
         text: &str,
-        first_chunk_pending: bool,
         flush: bool,
-    ) -> Result<(Vec<String>, String, bool), String> {
-        take_streaming_chunks_at_natural_boundaries(
+    ) -> Result<(Vec<String>, String), String> {
+        take_streaming_chunks_at_paragraph_boundaries(
             text,
             self.bundle.max_token_per_chunk,
-            first_chunk_pending,
             flush,
             |candidate| {
                 let Some(prepared) = prepare_april_prompt(candidate) else {
@@ -789,7 +784,6 @@ impl AprilPocketTts {
 fn split_at_natural_boundaries<F>(
     text: &str,
     max_tokens: usize,
-    isolate_first_sentence: bool,
     mut token_count: F,
 ) -> Result<Vec<String>, String>
 where
@@ -817,7 +811,6 @@ where
             break;
         }
 
-        let mut first_sentence_end = None;
         let mut sentence_end = None;
         let mut clause_end = None;
         let mut word_end = None;
@@ -843,7 +836,6 @@ where
             word_end = Some(end);
             match natural_boundary(&text[start..end], end == text.len()) {
                 TextBoundary::Sentence => {
-                    first_sentence_end.get_or_insert(end);
                     sentence_end = Some(end);
                 }
                 TextBoundary::Clause => clause_end = Some(end),
@@ -851,11 +843,7 @@ where
             }
         }
 
-        let preferred_end = if isolate_first_sentence && chunks.is_empty() {
-            first_sentence_end.or(clause_end).or(word_end)
-        } else {
-            sentence_end.or(clause_end).or(word_end)
-        };
+        let preferred_end = sentence_end.or(clause_end).or(word_end);
         let end = if let Some(end) = preferred_end {
             end
         } else {
@@ -898,13 +886,12 @@ where
     Ok(chunks)
 }
 
-pub(crate) fn take_streaming_chunks_at_natural_boundaries<F>(
+pub(crate) fn take_streaming_chunks_at_paragraph_boundaries<F>(
     text: &str,
     max_tokens: usize,
-    mut first_chunk_pending: bool,
     flush: bool,
     mut token_count: F,
-) -> Result<(Vec<String>, String, bool), String>
+) -> Result<(Vec<String>, String), String>
 where
     F: FnMut(&str) -> Result<usize, String>,
 {
@@ -912,81 +899,101 @@ where
     let mut ready = Vec::new();
 
     if pending.is_empty() {
-        return Ok((ready, pending, first_chunk_pending));
+        return Ok((ready, pending));
     }
 
-    if first_chunk_pending {
-        let first_sentence_end = pending.char_indices().find_map(|(offset, ch)| {
-            let end = offset + ch.len_utf8();
-            let at_boundary = end == pending.len()
-                || pending[end..]
-                    .chars()
-                    .next()
-                    .is_some_and(char::is_whitespace);
-            (at_boundary && natural_boundary(&pending[..end], false) == TextBoundary::Sentence)
-                .then_some(end)
-        });
-
-        if let Some(mut end) = first_sentence_end {
-            while pending[end..]
-                .chars()
-                .next()
-                .is_some_and(char::is_whitespace)
-            {
-                end += pending[end..]
-                    .chars()
-                    .next()
-                    .expect("checked above")
-                    .len_utf8();
-            }
-            let sentence = pending[..end].to_string();
-            if token_count(&sentence)? <= max_tokens {
-                ready.push(sentence);
-            } else {
-                ready.extend(split_at_natural_boundaries(
-                    &sentence,
-                    max_tokens,
-                    false,
-                    &mut token_count,
-                )?);
-            }
-            pending = pending[end..].to_string();
-            first_chunk_pending = false;
-        }
+    while let Some(end) = first_stable_paragraph_end(&pending) {
+        let paragraph = pending[..end].to_string();
+        ready.extend(split_at_natural_boundaries(
+            &paragraph,
+            max_tokens,
+            &mut token_count,
+        )?);
+        pending = pending[end..].trim_start().to_string();
     }
 
     if pending.is_empty() {
-        return Ok((ready, pending, first_chunk_pending));
+        return Ok((ready, pending));
     }
 
     if flush {
         ready.extend(split_at_natural_boundaries(
             &pending,
             max_tokens,
-            first_chunk_pending,
             &mut token_count,
         )?);
         pending.clear();
-        first_chunk_pending = false;
-        return Ok((ready, pending, first_chunk_pending));
+        return Ok((ready, pending));
     }
 
     if token_count(&pending)? > max_tokens {
-        let chunks = split_at_natural_boundaries(
-            &pending,
-            max_tokens,
-            first_chunk_pending,
-            &mut token_count,
-        )?;
+        let chunks = split_at_natural_boundaries(&pending, max_tokens, &mut token_count)?;
         if chunks.len() > 1 {
             let stable_count = chunks.len() - 1;
             ready.extend(chunks[..stable_count].iter().cloned());
             pending = chunks[stable_count].clone();
-            first_chunk_pending = false;
         }
     }
 
-    Ok((ready, pending, first_chunk_pending))
+    Ok((ready, pending))
+}
+
+fn first_stable_paragraph_end(text: &str) -> Option<usize> {
+    let mut saw_line_break = false;
+    for (offset, ch) in text.char_indices() {
+        if ch == '\n' {
+            if saw_line_break {
+                let separator_end = offset + ch.len_utf8();
+                let mut end = separator_end;
+                while text[end..].chars().next().is_some_and(char::is_whitespace) {
+                    end += text[end..]
+                        .chars()
+                        .next()
+                        .expect("checked above")
+                        .len_utf8();
+                }
+                if end == text.len() {
+                    return None;
+                }
+                if starts_markdown_list_item(text)
+                    && (starts_markdown_list_item(&text[end..])
+                        || next_block_is_indented(text, separator_end, end))
+                {
+                    saw_line_break = false;
+                    continue;
+                }
+                return Some(end);
+            }
+            saw_line_break = true;
+        } else if !ch.is_whitespace() {
+            saw_line_break = false;
+        }
+    }
+    None
+}
+
+fn next_block_is_indented(text: &str, separator_end: usize, content_start: usize) -> bool {
+    let line_start = text[separator_end..content_start]
+        .rfind('\n')
+        .map_or(separator_end, |offset| separator_end + offset + 1);
+    let indentation = &text[line_start..content_start];
+    indentation.contains('\t') || indentation.chars().filter(|ch| *ch == ' ').count() >= 2
+}
+
+fn starts_markdown_list_item(text: &str) -> bool {
+    let line = text.trim_start();
+    if line.starts_with("- ") || line.starts_with("* ") || line.starts_with("+ ") {
+        return true;
+    }
+    let marker_end = line
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .last()
+        .map(|(offset, ch)| offset + ch.len_utf8());
+    marker_end.is_some_and(|end| {
+        matches!(line[end..].chars().next(), Some('.' | ')'))
+            && line[end + 1..].starts_with(char::is_whitespace)
+    })
 }
 
 fn natural_boundary(candidate: &str, is_end_of_text: bool) -> TextBoundary {
@@ -1260,59 +1267,39 @@ mod tests {
     }
 
     #[test]
-    fn playback_split_keeps_first_sentence_separate_then_packs_the_remainder() {
-        let text = "One two. Three four. Five six.";
-        let chunks = split_at_natural_boundaries(text, 4, true, whitespace_token_count).unwrap();
-        assert_eq!(chunks, ["One two. ", "Three four. Five six."]);
-        assert_eq!(chunks.concat(), text);
-    }
-
-    #[test]
     fn model_split_packs_multiple_sentences_within_limit() {
         let text = "One two. Three four. Five six.";
-        let chunks = split_at_natural_boundaries(text, 4, false, whitespace_token_count).unwrap();
+        let chunks = split_at_natural_boundaries(text, 4, whitespace_token_count).unwrap();
         assert_eq!(chunks, ["One two. Three four. ", "Five six."]);
         assert_eq!(chunks.concat(), text);
     }
 
     #[test]
-    fn playback_then_model_split_does_not_isolate_later_sentences_again() {
+    fn model_split_does_not_isolate_the_first_sentence() {
         let text = "Alpha one. Beta two. Gamma three.";
-        let playback = split_at_natural_boundaries(text, 50, true, whitespace_token_count).unwrap();
-        assert_eq!(playback, ["Alpha one. ", "Beta two. Gamma three."]);
-
-        let model: Vec<_> = playback
-            .iter()
-            .flat_map(|chunk| {
-                split_at_natural_boundaries(chunk.trim(), 50, false, whitespace_token_count)
-                    .unwrap()
-            })
-            .collect();
-        assert_eq!(model, ["Alpha one.", "Beta two. Gamma three."]);
+        let chunks = split_at_natural_boundaries(text, 50, whitespace_token_count).unwrap();
+        assert_eq!(chunks, [text]);
     }
 
     #[test]
-    fn streaming_text_releases_the_first_sentence_immediately() {
-        let (ready, pending, first_pending) = take_streaming_chunks_at_natural_boundaries(
-            "One two. Three four",
+    fn streaming_text_releases_complete_paragraphs() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "One two.\n\nThree four",
             50,
-            true,
             false,
             whitespace_token_count,
         )
         .unwrap();
 
-        assert_eq!(ready, ["One two. "]);
+        assert_eq!(ready, ["One two.\n\n"]);
         assert_eq!(pending, "Three four");
-        assert!(!first_pending);
     }
 
     #[test]
-    fn streaming_text_keeps_later_sentences_pending_under_the_token_limit() {
-        let (ready, pending, first_pending) = take_streaming_chunks_at_natural_boundaries(
+    fn streaming_text_keeps_sentences_in_an_incomplete_paragraph_together() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
             "Three four. Five six.",
             5,
-            false,
             false,
             whitespace_token_count,
         )
@@ -1320,15 +1307,32 @@ mod tests {
 
         assert!(ready.is_empty());
         assert_eq!(pending, "Three four. Five six.");
-        assert!(!first_pending);
     }
 
     #[test]
-    fn streaming_text_drains_stable_natural_chunks_after_overflow() {
-        let (ready, pending, first_pending) = take_streaming_chunks_at_natural_boundaries(
+    fn streaming_text_never_emits_an_initial_model_delta_by_itself() {
+        let (ready, pending) =
+            take_streaming_chunks_at_paragraph_boundaries("N", 50, false, whitespace_token_count)
+                .unwrap();
+        assert!(ready.is_empty());
+        assert_eq!(pending, "N");
+
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            &format!("{pending}ora kept the lighthouse lit.\n\nA paper boat arrived."),
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+        assert_eq!(ready, ["Nora kept the lighthouse lit.\n\n"]);
+        assert_eq!(pending, "A paper boat arrived.");
+    }
+
+    #[test]
+    fn streaming_text_drains_model_safe_chunks_after_overflow() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
             "Three four. Five six. Seven eight.",
             4,
-            false,
             false,
             whitespace_token_count,
         )
@@ -1336,15 +1340,13 @@ mod tests {
 
         assert_eq!(ready, ["Three four. Five six. "]);
         assert_eq!(pending, "Seven eight.");
-        assert!(!first_pending);
     }
 
     #[test]
     fn streaming_text_flushes_the_growing_tail() {
-        let (ready, pending, first_pending) = take_streaming_chunks_at_natural_boundaries(
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
             "Three four. Five six.",
             5,
-            false,
             true,
             whitespace_token_count,
         )
@@ -1352,29 +1354,133 @@ mod tests {
 
         assert_eq!(ready, ["Three four. Five six."]);
         assert!(pending.is_empty());
-        assert!(!first_pending);
     }
 
     #[test]
-    fn streaming_text_waits_for_a_real_first_sentence_boundary() {
-        let (ready, pending, first_pending) = take_streaming_chunks_at_natural_boundaries(
-            "Dr. J. Smith is still speaking",
+    fn streaming_text_recognizes_a_whitespace_only_paragraph_break() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "Dr. J. Smith finished.\n  \nNext paragraph",
             50,
-            true,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(ready, ["Dr. J. Smith finished.\n  \n"]);
+        assert_eq!(pending, "Next paragraph");
+    }
+
+    #[test]
+    fn streaming_text_keeps_blank_line_separated_bullets_in_one_unit() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "- First finding.\n\n- Second finding.\n\nAfter the list",
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(ready, ["- First finding.\n\n- Second finding.\n\n"]);
+        assert_eq!(pending, "After the list");
+    }
+
+    #[test]
+    fn streaming_text_keeps_blank_line_separated_numbered_steps_in_one_unit() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "1. Inspect the change.\n\n2) Run the tests.\n\nSummary",
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(ready, ["1. Inspect the change.\n\n2) Run the tests.\n\n"]);
+        assert_eq!(pending, "Summary");
+    }
+
+    #[test]
+    fn streaming_text_keeps_indented_list_explanations_with_the_list() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "- First finding.\n\n  Supporting detail.\n\n- Second finding.\n\nSummary",
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(
+            ready,
+            ["- First finding.\n\n  Supporting detail.\n\n- Second finding.\n\n"]
+        );
+        assert_eq!(pending, "Summary");
+    }
+
+    #[test]
+    fn streaming_text_waits_to_classify_a_trailing_list_break() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "- First finding.\n\n",
+            50,
             false,
             whitespace_token_count,
         )
         .unwrap();
 
         assert!(ready.is_empty());
-        assert_eq!(pending, "Dr. J. Smith is still speaking");
-        assert!(first_pending);
+        assert_eq!(pending, "- First finding.\n\n");
+    }
+
+    #[test]
+    fn streaming_text_releases_prose_before_a_markdown_list() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "Here is the result.\n\n- First finding.\n\n- Second finding.",
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(ready, ["Here is the result.\n\n"]);
+        assert_eq!(pending, "- First finding.\n\n- Second finding.");
+    }
+
+    #[test]
+    fn streaming_text_matches_multi_paragraph_story_shape_from_berd_history() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "A lighthouse kept shining after the harbor closed.\n\nA paper boat arrived during a storm.\n\nIts note asked the keeper to leave the light on.",
+            50,
+            false,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(
+            ready,
+            [
+                "A lighthouse kept shining after the harbor closed.\n\n",
+                "A paper boat arrived during a storm.\n\n",
+            ]
+        );
+        assert_eq!(pending, "Its note asked the keeper to leave the light on.");
+    }
+
+    #[test]
+    fn streaming_text_flushes_a_complete_list_as_one_unit() {
+        let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
+            "- First finding.\n\n- Second finding.",
+            50,
+            true,
+            whitespace_token_count,
+        )
+        .unwrap();
+
+        assert_eq!(ready, ["- First finding.\n\n- Second finding."]);
+        assert!(pending.is_empty());
     }
 
     #[test]
     fn natural_split_prefers_preceding_sentence_boundary() {
         let text = "One two. Three four five six.";
-        let chunks = split_at_natural_boundaries(text, 5, true, whitespace_token_count).unwrap();
+        let chunks = split_at_natural_boundaries(text, 5, whitespace_token_count).unwrap();
         assert_eq!(chunks, ["One two. ", "Three four five six."]);
         assert_eq!(chunks.concat(), text);
     }
@@ -1383,13 +1489,13 @@ mod tests {
     fn oversized_sentence_uses_clause_then_word_fallback() {
         let clause_text = "One two three, four five six seven.";
         let clause_chunks =
-            split_at_natural_boundaries(clause_text, 5, true, whitespace_token_count).unwrap();
+            split_at_natural_boundaries(clause_text, 5, whitespace_token_count).unwrap();
         assert_eq!(clause_chunks, ["One two three, ", "four five six seven."]);
         assert_eq!(clause_chunks.concat(), clause_text);
 
         let word_text = "One two three four five six.";
         let word_chunks =
-            split_at_natural_boundaries(word_text, 4, true, whitespace_token_count).unwrap();
+            split_at_natural_boundaries(word_text, 4, whitespace_token_count).unwrap();
         assert_eq!(word_chunks, ["One two three four ", "five six."]);
         assert_eq!(word_chunks.concat(), word_text);
     }
@@ -1397,7 +1503,7 @@ mod tests {
     #[test]
     fn natural_split_preserves_unicode_punctuation_and_abbreviations() {
         let text = "“Café naïve?” Maybe—yes, definitely; 東京 speaks.";
-        let chunks = split_at_natural_boundaries(text, 3, true, whitespace_token_count).unwrap();
+        let chunks = split_at_natural_boundaries(text, 3, whitespace_token_count).unwrap();
         assert_eq!(
             chunks,
             ["“Café naïve?” ", "Maybe—yes, definitely; ", "東京 speaks."]
@@ -1405,14 +1511,13 @@ mod tests {
         assert_eq!(chunks.concat(), text);
 
         let abbreviation = "Dr. Smith waits. Then leaves.";
-        let chunks =
-            split_at_natural_boundaries(abbreviation, 3, true, whitespace_token_count).unwrap();
+        let chunks = split_at_natural_boundaries(abbreviation, 3, whitespace_token_count).unwrap();
         assert_eq!(chunks, ["Dr. Smith waits. ", "Then leaves."]);
         assert_eq!(chunks.concat(), abbreviation);
 
         let unspaced_clause = "alpha beta—gamma delta";
         let chunks =
-            split_at_natural_boundaries(unspaced_clause, 2, true, whitespace_token_count).unwrap();
+            split_at_natural_boundaries(unspaced_clause, 2, whitespace_token_count).unwrap();
         assert_eq!(chunks, ["alpha beta—", "gamma delta"]);
         assert_eq!(chunks.concat(), unspaced_clause);
     }
@@ -1420,7 +1525,7 @@ mod tests {
     #[test]
     fn natural_split_does_not_treat_numeric_punctuation_as_unspaced_clauses() {
         let text = "Meet at 12:30 with 1,000 guests onward.";
-        let chunks = split_at_natural_boundaries(text, 3, true, whitespace_token_count).unwrap();
+        let chunks = split_at_natural_boundaries(text, 3, whitespace_token_count).unwrap();
         assert_eq!(chunks, ["Meet at 12:30 ", "with 1,000 guests ", "onward."]);
         assert_eq!(chunks.concat(), text);
     }
@@ -1429,7 +1534,7 @@ mod tests {
     fn oversized_word_uses_utf8_scalar_boundary_without_loss() {
         let text = "éééé";
         let chunks =
-            split_at_natural_boundaries(text, 3, true, |chunk| Ok(chunk.chars().count())).unwrap();
+            split_at_natural_boundaries(text, 3, |chunk| Ok(chunk.chars().count())).unwrap();
         assert_eq!(chunks, ["ééé", "é"]);
         assert_eq!(chunks.concat(), text);
     }
@@ -1445,7 +1550,7 @@ mod tests {
         let tokenized_bytes = |repeats: usize| -> usize {
             let text = sentence.repeat(repeats).trim_end().to_string();
             let total = std::cell::Cell::new(0_usize);
-            let chunks = split_at_natural_boundaries(&text, 50, true, |chunk| {
+            let chunks = split_at_natural_boundaries(&text, 50, |chunk| {
                 total.set(total.get() + chunk.len());
                 whitespace_token_count(chunk)
             })

--- a/src-tauri/crates/berd-voice/src/pocket_april.rs
+++ b/src-tauri/crates/berd-voice/src/pocket_april.rs
@@ -1397,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    fn streaming_text_matches_multi_paragraph_story_shape_from_berd_history() {
+    fn streaming_text_preserves_multiple_paragraph_boundaries() {
         let (ready, pending) = take_streaming_chunks_at_paragraph_boundaries(
             "A lighthouse kept shining after the harbor closed.\n\nA paper boat arrived during a storm.\n\nIts note asked the keeper to leave the light on.",
             50,

--- a/src-tauri/crates/berd-voice/src/pocket_april.rs
+++ b/src-tauri/crates/berd-voice/src/pocket_april.rs
@@ -389,8 +389,8 @@ impl AprilPocketTts {
         &mut self,
         text: &str,
         flush: bool,
-    ) -> Result<(Vec<String>, String), String> {
-        take_streaming_chunks_at_paragraph_boundaries(
+    ) -> Result<crate::tts::StreamingTextChunks, String> {
+        split_streaming_text_for_pocket(
             text,
             self.bundle.max_token_per_chunk,
             flush,
@@ -886,23 +886,31 @@ where
     Ok(chunks)
 }
 
-pub(crate) fn take_streaming_chunks_at_paragraph_boundaries<F>(
+fn split_streaming_text_for_pocket<F>(
     text: &str,
     max_tokens: usize,
     flush: bool,
     mut token_count: F,
-) -> Result<(Vec<String>, String), String>
+) -> Result<crate::tts::StreamingTextChunks, String>
 where
     F: FnMut(&str) -> Result<usize, String>,
 {
     let split = crate::tts::take_streaming_text_chunks(text, flush);
     let mut ready = Vec::new();
-    for paragraph in split.ready {
-        ready.extend(split_at_natural_boundaries(
-            &paragraph,
+    for block in split.ready {
+        let pieces = split_at_natural_boundaries(
+            &block.text,
             max_tokens,
             &mut token_count,
-        )?);
+        )?;
+        let last = pieces.len().saturating_sub(1);
+        ready.extend(pieces.into_iter().enumerate().map(|(index, text)| {
+            crate::tts::StreamingTextChunk {
+                text,
+                starts_speech_block: block.starts_speech_block && index == 0,
+                ends_speech_block: block.ends_speech_block && index == last,
+            }
+        }));
     }
     let mut pending = split.pending;
 
@@ -910,12 +918,35 @@ where
         let chunks = split_at_natural_boundaries(&pending, max_tokens, &mut token_count)?;
         if chunks.len() > 1 {
             let stable_count = chunks.len() - 1;
-            ready.extend(chunks[..stable_count].iter().cloned());
+            ready.extend(chunks[..stable_count].iter().enumerate().map(
+                |(index, text)| crate::tts::StreamingTextChunk {
+                    text: text.clone(),
+                    starts_speech_block: index == 0,
+                    ends_speech_block: false,
+                },
+            ));
             pending = chunks[stable_count].clone();
         }
     }
 
-    Ok((ready, pending))
+    Ok(crate::tts::StreamingTextChunks { ready, pending })
+}
+
+#[cfg(test)]
+pub(crate) fn take_streaming_chunks_at_paragraph_boundaries<F>(
+    text: &str,
+    max_tokens: usize,
+    flush: bool,
+    token_count: F,
+) -> Result<(Vec<String>, String), String>
+where
+    F: FnMut(&str) -> Result<usize, String>,
+{
+    let split = split_streaming_text_for_pocket(text, max_tokens, flush, token_count)?;
+    Ok((
+        split.ready.into_iter().map(|chunk| chunk.text).collect(),
+        split.pending,
+    ))
 }
 
 fn natural_boundary(candidate: &str, is_end_of_text: bool) -> TextBoundary {

--- a/src-tauri/crates/berd-voice/src/tts.rs
+++ b/src-tauri/crates/berd-voice/src/tts.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 
 use crate::openai::{stream_openai_pcm, OpenAiPcmOutcome, OpenAiSpeechConfig};
 use crate::{
-    load_pocket_voice_style, load_text_to_speech, take_streaming_text_chunks, PocketTts,
-    StreamingTextChunks, VoiceStyle, SAMPLE_RATE,
+    load_pocket_voice_style, load_text_to_speech, PocketTts, VoiceStyle, SAMPLE_RATE,
 };
+
+const OPENAI_MAX_TTS_INPUT_CHARS: usize = 4096;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TtsPcmSpec {
@@ -25,6 +26,139 @@ pub enum TtsSynthesisEvent<'a> {
     /// A lifecycle polling opportunity while synthesis is blocked waiting for
     /// more PCM or a terminal provider result.
     Poll,
+}
+
+/// Stable synthesis units drained from a growing assistant response.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StreamingTextChunks {
+    pub ready: Vec<String>,
+    pub pending: String,
+}
+
+/// Drain complete speech blocks while retaining text that may still grow.
+///
+/// A speech block is one prose paragraph or one whole Markdown list, including
+/// adjacent list items and their indented explanations. A possible list marker
+/// at the streaming tail remains pending until it can be classified.
+pub(crate) fn take_streaming_text_chunks(text: &str, flush: bool) -> StreamingTextChunks {
+    let mut pending = text.trim_start().to_string();
+    let mut ready = Vec::new();
+
+    while let Some(end) = first_stable_speech_block_end(&pending) {
+        ready.push(pending[..end].to_string());
+        pending = pending[end..].trim_start().to_string();
+    }
+
+    if flush && !pending.is_empty() {
+        ready.push(std::mem::take(&mut pending));
+    }
+
+    StreamingTextChunks { ready, pending }
+}
+
+fn first_stable_speech_block_end(text: &str) -> Option<usize> {
+    let mut saw_line_break = false;
+    for (offset, ch) in text.char_indices() {
+        if ch == '\n' {
+            if saw_line_break {
+                let separator_end = offset + ch.len_utf8();
+                let mut end = separator_end;
+                while text[end..].chars().next().is_some_and(char::is_whitespace) {
+                    end += text[end..]
+                        .chars()
+                        .next()
+                        .expect("checked above")
+                        .len_utf8();
+                }
+                if end == text.len() {
+                    return None;
+                }
+                if starts_markdown_list_item(text)
+                    && (starts_markdown_list_item(&text[end..])
+                        || could_be_incomplete_markdown_list_marker(&text[end..])
+                        || next_block_is_indented(text, separator_end, end))
+                {
+                    saw_line_break = false;
+                    continue;
+                }
+                return Some(end);
+            }
+            saw_line_break = true;
+        } else if !ch.is_whitespace() {
+            saw_line_break = false;
+        }
+    }
+    None
+}
+
+fn next_block_is_indented(text: &str, separator_end: usize, content_start: usize) -> bool {
+    let line_start = text[separator_end..content_start]
+        .rfind('\n')
+        .map_or(separator_end, |offset| separator_end + offset + 1);
+    let indentation = &text[line_start..content_start];
+    indentation.contains('\t') || indentation.chars().filter(|ch| *ch == ' ').count() >= 2
+}
+
+fn starts_markdown_list_item(text: &str) -> bool {
+    let line = text.trim_start();
+    if line.starts_with("- ") || line.starts_with("* ") || line.starts_with("+ ") {
+        return true;
+    }
+    let marker_end = line
+        .char_indices()
+        .take_while(|(_, ch)| ch.is_ascii_digit())
+        .last()
+        .map(|(offset, ch)| offset + ch.len_utf8());
+    marker_end.is_some_and(|end| {
+        matches!(line[end..].chars().next(), Some('.' | ')'))
+            && line[end + 1..].starts_with(char::is_whitespace)
+    })
+}
+
+fn could_be_incomplete_markdown_list_marker(text: &str) -> bool {
+    let line = text.trim_start();
+    if matches!(line, "-" | "*" | "+") {
+        return true;
+    }
+    let digits = line.bytes().take_while(|byte| byte.is_ascii_digit()).count();
+    digits > 0
+        && (digits == line.len()
+            || (digits + 1 == line.len()
+                && matches!(line.as_bytes().get(digits), Some(b'.' | b')'))))
+}
+
+fn split_at_char_limit(text: &str, max_chars: usize) -> Vec<String> {
+    debug_assert!(max_chars > 0);
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let end = text[start..]
+            .char_indices()
+            .nth(max_chars)
+            .map_or(text.len(), |(offset, _)| start + offset);
+        let chunk = text[start..end].trim();
+        if !chunk.is_empty() {
+            chunks.push(chunk.to_string());
+        }
+        start = end;
+    }
+    chunks
+}
+
+fn apply_char_limit(mut split: StreamingTextChunks, max_chars: usize) -> StreamingTextChunks {
+    split.ready = split
+        .ready
+        .into_iter()
+        .flat_map(|text| split_at_char_limit(&text, max_chars))
+        .collect();
+    if split.pending.chars().count() > max_chars {
+        let mut chunks = split_at_char_limit(&split.pending, max_chars);
+        if let Some(pending) = chunks.pop() {
+            split.ready.extend(chunks);
+            split.pending = pending;
+        }
+    }
+    split
 }
 
 #[derive(Default)]
@@ -63,7 +197,7 @@ pub trait TtsBackend: Send + Sync {
         text: &str,
         flush: bool,
     ) -> Result<StreamingTextChunks, String> {
-        take_streaming_text_chunks(text, flush)
+        Ok(take_streaming_text_chunks(text, flush))
     }
 
     fn synthesize(
@@ -193,6 +327,17 @@ impl TtsBackend for OpenAiTts {
         }
     }
 
+    fn take_streaming_text_chunks(
+        &self,
+        text: &str,
+        flush: bool,
+    ) -> Result<StreamingTextChunks, String> {
+        Ok(apply_char_limit(
+            take_streaming_text_chunks(text, flush),
+            OPENAI_MAX_TTS_INPUT_CHARS,
+        ))
+    }
+
     fn synthesize(
         &self,
         text: &str,
@@ -218,7 +363,10 @@ impl TtsBackend for OpenAiTts {
 
 #[cfg(test)]
 mod tests {
-    use super::{PocketTtsBackend, StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec};
+    use super::{
+        apply_char_limit, take_streaming_text_chunks, PocketTtsBackend, StreamingTextChunks,
+        StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec,
+    };
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -271,6 +419,37 @@ mod tests {
         );
         assert_eq!(text.flush(&backend).unwrap(), ["The light remained"]);
         assert!(text.flush(&backend).unwrap().is_empty());
+    }
+
+    #[test]
+    fn streaming_text_waits_for_a_partial_list_marker() {
+        let split = take_streaming_text_chunks("- First.\n\n-", false);
+
+        assert!(split.ready.is_empty());
+        assert_eq!(split.pending, "- First.\n\n-");
+
+        let split = take_streaming_text_chunks("1. First.\n\n2.", false);
+
+        assert!(split.ready.is_empty());
+        assert_eq!(split.pending, "1. First.\n\n2.");
+
+        let split = take_streaming_text_chunks("- First.\n\n- Second.\n\nAfter", false);
+        assert_eq!(split.ready, ["- First.\n\n- Second.\n\n"]);
+        assert_eq!(split.pending, "After");
+    }
+
+    #[test]
+    fn provider_character_limit_releases_only_stable_overflow() {
+        let split = apply_char_limit(
+            StreamingTextChunks {
+                ready: vec!["12345678".into()],
+                pending: "abcdéfg".into(),
+            },
+            4,
+        );
+
+        assert_eq!(split.ready, ["1234", "5678", "abcd"]);
+        assert_eq!(split.pending, "éfg");
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/tts.rs
+++ b/src-tauri/crates/berd-voice/src/tts.rs
@@ -31,8 +31,18 @@ pub enum TtsSynthesisEvent<'a> {
 /// Stable synthesis units drained from a growing assistant response.
 #[derive(Debug, PartialEq, Eq)]
 pub struct StreamingTextChunks {
-    pub ready: Vec<String>,
+    pub ready: Vec<StreamingTextChunk>,
     pub pending: String,
+}
+
+/// One provider-safe piece of a speech block.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StreamingTextChunk {
+    pub text: String,
+    /// True only for the first provider piece in a prose paragraph or Markdown list.
+    pub starts_speech_block: bool,
+    /// True only for the final provider piece in a prose paragraph or Markdown list.
+    pub ends_speech_block: bool,
 }
 
 /// Drain complete speech blocks while retaining text that may still grow.
@@ -45,12 +55,20 @@ pub(crate) fn take_streaming_text_chunks(text: &str, flush: bool) -> StreamingTe
     let mut ready = Vec::new();
 
     while let Some(end) = first_stable_speech_block_end(&pending) {
-        ready.push(pending[..end].to_string());
+        ready.push(StreamingTextChunk {
+            text: pending[..end].to_string(),
+            starts_speech_block: true,
+            ends_speech_block: true,
+        });
         pending = pending[end..].trim_start().to_string();
     }
 
     if flush && !pending.is_empty() {
-        ready.push(std::mem::take(&mut pending));
+        ready.push(StreamingTextChunk {
+            text: std::mem::take(&mut pending),
+            starts_speech_block: true,
+            ends_speech_block: true,
+        });
     }
 
     StreamingTextChunks { ready, pending }
@@ -149,12 +167,32 @@ fn apply_char_limit(mut split: StreamingTextChunks, max_chars: usize) -> Streami
     split.ready = split
         .ready
         .into_iter()
-        .flat_map(|text| split_at_char_limit(&text, max_chars))
+        .flat_map(|chunk| {
+            let pieces = split_at_char_limit(&chunk.text, max_chars);
+            let last = pieces.len().saturating_sub(1);
+            pieces
+                .into_iter()
+                .enumerate()
+                .map(move |(index, text)| StreamingTextChunk {
+                    text,
+                    starts_speech_block: chunk.starts_speech_block && index == 0,
+                    ends_speech_block: chunk.ends_speech_block && index == last,
+                })
+        })
         .collect();
     if split.pending.chars().count() > max_chars {
         let mut chunks = split_at_char_limit(&split.pending, max_chars);
         if let Some(pending) = chunks.pop() {
-            split.ready.extend(chunks);
+            split.ready.extend(
+                chunks
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, text)| StreamingTextChunk {
+                        text,
+                        starts_speech_block: index == 0,
+                        ends_speech_block: false,
+                    }),
+            );
             split.pending = pending;
         }
     }
@@ -164,20 +202,40 @@ fn apply_char_limit(mut split: StreamingTextChunks, max_chars: usize) -> Streami
 #[derive(Default)]
 pub struct StreamingTtsText {
     pending: String,
+    pending_block_started: bool,
 }
 
 impl StreamingTtsText {
-    pub fn append(&mut self, backend: &dyn TtsBackend, delta: &str) -> Result<Vec<String>, String> {
+    pub fn append(
+        &mut self,
+        backend: &dyn TtsBackend,
+        delta: &str,
+    ) -> Result<Vec<StreamingTextChunk>, String> {
         self.pending.push_str(delta);
         self.take_ready(backend, false)
     }
 
-    pub fn flush(&mut self, backend: &dyn TtsBackend) -> Result<Vec<String>, String> {
+    pub fn flush(
+        &mut self,
+        backend: &dyn TtsBackend,
+    ) -> Result<Vec<StreamingTextChunk>, String> {
         self.take_ready(backend, true)
     }
 
-    fn take_ready(&mut self, backend: &dyn TtsBackend, flush: bool) -> Result<Vec<String>, String> {
-        let split = backend.take_streaming_text_chunks(&self.pending, flush)?;
+    fn take_ready(
+        &mut self,
+        backend: &dyn TtsBackend,
+        flush: bool,
+    ) -> Result<Vec<StreamingTextChunk>, String> {
+        let mut split = backend.take_streaming_text_chunks(&self.pending, flush)?;
+        if self.pending_block_started {
+            if let Some(first) = split.ready.first_mut() {
+                first.starts_speech_block = false;
+            }
+        }
+        if let Some(last) = split.ready.last() {
+            self.pending_block_started = !last.ends_speech_block;
+        }
         self.pending = split.pending;
         Ok(split.ready)
     }
@@ -364,13 +422,15 @@ impl TtsBackend for OpenAiTts {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_char_limit, take_streaming_text_chunks, PocketTtsBackend, StreamingTextChunks,
-        StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec,
+        apply_char_limit, take_streaming_text_chunks, PocketTtsBackend, StreamingTextChunk,
+        StreamingTextChunks, StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec,
     };
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     struct FakeTts;
+
+    struct FourCharacterTts;
 
     impl TtsBackend for FakeTts {
         fn pcm_spec(&self) -> TtsPcmSpec {
@@ -388,6 +448,32 @@ mod tests {
         ) -> Result<TtsOutcome, String> {
             on_frames(&[0.0, 0.5])?;
             Ok(TtsOutcome::Completed)
+        }
+    }
+
+    impl TtsBackend for FourCharacterTts {
+        fn pcm_spec(&self) -> TtsPcmSpec {
+            FakeTts.pcm_spec()
+        }
+
+        fn take_streaming_text_chunks(
+            &self,
+            text: &str,
+            flush: bool,
+        ) -> Result<StreamingTextChunks, String> {
+            Ok(apply_char_limit(
+                take_streaming_text_chunks(text, flush),
+                4,
+            ))
+        }
+
+        fn synthesize(
+            &self,
+            text: &str,
+            active: &AtomicBool,
+            on_frames: &mut dyn FnMut(&[f32]) -> Result<(), String>,
+        ) -> Result<TtsOutcome, String> {
+            FakeTts.synthesize(text, active, on_frames)
         }
     }
 
@@ -415,9 +501,20 @@ mod tests {
         assert_eq!(
             text.append(&backend, "ora waited.\n\nThe light remained")
                 .unwrap(),
-            ["Nora waited.\n\n"]
+            [StreamingTextChunk {
+                text: "Nora waited.\n\n".into(),
+                starts_speech_block: true,
+                ends_speech_block: true,
+            }]
         );
-        assert_eq!(text.flush(&backend).unwrap(), ["The light remained"]);
+        assert_eq!(
+            text.flush(&backend).unwrap(),
+            [StreamingTextChunk {
+                text: "The light remained".into(),
+                starts_speech_block: true,
+                ends_speech_block: true,
+            }]
+        );
         assert!(text.flush(&backend).unwrap().is_empty());
     }
 
@@ -434,7 +531,14 @@ mod tests {
         assert_eq!(split.pending, "1. First.\n\n2.");
 
         let split = take_streaming_text_chunks("- First.\n\n- Second.\n\nAfter", false);
-        assert_eq!(split.ready, ["- First.\n\n- Second.\n\n"]);
+        assert_eq!(
+            split.ready,
+            [StreamingTextChunk {
+                text: "- First.\n\n- Second.\n\n".into(),
+                starts_speech_block: true,
+                ends_speech_block: true,
+            }]
+        );
         assert_eq!(split.pending, "After");
     }
 
@@ -442,14 +546,67 @@ mod tests {
     fn provider_character_limit_releases_only_stable_overflow() {
         let split = apply_char_limit(
             StreamingTextChunks {
-                ready: vec!["12345678".into()],
+                ready: vec![StreamingTextChunk {
+                    text: "12345678".into(),
+                    starts_speech_block: true,
+                    ends_speech_block: true,
+                }],
                 pending: "abcdéfg".into(),
             },
             4,
         );
 
-        assert_eq!(split.ready, ["1234", "5678", "abcd"]);
+        assert_eq!(
+            split.ready,
+            [
+                StreamingTextChunk {
+                    text: "1234".into(),
+                    starts_speech_block: true,
+                    ends_speech_block: false,
+                },
+                StreamingTextChunk {
+                    text: "5678".into(),
+                    starts_speech_block: false,
+                    ends_speech_block: true,
+                },
+                StreamingTextChunk {
+                    text: "abcd".into(),
+                    starts_speech_block: true,
+                    ends_speech_block: false,
+                },
+            ]
+        );
         assert_eq!(split.pending, "éfg");
+    }
+
+    #[test]
+    fn provider_splits_do_not_create_false_speech_block_boundaries() {
+        let backend = FourCharacterTts;
+        let mut text = StreamingTtsText::default();
+
+        assert_eq!(
+            text.append(&backend, "abcdefghij").unwrap(),
+            [
+                StreamingTextChunk {
+                    text: "abcd".into(),
+                    starts_speech_block: true,
+                    ends_speech_block: false,
+                },
+                StreamingTextChunk {
+                    text: "efgh".into(),
+                    starts_speech_block: false,
+                    ends_speech_block: false,
+                },
+            ]
+        );
+        assert_eq!(
+            text.flush(&backend).unwrap(),
+            [StreamingTextChunk {
+                text: "ij".into(),
+                starts_speech_block: false,
+                ends_speech_block: true,
+            }]
+        );
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/tts.rs
+++ b/src-tauri/crates/berd-voice/src/tts.rs
@@ -3,7 +3,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::openai::{stream_openai_pcm, OpenAiPcmOutcome, OpenAiSpeechConfig};
-use crate::{load_pocket_voice_style, load_text_to_speech, PocketTts, VoiceStyle, SAMPLE_RATE};
+use crate::{
+    load_pocket_voice_style, load_text_to_speech, take_streaming_text_chunks, PocketTts,
+    StreamingTextChunks, VoiceStyle, SAMPLE_RATE,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TtsPcmSpec {
@@ -24,12 +27,44 @@ pub enum TtsSynthesisEvent<'a> {
     Poll,
 }
 
+#[derive(Default)]
+pub struct StreamingTtsText {
+    pending: String,
+}
+
+impl StreamingTtsText {
+    pub fn append(&mut self, backend: &dyn TtsBackend, delta: &str) -> Result<Vec<String>, String> {
+        self.pending.push_str(delta);
+        self.take_ready(backend, false)
+    }
+
+    pub fn flush(&mut self, backend: &dyn TtsBackend) -> Result<Vec<String>, String> {
+        self.take_ready(backend, true)
+    }
+
+    fn take_ready(&mut self, backend: &dyn TtsBackend, flush: bool) -> Result<Vec<String>, String> {
+        let split = backend.take_streaming_text_chunks(&self.pending, flush)?;
+        self.pending = split.pending;
+        Ok(split.ready)
+    }
+}
+
 /// A backend-neutral source of normalized mono, unit-scale Float32 PCM.
 ///
 /// Turn admission, output-device ownership, buffering, playback, and delivery
 /// events remain the session host's responsibility.
 pub trait TtsBackend: Send + Sync {
     fn pcm_spec(&self) -> TtsPcmSpec;
+
+    /// Drains stable synthesis units while retaining the growing text tail.
+    /// Backends may override this only to honor an actual provider limit.
+    fn take_streaming_text_chunks(
+        &self,
+        text: &str,
+        flush: bool,
+    ) -> Result<StreamingTextChunks, String> {
+        take_streaming_text_chunks(text, flush)
+    }
 
     fn synthesize(
         &self,
@@ -91,6 +126,14 @@ impl TtsBackend for PocketTtsBackend {
             sample_rate: SAMPLE_RATE,
             playback_rate: self.playback_rate,
         }
+    }
+
+    fn take_streaming_text_chunks(
+        &self,
+        text: &str,
+        flush: bool,
+    ) -> Result<StreamingTextChunks, String> {
+        self.engine.take_streaming_text_chunks(text, flush)
     }
 
     fn synthesize(
@@ -175,7 +218,7 @@ impl TtsBackend for OpenAiTts {
 
 #[cfg(test)]
 mod tests {
-    use super::{PocketTtsBackend, TtsBackend, TtsOutcome, TtsPcmSpec};
+    use super::{PocketTtsBackend, StreamingTtsText, TtsBackend, TtsOutcome, TtsPcmSpec};
     use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -213,6 +256,21 @@ mod tests {
         assert_eq!(backend.pcm_spec().sample_rate, 16_000);
         assert_eq!(outcome, TtsOutcome::Completed);
         assert_eq!(received, [0.0, 0.5]);
+    }
+
+    #[test]
+    fn streaming_text_accepts_deltas_and_releases_only_stable_units() {
+        let backend = FakeTts;
+        let mut text = StreamingTtsText::default();
+
+        assert!(text.append(&backend, "N").unwrap().is_empty());
+        assert_eq!(
+            text.append(&backend, "ora waited.\n\nThe light remained")
+                .unwrap(),
+            ["Nora waited.\n\n"]
+        );
+        assert_eq!(text.flush(&backend).unwrap(), ["The light remained"]);
+        assert!(text.flush(&backend).unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/crates/berd-voice/src/tts.rs
+++ b/src-tauri/crates/berd-voice/src/tts.rs
@@ -3,9 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::openai::{stream_openai_pcm, OpenAiPcmOutcome, OpenAiSpeechConfig};
-use crate::{
-    load_pocket_voice_style, load_text_to_speech, PocketTts, VoiceStyle, SAMPLE_RATE,
-};
+use crate::{load_pocket_voice_style, load_text_to_speech, PocketTts, VoiceStyle, SAMPLE_RATE};
 
 const OPENAI_MAX_TTS_INPUT_CHARS: usize = 4096;
 
@@ -138,7 +136,10 @@ fn could_be_incomplete_markdown_list_marker(text: &str) -> bool {
     if matches!(line, "-" | "*" | "+") {
         return true;
     }
-    let digits = line.bytes().take_while(|byte| byte.is_ascii_digit()).count();
+    let digits = line
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
     digits > 0
         && (digits == line.len()
             || (digits + 1 == line.len()
@@ -183,16 +184,18 @@ fn apply_char_limit(mut split: StreamingTextChunks, max_chars: usize) -> Streami
     if split.pending.chars().count() > max_chars {
         let mut chunks = split_at_char_limit(&split.pending, max_chars);
         if let Some(pending) = chunks.pop() {
-            split.ready.extend(
-                chunks
-                    .into_iter()
-                    .enumerate()
-                    .map(|(index, text)| StreamingTextChunk {
-                        text,
-                        starts_speech_block: index == 0,
-                        ends_speech_block: false,
-                    }),
-            );
+            split
+                .ready
+                .extend(
+                    chunks
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, text)| StreamingTextChunk {
+                            text,
+                            starts_speech_block: index == 0,
+                            ends_speech_block: false,
+                        }),
+                );
             split.pending = pending;
         }
     }
@@ -215,10 +218,7 @@ impl StreamingTtsText {
         self.take_ready(backend, false)
     }
 
-    pub fn flush(
-        &mut self,
-        backend: &dyn TtsBackend,
-    ) -> Result<Vec<StreamingTextChunk>, String> {
+    pub fn flush(&mut self, backend: &dyn TtsBackend) -> Result<Vec<StreamingTextChunk>, String> {
         self.take_ready(backend, true)
     }
 
@@ -461,10 +461,7 @@ mod tests {
             text: &str,
             flush: bool,
         ) -> Result<StreamingTextChunks, String> {
-            Ok(apply_char_limit(
-                take_streaming_text_chunks(text, flush),
-                4,
-            ))
+            Ok(apply_char_limit(take_streaming_text_chunks(text, flush), 4))
         }
 
         fn synthesize(

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -60,6 +60,16 @@ const INITIAL_PLAYBACK_BUFFER_FRAMES: usize = TTS_SAMPLE_RATE as usize / 5;
 const TTS_EVENT: &str = "openai-voice:stream-event";
 #[cfg(target_os = "macos")]
 const MAX_TTS_INPUT_CHARS: usize = 4096;
+#[cfg(any(test, target_os = "macos"))]
+const OPENAI_INTER_PARAGRAPH_BASE_SILENCE_FLOOR: Duration = Duration::from_millis(500);
+const MIN_PLAYBACK_SPEED: f32 = 0.75;
+const MAX_PLAYBACK_SPEED: f32 = 2.0;
+
+#[cfg(any(test, target_os = "macos"))]
+fn openai_inter_paragraph_silence_floor(speed: f32) -> Duration {
+    OPENAI_INTER_PARAGRAPH_BASE_SILENCE_FLOOR
+        .div_f32(speed.clamp(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED))
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct OpenAiVoiceState {
@@ -813,6 +823,7 @@ fn run_openai_voice_stream(
         TTS_SAMPLE_RATE,
         INITIAL_PLAYBACK_BUFFER_FRAMES,
     )?;
+    let inter_paragraph_silence_floor = openai_inter_paragraph_silence_floor(speed);
     let mut assistant_speech = None::<AssistantSpeechGuard>;
     let mut playback_drained_at = None::<Instant>;
     let mut streaming_text = StreamingTtsText::default();
@@ -843,6 +854,7 @@ fn run_openai_voice_stream(
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
+                    inter_paragraph_silence_floor,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -869,6 +881,7 @@ fn run_openai_voice_stream(
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
+                    inter_paragraph_silence_floor,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -895,6 +908,7 @@ fn run_openai_voice_stream(
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
+                    inter_paragraph_silence_floor,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -987,6 +1001,7 @@ fn speak_openai_stream_ready(
     stream_id: &str,
     backend: &dyn TtsBackend,
     playback: &mut OutboundPlayback<'_>,
+    inter_paragraph_silence_floor: Duration,
     ready: Vec<String>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
@@ -995,6 +1010,10 @@ fn speak_openai_stream_ready(
     playback_drained_at: &mut Option<Instant>,
 ) -> Result<OutboundOutcome, OutboundFailure> {
     for text in ready {
+        let outcome = playback.queue_inter_segment_silence_floor(inter_paragraph_silence_floor)?;
+        if outcome == OutboundOutcome::Interrupted {
+            return Ok(outcome);
+        }
         let mut ready = text;
         let outcome = speak_pending(
             app,
@@ -1136,6 +1155,22 @@ fn emit_openai_stream_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inter_paragraph_silence_floor_tracks_openai_synthesis_rate() {
+        assert!(
+            (openai_inter_paragraph_silence_floor(0.75).as_secs_f32() - (2.0 / 3.0)).abs()
+                < f32::EPSILON
+        );
+        assert_eq!(
+            openai_inter_paragraph_silence_floor(1.0),
+            Duration::from_millis(500)
+        );
+        assert_eq!(
+            openai_inter_paragraph_silence_floor(2.0),
+            Duration::from_millis(250)
+        );
+    }
 
     #[test]
     fn destroyed_window_only_stops_its_openai_stream() {

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -62,7 +62,9 @@ const TTS_EVENT: &str = "openai-voice:stream-event";
 // OpenAI returns variable trailing quiet PCM, so enforce a measured total
 // floor rather than stacking a fixed pause on top of provider padding.
 const OPENAI_INTER_PARAGRAPH_BASE_SILENCE_FLOOR: Duration = Duration::from_millis(500);
+#[cfg(any(test, target_os = "macos"))]
 const MIN_PLAYBACK_SPEED: f32 = 0.75;
+#[cfg(any(test, target_os = "macos"))]
 const MAX_PLAYBACK_SPEED: f32 = 2.0;
 
 #[cfg(any(test, target_os = "macos"))]

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     ConfiguredTtsSlot, DeliveryProgress as VoiceDeliveryProgress, DrainPolicy, OutboundFailure,
-    OutboundOutcome, OutboundPlayback, PocketAudioPlayer, TtsBackend, TtsConfiguration,
+    OutboundOutcome, OutboundPlayback, PocketAudioPlayer, StreamingTtsText, TtsBackend,
+    TtsConfiguration,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -814,7 +815,7 @@ fn run_openai_voice_stream(
     )?;
     let mut assistant_speech = None::<AssistantSpeechGuard>;
     let mut playback_drained_at = None::<Instant>;
-    let mut pending = String::new();
+    let mut streaming_text = StreamingTtsText::default();
     let mut last_progress = Instant::now();
 
     loop {
@@ -833,39 +834,42 @@ fn run_openai_voice_stream(
         }
         match receiver.recv_timeout(Duration::from_millis(20)) {
             Ok(OpenAiStreamCommand::Append(text)) => {
-                pending.push_str(&text);
-                if pending.len() >= 24 && pending.trim_end().ends_with(['.', '!', '?', '\n']) {
-                    match speak_pending(
-                        app,
-                        stream_id,
-                        backend.as_ref(),
-                        &mut playback,
-                        &mut pending,
-                        &native_voice,
-                        interruption_sensitivity,
-                        input_during_tts,
-                        &mut assistant_speech,
-                        &mut playback_drained_at,
-                    )
-                    .map_err(openai_playback_failure)?
-                    {
-                        OutboundOutcome::Interrupted => {
-                            return Ok(StreamOutcome {
-                                state: OpenAiStreamEventState::Interrupted,
-                                delivery: Some(playback.snapshot()),
-                            })
-                        }
-                        OutboundOutcome::Completed => {}
-                    }
-                }
-            }
-            Ok(OpenAiStreamCommand::Flush) => {
-                if speak_pending(
+                let ready = match streaming_text.append(backend.as_ref(), &text) {
+                    Ok(ready) => ready,
+                    Err(message) => return Err(openai_playback_failure(playback.abort(message))),
+                };
+                if speak_openai_stream_ready(
                     app,
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
-                    &mut pending,
+                    ready,
+                    &native_voice,
+                    interruption_sensitivity,
+                    input_during_tts,
+                    &mut assistant_speech,
+                    &mut playback_drained_at,
+                )
+                .map_err(openai_playback_failure)?
+                    == OutboundOutcome::Interrupted
+                {
+                    return Ok(StreamOutcome {
+                        state: OpenAiStreamEventState::Interrupted,
+                        delivery: Some(playback.snapshot()),
+                    });
+                }
+            }
+            Ok(OpenAiStreamCommand::Flush) => {
+                let ready = match streaming_text.flush(backend.as_ref()) {
+                    Ok(ready) => ready,
+                    Err(message) => return Err(openai_playback_failure(playback.abort(message))),
+                };
+                if speak_openai_stream_ready(
+                    app,
+                    stream_id,
+                    backend.as_ref(),
+                    &mut playback,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
@@ -882,12 +886,16 @@ fn run_openai_voice_stream(
                 }
             }
             Ok(OpenAiStreamCommand::Finish) => {
-                if speak_pending(
+                let ready = match streaming_text.flush(backend.as_ref()) {
+                    Ok(ready) => ready,
+                    Err(message) => return Err(openai_playback_failure(playback.abort(message))),
+                };
+                if speak_openai_stream_ready(
                     app,
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
-                    &mut pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
@@ -970,6 +978,41 @@ fn run_openai_voice_stream(
             }
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(clippy::too_many_arguments)]
+fn speak_openai_stream_ready(
+    app: &AppHandle,
+    stream_id: &str,
+    backend: &dyn TtsBackend,
+    playback: &mut OutboundPlayback<'_>,
+    ready: Vec<String>,
+    native_voice: &NativeVoiceState,
+    interruption_sensitivity: InterruptionSensitivity,
+    input_during_tts: InputDuringTtsPolicy,
+    assistant_speech: &mut Option<AssistantSpeechGuard>,
+    playback_drained_at: &mut Option<Instant>,
+) -> Result<OutboundOutcome, OutboundFailure> {
+    for text in ready {
+        let mut ready = text;
+        let outcome = speak_pending(
+            app,
+            stream_id,
+            backend,
+            playback,
+            &mut ready,
+            native_voice,
+            interruption_sensitivity,
+            input_during_tts,
+            assistant_speech,
+            playback_drained_at,
+        )?;
+        if outcome == OutboundOutcome::Interrupted {
+            return Ok(outcome);
+        }
+    }
+    Ok(OutboundOutcome::Completed)
 }
 
 #[cfg(target_os = "macos")]

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -58,9 +58,9 @@ const TTS_SAMPLE_RATE: u32 = 24_000;
 const INITIAL_PLAYBACK_BUFFER_FRAMES: usize = TTS_SAMPLE_RATE as usize / 5;
 #[cfg(target_os = "macos")]
 const TTS_EVENT: &str = "openai-voice:stream-event";
-#[cfg(target_os = "macos")]
-const MAX_TTS_INPUT_CHARS: usize = 4096;
 #[cfg(any(test, target_os = "macos"))]
+// OpenAI returns variable trailing quiet PCM, so enforce a measured total
+// floor rather than stacking a fixed pause on top of provider padding.
 const OPENAI_INTER_PARAGRAPH_BASE_SILENCE_FLOOR: Duration = Duration::from_millis(500);
 const MIN_PLAYBACK_SPEED: f32 = 0.75;
 const MAX_PLAYBACK_SPEED: f32 = 2.0;
@@ -1014,13 +1014,12 @@ fn speak_openai_stream_ready(
         if outcome == OutboundOutcome::Interrupted {
             return Ok(outcome);
         }
-        let mut ready = text;
-        let outcome = speak_pending(
+        let outcome = speak_openai_ready_unit(
             app,
             stream_id,
             backend,
             playback,
-            &mut ready,
+            &text,
             native_voice,
             interruption_sensitivity,
             input_during_tts,
@@ -1036,53 +1035,46 @@ fn speak_openai_stream_ready(
 
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
-fn speak_pending(
+fn speak_openai_ready_unit(
     app: &AppHandle,
     stream_id: &str,
     backend: &dyn TtsBackend,
     playback: &mut OutboundPlayback<'_>,
-    pending: &mut String,
+    text: &str,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
     assistant_speech: &mut Option<AssistantSpeechGuard>,
     playback_drained_at: &mut Option<Instant>,
 ) -> Result<OutboundOutcome, OutboundFailure> {
-    let text = std::mem::take(pending).trim().to_string();
+    let text = text.trim();
     if text.is_empty() {
         return Ok(OutboundOutcome::Completed);
     }
-    for chunk in chunk_text(&text, MAX_TTS_INPUT_CHARS) {
-        let outcome = playback.synthesize_segment(
-            backend,
-            chunk,
-            &mut |_| {
-                *playback_drained_at = None;
-                if assistant_speech.is_none() {
-                    *assistant_speech = Some(
-                        native_voice
-                            .begin_assistant_speech(interruption_sensitivity, input_during_tts),
-                    );
-                }
-                Ok(())
-            },
-            &mut || {
-                emit_openai_stream_event(
-                    app,
-                    stream_id,
-                    OpenAiStreamEventState::Started,
-                    None,
-                    None,
+    playback.synthesize_segment(
+        backend,
+        text,
+        &mut |_| {
+            *playback_drained_at = None;
+            if assistant_speech.is_none() {
+                *assistant_speech = Some(
+                    native_voice.begin_assistant_speech(interruption_sensitivity, input_during_tts),
                 );
-                Ok(())
-            },
-            &mut |_| Ok(()),
-        )?;
-        if outcome == OutboundOutcome::Interrupted {
-            return Ok(outcome);
-        }
-    }
-    Ok(OutboundOutcome::Completed)
+            }
+            Ok(())
+        },
+        &mut || {
+            emit_openai_stream_event(
+                app,
+                stream_id,
+                OpenAiStreamEventState::Started,
+                None,
+                None,
+            );
+            Ok(())
+        },
+        &mut |_| Ok(()),
+    )
 }
 
 #[cfg(target_os = "macos")]
@@ -1091,27 +1083,6 @@ fn openai_playback_failure(failure: OutboundFailure) -> StreamFailure {
         error: failure.message,
         delivery: Some(failure.delivery),
     }
-}
-
-#[cfg(target_os = "macos")]
-fn chunk_text(text: &str, max_chars: usize) -> Vec<&str> {
-    let mut chunks = Vec::new();
-    let mut start = 0;
-    while start < text.len() {
-        let mut end = (start + max_chars).min(text.len());
-        while end > start && !text.is_char_boundary(end) {
-            end -= 1;
-        }
-        if end == start {
-            end = text.len();
-        }
-        chunks.push(text[start..end].trim());
-        start = end;
-    }
-    chunks
-        .into_iter()
-        .filter(|chunk| !chunk.is_empty())
-        .collect()
 }
 
 #[cfg(target_os = "macos")]
@@ -1316,10 +1287,4 @@ mod tests {
         assert!(state.is_configured());
     }
 
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn chunks_tts_text_on_char_boundaries() {
-        assert_eq!(chunk_text("hello", 10), vec!["hello"]);
-        assert_eq!(chunk_text("ééé", 3), vec!["é", "é", "é"]);
-    }
 }

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -1064,13 +1064,7 @@ fn speak_openai_ready_unit(
             Ok(())
         },
         &mut || {
-            emit_openai_stream_event(
-                app,
-                stream_id,
-                OpenAiStreamEventState::Started,
-                None,
-                None,
-            );
+            emit_openai_stream_event(app, stream_id, OpenAiStreamEventState::Started, None, None);
             Ok(())
         },
         &mut |_| Ok(()),
@@ -1286,5 +1280,4 @@ mod tests {
 
         assert!(state.is_configured());
     }
-
 }

--- a/src-tauri/src/commands/openai_audio.rs
+++ b/src-tauri/src/commands/openai_audio.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     ConfiguredTtsSlot, DeliveryProgress as VoiceDeliveryProgress, DrainPolicy, OutboundFailure,
-    OutboundOutcome, OutboundPlayback, PocketAudioPlayer, StreamingTtsText, TtsBackend,
-    TtsConfiguration,
+    OutboundOutcome, OutboundPlayback, PocketAudioPlayer, StreamingTextChunk, StreamingTtsText,
+    TtsBackend, TtsConfiguration,
 };
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
@@ -1002,24 +1002,27 @@ fn speak_openai_stream_ready(
     backend: &dyn TtsBackend,
     playback: &mut OutboundPlayback<'_>,
     inter_paragraph_silence_floor: Duration,
-    ready: Vec<String>,
+    ready: Vec<StreamingTextChunk>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
     assistant_speech: &mut Option<AssistantSpeechGuard>,
     playback_drained_at: &mut Option<Instant>,
 ) -> Result<OutboundOutcome, OutboundFailure> {
-    for text in ready {
-        let outcome = playback.queue_inter_segment_silence_floor(inter_paragraph_silence_floor)?;
-        if outcome == OutboundOutcome::Interrupted {
-            return Ok(outcome);
+    for chunk in ready {
+        if chunk.starts_speech_block {
+            let outcome =
+                playback.queue_inter_segment_silence_floor(inter_paragraph_silence_floor)?;
+            if outcome == OutboundOutcome::Interrupted {
+                return Ok(outcome);
+            }
         }
         let outcome = speak_openai_ready_unit(
             app,
             stream_id,
             backend,
             playback,
-            &text,
+            &chunk.text,
             native_voice,
             interruption_sensitivity,
             input_during_tts,

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -20,8 +20,8 @@ use berd_voice::SAMPLE_RATE;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     load_pocket_voice_style, load_text_to_speech, ConfiguredTtsSlot, DrainPolicy,
-    DrainTimeoutOutcome, OutboundFailure, OutboundOutcome, OutboundPlayback, StreamingTtsText,
-    TtsBackend, TtsConfiguration,
+    DrainTimeoutOutcome, OutboundFailure, OutboundOutcome, OutboundPlayback, StreamingTextChunk,
+    StreamingTtsText, TtsBackend, TtsConfiguration,
 };
 use berd_voice::{parakeet_assets, pocket_assets};
 #[cfg(target_os = "macos")]
@@ -2187,7 +2187,7 @@ fn synthesize_pocket_stream_ready(
     stream_id: &str,
     backend: &dyn TtsBackend,
     playback: &mut OutboundPlayback<'_>,
-    ready: Vec<String>,
+    ready: Vec<StreamingTextChunk>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
@@ -2195,8 +2195,8 @@ fn synthesize_pocket_stream_ready(
     playback_drained_at: &mut Option<Instant>,
     last_progress_emit: &mut Instant,
 ) -> Result<bool, String> {
-    for text in ready {
-        let text = text.trim().to_string();
+    for chunk in ready {
+        let text = chunk.text.trim().to_string();
         let outcome = playback
             .synthesize_segment(
                 backend,

--- a/src-tauri/src/commands/pocket_voice.rs
+++ b/src-tauri/src/commands/pocket_voice.rs
@@ -20,8 +20,8 @@ use berd_voice::SAMPLE_RATE;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     load_pocket_voice_style, load_text_to_speech, ConfiguredTtsSlot, DrainPolicy,
-    DrainTimeoutOutcome, OutboundFailure, OutboundOutcome, OutboundPlayback, TtsBackend,
-    TtsConfiguration,
+    DrainTimeoutOutcome, OutboundFailure, OutboundOutcome, OutboundPlayback, StreamingTtsText,
+    TtsBackend, TtsConfiguration,
 };
 use berd_voice::{parakeet_assets, pocket_assets};
 #[cfg(target_os = "macos")]
@@ -1933,8 +1933,7 @@ fn run_pocket_voice_stream(
     let backend = tts.backend();
     let player = PocketAudioPlayer::new(SAMPLE_RATE, playback_rate, output_device)?;
     let mut playback = OutboundPlayback::new(&player, &active, SAMPLE_RATE, 0)?;
-    let mut pending = String::new();
-    let mut first_chunk_pending = true;
+    let mut streaming_text = StreamingTtsText::default();
     let mut assistant_speech = None::<AssistantSpeechGuard>;
     let mut playback_drained_at = None;
     let output_latency_grace = playback_latency_safety_duration(output_device);
@@ -1957,21 +1956,19 @@ fn run_pocket_voice_stream(
         let command = receiver.recv_timeout(Duration::from_millis(20));
         match command {
             Ok(PocketStreamCommand::Append(text)) => {
-                pending.push_str(&text);
+                let ready = streaming_text.append(backend.as_ref(), &text)?;
                 if !synthesize_pocket_stream_ready(
                     app,
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
                     &mut assistant_speech,
                     &mut playback_drained_at,
                     &mut last_progress_emit,
-                    false,
                 )? {
                     return Ok(PocketStreamOutcome {
                         state: PocketStreamEventState::Interrupted,
@@ -1980,20 +1977,19 @@ fn run_pocket_voice_stream(
                 }
             }
             Ok(PocketStreamCommand::Flush) => {
+                let ready = streaming_text.flush(backend.as_ref())?;
                 if !synthesize_pocket_stream_ready(
                     app,
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
                     &mut assistant_speech,
                     &mut playback_drained_at,
                     &mut last_progress_emit,
-                    true,
                 )? {
                     return Ok(PocketStreamOutcome {
                         state: PocketStreamEventState::Interrupted,
@@ -2002,20 +1998,19 @@ fn run_pocket_voice_stream(
                 }
             }
             Ok(PocketStreamCommand::Finish) => {
+                let ready = streaming_text.flush(backend.as_ref())?;
                 if !synthesize_pocket_stream_ready(
                     app,
                     stream_id,
                     backend.as_ref(),
                     &mut playback,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
                     &mut assistant_speech,
                     &mut playback_drained_at,
                     &mut last_progress_emit,
-                    true,
                 )? {
                     return Ok(PocketStreamOutcome {
                         state: PocketStreamEventState::Interrupted,
@@ -2192,20 +2187,15 @@ fn synthesize_pocket_stream_ready(
     stream_id: &str,
     backend: &dyn TtsBackend,
     playback: &mut OutboundPlayback<'_>,
-    pending: &mut String,
-    first_chunk_pending: &mut bool,
+    ready: Vec<String>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
     assistant_speech: &mut Option<AssistantSpeechGuard>,
     playback_drained_at: &mut Option<Instant>,
     last_progress_emit: &mut Instant,
-    flush: bool,
 ) -> Result<bool, String> {
-    let split = berd_voice::take_streaming_text_chunks(pending, *first_chunk_pending, flush)?;
-    *pending = split.pending;
-    *first_chunk_pending = split.first_chunk_pending;
-    for text in split.ready {
+    for text in ready {
         let text = text.trim().to_string();
         let outcome = playback
             .synthesize_segment(

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -46,7 +46,8 @@ use berd_voice::DeliverySegment as VoiceDeliverySegment;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     ConfiguredTtsSlot, DrainPolicy, OutboundFailure, OutboundOutcome, OutboundPlayback,
-    PcmAudioOutput, PocketAudioPlayer, StreamingTtsText, TtsBackend, TtsConfiguration,
+    PcmAudioOutput, PocketAudioPlayer, StreamingTextChunk, StreamingTtsText, TtsBackend,
+    TtsConfiguration,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -532,7 +533,7 @@ fn synthesize_siri_stream_ready(
     player: &PocketAudioPlayer,
     output_latency_grace: Duration,
     inter_paragraph_silence: Duration,
-    ready: Vec<String>,
+    ready: Vec<StreamingTextChunk>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
@@ -541,13 +542,15 @@ fn synthesize_siri_stream_ready(
     last_progress_emit: &mut Instant,
     last_progress: &mut Option<VoiceDeliveryProgress>,
 ) -> Result<bool, String> {
-    for text in ready {
-        if playback
-            .queue_inter_segment_silence(inter_paragraph_silence)
-            .map_err(|failure| failure.message)?
-            == OutboundOutcome::Interrupted
-        {
-            return Ok(false);
+    for chunk in ready {
+        if chunk.starts_speech_block {
+            if playback
+                .queue_inter_segment_silence(inter_paragraph_silence)
+                .map_err(|failure| failure.message)?
+                == OutboundOutcome::Interrupted
+            {
+                return Ok(false);
+            }
         }
         // The coordinator invokes these callbacks serially, but Rust cannot
         // infer that two callback values never overlap. Interior borrows keep
@@ -557,7 +560,7 @@ fn synthesize_siri_stream_ready(
         let outcome = playback
             .synthesize_segment(
                 backend,
-                text.trim(),
+                chunk.text.trim(),
                 &mut |_| {
                     let mut assistant_speech = assistant_speech_cell.borrow_mut();
                     if assistant_speech.is_none() {

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -543,14 +543,13 @@ fn synthesize_siri_stream_ready(
     last_progress: &mut Option<VoiceDeliveryProgress>,
 ) -> Result<bool, String> {
     for chunk in ready {
-        if chunk.starts_speech_block {
-            if playback
+        if chunk.starts_speech_block
+            && playback
                 .queue_inter_segment_silence(inter_paragraph_silence)
                 .map_err(|failure| failure.message)?
                 == OutboundOutcome::Interrupted
-            {
-                return Ok(false);
-            }
+        {
+            return Ok(false);
         }
         // The coordinator invokes these callbacks serially, but Rust cannot
         // infer that two callback values never overlap. Interior borrows keep

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -137,11 +137,16 @@ const SIRI_STREAM_EVENT: &str = "siri-voice:stream-event";
 const SIRI_OUTPUT_DRAIN_MARGIN: Duration = Duration::from_secs(60);
 #[cfg(target_os = "macos")]
 const PLAYBACK_PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(100);
-#[cfg(target_os = "macos")]
-const SIRI_INTER_CHUNK_SILENCE: Duration = Duration::from_millis(250);
+#[cfg(any(test, target_os = "macos"))]
+const SIRI_INTER_PARAGRAPH_BASE_SILENCE: Duration = Duration::from_millis(250);
 const MIN_PLAYBACK_SPEED: f32 = 0.5;
 const MAX_PLAYBACK_SPEED: f32 = 2.0;
 pub(crate) static SIRI_SETTINGS_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(any(test, target_os = "macos"))]
+fn siri_inter_paragraph_silence(speed: f32) -> Duration {
+    SIRI_INTER_PARAGRAPH_BASE_SILENCE.div_f32(speed.clamp(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED))
+}
 
 pub type SiriVoiceSelection = SiriVoiceIdentity;
 
@@ -524,6 +529,7 @@ fn synthesize_siri_stream_ready(
     playback: &mut OutboundPlayback<'_>,
     player: &PocketAudioPlayer,
     output_latency_grace: Duration,
+    inter_paragraph_silence: Duration,
     ready: Vec<String>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
@@ -535,7 +541,7 @@ fn synthesize_siri_stream_ready(
 ) -> Result<bool, String> {
     for text in ready {
         if playback
-            .queue_inter_segment_silence(SIRI_INTER_CHUNK_SILENCE)
+            .queue_inter_segment_silence(inter_paragraph_silence)
             .map_err(|failure| failure.message)?
             == OutboundOutcome::Interrupted
         {
@@ -669,6 +675,7 @@ fn run_siri_stream(
     let player =
         PocketAudioPlayer::new(pcm_spec.sample_rate, pcm_spec.playback_rate, output_device)?;
     let mut playback = OutboundPlayback::new(&player, &active, pcm_spec.sample_rate, 0)?;
+    let inter_paragraph_silence = siri_inter_paragraph_silence(speed);
     let mut streaming_text = StreamingTtsText::default();
     let mut assistant_speech = None::<AssistantSpeechGuard>;
     let mut playback_drained_at = None;
@@ -700,6 +707,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
+                    inter_paragraph_silence,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -724,6 +732,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
+                    inter_paragraph_silence,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -748,6 +757,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
+                    inter_paragraph_silence,
                     ready,
                     &native_voice,
                     interruption_sensitivity,
@@ -1153,6 +1163,22 @@ impl SiriVoiceState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inter_paragraph_silence_tracks_siri_synthesis_rate() {
+        assert_eq!(
+            siri_inter_paragraph_silence(0.5),
+            Duration::from_millis(500)
+        );
+        assert_eq!(
+            siri_inter_paragraph_silence(1.0),
+            Duration::from_millis(250)
+        );
+        assert_eq!(
+            siri_inter_paragraph_silence(2.0),
+            Duration::from_millis(125)
+        );
+    }
 
     #[test]
     fn voice_lookup_normalizes_language_but_preserves_exact_name() {

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -46,7 +46,7 @@ use berd_voice::DeliverySegment as VoiceDeliverySegment;
 #[cfg(target_os = "macos")]
 use berd_voice::{
     ConfiguredTtsSlot, DrainPolicy, OutboundFailure, OutboundOutcome, OutboundPlayback,
-    PcmAudioOutput, PocketAudioPlayer, TtsBackend, TtsConfiguration,
+    PcmAudioOutput, PocketAudioPlayer, StreamingTtsText, TtsBackend, TtsConfiguration,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -137,6 +137,8 @@ const SIRI_STREAM_EVENT: &str = "siri-voice:stream-event";
 const SIRI_OUTPUT_DRAIN_MARGIN: Duration = Duration::from_secs(60);
 #[cfg(target_os = "macos")]
 const PLAYBACK_PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(100);
+#[cfg(target_os = "macos")]
+const SIRI_INTER_CHUNK_SILENCE: Duration = Duration::from_millis(250);
 const MIN_PLAYBACK_SPEED: f32 = 0.5;
 const MAX_PLAYBACK_SPEED: f32 = 2.0;
 pub(crate) static SIRI_SETTINGS_LOCK: Mutex<()> = Mutex::new(());
@@ -522,8 +524,7 @@ fn synthesize_siri_stream_ready(
     playback: &mut OutboundPlayback<'_>,
     player: &PocketAudioPlayer,
     output_latency_grace: Duration,
-    pending: &mut String,
-    first_chunk_pending: &mut bool,
+    ready: Vec<String>,
     native_voice: &NativeVoiceState,
     interruption_sensitivity: InterruptionSensitivity,
     input_during_tts: InputDuringTtsPolicy,
@@ -531,12 +532,15 @@ fn synthesize_siri_stream_ready(
     playback_drained_at: &mut Option<Instant>,
     last_progress_emit: &mut Instant,
     last_progress: &mut Option<VoiceDeliveryProgress>,
-    flush: bool,
 ) -> Result<bool, String> {
-    let split = berd_voice::take_streaming_text_chunks(pending, *first_chunk_pending, flush)?;
-    *pending = split.pending;
-    *first_chunk_pending = split.first_chunk_pending;
-    for text in split.ready {
+    for text in ready {
+        if playback
+            .queue_inter_segment_silence(SIRI_INTER_CHUNK_SILENCE)
+            .map_err(|failure| failure.message)?
+            == OutboundOutcome::Interrupted
+        {
+            return Ok(false);
+        }
         // The coordinator invokes these callbacks serially, but Rust cannot
         // infer that two callback values never overlap. Interior borrows keep
         // the single host-owned guard state shared without duplicating it.
@@ -665,8 +669,7 @@ fn run_siri_stream(
     let player =
         PocketAudioPlayer::new(pcm_spec.sample_rate, pcm_spec.playback_rate, output_device)?;
     let mut playback = OutboundPlayback::new(&player, &active, pcm_spec.sample_rate, 0)?;
-    let mut pending = String::new();
-    let mut first_chunk_pending = true;
+    let mut streaming_text = StreamingTtsText::default();
     let mut assistant_speech = None::<AssistantSpeechGuard>;
     let mut playback_drained_at = None;
     let mut last_progress_emit = Instant::now();
@@ -689,7 +692,7 @@ fn run_siri_stream(
         let command = receiver.recv_timeout(Duration::from_millis(10));
         match command {
             Ok(SiriStreamCommand::Append(text)) => {
-                pending.push_str(&text);
+                let ready = streaming_text.append(backend.as_ref(), &text)?;
                 if !synthesize_siri_stream_ready(
                     &app,
                     &stream_id,
@@ -697,8 +700,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
@@ -706,7 +708,6 @@ fn run_siri_stream(
                     &mut playback_drained_at,
                     &mut last_progress_emit,
                     &mut last_progress,
-                    false,
                 )? {
                     return Ok(SiriStreamOutcome {
                         state: SiriStreamEventState::Interrupted,
@@ -715,6 +716,7 @@ fn run_siri_stream(
                 }
             }
             Ok(SiriStreamCommand::Flush) => {
+                let ready = streaming_text.flush(backend.as_ref())?;
                 if !synthesize_siri_stream_ready(
                     &app,
                     &stream_id,
@@ -722,8 +724,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
@@ -731,7 +732,6 @@ fn run_siri_stream(
                     &mut playback_drained_at,
                     &mut last_progress_emit,
                     &mut last_progress,
-                    true,
                 )? {
                     return Ok(SiriStreamOutcome {
                         state: SiriStreamEventState::Interrupted,
@@ -740,6 +740,7 @@ fn run_siri_stream(
                 }
             }
             Ok(SiriStreamCommand::Finish) => {
+                let ready = streaming_text.flush(backend.as_ref())?;
                 if !synthesize_siri_stream_ready(
                     &app,
                     &stream_id,
@@ -747,8 +748,7 @@ fn run_siri_stream(
                     &mut playback,
                     &player,
                     output_latency_grace,
-                    &mut pending,
-                    &mut first_chunk_pending,
+                    ready,
                     &native_voice,
                     interruption_sensitivity,
                     input_during_tts,
@@ -756,7 +756,6 @@ fn run_siri_stream(
                     &mut playback_drained_at,
                     &mut last_progress_emit,
                     &mut last_progress,
-                    true,
                 )? {
                     return Ok(SiriStreamOutcome {
                         state: SiriStreamEventState::Interrupted,

--- a/src-tauri/src/commands/siri_voice.rs
+++ b/src-tauri/src/commands/siri_voice.rs
@@ -138,6 +138,8 @@ const SIRI_OUTPUT_DRAIN_MARGIN: Duration = Duration::from_secs(60);
 #[cfg(target_os = "macos")]
 const PLAYBACK_PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(100);
 #[cfg(any(test, target_os = "macos"))]
+// Separate Siri synthesis requests lose part of the natural paragraph pause,
+// so add the measured deficit rather than treating existing PCM as the target.
 const SIRI_INTER_PARAGRAPH_BASE_SILENCE: Duration = Duration::from_millis(250);
 const MIN_PLAYBACK_SPEED: f32 = 0.5;
 const MAX_PLAYBACK_SPEED: f32 = 2.0;


### PR DESCRIPTION
## Summary

Streamed voice replies could send a tiny opening fragment to speech synthesis before the rest of the response arrived, producing an isolated letter or word followed by an awkward pause. Berd Voice holds incomplete text until a paragraph boundary and owns segmentation for Siri, OpenAI, and Pocket TTS. Adjacent Markdown list items stay in one speech block, while Pocket can still split a paragraph that exceeds its model token limit without treating those provider-safe pieces as separate paragraphs.

Paragraph transitions also preserve natural cadence at the selected speech rate. Siri uses a rate-adjusted pause. OpenAI measures quiet padding already present in the synthesized PCM and adds only the missing silence, including when that padding contains quiet nonzero samples rather than literal zeros.

## Reviewer-reproducible examples

1. In a voice-enabled Berd session, select Apple TTS and ask the coding agent: “Reply with two prose paragraphs followed by a three-item Markdown list.” Confirm speech begins with the complete opening phrase, pauses between prose paragraphs, and speaks the list as one block rather than pausing after every item.
2. Repeat with OpenAI TTS. Confirm the response does not speak an isolated opening letter or word and the paragraph gap sounds natural without stacking an extra pause on provider-generated silence.
3. Repeat both backends at normal and maximum speech speed. Confirm the paragraph cadence scales with the selected rate.
4. Select Pocket TTS and request one paragraph long enough to exceed Pocket’s model token limit followed by a short second paragraph. Confirm the long paragraph continues through its model-safe internal splits without paragraph-length pauses, then pauses once before the second paragraph.
5. Interrupt during the second paragraph. Confirm playback stops immediately and does not resume with queued paragraphs.