### PR TITLE
enable Astra for Codex ACP sessions

### DIFF
--- a/acp-tools.lock.json
+++ b/acp-tools.lock.json
@@ -176,9 +176,9 @@
             ]
           },
           "node_modules/@anthropic-ai/sdk": {
-            "version": "0.117.1",
-            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.117.1.tgz",
-            "integrity": "sha512-Yn2QlXfyCiKJ5YGCOOay7ZE78ISvII2XY621WMCiflmG8IYgwx59IBwPExxki3Xk9jKUtnD/Sj6UvplWr0rZxg==",
+            "version": "0.124.0",
+            "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.124.0.tgz",
+            "integrity": "sha512-cN5O8i9UVxHeOQAzj/XjshWXG8KiibJDw9OGpH2Z/eR3n/RBxdoLxDJOcfqAJWvjaMDFfHTBADU04hWRJVkDyA==",
             "peer": true,
             "dependencies": {
               "json-schema-to-ts": "^3.1.1",
@@ -591,9 +591,9 @@
             }
           },
           "node_modules/express-rate-limit": {
-            "version": "8.6.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
-            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.7.0.tgz",
+            "integrity": "sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==",
             "dependencies": {
               "debug": "^4.4.3",
               "ip-address": "^10.2.0"
@@ -619,9 +619,9 @@
             "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="
           },
           "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "funding": [
               {
                 "type": "github",
@@ -746,9 +746,9 @@
             }
           },
           "node_modules/hono": {
-            "version": "4.13.2",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-            "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+            "version": "4.13.7",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+            "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
             "peer": true,
             "engines": {
               "node": ">=16.9.0"
@@ -794,9 +794,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
           },
           "node_modules/ip-address": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+            "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
             "engines": {
               "node": ">= 12"
             }
@@ -820,9 +820,9 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
           },
           "node_modules/jose": {
-            "version": "6.2.8",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-            "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+            "version": "6.2.12",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.12.tgz",
+            "integrity": "sha512-9NiFmJEex0sy2Dk58j2UGBSHgUs2ypF9eZSu4L6vjOX3Dp96Sw1F3uL+H+D1sx02jZZdzUT0HgvCy59CuvXcWw==",
             "funding": {
               "url": "https://github.com/sponsors/panva"
             }
@@ -909,11 +909,30 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
           },
           "node_modules/negotiator": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+            "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+            "dependencies": {
+              "content-type": "^2.1.0"
+            },
             "engines": {
-              "node": ">= 0.6"
+              "node": ">=18"
+            },
+            "funding": {
+              "type": "opencollective",
+              "url": "https://opencollective.com/express"
+            }
+          },
+          "node_modules/negotiator/node_modules/content-type": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+            "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+            "engines": {
+              "node": ">=18"
+            },
+            "funding": {
+              "type": "opencollective",
+              "url": "https://opencollective.com/express"
             }
           },
           "node_modules/object-assign": {
@@ -1000,9 +1019,9 @@
             }
           },
           "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "dependencies": {
               "es-define-property": "^1.0.1",
               "side-channel": "^1.1.1"
