### PR TITLE
chore: release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.6.4](https://github.com/block/berd/releases/tag/v0.6.4) - 2026-09-10
+
+This release improves chat recovery, artifact actions, voice conversations, and agent setup across Berd.
+
+- **Artifact actions restored:** `Open in editor` and artifact-row actions work again, including in popped-out session windows. Actions are disabled when a file has been deleted and automatically return if it reappears.
+- **Unavailable remote chats:** When a remote session no longer exists, Berd now shows a clear read-only notice instead of a raw error while preserving any messages still available in memory.
+- **Archived chat recovery:** Sending a new message to an archived chat now restores it to the active chat list before continuing the conversation.
+- **Smoother voice replies:** Streamed responses are spoken in complete paragraphs, preventing isolated opening words and awkward pauses. Lists, playback speed, interruptions, and long Pocket TTS responses also sound more natural.
+- **Simpler voice settings:** Voice modes now have clearer descriptions and Local/Cloud labels, with Apple speech as the recommended direct-mode default. A new reset option restores defaults without removing credentials or selected models.
+- **More reliable live voice:** Expert and Spokesperson modes now switch more cleanly, avoid blocking during runtime changes, and handle speech cancellation, reconnection, and voice or speed changes more consistently.
+- **Pi agent support:** Pi is now available during onboarding with one-click installation and model selection. The wider model picker also makes long model names easier to read.
+- **GPT-6 Astra for Codex:** GPT-6 Astra can now be selected when starting a Codex ACP session.
+- **Safer MCP App messages:** Berd now asks for explicit confirmation before an MCP App can submit a message as you.
+
+**Full Changelog**: https://github.com/block/berd/compare/v0.6.3...3d3817f64
+
 ## [v0.6.3](https://github.com/block/berd/releases/tag/v0.6.3) - 2026-09-05
 
 This release brings major improvements to voice conversations, search, agents, Home, and CLI workflows, plus many reliability fixes across everyday chat use.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "berd",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Berd"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "berdctl"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "clap",
  "indexmap 2.13.1",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-berdctl"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "axum",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Berd"
-version = "0.6.3"
+version = "0.6.4"
 description = "Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/crates/berdctl/Cargo.toml
+++ b/src-tauri/crates/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "berdctl"
-version = "0.6.3"
+version = "0.6.4"
 description = "Command-line control of the Berd desktop app"
 authors = ["Block, Inc."]
 edition = "2021"

--- a/src-tauri/plugins/berdctl/Cargo.toml
+++ b/src-tauri/plugins/berdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-berdctl"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 links = "tauri-plugin-berdctl"
 build = "build.rs"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Berd",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "xyz.block.berd",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
## Summary

- synchronize Berd, berdctl, and tauri-plugin-berdctl at 0.6.4
- add the reviewed v0.6.4 changelog entry

### Related issue

N/A

### Testing

- `just release-version-check 0.6.4`
- `just release-validate 0.6.4`
