### PR TITLE
default project chats to a saved SSH environment

### DIFF
--- a/src/app/AppShell.navigation.test.tsx
+++ b/src/app/AppShell.navigation.test.tsx
@@ -1,3 +1,5 @@
+import * as remoteSession from "@/features/chat/lib/remoteSession";
+import { REMOTE_SSH_SESSIONS_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import { getModelSelectionIntent } from "@/features/chat/model-selection/modelSelectionIntent";
 import { beginModelSelectionIntent } from "@/features/chat/model-selection/modelSelectionIntent";
 import {
@@ -5652,6 +5654,50 @@ describe("AppShell global navigation", () => {
       screen.getByRole("button", { name: "Open builderbot automation" }),
     );
     expect(screen.queryByRole("link", { name: "Daily docs" })).toBeNull();
+  });
+
+  it.each([
+    true,
+    false,
+  ])("applies project SSH defaults only when enabled (%s)", async (enabled) => {
+    setExperimentEnabled(REMOTE_SSH_SESSIONS_EXPERIMENT_ID, enabled);
+    const connect = vi
+      .spyOn(remoteSession, "ensureRemoteHostConnected")
+      .mockImplementation(() => new Promise<void>(() => {}));
+    const project: ProjectInfo = {
+      id: "project-2",
+      path: "/tmp/project.md",
+      name: "Remote project",
+      description: "",
+      prompt: "",
+      icon: "",
+      color: "olive",
+      workingDirs: ["/local/repo"],
+      projectWorkspaces: [],
+      useWorktrees: false,
+      order: 0,
+      archivedAt: null,
+      environment: { remoteHost: "devbox", remoteWorkingDir: "/home/me/repo" },
+    };
+    useProjectStore.setState({ projects: [project] });
+    const user = userEvent.setup();
+    renderAppShell();
+    try {
+      await user.click(
+        screen.getByRole("button", { name: "Sidebar new project 2 chat" }),
+      );
+      await waitFor(() => {
+        const state = useChatSessionStore.getState();
+        const session = state.sessions.find(
+          (candidate) => candidate.id === state.activeSessionId,
+        );
+        expect(session?.projectId).toBe(project.id);
+        expect(session?.remoteHost).toBe(enabled ? "devbox" : undefined);
+        if (enabled) expect(session?.workingDir).toBe("/home/me/repo");
+      });
+    } finally {
+      connect.mockRestore();
+    }
   });
 
   it("shows only the session title for a project chat", async () => {

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,3 +1,4 @@
+import { projectEnvironment } from "@/features/projects/lib/projectEnvironment";
 import {
   useCallback,
   useEffect,
@@ -318,6 +319,8 @@ type DraftSessionCreationReady = {
   >["configOptionsSnapshot"];
 };
 type ProjectChatDraftOptions = {
+  remoteHost?: string;
+  remoteWorkingDir?: string;
   executionTarget?: SessionExecutionTarget;
   reuseExistingDraft?: boolean;
   reasoningEffort?: GlobalComposeOptions["reasoningEffort"];
@@ -2278,6 +2281,9 @@ export function AppShell({
       } = {},
     ) => {
       const shouldActivate = options.activate !== false;
+      options = options.remoteHost
+        ? options
+        : { ...options, ...projectEnvironment(project) };
       const remoteHost = options.remoteHost?.trim() || undefined;
       const remoteWorkingDir = options.remoteWorkingDir?.trim() || undefined;
       if (remoteHost && !remoteWorkingDir) {
@@ -2507,6 +2513,9 @@ export function AppShell({
       project: ProjectInfo,
       options: ProjectChatDraftOptions = {},
     ) => {
+      if (options.remoteHost || projectEnvironment(project)) {
+        return createNewTab(title, project, options);
+      }
       perfLog(
         `[perf:newtab] createNewProjectDraft start (project=${project.id})`,
       );
@@ -2579,6 +2588,7 @@ export function AppShell({
       return session;
     },
     [
+      createNewTab,
       createDraftSession,
       resolveSessionCreationTarget,
       setActiveSession,
@@ -2599,6 +2609,9 @@ export function AppShell({
         remoteWorkingDir?: string;
       } = {},
     ) => {
+      options = options.remoteHost
+        ? options
+        : { ...options, ...projectEnvironment(project) };
       const remoteHost = options.remoteHost?.trim() || undefined;
       const remoteWorkingDir = options.remoteWorkingDir?.trim() || undefined;
       if (remoteHost && !remoteWorkingDir) {
@@ -3045,6 +3058,7 @@ export function AppShell({
       // a remote compose keeps the project association but skips those plans.
       const requiresProjectWorkspaceDraftPlan =
         !options?.remoteHost &&
+        !projectEnvironment(project) &&
         workspaceRepository.mode === "multi" &&
         Boolean(project?.projectWorkspaces.length);
       const shouldRunComposerHandoff =
@@ -3118,7 +3132,7 @@ export function AppShell({
         // chats go through createNewTab, which carries the project association
         // and uses the remote working directory verbatim.
         const createChat =
-          project && !options?.remoteHost
+          project && !options?.remoteHost && !projectEnvironment(project)
             ? createNewProjectDraft(DEFAULT_CHAT_TITLE, project, chatOptions)
             : createNewTab(DEFAULT_CHAT_TITLE, project, chatOptions);
 
@@ -3318,7 +3332,7 @@ export function AppShell({
         // Remote project chats skip the local workspace-startup draft route
         // but keep the project association (see handleGlobalCompose).
         const session =
-          project && !options?.remoteHost
+          project && !options?.remoteHost && !projectEnvironment(project)
             ? await createNewProjectDraft(
                 DEFAULT_CHAT_TITLE,
                 project,

--- a/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
+++ b/src/features/chat/hooks/__tests__/useChatSessionController.test.ts
@@ -52,6 +52,7 @@ const mockMarkAgentBuilderSessionPreparationFailed = vi.fn();
 const mockDeletePersonaSource = vi.fn();
 const mockAcpCreateSession = vi.fn();
 const mockAcpSessionArchive = vi.fn();
+const mockAcpSessionProjectUpdate = vi.fn();
 const mockEnsureRemoteHostConnected = vi.fn();
 const mockUseChatRuntime = {
   chatState: "idle",
@@ -139,6 +140,8 @@ vi.mock("@/shared/api/acpConnection", () => {
         mockGoosePreferencesSave(...args),
       GooseUnstableProvidersSupportedModelsList: (...args: unknown[]) =>
         mockSupportedModelsList(...args),
+      GooseUnstableSessionProjectUpdate: (...args: unknown[]) =>
+        mockAcpSessionProjectUpdate(...args),
       GooseUnstableSessionArchive: (...args: unknown[]) =>
         mockAcpSessionArchive(...args),
     },
@@ -6583,6 +6586,76 @@ describe("useChatSessionController", () => {
     beforeEach(() => {
       mockEnsureRemoteHostConnected.mockReset().mockResolvedValue(undefined);
       setExperimentEnabled(REMOTE_SSH_SESSIONS_EXPERIMENT_ID, true);
+    });
+
+    it.each([
+      "succeeds",
+      "fails",
+    ] as const)("keeps the original environment until a project move %s", async (outcome) => {
+      const move = deferred();
+      mockAcpSessionProjectUpdate.mockReturnValueOnce(move.promise);
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+      useChatSessionStore.getState().patchSession("session-1", {
+        projectId: "original",
+      });
+      useProjectStore.setState({
+        projects: [
+          {
+            id: "destination",
+            path: "/tmp/destination.md",
+            name: "Destination",
+            projectWorkspaces: [],
+            workingDirs: [],
+            useWorktrees: false,
+            order: 0,
+            archivedAt: null,
+            artifact: null,
+            description: "",
+            prompt: "",
+            icon: "",
+            color: "",
+            environment: {
+              remoteHost: "destination-host",
+              remoteWorkingDir: "/destination",
+            },
+          },
+        ],
+      });
+      const { result } = renderHook(() =>
+        useChatSessionController({ sessionId: "session-1" }),
+      );
+      act(() => {
+        result.current.handleRemoteHostChange("original-host");
+        result.current.handleRemoteDirChange("/original");
+      });
+      act(() => result.current.handleProjectChange("destination"));
+      await waitFor(() =>
+        expect(mockAcpSessionProjectUpdate).toHaveBeenCalledWith({
+          sessionId: "session-1",
+          projectId: "destination",
+        }),
+      );
+      expect(result.current.selectedProjectId).toBe("original");
+      expect(result.current.selectedRemoteHost).toBe("original-host");
+      expect(result.current.selectedRemoteDir).toBe("/original");
+
+      await act(async () => {
+        if (outcome === "succeeds") move.resolve();
+        else move.reject(new Error("Project move failed"));
+      });
+      expect(result.current.selectedProjectId).toBe(
+        outcome === "succeeds" ? "destination" : "original",
+      );
+      expect(
+        useChatSessionStore.getState().getSession("session-1")?.projectId,
+      ).toBe(outcome === "succeeds" ? "destination" : "original");
+      expect(result.current.selectedRemoteHost).toBe(
+        outcome === "succeeds" ? "destination-host" : "original-host",
+      );
+      expect(result.current.selectedRemoteDir).toBe(
+        outcome === "succeeds" ? "/destination" : "/original",
+      );
+      errorLog.mockRestore();
     });
 
     it("is disabled while the experiment is off", () => {

--- a/src/features/chat/hooks/useChatSessionController.ts
+++ b/src/features/chat/hooks/useChatSessionController.ts
@@ -1497,21 +1497,33 @@ export function useChatSessionController({
 
   const handleProjectChange = useCallback(
     (projectId: string | null) => {
-      if (remoteHostSelectionEnabled) {
+      const applyProjectEnvironment = () => {
+        if (!remoteHostSelectionEnabled) return;
         const project = useProjectStore
           .getState()
           .projects.find((candidate) => candidate.id === projectId);
         const environment = projectEnvironment(project);
         setPendingRemoteHost(environment?.remoteHost ?? null);
         setPendingRemoteDir(environment?.remoteWorkingDir ?? null);
-      }
+      };
       if (!sessionId) {
         setPendingProjectId(projectId);
+        applyProjectEnvironment();
         return;
       }
-      void moveSessionToProject(sessionId, projectId).catch((error) => {
-        console.error("Failed to move session to project:", error);
-      });
+      void moveSessionToProject(sessionId, projectId)
+        .then(() => {
+          // Superseded moves can resolve without changing the session's project.
+          const liveSession = useChatSessionStore
+            .getState()
+            .getSession(sessionId);
+          if (liveSession && liveSession.projectId === projectId) {
+            applyProjectEnvironment();
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to move session to project:", error);
+        });
     },
     [sessionId, remoteHostSelectionEnabled],
   );

--- a/src/features/chat/hooks/useChatSessionController.ts
+++ b/src/features/chat/hooks/useChatSessionController.ts
@@ -1,3 +1,4 @@
+import { projectEnvironment } from "@/features/projects/lib/projectEnvironment";
 import {
   useCallback,
   useContext,
@@ -1496,6 +1497,14 @@ export function useChatSessionController({
 
   const handleProjectChange = useCallback(
     (projectId: string | null) => {
+      if (remoteHostSelectionEnabled) {
+        const project = useProjectStore
+          .getState()
+          .projects.find((candidate) => candidate.id === projectId);
+        const environment = projectEnvironment(project);
+        setPendingRemoteHost(environment?.remoteHost ?? null);
+        setPendingRemoteDir(environment?.remoteWorkingDir ?? null);
+      }
       if (!sessionId) {
         setPendingProjectId(projectId);
         return;
@@ -1504,7 +1513,7 @@ export function useChatSessionController({
         console.error("Failed to move session to project:", error);
       });
     },
-    [sessionId],
+    [sessionId, remoteHostSelectionEnabled],
   );
 
   const handleRemoteHostChange = useCallback(

--- a/src/features/chat/lib/newChat.test.ts
+++ b/src/features/chat/lib/newChat.test.ts
@@ -18,6 +18,27 @@ function makeSession(
 }
 
 describe("findExistingDraft", () => {
+  it("does not reuse an unavailable remote project chat", () => {
+    const missing = makeSession("remote-missing", {
+      projectId: "alpha",
+      remoteHost: "devbox",
+      remoteSessionUnavailable: true,
+    });
+    expect(
+      findExistingDraft({
+        sessions: [missing],
+        activeSessionId: missing.id,
+        draftsBySession: { [missing.id]: "Continue this work" },
+        messagesBySession: {},
+        request: {
+          title: "New chat",
+          projectId: "alpha",
+          remoteHost: "devbox",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("reuses a matching project draft with content", () => {
     const draft = makeSession("alpha-draft", {
       projectId: "alpha",

--- a/src/features/chat/lib/newChat.ts
+++ b/src/features/chat/lib/newChat.ts
@@ -69,6 +69,7 @@ function isReusableDraft(
 ): boolean {
   return (
     !session.archivedAt &&
+    !session.remoteSessionUnavailable &&
     session.intent !== "build-agent" &&
     session.messageCount === 0 &&
     (localMessages?.length ?? 0) === 0

--- a/src/features/projects/api/projects.test.ts
+++ b/src/features/projects/api/projects.test.ts
@@ -71,6 +71,53 @@ describe("projects API artifact metadata", () => {
     });
   });
 
+  it("round-trips a project environment and clears it when returning to local", async () => {
+    mocks.sourcesList.mockResolvedValue({ sources: [] });
+    mocks.sourcesCreate.mockImplementation(async (request) => ({
+      source: source(request.properties),
+    }));
+    mocks.sourcesUpdate.mockImplementation(async (request) => ({
+      source: source(request.properties),
+    }));
+    const { createProject, updateProject } = await import("./projects");
+    const environment = {
+      remoteHost: "devbox",
+      remoteWorkingDir: "/home/me/code",
+    };
+    const created = await createProject(
+      "Launch",
+      "",
+      "",
+      "",
+      "olive",
+      [],
+      false,
+      [],
+      environment,
+    );
+    expect(created.environment).toEqual(environment);
+    const renamed = await updateProject(created, { name: "Renamed" });
+    expect(renamed.environment).toEqual(environment);
+    const local = await updateProject(renamed, { environment: null });
+    expect(local.environment).toBeNull();
+    expect(
+      mocks.sourcesUpdate.mock.calls.at(-1)?.[0].properties,
+    ).not.toHaveProperty("environment");
+  });
+
+  it("ignores incomplete or malformed saved environments", async () => {
+    const { parseProjectEnvironment } = await import("./projects");
+    for (const value of [
+      null,
+      {},
+      { remoteHost: "devbox" },
+      { remoteHost: 4, remoteWorkingDir: "/tmp" },
+      { remoteHost: "devbox", remoteWorkingDir: " " },
+    ]) {
+      expect(parseProjectEnvironment(value)).toBeNull();
+    }
+  });
+
   it("stores artifact metadata when creating a project", async () => {
     mocks.sourcesList.mockResolvedValue({ sources: [] });
     mocks.sourcesCreate.mockImplementation(async (request) => ({

--- a/src/features/projects/api/projects.ts
+++ b/src/features/projects/api/projects.ts
@@ -45,6 +45,25 @@ export interface ProjectWorkspace extends WorkspaceAttachment {
   startupMode: ProjectWorkspaceStartupMode;
 }
 
+export interface ProjectEnvironment {
+  remoteHost: string;
+  remoteWorkingDir: string;
+}
+
+export function parseProjectEnvironment(
+  value: unknown,
+): ProjectEnvironment | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Partial<ProjectEnvironment>;
+  const remoteHost =
+    typeof raw.remoteHost === "string" ? raw.remoteHost.trim() : "";
+  const remoteWorkingDir =
+    typeof raw.remoteWorkingDir === "string" ? raw.remoteWorkingDir.trim() : "";
+  return remoteHost && remoteWorkingDir
+    ? { remoteHost, remoteWorkingDir }
+    : null;
+}
+
 export interface ProjectInfo {
   id: string;
   /** Stable on-disk path of the project source. Pass back to update/delete. */
@@ -61,6 +80,7 @@ export interface ProjectInfo {
   archivedAt: string | null;
   artifact?: ProjectArtifactMetadata | null;
   chatGroups?: ProjectChatGroupsMetadata | null;
+  environment?: ProjectEnvironment | null;
 }
 
 export interface ProjectChatGroupMetadata {
@@ -248,6 +268,7 @@ function toProjectInfo(source: SourceEntry): ProjectInfo {
     archivedAt: (p.archivedAt as string) ?? null,
     artifact: parseProjectArtifactMetadata(p.artifact),
     chatGroups: parseProjectChatGroupsMetadata(p.chatGroups),
+    environment: parseProjectEnvironment(p.environment),
   };
 }
 
@@ -262,6 +283,7 @@ interface ProjectMetadataFields {
   archivedAt: string | null;
   artifact?: ProjectArtifactMetadata | null;
   chatGroups?: ProjectChatGroupsMetadata | null;
+  environment?: ProjectEnvironment | null;
 }
 
 function toProperties(info: ProjectMetadataFields): Record<string, unknown> {
@@ -282,6 +304,8 @@ function toProperties(info: ProjectMetadataFields): Record<string, unknown> {
   if (info.archivedAt) props.archivedAt = info.archivedAt;
   if (info.artifact) props.artifact = info.artifact;
   if (info.chatGroups?.groups.length) props.chatGroups = info.chatGroups;
+  const environment = parseProjectEnvironment(info.environment);
+  if (environment) props.environment = environment;
   return props;
 }
 
@@ -389,6 +413,7 @@ export async function createProject(
     workingDirs,
     useWorktrees,
   ),
+  environment?: ProjectEnvironment | null,
 ): Promise<ProjectInfo> {
   const client = await getClient();
   const existing = await listAllProjects();
@@ -424,6 +449,7 @@ export async function createProject(
       archivedAt: null,
       artifact,
       chatGroups: null,
+      environment,
     }),
   });
   return toProjectInfo(raw.source as SourceEntry);
@@ -496,6 +522,7 @@ export async function updateProject(
       archivedAt: merged.archivedAt,
       artifact,
       chatGroups: merged.chatGroups,
+      environment: merged.environment,
     }),
   });
   return toProjectInfo(raw.source as SourceEntry);

--- a/src/features/projects/lib/projectEnvironment.ts
+++ b/src/features/projects/lib/projectEnvironment.ts
@@ -1,0 +1,10 @@
+import { parseProjectEnvironment, type ProjectInfo } from "../api/projects";
+import { getExperiment } from "@/features/experiments/experimentPreferences";
+import { REMOTE_SSH_SESSIONS_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
+
+/** Resolve defaults only at creation, without changing existing sessions. */
+export function projectEnvironment(project?: ProjectInfo) {
+  return getExperiment(REMOTE_SSH_SESSIONS_EXPERIMENT_ID)?.enabled
+    ? parseProjectEnvironment(project?.environment)
+    : null;
+}

--- a/src/features/projects/ui/CreateProjectDialog.tsx
+++ b/src/features/projects/ui/CreateProjectDialog.tsx
@@ -1,3 +1,7 @@
+import { RemoteHostSelector } from "@/features/chat/ui/RemoteHostSelector";
+import { RemoteDirectoryPicker } from "@/features/chat/ui/RemoteDirectoryPicker";
+import { useExperiment } from "@/features/experiments/experimentPreferences";
+import { REMOTE_SSH_SESSIONS_EXPERIMENT_ID } from "@/features/experiments/experimentDefinitions";
 import {
   useState,
   useEffect,
@@ -324,6 +328,11 @@ export function CreateProjectDialog({
   const { t } = useTranslation(["projects", "common"]);
   const workspaceRepository = useWorkspaceRepository();
   const isMultiWorkspaceMode = workspaceRepository.mode === "multi";
+  const remoteEnabled =
+    useExperiment(REMOTE_SSH_SESSIONS_EXPERIMENT_ID)?.enabled === true;
+  const [remoteHost, setRemoteHost] = useState<string | null>(null);
+  const [remoteDir, setRemoteDir] = useState<string | null>(null);
+  const [remoteDirectoryOpen, setRemoteDirectoryOpen] = useState(false);
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [projectWorkspaces, setProjectWorkspaces] = useState<
@@ -523,6 +532,9 @@ export function CreateProjectDialog({
   }
 
   if (justOpened || projectIdChanged) {
+    setRemoteHost(editingProject?.environment?.remoteHost ?? null);
+    setRemoteDir(editingProject?.environment?.remoteWorkingDir ?? null);
+    setRemoteDirectoryOpen(false);
     if (editingProject) {
       const projectWorkspaceSet =
         workspaceRepository.projectWorkspaces(editingProject);
@@ -555,7 +567,10 @@ export function CreateProjectDialog({
     }
   }
 
-  const canSave = name.trim().length > 0 && !saving;
+  const canSave =
+    name.trim().length > 0 &&
+    !saving &&
+    (!remoteHost || Boolean(remoteDir?.trim()));
 
   const handleClose = () => {
     setName("");
@@ -572,6 +587,8 @@ export function CreateProjectDialog({
   };
 
   const handleSave = async (e: FormEvent) => {
+    // SSH dialogs render forms in portals; their submissions bubble through React.
+    if (e.target !== e.currentTarget) return;
     e.preventDefault();
     if (!canSave) return;
     setSaving(true);
@@ -623,6 +640,10 @@ export function CreateProjectDialog({
     const savedWorkingDirs = sanitizedProjectWorkspaces.map(
       (workspace) => workspace.path,
     );
+    const environment =
+      remoteHost && remoteDir
+        ? { remoteHost, remoteWorkingDir: remoteDir }
+        : null;
     try {
       let savedProject: ProjectInfo;
       if (isEditing) {
@@ -635,6 +656,7 @@ export function CreateProjectDialog({
           workingDirs: savedWorkingDirs,
           useWorktrees: editingProject.useWorktrees,
           projectWorkspaces: sanitizedProjectWorkspaces,
+          environment,
         });
         // Completed only after the persist resolves; the returned ProjectInfo is
         // authoritative for has_working_dir / has_prompt.
@@ -649,6 +671,7 @@ export function CreateProjectDialog({
           savedWorkingDirs,
           false,
           sanitizedProjectWorkspaces,
+          environment,
         );
         trackProjectCreateCompleted(savedProject);
       }
@@ -1034,7 +1057,39 @@ export function CreateProjectDialog({
                 />
               </div>
 
-              {!isMultiWorkspaceMode ? (
+              {(remoteEnabled || remoteHost) && (
+                <div className="space-y-2">
+                  <Label className={panelLabelClass}>
+                    {t("dialog.environmentLabel")}
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    {t("dialog.environmentDescription")}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <RemoteHostSelector
+                      selectedHost={remoteHost}
+                      disabled={!remoteEnabled}
+                      onHostChange={(host) => {
+                        setRemoteHost(host);
+                        setRemoteDir(null);
+                      }}
+                    />
+                    {remoteHost && (
+                      <RemoteDirectoryPicker
+                        key={remoteHost}
+                        host={remoteHost}
+                        selectedDir={remoteDir}
+                        onDirChange={setRemoteDir}
+                        open={remoteDirectoryOpen}
+                        onOpenChange={setRemoteDirectoryOpen}
+                        disabled={!remoteEnabled}
+                      />
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {remoteHost ? null : !isMultiWorkspaceMode ? (
                 <div className="group/field space-y-2">
                   <div className="flex items-center gap-1.5">
                     <Label className={panelLabelClass}>

--- a/src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx
+++ b/src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx
@@ -237,6 +237,28 @@ describe("CreateProjectDialog", () => {
     vi.mocked(checkDirectoriesExist).mockResolvedValue([]);
   });
 
+  it("loads and preserves the saved SSH environment when editing", async () => {
+    const user = userEvent.setup();
+    const environment = {
+      remoteHost: "devbox",
+      remoteWorkingDir: "/home/me/code",
+    };
+    const editingProject = makeEditingProject({ environment });
+    render(
+      <CreateProjectDialog
+        {...defaultProps}
+        isOpen={true}
+        editingProject={editingProject}
+      />,
+    );
+    expect(screen.getByText("devbox")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+    expect(updateProject).toHaveBeenCalledWith(
+      editingProject,
+      expect.objectContaining({ environment }),
+    );
+  });
+
   describe("form populates on open", () => {
     it("populates the name field when opening with an editingProject", async () => {
       const editingProject = makeEditingProject();
@@ -465,6 +487,7 @@ describe("CreateProjectDialog", () => {
         [],
         false,
         [],
+        null,
       );
     });
 

--- a/src/shared/i18n/locales/en/projects.json
+++ b/src/shared/i18n/locales/en/projects.json
@@ -1,5 +1,7 @@
 {
   "dialog": {
+    "environmentLabel": "Environment",
+    "environmentDescription": "New chats use this host and folder. Existing chats keep their environment.",
     "addDirectory": "Add directory",
     "addDirectoryDialogTitle": "Select directory",
     "chooseColor": "Choose a project color",

--- a/src/shared/i18n/locales/es/projects.json
+++ b/src/shared/i18n/locales/es/projects.json
@@ -1,5 +1,7 @@
 {
   "dialog": {
+    "environmentLabel": "Entorno",
+    "environmentDescription": "Los chats nuevos usan este host y carpeta. Los chats existentes conservan su entorno.",
     "addDirectory": "Añadir directorio",
     "addDirectoryDialogTitle": "Seleccionar directorio",
     "chooseColor": "Elegir un color del proyecto",


### PR DESCRIPTION
**Category:** improvement
**User Impact:** Users can save an SSH host and folder on a project so new chats automatically use the same environment.

**Problem:** Working on a remote project requires selecting the same SSH host and location for every chat.
**Solution:** Add an Environment setting to the project editor and apply it when creating project chats or selecting a project before sending. Existing chats retain their environment, and the default respects the Remote SSH sessions experiment. Projects survive lost remote sessions; unavailable chats are excluded from draft reuse so users can start fresh chats.

<details>
<summary>File changes</summary>

**src/features/projects/api/projects.ts**
Persist and validate the optional SSH host and working directory in project metadata, preserving them across unrelated edits.

**src/features/projects/lib/projectEnvironment.ts**
Resolve saved defaults only while the SSH experiment is enabled.

**src/features/projects/ui/CreateProjectDialog.tsx**
Reuse the SSH host and folder pickers in the project editor. Require a remote folder before saving and prevent picker submissions from saving the project.

**src/app/AppShell.tsx**
Apply defaults across new project chat creation paths and skip local workspace setup for remote chats.

**src/features/chat/lib/newChat.ts**
Exclude unavailable remote sessions from draft reuse so New chat can recover within the existing project.

**src/features/chat/lib/newChat.test.ts**
Cover starting fresh when an unavailable remote project chat is active and has a draft.

**src/features/chat/hooks/useChatSessionController.ts**
Apply project defaults when selecting a project in a chat that has not started, only after the project move succeeds.

**src/features/chat/hooks/__tests__/useChatSessionController.test.ts**
Verify successful moves apply destination defaults and failed moves preserve the original project, pending SSH host, and folder.

**src/app/AppShell.navigation.test.tsx**
Cover new project chat routing with SSH enabled and disabled.

**src/features/projects/api/projects.test.ts**
Cover environment persistence, preservation, clearing, and malformed metadata.

**src/features/projects/ui/__tests__/CreateProjectDialog.test.tsx**
Verify saved SSH settings load and survive project edits; update the creation contract assertion.

**src/shared/i18n/locales/en/projects.json**
Add the environment label and explanation.

**src/shared/i18n/locales/es/projects.json**
Add the matching Spanish translations.

</details>

**Validation:** `just check`; `just test` (7,757 passed, one skipped). Initial isolated app build and launch validation through `just dev-e2e isolated=1`.

**Architectural laws:** Reviewed `LAWS/CHAT.md`; session readiness and queued-message dispatch behavior remain unchanged.


<img width="3036" height="1976" alt="image" src="https://github.com/user-attachments/assets/e5d6a355-3d55-484d-b97d-ac1848598f9b" />