@@ -1204,9 +1223,9 @@
             }
           },
           "node_modules/standardwebhooks": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-            "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+            "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
             "dependencies": {
               "@stablelib/base64": "^1.0.0",
               "fast-sha256": "^1.3.0"
@@ -1298,9 +1317,9 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
           },
           "node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+            "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
             "peer": true,
             "funding": {
               "url": "https://github.com/sponsors/colinhacks"
@@ -1319,7 +1338,7 @@
     },
     "codex-acp": {
       "package": "@agentclientprotocol/codex-acp",
-      "version": "1.2.0",
+      "version": "1.10.0",
       "nativeExecutables": {
         "aarch64-apple-darwin": "node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/bin/codex",
         "aarch64-unknown-linux-gnu": "node_modules/@openai/codex-linux-arm64/vendor/aarch64-unknown-linux-musl/bin/codex",
@@ -1332,7 +1351,7 @@
         "version": "0.0.0",
         "private": true,
         "dependencies": {
-          "@agentclientprotocol/codex-acp": "1.2.0"
+          "@agentclientprotocol/codex-acp": "1.10.0"
         }
       },
       "packageLock": {
@@ -1345,18 +1364,18 @@
             "name": "berd-managed-acp-install",
             "version": "0.0.0",
             "dependencies": {
-              "@agentclientprotocol/codex-acp": "1.2.0"
+              "@agentclientprotocol/codex-acp": "1.10.0"
             }
           },
           "node_modules/@agentclientprotocol/codex-acp": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@agentclientprotocol/codex-acp/-/codex-acp-1.2.0.tgz",
-            "integrity": "sha512-nj23pM4OfaCOB5Du5rsSq0kcyki5H8D5ql96+AwIv7lnu0YEKj9R2YDsxbOKzwLlt+5QD6s0mn4Grkm7SSAUUA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@agentclientprotocol/codex-acp/-/codex-acp-1.10.0.tgz",
+            "integrity": "sha512-b4dDCPkH/GgHRb3JelXz4QdNirdoTjO3yYM1ImUJMxVXxgZLZMguEXNhZOH2G755UKzf6ZypiiC7UHe3fKgp2Q==",
             "dependencies": {
-              "@agentclientprotocol/sdk": "^1.3.0",
-              "@openai/codex": "^0.147.0",
+              "@agentclientprotocol/sdk": "^1.4.0",
+              "@openai/codex": "^0.153.3",
               "diff": "^9.0.0",
-              "open": "^11.0.0",
+              "open": "^11.0.1",
               "vscode-jsonrpc": "^9.0.1",
               "zod": "^4.0.0"
             },
@@ -1365,17 +1384,17 @@
             }
           },
           "node_modules/@agentclientprotocol/sdk": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
-            "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.4.0.tgz",
+            "integrity": "sha512-/eufudw+aFY1LKLolT6yFE6UMmYRl7fMJ/DEONSIyR6wI3slHWITBsANRGqXEY8FRzqUxwh7QEaGiZHcJPVThg==",
             "peerDependencies": {
               "zod": "^3.25.0 || ^4.0.0"
             }
           },
           "node_modules/@openai/codex": {
-            "version": "0.147.0",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
-            "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
+            "version": "0.153.4",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4.tgz",
+            "integrity": "sha512-wbHDmit7S/YvBGVX1DQmk13xtWblZ2cApeJ/pB7xDZ10Cna+DZc5ij7f0F4OxdsXN4FW1oLT48OpogUI1+8Y2w==",
             "bin": {
               "codex": "bin/codex.js"
             },
@@ -1383,19 +1402,19 @@
               "node": ">=16"
             },
             "optionalDependencies": {
-              "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
-              "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
-              "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
-              "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
-              "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
-              "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
+              "@openai/codex-darwin-arm64": "npm:@openai/codex@0.153.4-darwin-arm64",
+              "@openai/codex-darwin-x64": "npm:@openai/codex@0.153.4-darwin-x64",
+              "@openai/codex-linux-arm64": "npm:@openai/codex@0.153.4-linux-arm64",
+              "@openai/codex-linux-x64": "npm:@openai/codex@0.153.4-linux-x64",
+              "@openai/codex-win32-arm64": "npm:@openai/codex@0.153.4-win32-arm64",
+              "@openai/codex-win32-x64": "npm:@openai/codex@0.153.4-win32-x64"
             }
           },
           "node_modules/@openai/codex-darwin-arm64": {
             "name": "@openai/codex",
-            "version": "0.147.0-darwin-arm64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
-            "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
+            "version": "0.153.4-darwin-arm64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-arm64.tgz",
+            "integrity": "sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==",
             "cpu": [
               "arm64"
             ],
@@ -1409,9 +1428,9 @@
           },
           "node_modules/@openai/codex-darwin-x64": {
             "name": "@openai/codex",
-            "version": "0.147.0-darwin-x64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
-            "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
+            "version": "0.153.4-darwin-x64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-darwin-x64.tgz",
+            "integrity": "sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==",
             "cpu": [
               "x64"
             ],
@@ -1425,9 +1444,9 @@
           },
           "node_modules/@openai/codex-linux-arm64": {
             "name": "@openai/codex",
-            "version": "0.147.0-linux-arm64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
-            "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
+            "version": "0.153.4-linux-arm64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-arm64.tgz",
+            "integrity": "sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==",
             "cpu": [
               "arm64"
             ],
@@ -1441,9 +1460,9 @@
           },
           "node_modules/@openai/codex-linux-x64": {
             "name": "@openai/codex",
-            "version": "0.147.0-linux-x64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
-            "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
+            "version": "0.153.4-linux-x64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-linux-x64.tgz",
+            "integrity": "sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==",
             "cpu": [
               "x64"
             ],
@@ -1457,9 +1476,9 @@
           },
           "node_modules/@openai/codex-win32-arm64": {
             "name": "@openai/codex",
-            "version": "0.147.0-win32-arm64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
-            "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
+            "version": "0.153.4-win32-arm64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-arm64.tgz",
+            "integrity": "sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==",
             "cpu": [
               "arm64"
             ],
@@ -1473,9 +1492,9 @@
           },
           "node_modules/@openai/codex-win32-x64": {
             "name": "@openai/codex",
-            "version": "0.147.0-win32-x64",
-            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
-            "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
+            "version": "0.153.4-win32-x64",
+            "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.153.4-win32-x64.tgz",
+            "integrity": "sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ==",
             "cpu": [
               "x64"
             ],
@@ -1502,9 +1521,9 @@
             }
           },
           "node_modules/default-browser": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+            "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
             "dependencies": {
               "bundle-name": "^4.1.0",
               "default-browser-id": "^5.0.0"
@@ -1603,15 +1622,15 @@
             }
           },
           "node_modules/open": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
-            "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
+            "version": "11.0.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-11.0.2.tgz",
+            "integrity": "sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==",
             "dependencies": {
-              "default-browser": "^5.4.0",
+              "default-browser": "^5.5.1",
               "define-lazy-prop": "^3.0.0",
               "is-in-ssh": "^1.0.0",
               "is-inside-container": "^1.0.0",
-              "powershell-utils": "^0.2.0",
+              "powershell-utils": "^0.2.1",
               "wsl-utils": "^1.0.0"
             },
             "engines": {
@@ -1622,9 +1641,9 @@
             }
           },
           "node_modules/powershell-utils": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-            "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.1.tgz",
+            "integrity": "sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==",
             "engines": {
               "node": ">=20"
             },
@@ -1644,9 +1663,9 @@
             }
           },
           "node_modules/vscode-jsonrpc": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
-            "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.2.tgz",
+            "integrity": "sha512-SbQSV9yRemARxeXw6LU5sS6Zq0e9/DgCCX5yelH263ZQWukbTk8EF8fjTrr1dziasf4GwlJbvTwFnTrnQFWZXQ==",
             "engines": {
               "node": ">=14.0.0"
             }
@@ -1678,9 +1697,9 @@
             }
           },
           "node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "version": "4.5.4",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+            "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
             "peer": true,
             "funding": {
               "url": "https://github.com/sponsors/colinhacks"

--- a/src-tauri/src/services/managed_acp_tools.rs
+++ b/src-tauri/src/services/managed_acp_tools.rs
@@ -290,7 +290,7 @@ pub const MANAGED_TOOLS: &[ManagedTool] = &[
         id: "codex-acp",
         binary: "codex-acp",
         package: "@agentclientprotocol/codex-acp",
-        version: "1.2.0",
+        version: "1.10.0",
     },
 ];
 


### PR DESCRIPTION
**Category:** fix
**User Impact:** Users can select GPT-6 Astra when starting sessions with the Codex harness.
**Problem:** Berd's managed Codex ACP bridge bundled an older Codex runtime, so its advertised model inventory did not include GPT-6 Astra even though Berd supported Astra through Goose.
**Solution:** Upgrade the release-controlled Codex ACP bridge and regenerate its integrity-pinned dependency graph so Berd installs a compatible Codex runtime on every supported platform.

<details>
<summary>File changes</summary>

**acp-tools.lock.json**
Regenerates the managed bridge installation documents for Codex ACP 1.10.0, including Codex 0.153.4 and verified native executable paths for every supported target. The generator also refreshes transitive dependencies covered by the release-controlled lock.

**src-tauri/src/services/managed_acp_tools.rs**
Updates Berd's managed Codex ACP version pin to match the regenerated installation lock.

</details>
